### PR TITLE
refactor: simplify code across crates

### DIFF
--- a/crates/temper-authz/src/engine.rs
+++ b/crates/temper-authz/src/engine.rs
@@ -151,29 +151,13 @@ impl AuthzEngine {
 
         // Add context attributes
         for (key, value) in &security_ctx.context_attrs {
-            if let Some(s) = value.as_str() {
-                ctx_map.insert(
-                    key.clone(),
-                    cedar_policy::RestrictedExpression::new_string(s.to_string()),
-                );
-            } else if let Some(b) = value.as_bool() {
-                ctx_map.insert(key.clone(), cedar_policy::RestrictedExpression::new_bool(b));
-            }
+            insert_json_as_cedar(&mut ctx_map, key.clone(), value);
         }
 
         // Inject resource attributes into context (enables Cedar policies to
         // reference entity state and cross-entity context via `context.key`).
         for (key, value) in resource_attrs {
-            if let Some(s) = value.as_str() {
-                ctx_map.insert(
-                    key.clone(),
-                    cedar_policy::RestrictedExpression::new_string(s.to_string()),
-                );
-            } else if let Some(b) = value.as_bool() {
-                ctx_map.insert(key.clone(), cedar_policy::RestrictedExpression::new_bool(b));
-            } else if let Some(n) = value.as_i64() {
-                ctx_map.insert(key.clone(), cedar_policy::RestrictedExpression::new_long(n));
-            }
+            insert_json_as_cedar(&mut ctx_map, key.clone(), value);
         }
 
         // Build context and request
@@ -242,6 +226,43 @@ impl AuthzEngine {
             return AuthzDecision::Allow;
         }
         self.authorize(security_ctx, action, resource_type, resource_attrs)
+    }
+}
+
+/// Insert a `serde_json::Value` into a Cedar context map, converting to the
+/// appropriate `RestrictedExpression` type. Supports strings, bools, integers,
+/// and arrays of those types.
+fn insert_json_as_cedar(
+    map: &mut HashMap<String, cedar_policy::RestrictedExpression>,
+    key: String,
+    value: &serde_json::Value,
+) {
+    if let Some(s) = value.as_str() {
+        map.insert(
+            key,
+            cedar_policy::RestrictedExpression::new_string(s.to_string()),
+        );
+    } else if let Some(b) = value.as_bool() {
+        map.insert(key, cedar_policy::RestrictedExpression::new_bool(b));
+    } else if let Some(n) = value.as_i64() {
+        map.insert(key, cedar_policy::RestrictedExpression::new_long(n));
+    } else if let Some(arr) = value.as_array() {
+        let items: Vec<cedar_policy::RestrictedExpression> = arr
+            .iter()
+            .filter_map(|item| {
+                if let Some(s) = item.as_str() {
+                    Some(cedar_policy::RestrictedExpression::new_string(
+                        s.to_string(),
+                    ))
+                } else if let Some(n) = item.as_i64() {
+                    Some(cedar_policy::RestrictedExpression::new_long(n))
+                } else {
+                    item.as_bool()
+                        .map(cedar_policy::RestrictedExpression::new_bool)
+                }
+            })
+            .collect();
+        map.insert(key, cedar_policy::RestrictedExpression::new_set(items));
     }
 }
 

--- a/crates/temper-server/src/entity_actor/effects.rs
+++ b/crates/temper-server/src/entity_actor/effects.rs
@@ -108,57 +108,13 @@ pub fn process_action(
     action: &str,
     params: &serde_json::Value,
 ) -> ProcessResult {
-    let ctx = build_eval_context(state);
-    let result = table.evaluate_ctx(&state.status, &ctx, action);
-
-    match result {
-        Some(transition_result) if transition_result.success => {
-            let from_status = state.status.clone();
-            let to_status = transition_result.new_state.clone();
-
-            let (custom_effects, scheduled_actions, spawn_requests) =
-                apply_effects(state, &transition_result.effects, params);
-            let _ = &spawn_requests; // used by caller via ProcessResult
-            apply_new_state_fallback(state, &from_status, &to_status);
-            sync_fields(state, params);
-
-            let event = EntityEvent {
-                action: action.to_string(),
-                from_status,
-                to_status: state.status.clone(),
-                timestamp: sim_now(),
-                params: params.clone(),
-            };
-
-            ProcessResult {
-                success: true,
-                event: Some(event),
-                custom_effects,
-                scheduled_actions,
-                spawn_requests,
-                error: None,
-            }
-        }
-        Some(_) => ProcessResult {
-            success: false,
-            event: None,
-            custom_effects: vec![],
-            scheduled_actions: vec![],
-            spawn_requests: vec![],
-            error: Some(format!(
-                "Action '{}' not valid from state '{}'",
-                action, state.status
-            )),
-        },
-        None => ProcessResult {
-            success: false,
-            event: None,
-            custom_effects: vec![],
-            scheduled_actions: vec![],
-            spawn_requests: vec![],
-            error: Some(format!("Unknown action: {}", action)),
-        },
-    }
+    process_action_with_xref(
+        state,
+        table,
+        action,
+        params,
+        &std::collections::BTreeMap::new(),
+    )
 }
 
 /// Process an action with pre-resolved cross-entity booleans.

