### PR TITLE
remediate audit gaps and harden spec/registry pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,11 @@ jobs:
       - name: cargo check --workspace
         run: cargo check --workspace
 
-      - name: cargo clippy --workspace
-        run: cargo clippy --workspace -- -D warnings
+      - name: cargo clippy --workspace --all-targets
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: cargo bench --workspace --no-run
+        run: cargo bench --workspace --no-run
 
   # ─────────────────────────────────────────────────────
   # Gate 2: Integrity checks (seconds)

--- a/crates/temper-authz/src/engine.rs
+++ b/crates/temper-authz/src/engine.rs
@@ -261,14 +261,6 @@ mod tests {
         ])
     }
 
-    fn agent_context(role: &str) -> SecurityContext {
-        SecurityContext::from_headers(&[
-            ("X-Temper-Principal-Id".to_string(), "agent-1".to_string()),
-            ("X-Temper-Principal-Kind".to_string(), "agent".to_string()),
-            ("X-Temper-Agent-Role".to_string(), role.to_string()),
-        ])
-    }
-
     #[test]
     fn test_permissive_engine_denies_by_default() {
         // No policies = no permits = deny

--- a/crates/temper-cli/src/init/mod.rs
+++ b/crates/temper-cli/src/init/mod.rs
@@ -37,13 +37,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-temper-runtime = { path = "../../crates/temper-runtime" }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-tokio = { version = "1", features = ["full"] }
-uuid = { version = "1", features = ["v4", "serde"] }
-chrono = { version = "0.4", features = ["serde"] }
-anyhow = "1"
+# Add Temper dependencies here (published crate, workspace path, etc.).
 "#;
 
 /// Run the `temper init <name>` command.

--- a/crates/temper-cli/src/serve/loader.rs
+++ b/crates/temper-cli/src/serve/loader.rs
@@ -184,14 +184,16 @@ pub(super) fn load_into_registry(
         .map(|(k, v)| (k.as_str(), v.as_str()))
         .collect();
 
-    registry.register_tenant_with_reactions_and_constraints(
-        tenant,
-        csdl,
-        csdl_xml,
-        &ioa_pairs,
-        reactions,
-        cross_invariants_toml.clone(),
-    );
+    registry
+        .try_register_tenant_with_reactions_and_constraints(
+            tenant,
+            csdl,
+            csdl_xml,
+            &ioa_pairs,
+            reactions,
+            cross_invariants_toml.clone(),
+        )
+        .with_context(|| format!("Failed to register tenant '{tenant}'"))?;
 
     Ok(LoadedTenantSpecs {
         csdl_xml: registry

--- a/crates/temper-cli/src/serve/mod.rs
+++ b/crates/temper-cli/src/serve/mod.rs
@@ -294,13 +294,7 @@ fn spawn_optimization_loop(state: &PlatformState) {
 
         loop {
             ticker.tick().await;
-            let applied = run_optimization_cycle(&store, &state).await;
-            if !applied.is_empty() {
-                tracing::info!(
-                    applied = applied.len(),
-                    "optimization cycle applied recommendations"
-                );
-            }
+            let _ = run_optimization_cycle(&store, &state).await;
         }
     });
 }

--- a/crates/temper-cli/src/serve/mod.rs
+++ b/crates/temper-cli/src/serve/mod.rs
@@ -296,7 +296,10 @@ fn spawn_optimization_loop(state: &PlatformState) {
             ticker.tick().await;
             let applied = run_optimization_cycle(&store, &state).await;
             if !applied.is_empty() {
-                println!("  [opt] applied {} recommendations", applied.len());
+                tracing::info!(
+                    applied = applied.len(),
+                    "optimization cycle applied recommendations"
+                );
             }
         }
     });

--- a/crates/temper-cli/src/serve/mod.rs
+++ b/crates/temper-cli/src/serve/mod.rs
@@ -18,7 +18,9 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 
 use temper_evolution::PostgresRecordStore;
+use temper_observe::ClickHouseStore;
 use temper_observe::otel::init_tracing;
+use temper_platform::optimization::run_optimization_cycle;
 use temper_platform::router::build_platform_router;
 use temper_platform::state::PlatformState;
 use temper_runtime::tenant::TenantId;
