### PR TITLE
feat: wire WasmEngine.invoke() into dispatch

### DIFF
--- a/crates/temper-cli/src/serve/loader.rs
+++ b/crates/temper-cli/src/serve/loader.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 
+use temper_runtime::tenant::TenantId;
 use temper_server::event_store::ServerEventStore;
 use temper_server::reaction::registry::parse_reactions;
 use temper_server::registry::SpecRegistry;
@@ -14,7 +15,6 @@ use temper_spec::cross_invariant::{
     CrossInvariantLintSeverity, lint_cross_invariants, parse_cross_invariants,
 };
 use temper_spec::csdl::{CsdlDocument, parse_csdl};
-use temper_runtime::tenant::TenantId;
 
 use super::LoadedTenantSpecs;
 
@@ -233,7 +233,9 @@ pub(super) fn read_ioa_sources(specs_dir: &Path) -> Result<HashMap<String, Strin
 }
 
 /// Read optional `reactions.toml` and parse it into reaction rules.
-pub(super) fn read_reactions(specs_dir: &Path) -> Result<Vec<temper_server::reaction::ReactionRule>> {
+pub(super) fn read_reactions(
+    specs_dir: &Path,
+) -> Result<Vec<temper_server::reaction::ReactionRule>> {
     let reactions_path = specs_dir.join("reactions.toml");
     if !reactions_path.exists() {
         return Ok(Vec::new());
@@ -434,7 +436,8 @@ effect = "set phantom true"
     fn load_into_registry_rejects_lint_errors() {
         let tmp = tempfile::tempdir().expect("tempdir");
         std::fs::write(tmp.path().join("model.csdl.xml"), TEST_CSDL).expect("write csdl"); // determinism-ok: test-only
-        std::fs::write( // determinism-ok: test-only
+        std::fs::write(
+            // determinism-ok: test-only
             tmp.path().join("order.ioa.toml"),
             r#"
 [automaton]

--- a/crates/temper-cli/src/serve/storage.rs
+++ b/crates/temper-cli/src/serve/storage.rs
@@ -36,7 +36,9 @@ struct PersistedTenantConstraintRow {
     cross_invariants_toml: String,
 }
 
-pub(super) async fn connect_postgres_store(database_url: &str) -> Result<(ServerEventStore, sqlx::PgPool)> {
+pub(super) async fn connect_postgres_store(
+    database_url: &str,
+) -> Result<(ServerEventStore, sqlx::PgPool)> {
     println!("  Connecting to Postgres...");
     let pool = sqlx::PgPool::connect(database_url)
         .await

--- a/crates/temper-jit/src/shadow.rs
+++ b/crates/temper-jit/src/shadow.rs
@@ -256,9 +256,7 @@ mod tests {
         new.rules[0].guard = Guard::BoolTrue("ready".into());
 
         let mut ctx_not_ready = EvalContext::default();
-        ctx_not_ready
-            .booleans
-            .insert("ready".to_string(), false);
+        ctx_not_ready.booleans.insert("ready".to_string(), false);
 
         let cases = vec![TestCase {
             state: "Draft".into(),
@@ -271,7 +269,17 @@ mod tests {
         // New table: BoolTrue("ready") checks booleans["ready"] = false → guard fails (success=false)
         assert!(!result.is_equivalent());
         assert_eq!(result.mismatches.len(), 1);
-        assert!(result.mismatches[0].old_result.as_ref().is_some_and(|r| r.success));
-        assert!(result.mismatches[0].new_result.as_ref().is_some_and(|r| !r.success));
+        assert!(
+            result.mismatches[0]
+                .old_result
+                .as_ref()
+                .is_some_and(|r| r.success)
+        );
+        assert!(
+            result.mismatches[0]
+                .new_result
+                .as_ref()
+                .is_some_and(|r| !r.success)
+        );
     }
 }

--- a/crates/temper-platform/src/hooks.rs
+++ b/crates/temper-platform/src/hooks.rs
@@ -89,10 +89,7 @@ fn handle_deploy_specs(
     let result = DeployPipeline::verify_and_deploy(state, &input);
 
     if result.success {
-        tracing::info!(
-            tenant = entity_id,
-            "DeploySpecs hook: pipeline succeeded"
-        );
+        tracing::info!(tenant = entity_id, "DeploySpecs hook: pipeline succeeded");
         // Remove specs from store on success.
         let mut store = state.spec_store.write().unwrap(); // ci-ok: infallible lock
         store.remove(entity_id);

--- a/crates/temper-platform/src/lib.rs
+++ b/crates/temper-platform/src/lib.rs
@@ -13,13 +13,13 @@
 pub mod agent;
 pub mod bootstrap;
 pub mod deploy;
-pub mod spec_store;
 pub mod evolution;
 pub mod hooks;
 pub mod integration;
 pub mod optimization;
 pub mod protocol;
 pub mod router;
+pub mod spec_store;
 pub mod state;
 
 // Re-export primary types at crate root.

--- a/crates/temper-runtime/src/scheduler/sim_actor_system.rs
+++ b/crates/temper-runtime/src/scheduler/sim_actor_system.rs
@@ -548,14 +548,19 @@ impl SimActorSystem {
         // For simplicity, check against all registered entity_type patterns.
         for trigger in &callbacks {
             // Try matching with the actor_id as-is for the entity_type lookup
-            if let Some(callback_action) = self.integration_responses.get_callback(actor_id, trigger) {
+            if let Some(callback_action) =
+                self.integration_responses.get_callback(actor_id, trigger)
+            {
                 self.pending_integration_callbacks
                     .push((actor_id.to_string(), callback_action.to_string()));
             }
             // Also try splitting on ':' (e.g., "Order:o1" → entity_type = "Order")
             else if let Some(colon_pos) = actor_id.find(':') {
                 let entity_type = &actor_id[..colon_pos];
-                if let Some(callback_action) = self.integration_responses.get_callback(entity_type, trigger) {
+                if let Some(callback_action) = self
+                    .integration_responses
+                    .get_callback(entity_type, trigger)
+                {
                     self.pending_integration_callbacks
                         .push((actor_id.to_string(), callback_action.to_string()));
                 }
@@ -565,7 +570,8 @@ impl SimActorSystem {
 
     /// Deliver any pending integration callbacks by executing them as actions.
     fn deliver_integration_callbacks(&mut self) {
-        let callbacks: Vec<(String, String)> = self.pending_integration_callbacks.drain(..).collect();
+        let callbacks: Vec<(String, String)> =
+            self.pending_integration_callbacks.drain(..).collect();
         for (actor_id, callback_action) in callbacks {
             // Execute the callback as a regular step (this checks invariants too)
             let _ = self.step(&actor_id, &callback_action, "{}");

--- a/crates/temper-server/src/dispatch.rs
+++ b/crates/temper-server/src/dispatch.rs
@@ -169,9 +169,10 @@ pub async fn handle_odata_get(
     };
 
     match odata_path {
-        ODataPath::Metadata => {
-            ODataXmlResponse { body: tenant_csdl_xml(&state, &tenant) }.into_response()
+        ODataPath::Metadata => ODataXmlResponse {
+            body: tenant_csdl_xml(&state, &tenant),
         }
+        .into_response(),
 
         ODataPath::ServiceDocument => {
             let entity_sets: Vec<serde_json::Value> = tenant_entity_sets(&state, &tenant)
@@ -181,23 +182,37 @@ pub async fn handle_odata_get(
             ODataResponse {
                 status: StatusCode::OK,
                 body: serde_json::json!({"@odata.context": "$metadata", "value": entity_sets}),
-            }.into_response()
+            }
+            .into_response()
         }
 
         ODataPath::EntitySet(name) => {
             let entity_type = match resolve_entity_type(&state, &tenant, &name) {
                 Some(t) => t,
-                None => return odata_error(StatusCode::NOT_FOUND, "EntitySetNotFound", &format!("Entity set '{name}' not found")).into_response(),
+                None => {
+                    return odata_error(
+                        StatusCode::NOT_FOUND,
+                        "EntitySetNotFound",
+                        &format!("Entity set '{name}' not found"),
+                    )
+                    .into_response();
+                }
             };
 
             // Enumerate all entities of this type
             let entity_ids = state.list_entity_ids(&tenant, &entity_type);
             let mut entities = Vec::new();
             for id in &entity_ids {
-                if let Ok(response) = state.get_tenant_entity_state(&tenant, &entity_type, id).await {
+                if let Ok(response) = state
+                    .get_tenant_entity_state(&tenant, &entity_type, id)
+                    .await
+                {
                     let mut entity = serde_json::to_value(&response.state).unwrap_or_default();
                     if let Some(obj) = entity.as_object_mut() {
-                        obj.insert("@odata.id".into(), serde_json::json!(format!("{name}('{id}')")));
+                        obj.insert(
+                            "@odata.id".into(),
+                            serde_json::json!(format!("{name}('{id}')")),
+                        );
                     }
                     entities.push(entity);
                 }
@@ -220,13 +235,24 @@ pub async fn handle_odata_get(
             if let Some(c) = count {
                 body["@odata.count"] = serde_json::json!(c);
             }
-            ODataResponse { status: StatusCode::OK, body }.into_response()
+            ODataResponse {
+                status: StatusCode::OK,
+                body,
+            }
+            .into_response()
         }
 
         ODataPath::Entity(set_name, key) => {
             let entity_type = match resolve_entity_type(&state, &tenant, &set_name) {
                 Some(t) => t,
-                None => return odata_error(StatusCode::NOT_FOUND, "EntitySetNotFound", &format!("Entity set '{set_name}' not found")).into_response(),
+                None => {
+                    return odata_error(
+                        StatusCode::NOT_FOUND,
+                        "EntitySetNotFound",
+                        &format!("Entity set '{set_name}' not found"),
+                    )
+                    .into_response();
+                }
             };
             let key_str = extract_key(&key);
 
@@ -236,15 +262,25 @@ pub async fn handle_odata_get(
                     StatusCode::NOT_FOUND,
                     "ResourceNotFound",
                     &format!("Entity '{set_name}' with key '{key_str}' not found"),
-                ).into_response();
+                )
+                .into_response();
             }
 
-            match state.get_tenant_entity_state(&tenant, &entity_type, &key_str).await {
+            match state
+                .get_tenant_entity_state(&tenant, &entity_type, &key_str)
+                .await
+            {
                 Ok(response) => {
                     let mut body = serde_json::to_value(&response.state).unwrap_or_default();
                     if let Some(obj) = body.as_object_mut() {
-                        obj.insert("@odata.context".into(), serde_json::json!(format!("$metadata#{set_name}/$entity")));
-                        obj.insert("@odata.id".into(), serde_json::json!(format!("{set_name}('{key_str}')")));
+                        obj.insert(
+                            "@odata.context".into(),
+                            serde_json::json!(format!("$metadata#{set_name}/$entity")),
+                        );
+                        obj.insert(
+                            "@odata.id".into(),
+                            serde_json::json!(format!("{set_name}('{key_str}')")),
+                        );
                     }
 
                     // Apply $expand to the single entity
@@ -257,30 +293,32 @@ pub async fn handle_odata_get(
                         body = select_fields(vec![body], select).pop().unwrap_or_default();
                     }
 
-                    ODataResponse { status: StatusCode::OK, body }.into_response()
+                    ODataResponse {
+                        status: StatusCode::OK,
+                        body,
+                    }
+                    .into_response()
                 }
-                Err(_) => {
-                    odata_error(
-                        StatusCode::NOT_FOUND,
-                        "ResourceNotFound",
-                        &format!("Entity '{set_name}' with key '{key_str}' not found"),
-                    ).into_response()
-                }
+                Err(_) => odata_error(
+                    StatusCode::NOT_FOUND,
+                    "ResourceNotFound",
+                    &format!("Entity '{set_name}' with key '{key_str}' not found"),
+                )
+                .into_response(),
             }
         }
 
         ODataPath::BoundFunction { parent, function } => {
             // Extract parent entity set + key from the parent path.
             let (parent_set, parent_key) = match *parent {
-                ODataPath::Entity(ref set_name, ref key) => {
-                    (set_name.clone(), extract_key(key))
-                }
+                ODataPath::Entity(ref set_name, ref key) => (set_name.clone(), extract_key(key)),
                 _ => {
                     return odata_error(
                         StatusCode::BAD_REQUEST,
                         "InvalidPath",
                         "Bound function requires an entity key parent path",
-                    ).into_response();
+                    )
+                    .into_response();
                 }
             };
 
@@ -291,7 +329,8 @@ pub async fn handle_odata_get(
                         StatusCode::NOT_FOUND,
                         "ResourceNotFound",
                         &format!("Entity set '{}' not found", parent_set),
-                    ).into_response();
+                    )
+                    .into_response();
                 }
             };
 
@@ -300,10 +339,14 @@ pub async fn handle_odata_get(
                     StatusCode::NOT_FOUND,
                     "ResourceNotFound",
                     &format!("Entity '{parent_set}' with key '{parent_key}' not found"),
-                ).into_response();
+                )
+                .into_response();
             }
 
-            match state.get_tenant_entity_state(&tenant, &entity_type, &parent_key).await {
+            match state
+                .get_tenant_entity_state(&tenant, &entity_type, &parent_key)
+                .await
+            {
                 Ok(response) => {
                     let mut body = serde_json::to_value(&response.state).unwrap_or_default();
                     if let Some(obj) = body.as_object_mut() {
@@ -311,10 +354,7 @@ pub async fn handle_odata_get(
                             "@odata.context".to_string(),
                             serde_json::json!(format!("$metadata#{entity_type}")),
                         );
-                        obj.insert(
-                            "@odata.function".to_string(),
-                            serde_json::json!(function),
-                        );
+                        obj.insert("@odata.function".to_string(), serde_json::json!(function));
                     }
 
                     // Apply $select and $expand from query options.
@@ -326,23 +366,36 @@ pub async fn handle_odata_get(
                     }
                     if let Some(ref expand_items) = query_options.expand {
                         crate::query_eval::expand_entity(
-                            &mut body, expand_items, &entity_type, &state, &tenant,
-                        ).await;
+                            &mut body,
+                            expand_items,
+                            &entity_type,
+                            &state,
+                            &tenant,
+                        )
+                        .await;
                     }
 
-                    ODataResponse { status: StatusCode::OK, body }.into_response()
+                    ODataResponse {
+                        status: StatusCode::OK,
+                        body,
+                    }
+                    .into_response()
                 }
-                Err(_) => {
-                    odata_error(
-                        StatusCode::NOT_FOUND,
-                        "ResourceNotFound",
-                        &format!("Entity '{parent_set}' with key '{parent_key}' not found"),
-                    ).into_response()
-                }
+                Err(_) => odata_error(
+                    StatusCode::NOT_FOUND,
+                    "ResourceNotFound",
+                    &format!("Entity '{parent_set}' with key '{parent_key}' not found"),
+                )
+                .into_response(),
             }
         }
 
-        _ => odata_error(StatusCode::NOT_IMPLEMENTED, "NotImplemented", "This path pattern is not yet supported").into_response(),
+        _ => odata_error(
+            StatusCode::NOT_IMPLEMENTED,
+            "NotImplemented",
+            "This path pattern is not yet supported",
+        )
+        .into_response(),
     }
 }
 

--- a/crates/temper-server/src/eventual_invariants.rs
+++ b/crates/temper-server/src/eventual_invariants.rs
@@ -131,7 +131,8 @@ pub fn spawn_eventual_recheck(
     state: crate::state::ServerState,
     interval: std::time::Duration,
 ) -> tokio::task::JoinHandle<()> {
-    tokio::spawn(async move { // determinism-ok: background convergence task
+    tokio::spawn(async move {
+        // determinism-ok: background convergence task
         let mut ticker = tokio::time::interval(interval); // determinism-ok: convergence polling
         loop {
             ticker.tick().await;
@@ -151,9 +152,11 @@ pub fn spawn_eventual_recheck(
                     if let Ok(mut tracker) = state.eventual_tracker.write() {
                         tracker.resolve(&key);
                     }
-                    state
-                        .metrics
-                        .record_cross_invariant_check(&inv.tenant, &inv.entity_type, "eventual_converged");
+                    state.metrics.record_cross_invariant_check(
+                        &inv.tenant,
+                        &inv.entity_type,
+                        "eventual_converged",
+                    );
                     tracing::info!(
                         invariant = %inv.name,
                         tenant = %inv.tenant,
@@ -177,9 +180,11 @@ pub fn spawn_eventual_recheck(
                 if let Ok(mut tracker) = state.eventual_tracker.write() {
                     tracker.resolve(&key);
                 }
-                state
-                    .metrics
-                    .record_cross_invariant_violation(&inv.tenant, &inv.name, "eventual_convergence_failed");
+                state.metrics.record_cross_invariant_violation(
+                    &inv.tenant,
+                    &inv.name,
+                    "eventual_convergence_failed",
+                );
                 tracing::error!(
                     invariant = %inv.name,
                     tenant = %inv.tenant,
@@ -205,7 +210,10 @@ async fn check_invariant_convergence(
         let tc = registry.get_tenant(tenant);
         tc.and_then(|tc| {
             tc.cross_invariants.as_ref().and_then(|ci| {
-                ci.invariants.iter().find(|i| i.name == inv.name).map(|i| i.assertion.clone())
+                ci.invariants
+                    .iter()
+                    .find(|i| i.name == inv.name)
+                    .map(|i| i.assertion.clone())
             })
         })
     };
@@ -215,7 +223,9 @@ async fn check_invariant_convergence(
         return true;
     };
 
-    let Some(assertion) = temper_spec::cross_invariant::parse_related_status_in_assert(&assertion_str) else {
+    let Some(assertion) =
+        temper_spec::cross_invariant::parse_related_status_in_assert(&assertion_str)
+    else {
         return true; // Invalid assertion — skip
     };
 
@@ -231,7 +241,11 @@ async fn check_invariant_convergence(
     // Extract the target ID from the entity fields
     let Some(target_id) = fields
         .get(&assertion.source_field)
-        .or_else(|| fields.get("fields").and_then(|f| f.get(&assertion.source_field)))
+        .or_else(|| {
+            fields
+                .get("fields")
+                .and_then(|f| f.get(&assertion.source_field))
+        })
         .and_then(|v| v.as_str())
     else {
         return false;

--- a/crates/temper-server/src/lib.rs
+++ b/crates/temper-server/src/lib.rs
@@ -5,11 +5,11 @@
 //! ensuring the same logic verified by DST runs in production.
 
 mod constraint_engine;
-pub mod eventual_invariants;
 mod dispatch;
 pub mod entity_actor;
 pub mod event_store;
 pub mod events;
+pub mod eventual_invariants;
 #[cfg(feature = "observe")]
 pub mod observe;
 mod query_eval;

--- a/crates/temper-server/src/observe/entities.rs
+++ b/crates/temper-server/src/observe/entities.rs
@@ -19,7 +19,9 @@ use super::{EntityInstanceSummary, EventStreamParams};
 /// GET /observe/entities -- list active entity instances from the actor registry.
 ///
 /// Returns deduplicated entities with their current state, sorted newest first.
-pub(crate) async fn list_entities(State(state): State<ServerState>) -> Json<Vec<EntityInstanceSummary>> {
+pub(crate) async fn list_entities(
+    State(state): State<ServerState>,
+) -> Json<Vec<EntityInstanceSummary>> {
     let registry = state.actor_registry.read().unwrap(); // ci-ok: infallible lock
     let cache = state.entity_state_cache.read().unwrap(); // ci-ok: infallible lock
     let mut entities: Vec<EntityInstanceSummary> = registry

--- a/crates/temper-server/src/observe/evolution.rs
+++ b/crates/temper-server/src/observe/evolution.rs
@@ -770,7 +770,9 @@ pub(crate) async fn handle_decide(
 }
 
 /// GET /observe/evolution/insights -- list ranked insights (I-Records).
-pub(crate) async fn list_evolution_insights(State(state): State<ServerState>) -> Json<serde_json::Value> {
+pub(crate) async fn list_evolution_insights(
+    State(state): State<ServerState>,
+) -> Json<serde_json::Value> {
     let insights = if let Some(ref pg_store) = state.pg_record_store {
         match pg_store.ranked_insights().await {
             Ok(items) => items,

--- a/crates/temper-server/src/observe/mod.rs
+++ b/crates/temper-server/src/observe/mod.rs
@@ -157,14 +157,8 @@ pub fn build_observe_router() -> Router<ServerState> {
         .route("/metrics", get(metrics::handle_metrics))
         .route("/trajectories", get(evolution::handle_trajectories))
         .route("/trajectories/unmet", post(evolution::handle_unmet_intent))
-        .route(
-            "/sentinel/check",
-            post(evolution::handle_sentinel_check),
-        )
-        .route(
-            "/evolution/records",
-            get(evolution::list_evolution_records),
-        )
+        .route("/sentinel/check", post(evolution::handle_sentinel_check))
+        .route("/evolution/records", get(evolution::list_evolution_records))
         .route(
             "/evolution/records/{id}",
             get(evolution::get_evolution_record),
@@ -939,7 +933,7 @@ mod tests {
                         r#"{"decision":"rejected","decided_by":"bob","rationale":"nope"}"#,
                     ))
                     .unwrap(),
-                )
+            )
             .await
             .unwrap();
 
@@ -1092,12 +1086,14 @@ mod tests {
         let temp_specs =
             std::env::temp_dir().join(format!("temper-load-dir-lint-{}", uuid::Uuid::new_v4())); // determinism-ok: test-only temp dir
         std::fs::create_dir_all(&temp_specs).expect("create temp specs dir"); // determinism-ok: test-only
-        std::fs::write( // determinism-ok: test-only
+        std::fs::write(
+            // determinism-ok: test-only
             temp_specs.join("model.csdl.xml"),
             include_str!("../../../../test-fixtures/specs/model.csdl.xml"),
         )
         .expect("write csdl");
-        std::fs::write( // determinism-ok: test-only
+        std::fs::write(
+            // determinism-ok: test-only
             temp_specs.join("order.ioa.toml"),
             r#"
 [automaton]

--- a/crates/temper-server/src/observe/specs.rs
+++ b/crates/temper-server/src/observe/specs.rs
@@ -278,7 +278,8 @@ pub(crate) async fn handle_load_dir(
         ));
     }
 
-    let csdl_xml = std::fs::read_to_string(&csdl_path).map_err(|e| { // determinism-ok: HTTP handler reads spec files
+    let csdl_xml = std::fs::read_to_string(&csdl_path).map_err(|e| {
+        // determinism-ok: HTTP handler reads spec files
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("Failed to read CSDL: {e}"),
@@ -294,7 +295,8 @@ pub(crate) async fn handle_load_dir(
     // Read all *.ioa.toml files
     let mut ioa_sources: std::collections::BTreeMap<String, String> =
         std::collections::BTreeMap::new();
-    let entries = std::fs::read_dir(specs_path).map_err(|e| { // determinism-ok: HTTP handler reads spec directory
+    let entries = std::fs::read_dir(specs_path).map_err(|e| {
+        // determinism-ok: HTTP handler reads spec directory
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("Failed to read specs directory: {e}"),
@@ -315,7 +317,8 @@ pub(crate) async fn handle_load_dir(
         if file_name.ends_with(".ioa.toml") {
             let entity_name = file_name.strip_suffix(".ioa.toml").unwrap_or_default();
             let entity_name = to_pascal_case(entity_name);
-            let source = std::fs::read_to_string(&path).map_err(|e| { // determinism-ok: HTTP handler reads spec files
+            let source = std::fs::read_to_string(&path).map_err(|e| {
+                // determinism-ok: HTTP handler reads spec files
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     format!("Failed to read {}: {e}", path.display()),
@@ -336,7 +339,8 @@ pub(crate) async fn handle_load_dir(
     let reactions = {
         let path = specs_path.join("reactions.toml");
         if path.exists() {
-            let source = std::fs::read_to_string(&path).map_err(|e| { // determinism-ok: HTTP handler reads reactions file
+            let source = std::fs::read_to_string(&path).map_err(|e| {
+                // determinism-ok: HTTP handler reads reactions file
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     format!("Failed to read {}: {e}", path.display()),
@@ -357,7 +361,8 @@ pub(crate) async fn handle_load_dir(
     let cross_invariants_toml = {
         let path = specs_path.join("cross-invariants.toml");
         if path.exists() {
-            Some(std::fs::read_to_string(&path).map_err(|e| { // determinism-ok: HTTP handler reads cross-invariants
+            Some(std::fs::read_to_string(&path).map_err(|e| {
+                // determinism-ok: HTTP handler reads cross-invariants
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     format!("Failed to read {}: {e}", path.display()),
@@ -462,7 +467,8 @@ pub(crate) async fn handle_load_dir(
         let registry_path = state.data_dir.join("specs-registry.json");
         let mut specs_registry = std::collections::BTreeMap::<String, String>::new();
 
-        if let Ok(content) = std::fs::read_to_string(&registry_path) { // determinism-ok: HTTP handler reads specs registry
+        if let Ok(content) = std::fs::read_to_string(&registry_path) {
+            // determinism-ok: HTTP handler reads specs registry
             if let Ok(value) = serde_json::from_str::<serde_json::Value>(&content) {
                 if let Some(obj) = value.as_object() {
                     for (tenant, specs_dir) in obj {
@@ -496,7 +502,8 @@ pub(crate) async fn handle_load_dir(
         .filter(|f| matches!(f.severity, CrossInvariantLintSeverity::Warning))
         .collect();
 
-    tokio::spawn(async move { // determinism-ok: HTTP handler streams verification results inline
+    tokio::spawn(async move {
+        // determinism-ok: HTTP handler streams verification results inline
         let now = sim_now();
 
         // Emit specs_loaded line
@@ -619,7 +626,8 @@ pub(crate) async fn handle_load_dir(
 
             // Run verification (blocking, sequential per entity)
             let ioa_source = ioa_sources[entity_name].clone();
-            let result = tokio::task::spawn_blocking(move || { // determinism-ok: HTTP handler offloads CPU-intensive verification
+            let result = tokio::task::spawn_blocking(move || {
+                // determinism-ok: HTTP handler offloads CPU-intensive verification
                 temper_verify::VerificationCascade::from_ioa(&ioa_source)
                     .with_sim_seeds(5)
                     .with_prop_test_cases(100)
@@ -943,7 +951,8 @@ pub(crate) async fn handle_load_inline(
     // Write specs to a temp directory
     let tmp_dir = std::env::temp_dir().join(format!("temper-inline-{}", tenant)); // determinism-ok: HTTP handler writes user specs to temp dir for loading
     let _ = std::fs::remove_dir_all(&tmp_dir); // determinism-ok: HTTP handler cleans previous temp dir
-    std::fs::create_dir_all(&tmp_dir).map_err(|e| { // determinism-ok: HTTP handler creates temp dir for inline specs
+    std::fs::create_dir_all(&tmp_dir).map_err(|e| {
+        // determinism-ok: HTTP handler creates temp dir for inline specs
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("Failed to create temp dir: {e}"),
@@ -952,7 +961,8 @@ pub(crate) async fn handle_load_inline(
 
     for (filename, content) in &body.specs {
         let path = tmp_dir.join(filename);
-        std::fs::write(&path, content).map_err(|e| { // determinism-ok: HTTP handler writes user specs to temp dir
+        std::fs::write(&path, content).map_err(|e| {
+            // determinism-ok: HTTP handler writes user specs to temp dir
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 format!("Failed to write {filename}: {e}"),
@@ -961,7 +971,8 @@ pub(crate) async fn handle_load_inline(
     }
 
     if let Some(source) = body.cross_invariants_toml.as_deref() {
-        std::fs::write(tmp_dir.join("cross-invariants.toml"), source).map_err(|e| { // determinism-ok: HTTP handler writes cross-invariants
+        std::fs::write(tmp_dir.join("cross-invariants.toml"), source).map_err(|e| {
+            // determinism-ok: HTTP handler writes cross-invariants
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 format!("Failed to write cross-invariants.toml: {e}"),

--- a/crates/temper-server/src/observe/wasm.rs
+++ b/crates/temper-server/src/observe/wasm.rs
@@ -63,10 +63,12 @@ pub async fn upload_wasm_module(
     }
 
     // Compile and cache
-    let hash = state
-        .wasm_engine
-        .compile_and_cache(&body)
-        .map_err(|e| (StatusCode::BAD_REQUEST, format!("WASM compilation failed: {e}")))?;
+    let hash = state.wasm_engine.compile_and_cache(&body).map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("WASM compilation failed: {e}"),
+        )
+    })?;
 
     // Register in module registry
     {

--- a/crates/temper-server/src/query_eval.rs
+++ b/crates/temper-server/src/query_eval.rs
@@ -277,7 +277,16 @@ pub async fn expand_entity(
     state: &crate::state::ServerState,
     tenant: &temper_runtime::tenant::TenantId,
 ) {
-    expand_entity_recursive(entity, expand_items, entity_type, state, tenant, 0, &mut vec![]).await;
+    expand_entity_recursive(
+        entity,
+        expand_items,
+        entity_type,
+        state,
+        tenant,
+        0,
+        &mut vec![],
+    )
+    .await;
 }
 
 /// Recursive implementation of $expand with depth and cycle guards.

--- a/crates/temper-server/src/state/dispatch.rs
+++ b/crates/temper-server/src/state/dispatch.rs
@@ -1,9 +1,11 @@
 //! Action dispatch and WASM integration methods for ServerState.
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use temper_runtime::scheduler::sim_now;
 use temper_runtime::tenant::TenantId;
+use temper_wasm::{ProductionWasmHost, WasmHost, WasmInvocationContext, WasmResourceLimits};
 use super::ServerState;
 use super::trajectory::TrajectoryEntry;
 use crate::entity_actor::{EntityMsg, EntityResponse, EntityState};
@@ -15,11 +17,8 @@ impl ServerState {
     /// For each custom effect matching a WASM integration, this method:
     /// 1. Looks up the integration config from the spec
     /// 2. Looks up the module hash from the WASM registry
-    /// 3. Dispatches the callback action (on_success or on_failure) back to the entity
-    ///
-    /// In production, this would invoke the WASM module via `WasmEngine`.
-    /// For now, this records the integration trigger in the trajectory log.
-    /// The actual WASM invocation is wired when `temper-wasm` is integrated.
+    /// 3. Invokes the WASM module via `WasmEngine`
+    /// 4. Dispatches the callback action (on_success or on_failure) based on the result
     pub fn dispatch_wasm_integrations(
         &self,
         tenant: &TenantId,
@@ -101,44 +100,107 @@ impl ServerState {
                 continue;
             }
 
+            // Build invocation context
+            let ctx = WasmInvocationContext {
+                tenant: tenant.to_string(),
+                entity_type: entity_type.to_string(),
+                entity_id: entity_id.to_string(),
+                trigger_action: _action.to_string(),
+                trigger_params: serde_json::Value::Null,
+                entity_state: serde_json::to_value(_entity_state).unwrap_or_default(),
+            };
+
+            // Look up module hash
+            let module_hash = {
+                let wasm_reg = self.wasm_module_registry.read().unwrap();
+                wasm_reg.get_hash(tenant, module_name).map(|s| s.to_string())
+            };
+            let Some(hash) = module_hash else {
+                // Already checked has_module above — should not happen
+                continue;
+            };
+
             tracing::info!(
                 tenant = %tenant,
                 entity_type,
                 entity_id,
                 integration = %integration.name,
                 module = %module_name,
-                "WASM integration triggered (module invocation pending temper-wasm integration)"
+                hash = %hash,
+                "invoking WASM integration module"
             );
 
-            // Phase 1: dispatch success callback directly (module invocation deferred).
-            // When temper-wasm engine is wired in, this block will build a
-            // WasmInvocationContext, call engine.invoke(), and choose on_success
-            // or on_failure based on the result.
-            if let Some(ref on_success) = integration.on_success {
-                let state = self.clone();
-                let t = tenant.clone();
-                let et = entity_type.to_string();
-                let eid = entity_id.to_string();
-                let cb = on_success.clone();
-                let int_name = integration.name.clone();
-                let mod_name = module_name.clone();
-                tokio::spawn(async move { // determinism-ok: async callback delivery
-                    let success_params = serde_json::json!({
-                        "integration": int_name,
-                        "module": mod_name,
-                    });
-                    if let Err(e) = state
-                        .dispatch_tenant_action(&t, &et, &eid, &cb, success_params)
-                        .await
-                    {
-                        tracing::error!(
-                            callback = %cb,
-                            error = %e,
-                            "failed to dispatch WASM success callback"
+            let engine = self.wasm_engine.clone();
+            let host: Arc<dyn WasmHost> = Arc::new(ProductionWasmHost::new(BTreeMap::new()));
+            let limits = WasmResourceLimits::default();
+            let state = self.clone();
+            let t = tenant.clone();
+            let et = entity_type.to_string();
+            let eid = entity_id.to_string();
+            let on_ok = integration.on_success.clone();
+            let on_fail = integration.on_failure.clone();
+            let int_name = integration.name.clone();
+
+            tokio::spawn(async move { // determinism-ok: async WASM invocation
+                match engine.invoke(&hash, &ctx, host, &limits).await {
+                    Ok(result) if result.success => {
+                        tracing::info!(
+                            integration = %int_name,
+                            callback_action = %result.callback_action,
+                            duration_ms = result.duration_ms,
+                            "WASM integration succeeded"
                         );
+                        if let Some(cb) = on_ok {
+                            let params = result.callback_params;
+                            if let Err(e) = state
+                                .dispatch_tenant_action(&t, &et, &eid, &cb, params)
+                                .await
+                            {
+                                tracing::error!(callback = %cb, error = %e, "failed to dispatch WASM success callback");
+                            }
+                        }
                     }
-                });
-            }
+                    Ok(result) => {
+                        tracing::warn!(
+                            integration = %int_name,
+                            error = ?result.error,
+                            duration_ms = result.duration_ms,
+                            "WASM integration returned failure"
+                        );
+                        if let Some(cb) = on_fail {
+                            let params = serde_json::json!({
+                                "error": result.error.unwrap_or_default(),
+                                "integration": int_name,
+                            });
+                            if let Err(e) = state
+                                .dispatch_tenant_action(&t, &et, &eid, &cb, params)
+                                .await
+                            {
+                                tracing::error!(callback = %cb, error = %e, "failed to dispatch WASM failure callback");
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            integration = %int_name,
+                            error = %e,
+                            "WASM module invocation error"
+                        );
+                        if let Some(cb) = on_fail {
+                            let params = serde_json::json!({
+                                "error": e.to_string(),
+                                "integration": int_name,
+                            });
+                            if let Err(e) = state
+                                .dispatch_tenant_action(&t, &et, &eid, &cb, params)
+                                .await
+                            {
+                                tracing::error!(callback = %cb, error = %e, "failed to dispatch WASM error callback");
+                            }
+                        }
+                    }
+                }
+            });
         }
     }
 

--- a/crates/temper-server/src/state/dispatch.rs
+++ b/crates/temper-server/src/state/dispatch.rs
@@ -3,13 +3,13 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use temper_runtime::scheduler::sim_now;
-use temper_runtime::tenant::TenantId;
-use temper_wasm::{ProductionWasmHost, WasmHost, WasmInvocationContext, WasmResourceLimits};
 use super::ServerState;
 use super::trajectory::TrajectoryEntry;
 use crate::entity_actor::{EntityMsg, EntityResponse, EntityState};
 use crate::events::EntityStateChange;
+use temper_runtime::scheduler::sim_now;
+use temper_runtime::tenant::TenantId;
+use temper_wasm::{ProductionWasmHost, WasmHost, WasmInvocationContext, WasmResourceLimits};
 
 impl ServerState {
     /// Dispatch WASM integrations for custom effects produced by a transition.
@@ -39,9 +39,9 @@ impl ServerState {
 
         for effect_name in custom_effects {
             // Find matching WASM integration
-            let matching = integrations.iter().find(|ig| {
-                ig.integration_type == "wasm" && ig.trigger == *effect_name
-            });
+            let matching = integrations
+                .iter()
+                .find(|ig| ig.integration_type == "wasm" && ig.trigger == *effect_name);
 
             let Some(integration) = matching else {
                 continue;
@@ -80,7 +80,8 @@ impl ServerState {
                     let cb = on_failure.clone();
                     let int_name = integration.name.clone();
                     let mod_name = module_name.clone();
-                    tokio::spawn(async move { // determinism-ok: async callback delivery
+                    tokio::spawn(async move {
+                        // determinism-ok: async callback delivery
                         let fail_params = serde_json::json!({
                             "error": format!("WASM module '{}' not found", mod_name),
                             "integration": int_name,
@@ -113,7 +114,9 @@ impl ServerState {
             // Look up module hash
             let module_hash = {
                 let wasm_reg = self.wasm_module_registry.read().unwrap();
-                wasm_reg.get_hash(tenant, module_name).map(|s| s.to_string())
+                wasm_reg
+                    .get_hash(tenant, module_name)
+                    .map(|s| s.to_string())
             };
             let Some(hash) = module_hash else {
                 // Already checked has_module above — should not happen
@@ -141,7 +144,8 @@ impl ServerState {
             let on_fail = integration.on_failure.clone();
             let int_name = integration.name.clone();
 
-            tokio::spawn(async move { // determinism-ok: async WASM invocation
+            tokio::spawn(async move {
+                // determinism-ok: async WASM invocation
                 match engine.invoke(&hash, &ctx, host, &limits).await {
                     Ok(result) if result.success => {
                         tracing::info!(
@@ -378,7 +382,8 @@ impl ServerState {
         if let Some(ref dispatcher) = self.webhook_dispatcher {
             let dispatcher = Arc::clone(dispatcher);
             let entry = trajectory_entry;
-            tokio::spawn(async move { // determinism-ok: external side-effect, no simulation-visible state
+            tokio::spawn(async move {
+                // determinism-ok: external side-effect, no simulation-visible state
                 dispatcher.dispatch(&entry);
             });
         }

--- a/crates/temper-server/src/state/metrics.rs
+++ b/crates/temper-server/src/state/metrics.rs
@@ -1,8 +1,8 @@
 //! Lightweight metrics collector for the /observe endpoints.
 
 use std::collections::BTreeMap;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::RwLock;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Lightweight metrics collector for the /observe endpoints.
 ///

--- a/crates/temper-server/src/state/mod.rs
+++ b/crates/temper-server/src/state/mod.rs
@@ -11,8 +11,8 @@ pub use metrics::MetricsCollector;
 pub use trajectory::{TrajectoryEntry, TrajectoryLog};
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::time::Duration;
 use std::sync::{Arc, RwLock};
+use std::time::Duration;
 use temper_authz::AuthzEngine;
 use temper_evolution::{PostgresRecordStore, RecordStore};
 use temper_jit::table::TransitionTable;
@@ -63,7 +63,8 @@ pub(crate) const TRAJECTORY_LOG_CAPACITY: usize = 10_000;
 const DESIGN_TIME_LOG_CAPACITY: usize = 10_000;
 
 fn env_bool(name: &str, default: bool) -> bool {
-    match std::env::var(name) { // determinism-ok: read once at startup, not per simulation step
+    match std::env::var(name) {
+        // determinism-ok: read once at startup, not per simulation step
         Ok(v) => match v.trim().to_ascii_lowercase().as_str() {
             "0" | "false" | "off" | "no" => false,
             "1" | "true" | "on" | "yes" => true,
@@ -197,7 +198,9 @@ impl ServerState {
             design_time_log: Arc::new(RwLock::new(Vec::new())),
             entity_state_cache: Arc::new(RwLock::new(BTreeMap::new())),
             action_dispatch_timeout: env_timeout(),
-            eventual_tracker: Arc::new(RwLock::new(crate::eventual_invariants::EventualInvariantTracker::new())),
+            eventual_tracker: Arc::new(RwLock::new(
+                crate::eventual_invariants::EventualInvariantTracker::new(),
+            )),
         }
     }
 
@@ -288,7 +291,9 @@ impl ServerState {
             design_time_log: Arc::new(RwLock::new(Vec::new())),
             entity_state_cache: Arc::new(RwLock::new(BTreeMap::new())),
             action_dispatch_timeout: env_timeout(),
-            eventual_tracker: Arc::new(RwLock::new(crate::eventual_invariants::EventualInvariantTracker::new())),
+            eventual_tracker: Arc::new(RwLock::new(
+                crate::eventual_invariants::EventualInvariantTracker::new(),
+            )),
         }
     }
 

--- a/crates/temper-server/src/state/persistence.rs
+++ b/crates/temper-server/src/state/persistence.rs
@@ -3,8 +3,8 @@
 use sqlx::types::Json;
 use temper_runtime::scheduler::sim_now;
 
-use super::{ServerState, DESIGN_TIME_LOG_CAPACITY, DesignTimeEvent};
 use super::trajectory::TrajectoryEntry;
+use super::{DESIGN_TIME_LOG_CAPACITY, DesignTimeEvent, ServerState};
 use crate::registry::EntityVerificationResult;
 
 impl ServerState {
@@ -68,14 +68,15 @@ impl ServerState {
         };
 
         if let Some(pool) = store.postgres_pool() {
-            let result = sqlx::query(
-                "DELETE FROM wasm_modules WHERE tenant = $1 AND module_name = $2",
-            )
-            .bind(tenant)
-            .bind(module_name)
-            .execute(pool)
-            .await
-            .map_err(|e| format!("failed to delete WASM module {tenant}/{module_name}: {e}"))?;
+            let result =
+                sqlx::query("DELETE FROM wasm_modules WHERE tenant = $1 AND module_name = $2")
+                    .bind(tenant)
+                    .bind(module_name)
+                    .execute(pool)
+                    .await
+                    .map_err(|e| {
+                        format!("failed to delete WASM module {tenant}/{module_name}: {e}")
+                    })?;
             return Ok(result.rows_affected() > 0);
         }
 

--- a/crates/temper-server/src/wasm_registry.rs
+++ b/crates/temper-server/src/wasm_registry.rs
@@ -23,12 +23,7 @@ impl WasmModuleRegistry {
     }
 
     /// Register a module hash for a tenant.
-    pub fn register(
-        &mut self,
-        tenant: &TenantId,
-        module_name: &str,
-        sha256_hash: &str,
-    ) {
+    pub fn register(&mut self, tenant: &TenantId, module_name: &str, sha256_hash: &str) {
         self.modules.insert(
             (tenant.to_string(), module_name.to_string()),
             sha256_hash.to_string(),

--- a/crates/temper-store-postgres/src/schema.rs
+++ b/crates/temper-store-postgres/src/schema.rs
@@ -272,15 +272,28 @@ mod tests {
     #[test]
     fn wasm_modules_table_has_required_columns() {
         let sql = CREATE_WASM_MODULES_TABLE.to_uppercase();
-        for col in &["TENANT", "MODULE_NAME", "WASM_BYTES", "SHA256_HASH", "VERSION", "SIZE_BYTES"] {
-            assert!(sql.contains(col), "wasm_modules schema missing column: {col}");
+        for col in &[
+            "TENANT",
+            "MODULE_NAME",
+            "WASM_BYTES",
+            "SHA256_HASH",
+            "VERSION",
+            "SIZE_BYTES",
+        ] {
+            assert!(
+                sql.contains(col),
+                "wasm_modules schema missing column: {col}"
+            );
         }
     }
 
     #[test]
     fn wasm_modules_table_has_unique_constraint() {
         let sql = CREATE_WASM_MODULES_TABLE.to_uppercase();
-        assert!(sql.contains("UNIQUE"), "wasm_modules should have UNIQUE constraint");
+        assert!(
+            sql.contains("UNIQUE"),
+            "wasm_modules should have UNIQUE constraint"
+        );
     }
 
     #[test]

--- a/crates/temper-store-turso/src/lib.rs
+++ b/crates/temper-store-turso/src/lib.rs
@@ -9,6 +9,5 @@ pub mod schema;
 pub mod store;
 
 pub use store::{
-    TursoEventStore, TursoSpecRow, TursoTenantConstraintRow, TursoTrajectoryRow,
-    TursoWasmModuleRow,
+    TursoEventStore, TursoSpecRow, TursoTenantConstraintRow, TursoTrajectoryRow, TursoWasmModuleRow,
 };

--- a/crates/temper-store-turso/src/schema.rs
+++ b/crates/temper-store-turso/src/schema.rs
@@ -111,8 +111,18 @@ mod tests {
     #[test]
     fn wasm_modules_table_has_required_columns() {
         let sql = CREATE_WASM_MODULES_TABLE.to_uppercase();
-        for col in &["TENANT", "MODULE_NAME", "WASM_BYTES", "SHA256_HASH", "VERSION", "SIZE_BYTES"] {
-            assert!(sql.contains(col), "wasm_modules schema missing column: {col}");
+        for col in &[
+            "TENANT",
+            "MODULE_NAME",
+            "WASM_BYTES",
+            "SHA256_HASH",
+            "VERSION",
+            "SIZE_BYTES",
+        ] {
+            assert!(
+                sql.contains(col),
+                "wasm_modules schema missing column: {col}"
+            );
         }
     }
 }

--- a/crates/temper-wasm/src/engine.rs
+++ b/crates/temper-wasm/src/engine.rs
@@ -10,7 +10,9 @@ use sha2::{Digest, Sha256};
 use wasmtime::{Caller, Config, Engine, Linker, Module, Store};
 
 use crate::host_trait::WasmHost;
-use crate::types::{WasmInvocationContext, WasmInvocationResult, WasmResourceLimits, MAX_MODULE_SIZE};
+use crate::types::{
+    MAX_MODULE_SIZE, WasmInvocationContext, WasmInvocationResult, WasmResourceLimits,
+};
 
 /// Errors from the WASM engine.
 #[derive(Debug, thiserror::Error)]
@@ -167,9 +169,9 @@ impl WasmEngine {
             limits: limits.clone(),
         };
         let mut store = Store::new(&self.engine, host_state);
-        store.set_fuel(limits.max_fuel).map_err(|e| {
-            WasmError::Invocation(format!("failed to set fuel: {e}"))
-        })?;
+        store
+            .set_fuel(limits.max_fuel)
+            .map_err(|e| WasmError::Invocation(format!("failed to set fuel: {e}")))?;
 
         // Link host functions
         let mut linker = Linker::new(&self.engine);
@@ -192,9 +194,9 @@ impl WasmEngine {
 
         let ctx_bytes = context_json.as_bytes();
         let ctx_ptr = 1024_usize; // Fixed offset for context data
-        memory
-            .write(&mut store, ctx_ptr, ctx_bytes)
-            .map_err(|e| WasmError::Invocation(format!("failed to write context to memory: {e}")))?;
+        memory.write(&mut store, ctx_ptr, ctx_bytes).map_err(|e| {
+            WasmError::Invocation(format!("failed to write context to memory: {e}"))
+        })?;
 
         // Call run(ptr, len) -> result_ptr
         let result_ptr = run_fn
@@ -242,9 +244,8 @@ impl WasmEngine {
             });
         }
 
-        let parsed: serde_json::Value = serde_json::from_str(&result_json).map_err(|e| {
-            WasmError::Invocation(format!("failed to parse result JSON: {e}"))
-        })?;
+        let parsed: serde_json::Value = serde_json::from_str(&result_json)
+            .map_err(|e| WasmError::Invocation(format!("failed to parse result JSON: {e}")))?;
 
         Ok(WasmInvocationResult {
             callback_action: parsed
@@ -439,7 +440,8 @@ fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), WasmError> 
 
                 // Bridge async -> sync
                 let host = caller.data().host.clone();
-                let result = tokio::task::block_in_place(|| { // determinism-ok: blocking bridge for WASM host call
+                let result = tokio::task::block_in_place(|| {
+                    // determinism-ok: blocking bridge for WASM host call
                     tokio::runtime::Handle::current()
                         .block_on(host.http_call(&method, &url, &headers, &body))
                 });

--- a/crates/temper-wasm/src/host_trait.rs
+++ b/crates/temper-wasm/src/host_trait.rs
@@ -133,8 +133,7 @@ impl SimWasmHost {
 
     /// Add a canned secret.
     pub fn with_secret(mut self, key: &str, value: &str) -> Self {
-        self.secrets
-            .insert(key.to_string(), value.to_string());
+        self.secrets.insert(key.to_string(), value.to_string());
         self
     }
 


### PR DESCRIPTION
## Summary
- Replace Phase 1 stub in `dispatch_wasm_integrations()` with real `WasmEngine::invoke()` call
- Build `WasmInvocationContext` with entity state, trigger action, and tenant info
- Route to `on_success` or `on_failure` callback based on invocation result (success / guest failure / engine error)
- Add `determinism-ok` annotation to `engine.rs` Instant::now() (telemetry-only)

This closes the last gap in the WASM integration — the full e2e flow is now: action → trigger effect → lookup integration → lookup module → invoke WASM → dispatch callback.

## Test plan
- [x] `cargo check --workspace` — clean
- [x] `cargo test --workspace` — all tests pass
- [x] DST compliance review — PASS
- [x] Code quality review — PASS
- [x] Pre-push 4-gate pipeline — ALL GATES PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)