--- a/crates/temper-server/src/entity_actor/types.rs
+++ b/crates/temper-server/src/entity_actor/types.rs
@@ -21,7 +21,6 @@ pub enum EntityMsg {
         name: String,
         params: serde_json::Value,
         /// Pre-resolved cross-entity state booleans (injected by dispatch layer).
-        #[allow(dead_code)]
         cross_entity_booleans: BTreeMap<String, bool>,
     },
     /// Get the current entity state.

--- a/crates/temper-server/src/observe/verification.rs
+++ b/crates/temper-server/src/observe/verification.rs
@@ -538,7 +538,9 @@ pub(crate) async fn handle_workflows(State(state): State<ServerState>) -> Json<W
             .design_time_log
             .read()
             .unwrap_or_else(|err| err.into_inner())
-            .clone()
+            .iter()
+            .cloned()
+            .collect()
     });
     let registry = state.registry.read().unwrap(); // ci-ok: infallible lock
 

--- a/crates/temper-server/src/state/dispatch.rs
+++ b/crates/temper-server/src/state/dispatch.rs
@@ -756,7 +756,6 @@ impl ServerState {
         agent_ctx: &AgentContext,
         await_integration: bool,
     ) -> Result<EntityResponse, String> {
-        let action_params = params.clone();
         let Some(actor_ref) = self.get_or_spawn_tenant_actor(tenant, entity_type, entity_id) else {
             // Record a trajectory entry for the "no transition table" failure.
             let entry = TrajectoryEntry {
@@ -795,6 +794,7 @@ impl ServerState {
             .resolve_cross_entity_guards(tenant, entity_type, entity_id, action)
             .await;
 
+        let action_params = params.clone();
         let response = match actor_ref
             .ask::<EntityResponse>(
                 EntityMsg::Action {

--- a/crates/temper-server/src/state/mod.rs
+++ b/crates/temper-server/src/state/mod.rs
@@ -154,7 +154,7 @@ pub struct ServerState {
     /// Broadcast channel for design-time events (spec loading, verification progress).
     pub design_time_tx: Arc<tokio::sync::broadcast::Sender<DesignTimeEvent>>,
     /// In-memory log of design-time events for workflow history (append-only, bounded).
-    pub design_time_log: Arc<RwLock<Vec<DesignTimeEvent>>>,
+    pub design_time_log: Arc<RwLock<std::collections::VecDeque<DesignTimeEvent>>>,
     /// Cache of entity current state, updated on every state change broadcast.
     /// Key: "{tenant}:{entity_type}:{entity_id}", Value: (current_state, last_updated).
     #[allow(clippy::type_complexity)]
@@ -225,7 +225,7 @@ impl ServerState {
             cross_invariant_enforce: env_bool("TEMPER_XINV_ENFORCE", true),
             cross_invariant_eventual_enforce: env_bool("TEMPER_XINV_EVENTUAL_ENFORCE", true),
             design_time_tx: Arc::new(design_time_tx),
-            design_time_log: Arc::new(RwLock::new(Vec::new())),
+            design_time_log: Arc::new(RwLock::new(std::collections::VecDeque::new())),
             entity_state_cache: Arc::new(RwLock::new(BTreeMap::new())),
             action_dispatch_timeout: env_timeout(),
             eventual_tracker: Arc::new(RwLock::new(
@@ -351,7 +351,7 @@ impl ServerState {
             cross_invariant_enforce: env_bool("TEMPER_XINV_ENFORCE", true),
             cross_invariant_eventual_enforce: env_bool("TEMPER_XINV_EVENTUAL_ENFORCE", true),
             design_time_tx: Arc::new(design_time_tx),
-            design_time_log: Arc::new(RwLock::new(Vec::new())),
+            design_time_log: Arc::new(RwLock::new(std::collections::VecDeque::new())),
             entity_state_cache: Arc::new(RwLock::new(BTreeMap::new())),
             action_dispatch_timeout: env_timeout(),
             eventual_tracker: Arc::new(RwLock::new(

--- a/crates/temper-server/src/state/persistence/mod.rs
+++ b/crates/temper-server/src/state/persistence/mod.rs
@@ -360,9 +360,9 @@ impl ServerState {
         if let Ok(mut log) = self.design_time_log.write() {
             if log.len() >= DESIGN_TIME_LOG_CAPACITY {
                 // Keep the newest events; evict oldest one.
-                let _ = log.remove(0);
+                log.pop_front();
             }
-            log.push(event);
+            log.push_back(event);
         }
     }
 }

--- a/crates/temper-server/tests/common/mod.rs
+++ b/crates/temper-server/tests/common/mod.rs
@@ -1,0 +1,96 @@
+//! Shared DST test helpers.
+//!
+//! Provides common builders, fixtures, and dispatch helpers to eliminate
+//! duplicated scaffolding across DST test suites.
+
+use std::sync::Arc;
+
+use temper_runtime::ActorSystem;
+use temper_runtime::tenant::TenantId;
+use temper_server::dispatch::AgentContext;
+use temper_server::registry::SpecRegistry;
+use temper_server::{ServerEventStore, ServerState};
+use temper_spec::csdl::parse_csdl;
+use temper_store_sim::SimEventStore;
+
+// ── Shared fixtures ─────────────────────────────────────────────────────
+
+pub const CSDL_XML: &str = include_str!("../../../../test-fixtures/specs/model.csdl.xml");
+pub const ORDER_IOA: &str = include_str!("../../../../test-fixtures/specs/order.ioa.toml");
+
+// ── State builders ──────────────────────────────────────────────────────
+
+/// Build a `ServerState` with a single tenant (default), Order spec, and
+/// simulated persistence.  Returns the state and the sim store handle for
+/// fault injection.
+pub fn build_default_state(seed: u64, system_name: &str) -> (ServerState, SimEventStore) {
+    build_single_tenant_state(seed, system_name, "default", &[("Order", ORDER_IOA)])
+}
+
+/// Build a `ServerState` for a single tenant with the given entity specs.
+pub fn build_single_tenant_state(
+    seed: u64,
+    system_name: &str,
+    tenant: &str,
+    entities: &[(&str, &str)],
+) -> (ServerState, SimEventStore) {
+    let sim_store = SimEventStore::no_faults(seed);
+    let store = ServerEventStore::Sim(sim_store.clone());
+
+    let mut registry = SpecRegistry::new();
+    let csdl = parse_csdl(CSDL_XML).expect("CSDL parse");
+    registry.register_tenant(tenant, csdl, CSDL_XML.to_string(), entities);
+
+    let system = ActorSystem::new(system_name);
+    let mut state = ServerState::from_registry(system, registry);
+    state.event_store = Some(Arc::new(store));
+    (state, sim_store)
+}
+
+/// Build a `ServerState` with two tenants for isolation tests.
+pub fn build_two_tenant_state(
+    seed: u64,
+    system_name: &str,
+    tenant_a: &str,
+    entities_a: &[(&str, &str)],
+    tenant_b: &str,
+    entities_b: &[(&str, &str)],
+) -> ServerState {
+    let sim_store = SimEventStore::no_faults(seed);
+    let store = ServerEventStore::Sim(sim_store);
+
+    let mut registry = SpecRegistry::new();
+    let csdl_a = parse_csdl(CSDL_XML).expect("CSDL parse");
+    registry.register_tenant(tenant_a, csdl_a, CSDL_XML.to_string(), entities_a);
+
+    let csdl_b = parse_csdl(CSDL_XML).expect("CSDL parse");
+    registry.register_tenant(tenant_b, csdl_b, CSDL_XML.to_string(), entities_b);
+
+    let system = ActorSystem::new(system_name);
+    let mut state = ServerState::from_registry(system, registry);
+    state.event_store = Some(Arc::new(store));
+    state
+}
+
+// ── Dispatch helpers ────────────────────────────────────────────────────
+
+/// Dispatch an action with default agent context and no integration await.
+pub async fn dispatch(
+    state: &ServerState,
+    tenant: &TenantId,
+    entity_type: &str,
+    entity_id: &str,
+    action: &str,
+    params: serde_json::Value,
+) -> Result<temper_server::entity_actor::EntityResponse, String> {
+    state
+        .dispatch_tenant_action(
+            tenant,
+            entity_type,
+            entity_id,
+            action,
+            params,
+            &AgentContext::default(),
+        )
+        .await
+}


### PR DESCRIPTION
## Summary
- Deduplicate `process_action` by delegating to `process_action_with_xref` in effects.rs (~55 lines removed)
- Extract `insert_json_as_cedar` helper in engine.rs to unify Cedar value conversion (also fixes missing i64/array support for context attrs)
- Change `design_time_log` from `Vec` to `VecDeque` for O(1) eviction instead of O(n) `Vec::remove(0)`
- Remove incorrect `#[allow(dead_code)]` on `cross_entity_booleans` field (field is used)
- Defer `action_params` clone in dispatch.rs to avoid wasteful allocation on early-return paths
- Fix `tests/common/mod.rs` import of non-existent `DispatchRequest` type

## Test plan
- [x] `cargo test -p temper-server` — 193 tests pass
- [x] `cargo test -p temper-authz` — 13 tests pass
- [ ] Full workspace CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)