@@ -263,6 +265,7 @@ pub async fn run(
     for (tenant, dir) in &apps {
         spawn_background_verification(&state, dir, tenant).await;
     }
+    spawn_optimization_loop(&state);
 
     println!("Listening on http://0.0.0.0:{port}");
     axum::serve(listener, router)
@@ -270,6 +273,33 @@ pub async fn run(
         .context("Server error")?;
 
     Ok(())
+}
+
+fn spawn_optimization_loop(state: &PlatformState) {
+    let Some(store_url) = std::env::var("TEMPER_OPTIMIZE_STORE_URL").ok() else {
+        return;
+    };
+    let interval_secs = std::env::var("TEMPER_OPTIMIZE_INTERVAL_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(300)
+        .clamp(1, 86_400);
+
+    let state = state.clone();
+    tokio::spawn(async move {
+        let store = ClickHouseStore::new(&store_url);
+        let mut ticker = tokio::time::interval(std::time::Duration::from_secs(interval_secs));
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        ticker.tick().await; // consume immediate tick
+
+        loop {
+            ticker.tick().await;
+            let applied = run_optimization_cycle(&store, &state).await;
+            if !applied.is_empty() {
+                println!("  [opt] applied {} recommendations", applied.len());
+            }
+        }
+    });
 }
 
 /// Spawn background verification tasks for each entity in the specs directory.

--- a/crates/temper-cli/src/serve/storage.rs
+++ b/crates/temper-cli/src/serve/storage.rs
@@ -235,14 +235,16 @@ pub(super) async fn load_registry_from_postgres(
             .collect();
 
         let cross_invariants_toml = constraints_by_tenant.remove(&tenant);
-        registry.register_tenant_with_reactions_and_constraints(
-            tenant.as_str(),
-            csdl,
-            csdl_xml,
-            &ioa_pairs,
-            Vec::new(),
-            cross_invariants_toml,
-        );
+        registry
+            .try_register_tenant_with_reactions_and_constraints(
+                tenant.as_str(),
+                csdl,
+                csdl_xml,
+                &ioa_pairs,
+                Vec::new(),
+                cross_invariants_toml,
+            )
+            .with_context(|| format!("Failed to restore tenant '{tenant}' into registry"))?;
         let tenant_id = TenantId::new(&tenant);
         for row in &tenant_rows {
             registry.set_verification_status(
@@ -308,14 +310,16 @@ pub(super) async fn load_registry_from_turso(
             .collect();
 
         let cross_invariants_toml = constraints_by_tenant.remove(&tenant);
-        registry.register_tenant_with_reactions_and_constraints(
-            tenant.as_str(),
-            csdl,
-            csdl_xml,
-            &ioa_pairs,
-            Vec::new(),
-            cross_invariants_toml,
-        );
+        registry
+            .try_register_tenant_with_reactions_and_constraints(
+                tenant.as_str(),
+                csdl,
+                csdl_xml,
+                &ioa_pairs,
+                Vec::new(),
+                cross_invariants_toml,
+            )
+            .with_context(|| format!("Failed to restore tenant '{tenant}' into registry"))?;
         let tenant_id = TenantId::new(&tenant);
         for row in &tenant_rows {
             registry.set_verification_status(

--- a/crates/temper-jit/src/shadow.rs
+++ b/crates/temper-jit/src/shadow.rs
@@ -202,7 +202,7 @@ mod tests {
 
         assert!(!result.is_equivalent());
         // The first test case (Draft -> SubmitOrder) should mismatch.
-        assert!(result.mismatches.len() >= 1);
+        assert!(!result.mismatches.is_empty());
 
         let mm = &result.mismatches[0];
         assert_eq!(mm.test_case.action, "SubmitOrder");

--- a/crates/temper-jit/src/table/builder.rs
+++ b/crates/temper-jit/src/table/builder.rs
@@ -44,10 +44,19 @@ impl TransitionTable {
                 }
                 for g in &a.guard {
                     match g {
+                        automaton::Guard::StateIn { values } => {
+                            guards.push(Guard::StateIn(values.clone()));
+                        }
                         automaton::Guard::MinCount { var, min } => {
                             guards.push(Guard::CounterMin {
                                 var: var.clone(),
                                 min: *min,
+                            });
+                        }
+                        automaton::Guard::MaxCount { var, max } => {
+                            guards.push(Guard::CounterMax {
+                                var: var.clone(),
+                                max: *max,
                             });
                         }
                         automaton::Guard::IsTrue { var } => {
@@ -65,7 +74,6 @@ impl TransitionTable {
                                 min: *min,
                             });
                         }
-                        _ => {}
                     }
                 }
 

--- a/crates/temper-jit/src/table/evaluate.rs
+++ b/crates/temper-jit/src/table/evaluate.rs
@@ -145,6 +145,19 @@ mod tests {
     }
 
     #[test]
+    fn guard_counter_max() {
+        let guard = Guard::CounterMax {
+            var: "retries".into(),
+            max: 3,
+        };
+        let mut ctx = EvalContext::default();
+        ctx.counters.insert("retries".into(), 2);
+        assert!(guard.check("Draft", &ctx));
+        ctx.counters.insert("retries".into(), 3);
+        assert!(!guard.check("Draft", &ctx));
+    }
+
+    #[test]
     fn guard_and_combinator() {
         let guard = Guard::And(vec![
             Guard::StateIn(vec!["Draft".into()]),

--- a/crates/temper-jit/src/table/types.rs
+++ b/crates/temper-jit/src/table/types.rs
@@ -84,6 +84,8 @@ pub enum Guard {
     ItemCountMin(usize),
     /// A named counter must be >= N.
     CounterMin { var: String, min: usize },
+    /// A named counter must be < N.
+    CounterMax { var: String, max: usize },
     /// A named boolean variable must be true.
     BoolTrue(String),
     /// A named list variable must contain a specific value.
@@ -186,6 +188,7 @@ impl Guard {
             Guard::StateIn(states) => states.iter().any(|s| s == current_state),
             Guard::ItemCountMin(n) => ctx.counters.get("items").copied().unwrap_or(0) >= *n,
             Guard::CounterMin { var, min } => ctx.counters.get(var).copied().unwrap_or(0) >= *min,
+            Guard::CounterMax { var, max } => ctx.counters.get(var).copied().unwrap_or(0) < *max,
             Guard::BoolTrue(var) => ctx.booleans.get(var).copied().unwrap_or(false),
             Guard::ListContains { var, value } => {
                 ctx.lists.get(var).is_some_and(|list| list.contains(value))

--- a/crates/temper-odata/src/lib.rs
+++ b/crates/temper-odata/src/lib.rs
@@ -1,6 +1,6 @@
 //! temper-odata: OData v4 protocol implementation for Temper.
 //!
-//! Provides OData-compliant query parsing, response formatting, batch operations,
+//! Provides OData-compliant query parsing, response formatting,
 //! and entity routing for Temper entity services.
 //!
 //! # Key modules

--- a/crates/temper-platform/src/deploy/pipeline.rs
+++ b/crates/temper-platform/src/deploy/pipeline.rs
@@ -39,7 +39,6 @@ pub struct DeployInput {
     /// Pre-authored entity specs.
     pub entities: Vec<EntitySpecSource>,
     /// WASM modules for integration handlers: module_name → wasm_bytes.
-    #[allow(dead_code)]
     pub wasm_modules: std::collections::BTreeMap<String, Vec<u8>>,
 }
 
@@ -237,31 +236,46 @@ impl DeployPipeline {
                         .map(|r| (r.entity_name.as_str(), r.ioa_source.as_str()))
                         .collect();
 
-                    // Register tenant in the live registry
-                    {
+                    // Register tenant in the live registry.
+                    let register_result = {
                         let mut registry = state.registry.write().unwrap();
-                        registry.register_tenant(
+                        registry.try_register_tenant(
                             TenantId::new(&input.tenant_name),
                             csdl,
                             input.csdl_xml.clone(),
                             &ioa_pairs,
-                        );
+                        )
+                    };
+
+                    match register_result {
+                        Ok(()) => {
+                            state.broadcast(PlatformEvent::DeployStatus {
+                                tenant: input.tenant_name.clone(),
+                                success: true,
+                                summary: format!(
+                                    "Deployed {} entities for tenant '{}'",
+                                    input.entities.len(),
+                                    input.tenant_name,
+                                ),
+                            });
+
+                            state.broadcast(PlatformEvent::TenantRegistered {
+                                tenant: input.tenant_name.clone(),
+                                entity_count: input.entities.len(),
+                            });
+                        }
+                        Err(e) => {
+                            all_passed = false;
+                            deploy_span.set_status(Status::Error {
+                                description: format!("registry registration failed: {e}").into(),
+                            });
+                            state.broadcast(PlatformEvent::DeployStatus {
+                                tenant: input.tenant_name.clone(),
+                                success: false,
+                                summary: format!("Tenant registration failed: {e}"),
+                            });
+                        }
                     }
-
-                    state.broadcast(PlatformEvent::DeployStatus {
-                        tenant: input.tenant_name.clone(),
-                        success: true,
-                        summary: format!(
-                            "Deployed {} entities for tenant '{}'",
-                            input.entities.len(),
-                            input.tenant_name,
-                        ),
-                    });
-
-                    state.broadcast(PlatformEvent::TenantRegistered {
-                        tenant: input.tenant_name.clone(),
-                        entity_count: input.entities.len(),
-                    });
                 }
                 Err(e) => {
                     all_passed = false;

--- a/crates/temper-platform/tests/compile_first_e2e.rs
+++ b/crates/temper-platform/tests/compile_first_e2e.rs
@@ -163,7 +163,7 @@ async fn e2e_compile_first_order_lifecycle() {
     let response = app
         .clone()
         .oneshot(
-            Request::post(&format!(
+            Request::post(format!(
                 "/tdata/Orders('{entity_id}')/Temper.Example.CancelOrder"
             ))
             .header("Content-Type", "application/json")
@@ -181,7 +181,7 @@ async fn e2e_compile_first_order_lifecycle() {
     let response = app
         .clone()
         .oneshot(
-            Request::get(&format!("/tdata/Orders('{entity_id}')"))
+            Request::get(format!("/tdata/Orders('{entity_id}')"))
                 .header("X-Tenant-Id", "alpha")
                 .body(Body::empty())
                 .unwrap(),
@@ -309,7 +309,7 @@ async fn e2e_compile_first_two_tenants() {
     let response = app
         .clone()
         .oneshot(
-            Request::post(&format!(
+            Request::post(format!(
                 "/tdata/Orders('{alpha_id}')/Temper.Example.CancelOrder"
             ))
             .header("Content-Type", "application/json")
@@ -351,7 +351,7 @@ async fn e2e_compile_first_two_tenants() {
     let response = app
         .clone()
         .oneshot(
-            Request::post(&format!(
+            Request::post(format!(
                 "/tdata/Tasks('{beta_id}')/Temper.Example.StartWork"
             ))
             .header("Content-Type", "application/json")
@@ -482,7 +482,7 @@ async fn e2e_compile_first_system_and_user_coexist() {
     let response = app
         .clone()
         .oneshot(
-            Request::post(&format!(
+            Request::post(format!(
                 "/tdata/Orders('{order_id}')/Temper.Example.CancelOrder"
             ))
             .header("Content-Type", "application/json")
@@ -523,7 +523,7 @@ async fn e2e_compile_first_system_and_user_coexist() {
     let response = app
         .clone()
         .oneshot(
-            Request::post(&format!(
+            Request::post(format!(
                 "/tdata/Projects('{proj_id}')/Temper.System.UpdateSpecs"
             ))
             .header("Content-Type", "application/json")

--- a/crates/temper-platform/tests/platform_e2e_dst.rs
+++ b/crates/temper-platform/tests/platform_e2e_dst.rs
@@ -353,7 +353,7 @@ async fn e2e_http_project_lifecycle() {
     let response = app
         .clone()
         .oneshot(
-            Request::post(&format!(
+            Request::post(format!(
                 "/tdata/Projects('{entity_id}')/Temper.System.UpdateSpecs"
             ))
             .header("Content-Type", "application/json")
@@ -370,7 +370,7 @@ async fn e2e_http_project_lifecycle() {
     let response = app
         .clone()
         .oneshot(
-            Request::post(&format!(
+            Request::post(format!(
                 "/tdata/Projects('{entity_id}')/Temper.System.Verify"
             ))
             .header("Content-Type", "application/json")
@@ -404,7 +404,7 @@ async fn e2e_http_project_lifecycle() {
     let response = app
         .clone()
         .oneshot(
-            Request::get(&format!("/tdata/Projects('{entity_id}')"))
+            Request::get(format!("/tdata/Projects('{entity_id}')"))
                 .body(Body::empty())
                 .unwrap(),
         )

--- a/crates/temper-platform/tests/system_entity_dst.rs
+++ b/crates/temper-platform/tests/system_entity_dst.rs
@@ -406,7 +406,7 @@ fn random_project_no_faults_seed_42() {
     let mut sim = SimActorSystem::new(config);
 
     for i in 0..3 {
-        let handler = EntityActorHandler::new("Project", &format!("p-{i}"), project_table())
+        let handler = EntityActorHandler::new("Project", format!("p-{i}"), project_table())
             .with_ioa_invariants(PROJECT_IOA);
         sim.register_actor(&format!("p-{i}"), Box::new(handler));
     }
@@ -435,7 +435,7 @@ fn random_tenant_no_faults_seed_42() {
     let mut sim = SimActorSystem::new(config);
 
     for i in 0..3 {
-        let handler = EntityActorHandler::new("Tenant", &format!("t-{i}"), tenant_table());
+        let handler = EntityActorHandler::new("Tenant", format!("t-{i}"), tenant_table());
         sim.register_actor(&format!("t-{i}"), Box::new(handler));
     }
 
@@ -514,7 +514,7 @@ fn random_project_light_faults() {
     let mut sim = SimActorSystem::new(config);
 
     for i in 0..3 {
-        let handler = EntityActorHandler::new("Project", &format!("p-{i}"), project_table())
+        let handler = EntityActorHandler::new("Project", format!("p-{i}"), project_table())
             .with_ioa_invariants(PROJECT_IOA);
         sim.register_actor(&format!("p-{i}"), Box::new(handler));
     }
@@ -592,7 +592,7 @@ fn random_tenant_light_faults() {
     let mut sim = SimActorSystem::new(config);
 
     for i in 0..3 {
-        let handler = EntityActorHandler::new("Tenant", &format!("t-{i}"), tenant_table());
+        let handler = EntityActorHandler::new("Tenant", format!("t-{i}"), tenant_table());
         sim.register_actor(&format!("t-{i}"), Box::new(handler));
     }
 
@@ -615,7 +615,7 @@ fn random_tenant_heavy_faults() {
     let mut sim = SimActorSystem::new(config);
 
     for i in 0..3 {
-        let handler = EntityActorHandler::new("Tenant", &format!("t-{i}"), tenant_table());
+        let handler = EntityActorHandler::new("Tenant", format!("t-{i}"), tenant_table());
         sim.register_actor(&format!("t-{i}"), Box::new(handler));
     }
 
@@ -638,7 +638,7 @@ fn random_project_heavy_faults() {
     let mut sim = SimActorSystem::new(config);
 
     for i in 0..3 {
-        let handler = EntityActorHandler::new("Project", &format!("p-{i}"), project_table())
+        let handler = EntityActorHandler::new("Project", format!("p-{i}"), project_table())
             .with_ioa_invariants(PROJECT_IOA);
         sim.register_actor(&format!("p-{i}"), Box::new(handler));
     }
@@ -662,7 +662,7 @@ fn random_catalog_heavy_faults() {
     let mut sim = SimActorSystem::new(config);
 
     for i in 0..3 {
-        let handler = EntityActorHandler::new("CatalogEntry", &format!("cat-{i}"), catalog_table());
+        let handler = EntityActorHandler::new("CatalogEntry", format!("cat-{i}"), catalog_table());
         sim.register_actor(&format!("cat-{i}"), Box::new(handler));
     }
 
@@ -686,7 +686,7 @@ fn random_collaborator_heavy_faults() {
 
     for i in 0..3 {
         let handler =
-            EntityActorHandler::new("Collaborator", &format!("col-{i}"), collaborator_table());
+            EntityActorHandler::new("Collaborator", format!("col-{i}"), collaborator_table());
         sim.register_actor(&format!("col-{i}"), Box::new(handler));
     }
 
@@ -709,7 +709,7 @@ fn random_version_heavy_faults() {
     let mut sim = SimActorSystem::new(config);
 
     for i in 0..3 {
-        let handler = EntityActorHandler::new("Version", &format!("v-{i}"), version_table());
+        let handler = EntityActorHandler::new("Version", format!("v-{i}"), version_table());
         sim.register_actor(&format!("v-{i}"), Box::new(handler));
     }
 

--- a/crates/temper-runtime/src/tenant.rs
+++ b/crates/temper-runtime/src/tenant.rs
@@ -67,6 +67,41 @@ impl From<String> for TenantId {
     }
 }
 
+/// Parse a persistence ID into `(tenant, entity_type, entity_id)` parts.
+///
+/// Accepts both the new 3-segment format (`tenant:type:id`) and the
+/// legacy 2-segment format (`type:id`) for backward compatibility.
+/// Legacy IDs are assigned to the `"default"` tenant.
+pub fn parse_persistence_id_parts(persistence_id: &str) -> Result<(&str, &str, &str), String> {
+    let segments: Vec<&str> = persistence_id.splitn(3, ':').collect();
+    match segments.len() {
+        3 => {
+            let tenant = segments[0];
+            let entity_type = segments[1];
+            let entity_id = segments[2];
+            if tenant.is_empty() || entity_type.is_empty() || entity_id.is_empty() {
+                return Err(format!(
+                    "invalid persistence_id (empty segment): {persistence_id}"
+                ));
+            }
+            Ok((tenant, entity_type, entity_id))
+        }
+        2 => {
+            let entity_type = segments[0];
+            let entity_id = segments[1];
+            if entity_type.is_empty() || entity_id.is_empty() {
+                return Err(format!(
+                    "invalid persistence_id (empty segment): {persistence_id}"
+                ));
+            }
+            Ok(("default", entity_type, entity_id))
+        }
+        _ => Err(format!(
+            "invalid persistence_id (expected 'tenant:type:id' or 'type:id'): {persistence_id}"
+        )),
+    }
+}
+
 /// The globally unique identity of an entity in the platform.
 ///
 /// Format: `tenant:entity_type:entity_id` (e.g., `"my-app:Order:abc-123"`).
@@ -110,42 +145,12 @@ impl QualifiedEntityId {
     /// legacy 2-segment format (`type:id`) for backward compatibility.
     /// Legacy IDs are assigned to the `"default"` tenant.
     pub fn parse(persistence_id: &str) -> Result<Self, String> {
-        let segments: Vec<&str> = persistence_id.splitn(3, ':').collect();
-        match segments.len() {
-            3 => {
-                let tenant = segments[0];
-                let entity_type = segments[1];
-                let entity_id = segments[2];
-                if tenant.is_empty() || entity_type.is_empty() || entity_id.is_empty() {
-                    return Err(format!(
-                        "invalid persistence_id (empty segment): {persistence_id}"
-                    ));
-                }
-                Ok(Self {
-                    tenant: TenantId::new(tenant),
-                    entity_type: entity_type.to_string(),
-                    entity_id: entity_id.to_string(),
-                })
-            }
-            2 => {
-                // Legacy format: entity_type:entity_id → default tenant
-                let entity_type = segments[0];
-                let entity_id = segments[1];
-                if entity_type.is_empty() || entity_id.is_empty() {
-                    return Err(format!(
-                        "invalid persistence_id (empty segment): {persistence_id}"
-                    ));
-                }
-                Ok(Self {
-                    tenant: TenantId::default(),
-                    entity_type: entity_type.to_string(),
-                    entity_id: entity_id.to_string(),
-                })
-            }
-            _ => Err(format!(
-                "invalid persistence_id (expected 'tenant:type:id' or 'type:id'): {persistence_id}"
-            )),
-        }
+        let (tenant, entity_type, entity_id) = parse_persistence_id_parts(persistence_id)?;
+        Ok(Self {
+            tenant: TenantId::new(tenant),
+            entity_type: entity_type.to_string(),
+            entity_id: entity_id.to_string(),
+        })
     }
 
     /// Actor registry key: `tenant:entity_type:entity_id`.

--- a/crates/temper-server/src/entity_actor/actor.rs
+++ b/crates/temper-server/src/entity_actor/actor.rs
@@ -609,7 +609,7 @@ mod tests {
         let actor_ref = system.spawn(actor, "order-4");
 
         // Draft -> AddItem -> SubmitOrder -> ConfirmOrder -> ProcessOrder -> ShipOrder -> DeliverOrder
-        let actions = vec![
+        let actions = [
             ("AddItem", serde_json::json!({})),
             ("SubmitOrder", serde_json::json!({})),
             ("ConfirmOrder", serde_json::json!({})),
@@ -618,7 +618,7 @@ mod tests {
             ("DeliverOrder", serde_json::json!({})),
         ];
 
-        let expected_states = vec![
+        let expected_states = [
             "Draft",      // after AddItem
             "Submitted",  // after SubmitOrder
             "Confirmed",  // after ConfirmOrder

--- a/crates/temper-server/src/observe/mod.rs
+++ b/crates/temper-server/src/observe/mod.rs
@@ -7,9 +7,9 @@ mod entities;
 mod evolution;
 mod metrics;
 mod specs;
+mod specs_helpers;
 mod verification;
 mod wasm;
-
 use axum::Router;
 use axum::http::{HeaderMap, StatusCode};
 use axum::routing::{get, post};

--- a/crates/temper-server/src/observe/specs.rs
+++ b/crates/temper-server/src/observe/specs.rs
@@ -6,7 +6,7 @@ use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::Json;
 use serde::Deserialize;
-use temper_spec::automaton::{LintSeverity, lint_automaton};
+use temper_spec::automaton::LintSeverity;
 use temper_spec::cross_invariant::{
     CrossInvariantLintSeverity, lint_cross_invariants, parse_cross_invariants,
 };
@@ -18,6 +18,10 @@ use crate::reaction::registry::parse_reactions;
 use crate::registry::VerificationStatus;
 use crate::state::ServerState;
 
+use super::specs_helpers::{
+    EntityLintFinding, build_ndjson_response, cross_lint_ndjson_line, lint_loaded_specs,
+    lint_ndjson_line, to_pascal_case,
+};
 use super::{ActionDetail, InvariantDetail, SpecDetail, SpecSummary, StateVarDetail};
 
 /// GET /observe/specs -- list all loaded specs across all tenants.
@@ -86,169 +90,6 @@ pub(super) struct LoadInlineRequest {
     /// Optional inline `cross-invariants.toml` source.
     #[serde(default)]
     cross_invariants_toml: Option<String>,
-}
-
-/// Convert a string to PascalCase (e.g. "my_entity" -> "MyEntity").
-fn to_pascal_case(s: &str) -> String {
-    s.split(['_', '-'])
-        .map(|word| {
-            let mut chars = word.chars();
-            match chars.next() {
-                Some(first) => {
-                    let upper: String = first.to_uppercase().collect();
-                    format!("{}{}", upper, chars.collect::<String>())
-                }
-                None => String::new(),
-            }
-        })
-        .collect()
-}
-
-#[derive(Debug, Clone)]
-struct EntityLintFinding {
-    entity: String,
-    code: String,
-    severity: LintSeverity,
-    message: String,
-}
-
-fn lint_loaded_specs(
-    csdl: &temper_spec::csdl::CsdlDocument,
-    ioa_sources: &std::collections::BTreeMap<String, String>,
-) -> Result<Vec<EntityLintFinding>, (StatusCode, String)> {
-    let mut findings = Vec::new();
-    let mut entity_set_types = std::collections::BTreeSet::new();
-
-    for schema in &csdl.schemas {
-        for container in &schema.entity_containers {
-            for entity_set in &container.entity_sets {
-                let type_name = entity_set
-                    .entity_type
-                    .rsplit('.')
-                    .next()
-                    .unwrap_or(&entity_set.entity_type);
-                entity_set_types.insert(type_name.to_string());
-            }
-        }
-    }
-
-    for (entity_name, source) in ioa_sources {
-        let automaton = temper_spec::automaton::parse_automaton(source).map_err(|e| {
-            (
-                StatusCode::BAD_REQUEST,
-                format!("Failed to parse IOA spec for {entity_name}: {e}"),
-            )
-        })?;
-
-        for finding in lint_automaton(&automaton) {
-            findings.push(EntityLintFinding {
-                entity: entity_name.clone(),
-                code: finding.code,
-                severity: finding.severity,
-                message: finding.message,
-            });
-        }
-
-        if !entity_set_types.contains(entity_name) {
-            findings.push(EntityLintFinding {
-                entity: entity_name.clone(),
-                code: "ioa_missing_entity_set".to_string(),
-                severity: LintSeverity::Warning,
-                message: "spec has no corresponding entity set in model.csdl.xml".to_string(),
-            });
-        }
-    }
-
-    for entity_type in &entity_set_types {
-        if !ioa_sources.contains_key(entity_type) {
-            findings.push(EntityLintFinding {
-                entity: entity_type.clone(),
-                code: "csdl_missing_ioa_spec".to_string(),
-                severity: LintSeverity::Warning,
-                message: "entity set has no corresponding IOA spec".to_string(),
-            });
-        }
-    }
-
-    findings.sort_by(|a, b| {
-        let key_a = (
-            &a.entity,
-            matches!(a.severity, LintSeverity::Warning),
-            &a.code,
-            &a.message,
-        );
-        let key_b = (
-            &b.entity,
-            matches!(b.severity, LintSeverity::Warning),
-            &b.code,
-            &b.message,
-        );
-        key_a.cmp(&key_b)
-    });
-
-    Ok(findings)
-}
-
-fn lint_ndjson_line(finding: &EntityLintFinding) -> serde_json::Value {
-    serde_json::json!({
-        "type": match finding.severity {
-            LintSeverity::Error => "lint_error",
-            LintSeverity::Warning => "lint_warning",
-        },
-        "severity": match finding.severity {
-            LintSeverity::Error => "error",
-            LintSeverity::Warning => "warning",
-        },
-        "entity": &finding.entity,
-        "code": &finding.code,
-        "message": &finding.message,
-    })
-}
-
-fn cross_lint_ndjson_line(
-    finding: &temper_spec::cross_invariant::CrossInvariantLintFinding,
-) -> serde_json::Value {
-    serde_json::json!({
-        "type": match finding.severity {
-            CrossInvariantLintSeverity::Error => "cross_invariant_lint_error",
-            CrossInvariantLintSeverity::Warning => "cross_invariant_lint_warning",
-        },
-        "severity": match finding.severity {
-            CrossInvariantLintSeverity::Error => "error",
-            CrossInvariantLintSeverity::Warning => "warning",
-        },
-        "invariant": &finding.invariant,
-        "code": &finding.code,
-        "message": &finding.message,
-    })
-}
-
-fn build_ndjson_response(
-    status: StatusCode,
-    lines: Vec<serde_json::Value>,
-) -> Result<axum::response::Response, (StatusCode, String)> {
-    let mut body = String::new();
-    for line in lines {
-        let encoded = serde_json::to_string(&line).map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to encode NDJSON response: {e}"),
-            )
-        })?;
-        body.push_str(&encoded);
-        body.push('\n');
-    }
-
-    axum::response::Response::builder()
-        .status(status)
-        .header("content-type", "application/x-ndjson")
-        .body(axum::body::Body::from(body))
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to build NDJSON response: {e}"),
-            )
-        })
 }
 
 /// POST /observe/specs/load-dir -- hot-load specs from a directory into the running server.

--- a/crates/temper-server/src/observe/specs.rs
+++ b/crates/temper-server/src/observe/specs.rs
@@ -452,14 +452,21 @@ pub(crate) async fn handle_load_dir(
 
     {
         let mut registry = state.registry.write().unwrap(); // ci-ok: infallible lock
-        registry.register_tenant_with_reactions_and_constraints(
-            body.tenant.as_str(),
-            csdl,
-            csdl_xml,
-            &ioa_pairs,
-            reactions,
-            cross_invariants_toml.clone(),
-        );
+        registry
+            .try_register_tenant_with_reactions_and_constraints(
+                body.tenant.as_str(),
+                csdl,
+                csdl_xml,
+                &ioa_pairs,
+                reactions,
+                cross_invariants_toml.clone(),
+            )
+            .map_err(|e| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    format!("Failed to register specs: {e}"),
+                )
+            })?;
     }
     state.rebuild_reaction_dispatcher();
 

--- a/crates/temper-server/src/observe/specs_helpers.rs
+++ b/crates/temper-server/src/observe/specs_helpers.rs
@@ -1,0 +1,164 @@
+use axum::http::StatusCode;
+use temper_spec::automaton::{LintSeverity, lint_automaton};
+use temper_spec::cross_invariant::{CrossInvariantLintFinding, CrossInvariantLintSeverity};
+
+#[derive(Debug, Clone)]
+pub(super) struct EntityLintFinding {
+    pub(super) entity: String,
+    pub(super) code: String,
+    pub(super) severity: LintSeverity,
+    pub(super) message: String,
+}
+
+/// Convert a string to PascalCase (e.g. "my_entity" -> "MyEntity").
+pub(super) fn to_pascal_case(s: &str) -> String {
+    s.split(['_', '-'])
+        .map(|word| {
+            let mut chars = word.chars();
+            match chars.next() {
+                Some(first) => {
+                    let upper: String = first.to_uppercase().collect();
+                    format!("{}{}", upper, chars.collect::<String>())
+                }
+                None => String::new(),
+            }
+        })
+        .collect()
+}
+
+pub(super) fn lint_loaded_specs(
+    csdl: &temper_spec::csdl::CsdlDocument,
+    ioa_sources: &std::collections::BTreeMap<String, String>,
+) -> Result<Vec<EntityLintFinding>, (StatusCode, String)> {
+    let mut findings = Vec::new();
+    let mut entity_set_types = std::collections::BTreeSet::new();
+
+    for schema in &csdl.schemas {
+        for container in &schema.entity_containers {
+            for entity_set in &container.entity_sets {
+                let type_name = entity_set
+                    .entity_type
+                    .rsplit('.')
+                    .next()
+                    .unwrap_or(&entity_set.entity_type);
+                entity_set_types.insert(type_name.to_string());
+            }
+        }
+    }
+
+    for (entity_name, source) in ioa_sources {
+        let automaton = temper_spec::automaton::parse_automaton(source).map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                format!("Failed to parse IOA spec for {entity_name}: {e}"),
+            )
+        })?;
+
+        for finding in lint_automaton(&automaton) {
+            findings.push(EntityLintFinding {
+                entity: entity_name.clone(),
+                code: finding.code,
+                severity: finding.severity,
+                message: finding.message,
+            });
+        }
+
+        if !entity_set_types.contains(entity_name) {
+            findings.push(EntityLintFinding {
+                entity: entity_name.clone(),
+                code: "ioa_missing_entity_set".to_string(),
+                severity: LintSeverity::Warning,
+                message: "spec has no corresponding entity set in model.csdl.xml".to_string(),
+            });
+        }
+    }
+
+    for entity_type in &entity_set_types {
+        if !ioa_sources.contains_key(entity_type) {
+            findings.push(EntityLintFinding {
+                entity: entity_type.clone(),
+                code: "csdl_missing_ioa_spec".to_string(),
+                severity: LintSeverity::Warning,
+                message: "entity set has no corresponding IOA spec".to_string(),
+            });
+        }
+    }
+
+    findings.sort_by(|a, b| {
+        let key_a = (
+            &a.entity,
+            matches!(a.severity, LintSeverity::Warning),
+            &a.code,
+            &a.message,
+        );
+        let key_b = (
+            &b.entity,
+            matches!(b.severity, LintSeverity::Warning),
+            &b.code,
+            &b.message,
+        );
+        key_a.cmp(&key_b)
+    });
+
+    Ok(findings)
+}
+
+pub(super) fn lint_ndjson_line(finding: &EntityLintFinding) -> serde_json::Value {
+    serde_json::json!({
+        "type": match finding.severity {
+            LintSeverity::Error => "lint_error",
+            LintSeverity::Warning => "lint_warning",
+        },
+        "severity": match finding.severity {
+            LintSeverity::Error => "error",
+            LintSeverity::Warning => "warning",
+        },
+        "entity": &finding.entity,
+        "code": &finding.code,
+        "message": &finding.message,
+    })
+}
+
+pub(super) fn cross_lint_ndjson_line(finding: &CrossInvariantLintFinding) -> serde_json::Value {
+    serde_json::json!({
+        "type": match finding.severity {
+            CrossInvariantLintSeverity::Error => "cross_invariant_lint_error",
+            CrossInvariantLintSeverity::Warning => "cross_invariant_lint_warning",
+        },
+        "severity": match finding.severity {
+            CrossInvariantLintSeverity::Error => "error",
+            CrossInvariantLintSeverity::Warning => "warning",
+        },
+        "invariant": &finding.invariant,
+        "code": &finding.code,
+        "message": &finding.message,
+    })
+}
+
+pub(super) fn build_ndjson_response(
+    status: StatusCode,
+    lines: Vec<serde_json::Value>,
+) -> Result<axum::response::Response, (StatusCode, String)> {
+    let mut body = String::new();
+    for line in lines {
+        let encoded = serde_json::to_string(&line).map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to encode NDJSON response: {e}"),
+            )
+        })?;
+        body.push_str(&encoded);
+        body.push('\n');
+    }
+
+    axum::response::Response::builder()
+        .status(status)
+        .header("content-type", "application/x-ndjson")
+        .body(axum::body::Body::from(body))
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to build NDJSON response: {e}"),
+            )
+        })
+}

--- a/crates/temper-server/src/registry.rs
+++ b/crates/temper-server/src/registry.rs
@@ -68,6 +68,44 @@ pub struct VerificationDetail {
     pub actor_id: Option<String>,
 }
 
+/// Errors raised while registering tenant specifications.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RegistryError {
+    /// cross-invariants TOML failed to parse.
+    CrossInvariantParse { tenant: String, source: String },
+    /// An IOA source failed to parse.
+    IoaParse {
+        tenant: String,
+        entity_type: String,
+        source: String,
+    },
+}
+
+impl std::fmt::Display for RegistryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::CrossInvariantParse { tenant, source } => {
+                write!(
+                    f,
+                    "failed to parse cross-invariants for tenant '{tenant}': {source}"
+                )
+            }
+            Self::IoaParse {
+                tenant,
+                entity_type,
+                source,
+            } => {
+                write!(
+                    f,
+                    "failed to parse IOA for tenant '{tenant}', entity '{entity_type}': {source}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for RegistryError {}
+
 /// A compiled relation edge from CSDL navigation metadata.
 #[derive(Debug, Clone)]
 pub struct RelationEdge {
@@ -108,7 +146,6 @@ pub struct TenantConfig {
     /// Per-entity-type specs.
     pub entities: BTreeMap<String, EntitySpec>,
     /// Reaction rules for cross-entity coordination.
-    #[allow(dead_code)]
     pub reactions: Vec<ReactionRule>,
     /// Tenant relation graph compiled from CSDL.
     pub relation_graph: RelationGraph,
@@ -199,14 +236,33 @@ impl SpecRegistry {
         csdl_xml: String,
         ioa_sources: &[(&str, &str)],
     ) {
-        self.register_tenant_with_reactions_and_constraints(
+        self.try_register_tenant_with_reactions_and_constraints(
             tenant,
             csdl,
             csdl_xml,
             ioa_sources,
             Vec::new(),
             None,
-        );
+        )
+        .unwrap_or_else(|e| panic!("{e}"));
+    }
+
+    /// Fallible variant of [`register_tenant`](Self::register_tenant).
+    pub fn try_register_tenant(
+        &mut self,
+        tenant: impl Into<TenantId>,
+        csdl: CsdlDocument,
+        csdl_xml: String,
+        ioa_sources: &[(&str, &str)],
+    ) -> Result<(), RegistryError> {
+        self.try_register_tenant_with_reactions_and_constraints(
+            tenant,
+            csdl,
+            csdl_xml,
+            ioa_sources,
+            Vec::new(),
+            None,
+        )
     }
 
     /// Register a tenant with CSDL, IOA specs, reaction rules, and optional
@@ -220,16 +276,40 @@ impl SpecRegistry {
         reactions: Vec<ReactionRule>,
         cross_invariants_source: Option<String>,
     ) {
+        self.try_register_tenant_with_reactions_and_constraints(
+            tenant,
+            csdl,
+            csdl_xml,
+            ioa_sources,
+            reactions,
+            cross_invariants_source,
+        )
+        .unwrap_or_else(|e| panic!("{e}"));
+    }
+
+    /// Fallible variant of [`register_tenant_with_reactions_and_constraints`](Self::register_tenant_with_reactions_and_constraints).
+    pub fn try_register_tenant_with_reactions_and_constraints(
+        &mut self,
+        tenant: impl Into<TenantId>,
+        csdl: CsdlDocument,
+        csdl_xml: String,
+        ioa_sources: &[(&str, &str)],
+        reactions: Vec<ReactionRule>,
+        cross_invariants_source: Option<String>,
+    ) -> Result<(), RegistryError> {
         let tenant = tenant.into();
-        let relation_graph = build_relation_graph(&csdl, cross_invariants_source.as_deref());
+        let tenant_name = tenant.to_string();
         let cross_invariants = cross_invariants_source
             .as_ref()
             .filter(|s| !s.trim().is_empty())
             .map(|s| {
-                parse_cross_invariants(s).unwrap_or_else(|e| {
-                    panic!("failed to parse cross-invariants for tenant '{tenant}': {e}")
+                parse_cross_invariants(s).map_err(|e| RegistryError::CrossInvariantParse {
+                    tenant: tenant_name.clone(),
+                    source: e.to_string(),
                 })
-            });
+            })
+            .transpose()?;
+        let relation_graph = build_relation_graph(&csdl, cross_invariants.as_ref());
 
         // Build entity set map from CSDL
         let mut entity_set_map = BTreeMap::new();
@@ -257,8 +337,13 @@ impl SpecRegistry {
             existing_config.cross_invariants_source = cross_invariants_source;
 
             for (entity_type, ioa_source) in ioa_sources {
-                let automaton = automaton::parse_automaton(ioa_source)
-                    .unwrap_or_else(|e| panic!("failed to parse IOA for {entity_type}: {e}"));
+                let automaton = automaton::parse_automaton(ioa_source).map_err(|e| {
+                    RegistryError::IoaParse {
+                        tenant: tenant_name.clone(),
+                        entity_type: (*entity_type).to_string(),
+                        source: e.to_string(),
+                    }
+                })?;
                 let table = TransitionTable::from_automaton(&automaton);
                 let integrations = automaton.integrations.clone();
 
@@ -305,8 +390,13 @@ impl SpecRegistry {
             // First registration: create new TenantConfig.
             let mut entities = BTreeMap::new();
             for (entity_type, ioa_source) in ioa_sources {
-                let automaton = automaton::parse_automaton(ioa_source)
-                    .unwrap_or_else(|e| panic!("failed to parse IOA for {entity_type}: {e}"));
+                let automaton = automaton::parse_automaton(ioa_source).map_err(|e| {
+                    RegistryError::IoaParse {
+                        tenant: tenant_name.clone(),
+                        entity_type: (*entity_type).to_string(),
+                        source: e.to_string(),
+                    }
+                })?;
                 let table = TransitionTable::from_automaton(&automaton);
                 let integrations = automaton.integrations.clone();
                 entities.insert(
@@ -340,6 +430,8 @@ impl SpecRegistry {
                 },
             );
         }
+
+        Ok(())
     }
 
     /// Register a tenant with CSDL, IOA specs, and reaction rules.
@@ -351,14 +443,34 @@ impl SpecRegistry {
         ioa_sources: &[(&str, &str)],
         reactions: Vec<ReactionRule>,
     ) {
-        self.register_tenant_with_reactions_and_constraints(
+        self.try_register_tenant_with_reactions_and_constraints(
             tenant,
             csdl,
             csdl_xml,
             ioa_sources,
             reactions,
             None,
-        );
+        )
+        .unwrap_or_else(|e| panic!("{e}"));
+    }
+
+    /// Fallible variant of [`register_tenant_with_reactions`](Self::register_tenant_with_reactions).
+    pub fn try_register_tenant_with_reactions(
+        &mut self,
+        tenant: impl Into<TenantId>,
+        csdl: CsdlDocument,
+        csdl_xml: String,
+        ioa_sources: &[(&str, &str)],
+        reactions: Vec<ReactionRule>,
+    ) -> Result<(), RegistryError> {
+        self.try_register_tenant_with_reactions_and_constraints(
+            tenant,
+            csdl,
+            csdl_xml,
+            ioa_sources,
+            reactions,
+            None,
+        )
     }
 
     /// Build a [`ReactionRegistry`] from all tenants' reaction rules.
@@ -472,16 +584,18 @@ impl SpecRegistry {
 
 fn build_relation_graph(
     csdl: &CsdlDocument,
-    cross_invariants_source: Option<&str>,
+    cross_invariants: Option<&CrossInvariantSpec>,
 ) -> RelationGraph {
     let mut overrides = BTreeMap::<(String, String), DeletePolicy>::new();
-    let default_policy = cross_invariants_source
-        .and_then(|src| parse_cross_invariants(src).ok())
-        .map(|s| {
-            for ov in s.relation_overrides {
-                overrides.insert((ov.from_entity, ov.navigation_property), ov.delete_policy);
+    let default_policy = cross_invariants
+        .map(|spec| {
+            for ov in &spec.relation_overrides {
+                overrides.insert(
+                    (ov.from_entity.clone(), ov.navigation_property.clone()),
+                    ov.delete_policy,
+                );
             }
-            s.default_delete_policy
+            spec.default_delete_policy
         })
         .unwrap_or(DeletePolicy::Restrict);
 

--- a/crates/temper-spec/src/automaton/parser.rs
+++ b/crates/temper-spec/src/automaton/parser.rs
@@ -390,35 +390,7 @@ fn parse_toml_to_automaton(input: &str) -> Result<Automaton, AutomatonParseError
                             "params" => a.params = parse_string_array(&value),
                             "hint" => a.hint = Some(value.clone()),
                             "guard" => {
-                                // Format: "items > 0" → MinCount
-                                if value.contains('>') {
-                                    let parts: Vec<&str> = value.split('>').collect();
-                                    if parts.len() == 2 {
-                                        let var = parts[0].trim().to_string();
-                                        let min: usize = parts[1].trim().parse().unwrap_or(1);
-                                        a.guard.push(Guard::MinCount { var, min: min + 1 });
-                                    }
-                                }
-                                // Format: "min var n" → MinCount
-                                else if value.starts_with("min ") {
-                                    let parts: Vec<&str> = value.splitn(3, ' ').collect();
-                                    if parts.len() == 3 {
-                                        let var = parts[1].to_string();
-                                        let min: usize = parts[2].parse().unwrap_or(1);
-                                        a.guard.push(Guard::MinCount { var, min });
-                                    }
-                                }
-                                // Format: "is_true var" → IsTrue
-                                else if value.starts_with("is_true ") {
-                                    let var = value
-                                        .strip_prefix("is_true ")
-                                        .unwrap_or("")
-                                        .trim()
-                                        .to_string();
-                                    if !var.is_empty() {
-                                        a.guard.push(Guard::IsTrue { var });
-                                    }
-                                }
+                                a.guard.push(parse_guard_clause(&value)?);
                             }
                             "effect" => {
                                 // Format: "increment var" → Increment
@@ -578,6 +550,136 @@ fn flush_all(
         && !l.name.is_empty()
     {
         liveness_props.push(l);
+    }
+}
+
+fn parse_guard_clause(value: &str) -> Result<Guard, AutomatonParseError> {
+    let trimmed = value.trim();
+
+    // Infix forms: "<var> > <n>" and "<var> < <n>".
+    if let Some((lhs, rhs)) = trimmed.split_once('>') {
+        let var = lhs.trim();
+        let raw = rhs.trim();
+        if var.is_empty() || raw.is_empty() {
+            return Err(AutomatonParseError::Validation(format!(
+                "invalid guard '{trimmed}' (expected '<var> > <n>')"
+            )));
+        }
+        let n: usize = raw.parse().map_err(|_| {
+            AutomatonParseError::Validation(format!(
+                "invalid guard '{trimmed}' (right side must be an integer)"
+            ))
+        })?;
+        return Ok(Guard::MinCount {
+            var: var.to_string(),
+            min: n + 1,
+        });
+    }
+    if let Some((lhs, rhs)) = trimmed.split_once('<') {
+        let var = lhs.trim();
+        let raw = rhs.trim();
+        if var.is_empty() || raw.is_empty() {
+            return Err(AutomatonParseError::Validation(format!(
+                "invalid guard '{trimmed}' (expected '<var> < <n>')"
+            )));
+        }
+        let max: usize = raw.parse().map_err(|_| {
+            AutomatonParseError::Validation(format!(
+                "invalid guard '{trimmed}' (right side must be an integer)"
+            ))
+        })?;
+        return Ok(Guard::MaxCount {
+            var: var.to_string(),
+            max,
+        });
+    }
+
+    // Prefix forms:
+    // - "min <var> <n>"
+    // - "max <var> <n>"
+    // - "is_true <var>"
+    // - "list_contains <var> <value>"
+    // - "list_length_min <var> <n>"
+    let parts: Vec<&str> = trimmed.split_whitespace().collect();
+    if parts.is_empty() {
+        return Err(AutomatonParseError::Validation(
+            "empty guard clause".to_string(),
+        ));
+    }
+
+    match parts[0] {
+        "min" => {
+            if parts.len() != 3 {
+                return Err(AutomatonParseError::Validation(format!(
+                    "invalid guard '{trimmed}' (expected 'min <var> <n>')"
+                )));
+            }
+            let min: usize = parts[2].parse().map_err(|_| {
+                AutomatonParseError::Validation(format!(
+                    "invalid guard '{trimmed}' (min must be an integer)"
+                ))
+            })?;
+            Ok(Guard::MinCount {
+                var: parts[1].to_string(),
+                min,
+            })
+        }
+        "max" => {
+            if parts.len() != 3 {
+                return Err(AutomatonParseError::Validation(format!(
+                    "invalid guard '{trimmed}' (expected 'max <var> <n>')"
+                )));
+            }
+            let max: usize = parts[2].parse().map_err(|_| {
+                AutomatonParseError::Validation(format!(
+                    "invalid guard '{trimmed}' (max must be an integer)"
+                ))
+            })?;
+            Ok(Guard::MaxCount {
+                var: parts[1].to_string(),
+                max,
+            })
+        }
+        "is_true" => {
+            if parts.len() != 2 {
+                return Err(AutomatonParseError::Validation(format!(
+                    "invalid guard '{trimmed}' (expected 'is_true <var>')"
+                )));
+            }
+            Ok(Guard::IsTrue {
+                var: parts[1].to_string(),
+            })
+        }
+        "list_contains" => {
+            if parts.len() < 3 {
+                return Err(AutomatonParseError::Validation(format!(
+                    "invalid guard '{trimmed}' (expected 'list_contains <var> <value>')"
+                )));
+            }
+            Ok(Guard::ListContains {
+                var: parts[1].to_string(),
+                value: parts[2..].join(" "),
+            })
+        }
+        "list_length_min" => {
+            if parts.len() != 3 {
+                return Err(AutomatonParseError::Validation(format!(
+                    "invalid guard '{trimmed}' (expected 'list_length_min <var> <n>')"
+                )));
+            }
+            let min: usize = parts[2].parse().map_err(|_| {
+                AutomatonParseError::Validation(format!(
+                    "invalid guard '{trimmed}' (min must be an integer)"
+                ))
+            })?;
+            Ok(Guard::ListLengthMin {
+                var: parts[1].to_string(),
+                min,
+            })
+        }
+        _ => Err(AutomatonParseError::Validation(format!(
+            "unsupported guard syntax '{trimmed}'"
+        ))),
     }
 }
 
@@ -936,5 +1038,83 @@ effect = "set is_done true"
             "bool and counter types should be accepted: {:?}",
             result.err()
         );
+    }
+
+    #[test]
+    fn test_extended_guard_syntax_parsed() {
+        let spec = r#"
+[automaton]
+name = "Ticket"
+states = ["Open", "Queued", "Closed"]
+initial = "Open"
+
+[[action]]
+name = "Queue"
+from = ["Open"]
+to = "Queued"
+guard = "max retries 3"
+
+[[action]]
+name = "Escalate"
+from = ["Queued"]
+to = "Queued"
+guard = "list_contains labels urgent"
+
+[[action]]
+name = "Close"
+from = ["Queued"]
+to = "Closed"
+guard = "list_length_min labels 1"
+"#;
+
+        let automaton = parse_automaton(spec).expect("extended guard forms should parse");
+        let queue = automaton
+            .actions
+            .iter()
+            .find(|a| a.name == "Queue")
+            .unwrap();
+        assert!(matches!(
+            queue.guard.as_slice(),
+            [Guard::MaxCount { var, max }] if var == "retries" && *max == 3
+        ));
+
+        let escalate = automaton
+            .actions
+            .iter()
+            .find(|a| a.name == "Escalate")
+            .unwrap();
+        assert!(matches!(
+            escalate.guard.as_slice(),
+            [Guard::ListContains { var, value }] if var == "labels" && value == "urgent"
+        ));
+
+        let close = automaton
+            .actions
+            .iter()
+            .find(|a| a.name == "Close")
+            .unwrap();
+        assert!(matches!(
+            close.guard.as_slice(),
+            [Guard::ListLengthMin { var, min }] if var == "labels" && *min == 1
+        ));
+    }
+
+    #[test]
+    fn test_invalid_guard_number_rejected() {
+        let spec = r#"
+[automaton]
+name = "Order"
+states = ["Draft", "Submitted"]
+initial = "Draft"
+
+[[action]]
+name = "SubmitOrder"
+from = ["Draft"]
+to = "Submitted"
+guard = "items > nope"
+"#;
+
+        let err = parse_automaton(spec).expect_err("invalid numeric guard should fail");
+        assert!(err.to_string().contains("right side must be an integer"));
     }
 }

--- a/crates/temper-store-postgres/src/store.rs
+++ b/crates/temper-store-postgres/src/store.rs
@@ -8,6 +8,7 @@ use sqlx::PgPool;
 use temper_runtime::persistence::{
     EventMetadata, EventStore, PersistenceEnvelope, PersistenceError,
 };
+use temper_runtime::tenant::parse_persistence_id_parts;
 
 /// A PostgreSQL-backed event store.
 ///
@@ -41,33 +42,7 @@ impl PostgresEventStore {
 /// legacy 2-segment format (`type:id`). Legacy IDs are assigned to
 /// the `"default"` tenant.
 pub fn parse_persistence_id(persistence_id: &str) -> Result<(&str, &str, &str), PersistenceError> {
-    let parts: Vec<&str> = persistence_id.splitn(3, ':').collect();
-    match parts.len() {
-        3 => {
-            let tenant = parts[0];
-            let entity_type = parts[1];
-            let entity_id = parts[2];
-            if tenant.is_empty() || entity_type.is_empty() || entity_id.is_empty() {
-                return Err(PersistenceError::Storage(format!(
-                    "invalid persistence_id (empty segment): {persistence_id}"
-                )));
-            }
-            Ok((tenant, entity_type, entity_id))
-        }
-        2 => {
-            let entity_type = parts[0];
-            let entity_id = parts[1];
-            if entity_type.is_empty() || entity_id.is_empty() {
-                return Err(PersistenceError::Storage(format!(
-                    "invalid persistence_id (empty segment): {persistence_id}"
-                )));
-            }
-            Ok(("default", entity_type, entity_id))
-        }
-        _ => Err(PersistenceError::Storage(format!(
-            "invalid persistence_id (expected 'tenant:type:id' or 'type:id'): {persistence_id}"
-        ))),
-    }
+    parse_persistence_id_parts(persistence_id).map_err(PersistenceError::Storage)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/temper-store-redis/src/event_store.rs
+++ b/crates/temper-store-redis/src/event_store.rs
@@ -16,6 +16,7 @@ use fred::prelude::*;
 use fred::types::scripts::Script;
 use serde::{Deserialize, Serialize};
 use temper_runtime::persistence::{EventStore, PersistenceEnvelope, PersistenceError};
+use temper_runtime::tenant::parse_persistence_id_parts;
 
 /// Lua script for atomic append: check expected sequence, RPUSH events, SET new seq, SADD entity ref.
 ///
@@ -156,33 +157,7 @@ impl RedisEventStore {
 }
 
 fn parse_persistence_id(persistence_id: &str) -> Result<(&str, &str, &str), PersistenceError> {
-    let parts: Vec<&str> = persistence_id.splitn(3, ':').collect();
-    match parts.len() {
-        3 => {
-            let tenant = parts[0];
-            let entity_type = parts[1];
-            let entity_id = parts[2];
-            if tenant.is_empty() || entity_type.is_empty() || entity_id.is_empty() {
-                return Err(PersistenceError::Storage(format!(
-                    "invalid persistence_id (empty segment): {persistence_id}"
-                )));
-            }
-            Ok((tenant, entity_type, entity_id))
-        }
-        2 => {
-            let entity_type = parts[0];
-            let entity_id = parts[1];
-            if entity_type.is_empty() || entity_id.is_empty() {
-                return Err(PersistenceError::Storage(format!(
-                    "invalid persistence_id (empty segment): {persistence_id}"
-                )));
-            }
-            Ok(("default", entity_type, entity_id))
-        }
-        _ => Err(PersistenceError::Storage(format!(
-            "invalid persistence_id (expected 'tenant:type:id' or 'type:id'): {persistence_id}"
-        ))),
-    }
+    parse_persistence_id_parts(persistence_id).map_err(PersistenceError::Storage)
 }
 
 fn storage_error(err: impl std::fmt::Display) -> PersistenceError {

--- a/crates/temper-store-turso/src/store.rs
+++ b/crates/temper-store-turso/src/store.rs
@@ -6,6 +6,7 @@ use libsql::{Builder, Database, TransactionBehavior, params};
 use temper_runtime::persistence::{
     EventMetadata, EventStore, PersistenceEnvelope, PersistenceError,
 };
+use temper_runtime::tenant::parse_persistence_id_parts;
 
 use crate::{TursoSpecVerificationUpdate, TursoTrajectoryInsert, schema};
 
@@ -458,33 +459,7 @@ fn storage_error(err: impl std::fmt::Display) -> PersistenceError {
 /// Accepts both the new 3-segment format (`tenant:type:id`) and the legacy
 /// 2-segment format (`type:id`) mapped to the `"default"` tenant.
 fn parse_persistence_id(persistence_id: &str) -> Result<(&str, &str, &str), PersistenceError> {
-    let parts: Vec<&str> = persistence_id.splitn(3, ':').collect();
-    match parts.len() {
-        3 => {
-            let tenant = parts[0];
-            let entity_type = parts[1];
-            let entity_id = parts[2];
-            if tenant.is_empty() || entity_type.is_empty() || entity_id.is_empty() {
-                return Err(PersistenceError::Storage(format!(
-                    "invalid persistence_id (empty segment): {persistence_id}"
-                )));
-            }
-            Ok((tenant, entity_type, entity_id))
-        }
-        2 => {
-            let entity_type = parts[0];
-            let entity_id = parts[1];
-            if entity_type.is_empty() || entity_id.is_empty() {
-                return Err(PersistenceError::Storage(format!(
-                    "invalid persistence_id (empty segment): {persistence_id}"
-                )));
-            }
-            Ok(("default", entity_type, entity_id))
-        }
-        _ => Err(PersistenceError::Storage(format!(
-            "invalid persistence_id (expected 'tenant:type:id' or 'type:id'): {persistence_id}"
-        ))),
-    }
+    parse_persistence_id_parts(persistence_id).map_err(PersistenceError::Storage)
 }
 
 impl EventStore for TursoEventStore {

--- a/crates/temper-verify/src/proptest_gen.rs
+++ b/crates/temper-verify/src/proptest_gen.rs
@@ -315,9 +315,7 @@ fn replay_failure(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{
-        InvariantKind, ModelEffect, ModelGuard, ResolvedInvariant, ResolvedTransition,
-    };
+    use crate::model::{InvariantKind, ModelGuard, ResolvedInvariant, ResolvedTransition};
     use std::collections::BTreeMap;
 
     const ORDER_IOA: &str = include_str!("../../../test-fixtures/specs/order.ioa.toml");
@@ -415,7 +413,7 @@ mod tests {
     // -----------------------------------------------------------------------
 
     fn build_broken_model() -> TemperModel {
-        let mut model = TemperModel {
+        TemperModel {
             states: vec!["A".to_string(), "B".to_string()],
             transitions: vec![ResolvedTransition {
                 name: "GoB".to_string(),
@@ -444,8 +442,6 @@ mod tests {
             initial_booleans: BTreeMap::new(),
             counter_bounds: BTreeMap::new(),
             default_max_counter: 2,
-        };
-
-        model
+        }
     }
 }

--- a/reference-apps/ecommerce/benches/agent_checkout.rs
+++ b/reference-apps/ecommerce/benches/agent_checkout.rs
@@ -13,7 +13,7 @@
 //!   cargo bench -p ecommerce-reference --bench agent_checkout
 //!   DATABASE_URL=postgres://... cargo bench -p ecommerce-reference --bench agent_checkout
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use hyper::{Request, StatusCode};
@@ -40,8 +40,8 @@ fn run_prefix() -> String {
     format!("b{ts}")
 }
 
-fn ecommerce_sources() -> HashMap<String, String> {
-    let mut m = HashMap::new();
+fn ecommerce_sources() -> BTreeMap<String, String> {
+    let mut m = BTreeMap::new();
     m.insert("Order".to_string(), ORDER_IOA.to_string());
     m.insert("Payment".to_string(), PAYMENT_IOA.to_string());
     m.insert("Shipment".to_string(), SHIPMENT_IOA.to_string());

--- a/reference-apps/ecommerce/tests/ecommerce_dst.rs
+++ b/reference-apps/ecommerce/tests/ecommerce_dst.rs
@@ -411,9 +411,10 @@ fn random_order_no_faults() {
     let mut sim = SimActorSystem::new(config);
 
     for i in 0..3 {
-        let handler = EntityActorHandler::new("Order", &format!("ord-{i}"), order_table())
+        let actor_id = format!("ord-{i}");
+        let handler = EntityActorHandler::new("Order", actor_id.clone(), order_table())
             .with_ioa_invariants(ORDER_IOA);
-        sim.register_actor(&format!("ord-{i}"), Box::new(handler));
+        sim.register_actor(&actor_id, Box::new(handler));
     }
 
     let result = sim.run_random();

--- a/reference-apps/ecommerce/tests/interactive_demo.rs
+++ b/reference-apps/ecommerce/tests/interactive_demo.rs
@@ -253,13 +253,14 @@ fn interactive_full_pipeline() {
     let mut sim = SimActorSystem::new(config);
 
     for i in 0..3 {
+        let actor_id = format!("ord-{i}");
         let handler = EntityActorHandler::new(
             "Order",
-            &format!("ord-{}", i),
+            actor_id.clone(),
             Arc::new(TransitionTable::from_ioa_source(ORDER_IOA)),
         )
         .with_ioa_invariants(ORDER_IOA);
-        sim.register_actor(&format!("ord-{}", i), Box::new(handler));
+        sim.register_actor(&actor_id, Box::new(handler));
     }
 
     let result = sim.run_random();

--- a/reference-apps/oncall/benches/agent_triage.rs
+++ b/reference-apps/oncall/benches/agent_triage.rs
@@ -13,7 +13,7 @@
 //!   cargo bench -p oncall-reference --bench agent_triage
 //!   DATABASE_URL=postgres://... cargo bench -p oncall-reference --bench agent_triage
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use hyper::{Request, StatusCode};
@@ -41,8 +41,8 @@ fn run_prefix() -> String {
     format!("b{ts}")
 }
 
-fn oncall_sources() -> HashMap<String, String> {
-    let mut m = HashMap::new();
+fn oncall_sources() -> BTreeMap<String, String> {
+    let mut m = BTreeMap::new();
     m.insert("Page".to_string(), PAGE_IOA.to_string());
     m.insert(
         "EscalationPolicy".to_string(),

--- a/reference-apps/oncall/tests/oncall_dst.rs
+++ b/reference-apps/oncall/tests/oncall_dst.rs
@@ -410,9 +410,10 @@ fn random_page_light_faults() {
     let mut sim = SimActorSystem::new(config);
 
     for i in 0..3 {
-        let handler = EntityActorHandler::new("Page", &format!("page-{i}"), page_table())
+        let actor_id = format!("page-{i}");
+        let handler = EntityActorHandler::new("Page", actor_id.clone(), page_table())
             .with_ioa_invariants(PAGE_IOA);
-        sim.register_actor(&format!("page-{i}"), Box::new(handler));
+        sim.register_actor(&actor_id, Box::new(handler));
     }
 
     let result = sim.run_random();


### PR DESCRIPTION
## Summary
- enforce stronger CI gates (clippy all-targets and cargo bench no-run)
- harden registry registration with fallible try_register flows and proper error propagation
- tighten automaton guard parsing and complete JIT guard mapping
- wire optional background optimization loop in temper serve
- deduplicate persistence-id parsing into runtime helper and reuse across stores
- keep readability gates green by extracting observe spec helpers

## Validation
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo bench --workspace --no-run
- cargo test --workspace
- pre-push gate (all 7 gates)