### PR TITLE
feat: project-management OS app + remote MCP --url support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3916,6 +3916,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "project-management"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+ "temper-jit",
+ "temper-runtime",
+ "temper-server",
+ "temper-spec",
+ "temper-store-postgres",
+ "temper-verify",
+ "tokio",
+]
+
+[[package]]
 name = "proptest"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "crates/temper-sandbox",
     "reference-apps/ecommerce",
     "reference-apps/oncall",
+    "os-apps/project-management",
 ]
 
 [workspace.package]

--- a/crates/temper-cli/src/main.rs
+++ b/crates/temper-cli/src/main.rs
@@ -84,9 +84,14 @@ enum Commands {
     },
     /// Start the stdio MCP server for Code Mode
     Mcp {
-        /// Port where Temper HTTP server is running (omit for self-contained mode)
-        #[arg(short, long)]
+        /// Port where Temper HTTP server is running (omit for self-contained mode).
+        /// Mutually exclusive with --url.
+        #[arg(short, long, conflicts_with = "url")]
         port: Option<u16>,
+        /// Full URL of a remote Temper server (e.g. https://temper.railway.app).
+        /// Mutually exclusive with --port.
+        #[arg(long, conflicts_with = "port")]
+        url: Option<String>,
         /// Load an app: --app name=specs-dir (repeatable)
         #[arg(long)]
         app: Vec<String>,
@@ -140,6 +145,7 @@ async fn main() -> anyhow::Result<()> {
         }
         Commands::Mcp {
             port,
+            url,
             app,
             agent_id,
         } => {
@@ -151,7 +157,7 @@ async fn main() -> anyhow::Result<()> {
                     anyhow::bail!("Invalid --app format: '{entry}'. Expected name=specs-dir");
                 }
             }
-            mcp::run(port, apps, agent_id).await?
+            mcp::run(port, url, apps, agent_id).await?
         }
     }
 
@@ -317,8 +323,14 @@ mod tests {
     fn test_cli_parse_mcp_no_port() {
         let cli = Cli::parse_from(["temper", "mcp"]);
         match cli.command {
-            Commands::Mcp { port, agent_id, .. } => {
+            Commands::Mcp {
+                port,
+                url,
+                agent_id,
+                ..
+            } => {
                 assert_eq!(port, None);
+                assert_eq!(url, None);
                 assert_eq!(agent_id, None);
             }
             _ => panic!("expected Mcp command"),
@@ -338,10 +350,12 @@ mod tests {
         match cli.command {
             Commands::Mcp {
                 port,
+                url,
                 app,
                 agent_id,
             } => {
                 assert_eq!(port, Some(3001));
+                assert_eq!(url, None);
                 assert_eq!(app, vec!["haku-ops=apps/haku-ops/specs"]);
                 assert_eq!(agent_id, None);
             }
@@ -364,14 +378,58 @@ mod tests {
         match cli.command {
             Commands::Mcp {
                 port,
+                url,
                 app,
                 agent_id,
             } => {
                 assert_eq!(port, Some(3001));
+                assert_eq!(url, None);
                 assert_eq!(app, vec!["haku-ops=apps/haku-ops/specs"]);
                 assert_eq!(agent_id, Some("haku".to_string()));
             }
             _ => panic!("expected Mcp command"),
         }
+    }
+
+    #[test]
+    fn test_cli_parse_mcp_with_url() {
+        let cli = Cli::parse_from([
+            "temper",
+            "mcp",
+            "--url",
+            "https://temper.railway.app",
+            "--app",
+            "demo=specs/demo",
+        ]);
+        match cli.command {
+            Commands::Mcp {
+                port,
+                url,
+                app,
+                agent_id,
+            } => {
+                assert_eq!(port, None);
+                assert_eq!(url, Some("https://temper.railway.app".to_string()));
+                assert_eq!(app, vec!["demo=specs/demo"]);
+                assert_eq!(agent_id, None);
+            }
+            _ => panic!("expected Mcp command"),
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_mcp_url_and_port_conflict() {
+        let result = Cli::try_parse_from([
+            "temper",
+            "mcp",
+            "--port",
+            "3001",
+            "--url",
+            "https://temper.railway.app",
+        ]);
+        assert!(
+            result.is_err(),
+            "--port and --url should be mutually exclusive"
+        );
     }
 }

--- a/crates/temper-cli/src/mcp/mod.rs
+++ b/crates/temper-cli/src/mcp/mod.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 
 pub async fn run(
     port: Option<u16>,
+    url: Option<String>,
     apps: Vec<(String, String)>,
     agent_id: Option<String>,
 ) -> Result<()> {
@@ -15,6 +16,7 @@ pub async fn run(
 
     temper_mcp::run_stdio_server(temper_mcp::McpConfig {
         temper_port: port,
+        temper_url: url,
         apps,
         principal_id: agent_id.or_else(|| Some("mcp-agent".to_string())),
     })

--- a/crates/temper-cli/src/serve/mod.rs
+++ b/crates/temper-cli/src/serve/mod.rs
@@ -186,10 +186,10 @@ pub async fn run(
             upsert_loaded_specs_to_postgres(pool, tenant, &loaded).await?;
         } else if let Some(ServerEventStore::Turso(ref turso)) = event_store {
             upsert_loaded_specs_to_turso(turso, tenant, &loaded).await?;
-        } else if let Some(ServerEventStore::TenantRouted(ref router)) = event_store {
-            if let Ok(store) = router.store_for_tenant(tenant).await {
-                upsert_loaded_specs_to_turso(&store, tenant, &loaded).await?;
-            }
+        } else if let Some(ServerEventStore::TenantRouted(ref router)) = event_store
+            && let Ok(store) = router.store_for_tenant(tenant).await
+        {
+            upsert_loaded_specs_to_turso(&store, tenant, &loaded).await?;
         }
     }
 

--- a/crates/temper-mcp/src/lib.rs
+++ b/crates/temper-mcp/src/lib.rs
@@ -28,6 +28,9 @@ pub struct AppConfig {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct McpConfig {
     pub temper_port: Option<u16>,
+    /// Full URL of a remote Temper server (e.g. `https://temper.railway.app`).
+    /// Mutually exclusive with `temper_port`.
+    pub temper_url: Option<String>,
     pub apps: Vec<AppConfig>,
     /// Agent principal ID for `X-Temper-Principal-Id` header. When set, all
     /// requests include agent identity headers for Cedar authorization.

--- a/crates/temper-mcp/src/lib_tests.rs
+++ b/crates/temper-mcp/src/lib_tests.rs
@@ -124,6 +124,7 @@ async fn start_test_temper_server() -> (u16, oneshot::Sender<()>) {
 async fn mcp_initialize_handshake() {
     let ctx = RuntimeContext::from_config(&McpConfig {
         temper_port: Some(3001),
+        temper_url: None,
         apps: vec![],
         principal_id: None,
     })
@@ -152,6 +153,7 @@ async fn search_returns_filtered_spec_data() {
     let tmp = write_temp_specs();
     let ctx = RuntimeContext::from_config(&McpConfig {
         temper_port: Some(3001),
+        temper_url: None,
         apps: vec![app("demo", tmp.path())],
         principal_id: None,
     })
@@ -180,6 +182,7 @@ async fn execute_creates_entity_and_reads_it_back() {
     let (port, shutdown) = start_test_temper_server().await;
     let ctx = RuntimeContext::from_config(&McpConfig {
         temper_port: Some(port),
+        temper_url: None,
         apps: vec![app("demo", tmp.path())],
         principal_id: None,
     })
@@ -213,6 +216,7 @@ async fn execute_invalid_action_returns_409_cleanly() {
     let (port, shutdown) = start_test_temper_server().await;
     let ctx = RuntimeContext::from_config(&McpConfig {
         temper_port: Some(port),
+        temper_url: None,
         apps: vec![app("demo", tmp.path())],
         principal_id: None,
     })
@@ -247,6 +251,7 @@ async fn sandbox_blocks_filesystem_access() {
     let tmp = write_temp_specs();
     let ctx = RuntimeContext::from_config(&McpConfig {
         temper_port: Some(3001),
+        temper_url: None,
         apps: vec![app("demo", tmp.path())],
         principal_id: None,
     })
@@ -275,6 +280,7 @@ async fn execute_supports_compound_operation() {
     let (port, shutdown) = start_test_temper_server().await;
     let ctx = RuntimeContext::from_config(&McpConfig {
         temper_port: Some(port),
+        temper_url: None,
         apps: vec![app("demo", tmp.path())],
         principal_id: None,
     })
@@ -308,6 +314,7 @@ async fn search_spec_tenants() {
     let tmp = write_temp_specs();
     let ctx = RuntimeContext::from_config(&McpConfig {
         temper_port: Some(3001),
+        temper_url: None,
         apps: vec![app("demo", tmp.path())],
         principal_id: None,
     })
@@ -330,6 +337,7 @@ async fn search_spec_entities() {
     let tmp = write_temp_specs();
     let ctx = RuntimeContext::from_config(&McpConfig {
         temper_port: Some(3001),
+        temper_url: None,
         apps: vec![app("demo", tmp.path())],
         principal_id: None,
     })
@@ -356,6 +364,7 @@ async fn search_spec_describe() {
     let tmp = write_temp_specs();
     let ctx = RuntimeContext::from_config(&McpConfig {
         temper_port: Some(3001),
+        temper_url: None,
         apps: vec![app("demo", tmp.path())],
         principal_id: None,
     })
@@ -385,6 +394,7 @@ async fn search_spec_actions_from() {
     let tmp = write_temp_specs();
     let ctx = RuntimeContext::from_config(&McpConfig {
         temper_port: Some(3001),
+        temper_url: None,
         apps: vec![app("demo", tmp.path())],
         principal_id: None,
     })
@@ -419,6 +429,7 @@ async fn tool_list_includes_loaded_summary() {
     let tmp = write_temp_specs();
     let ctx = RuntimeContext::from_config(&McpConfig {
         temper_port: Some(3001),
+        temper_url: None,
         apps: vec![app("demo", tmp.path())],
         principal_id: None,
     })
@@ -457,6 +468,7 @@ async fn execute_show_spec_returns_spec_data() {
     let tmp = write_temp_specs();
     let ctx = RuntimeContext::from_config(&McpConfig {
         temper_port: Some(3001),
+        temper_url: None,
         apps: vec![app("demo", tmp.path())],
         principal_id: None,
     })
@@ -490,6 +502,7 @@ async fn e2e_agent_denial_human_approve_retry() {
     // Use agent identity so Cedar authorization applies (default-deny for agents).
     let ctx = RuntimeContext::from_config(&McpConfig {
         temper_port: Some(port),
+        temper_url: None,
         apps: vec![app("demo", tmp.path())],
         principal_id: Some("checkout-bot".to_string()),
     })
@@ -623,6 +636,7 @@ async fn e2e_search_chained_discovery() {
     let tmp = write_temp_specs();
     let ctx = RuntimeContext::from_config(&McpConfig {
         temper_port: Some(3001),
+        temper_url: None,
         apps: vec![app("demo", tmp.path())],
         principal_id: None,
     })
@@ -669,6 +683,7 @@ async fn e2e_show_spec_matches_search_describe() {
     let tmp = write_temp_specs();
     let ctx = RuntimeContext::from_config(&McpConfig {
         temper_port: Some(3001),
+        temper_url: None,
         apps: vec![app("demo", tmp.path())],
         principal_id: None,
     })
@@ -710,6 +725,7 @@ async fn execute_without_server_returns_helpful_error() {
     let tmp = write_temp_specs();
     let ctx = RuntimeContext::from_config(&McpConfig {
         temper_port: None,
+        temper_url: None,
         apps: vec![app("demo", tmp.path())],
         principal_id: None,
     })
@@ -738,6 +754,7 @@ async fn search_works_without_server() {
     let tmp = write_temp_specs();
     let ctx = RuntimeContext::from_config(&McpConfig {
         temper_port: None,
+        temper_url: None,
         apps: vec![app("demo", tmp.path())],
         principal_id: None,
     })
@@ -862,6 +879,7 @@ async fn get_decision_status_returns_decision() {
     // Use agent identity so Cedar authorization applies (default-deny for agents).
     let ctx = RuntimeContext::from_config(&McpConfig {
         temper_port: Some(port),
+        temper_url: None,
         apps: vec![app("demo", tmp.path())],
         principal_id: Some("status-bot".to_string()),
     })

--- a/crates/temper-mcp/src/runtime.rs
+++ b/crates/temper-mcp/src/runtime.rs
@@ -30,6 +30,9 @@ pub(crate) struct RuntimeContext {
     /// Port of the Temper HTTP server. Set at construction when an explicit
     /// port is provided, or later by `start_server` in self-contained mode.
     pub(crate) server_port: Arc<std::sync::OnceLock<u16>>,
+    /// Full URL of a remote Temper server (e.g. `https://temper.railway.app`).
+    /// When set, takes precedence over `server_port` for base URL resolution.
+    pub(crate) server_url: Option<String>,
     /// App configurations (used to build `--app` args when spawning server).
     pub(crate) apps: Vec<crate::AppConfig>,
     /// Path to the temper binary (for spawning `temper serve`).
@@ -45,10 +48,16 @@ impl RuntimeContext {
         if let Some(p) = config.temper_port {
             let _ = server_port.set(p);
         }
+        // Strip trailing slash from URL if present.
+        let server_url = config
+            .temper_url
+            .as_ref()
+            .map(|u| u.trim_end_matches('/').to_string());
         Ok(Self {
             spec,
             app_metadata,
             server_port,
+            server_url,
             apps: config.apps.clone(),
             binary_path: std::env::current_exe().ok(),
             http: reqwest::Client::new(),
@@ -238,6 +247,7 @@ impl RuntimeContext {
     pub(crate) async fn run_execute(&self, code: &str) -> Result<String> {
         let http = self.http.clone();
         let server_port = self.server_port.clone();
+        let server_url = self.server_url.clone();
         let app_metadata = self.app_metadata.clone();
         let principal_id = self.principal_id.clone();
         let binary_path = self.binary_path.clone();
@@ -251,6 +261,7 @@ impl RuntimeContext {
             |function_name: String, args: Vec<MontyObject>, kwargs: Vec<(MontyObject, MontyObject)>| {
                 let http = http.clone();
                 let server_port = server_port.clone();
+                let server_url = server_url.clone();
                 let app_metadata = app_metadata.clone();
                 let principal_id = principal_id.clone();
                 let binary_path = binary_path.clone();
@@ -268,7 +279,7 @@ impl RuntimeContext {
 
                     // Handle MCP-only methods before tenant extraction
                     if function_name == "start_server" {
-                        return handle_start_server(&server_port, &binary_path, &apps).await;
+                        return handle_start_server(&server_port, &server_url, &binary_path, &apps).await;
                     }
                     if function_name == "show_spec" {
                         let tenant = temper_sandbox::helpers::expect_string_arg(args, 0, "tenant", &function_name)?;
@@ -285,12 +296,16 @@ impl RuntimeContext {
                     let tenant = temper_sandbox::helpers::expect_string_arg(args, 0, "tenant", &function_name)?;
                     let remaining = if args.len() > 1 { &args[1..] } else { &[] };
 
-                    let port = server_port.get().ok_or_else(|| {
-                        "Server not running. Call `await temper.start_server()` first, \
-                         or restart MCP with --port to connect to an existing server."
-                            .to_string()
-                    })?;
-                    let base_url = format!("http://127.0.0.1:{port}");
+                    let base_url = if let Some(url) = &server_url {
+                        url.clone()
+                    } else {
+                        let port = server_port.get().ok_or_else(|| {
+                            "Server not running. Call `await temper.start_server()` first, \
+                             or restart MCP with --port/--url to connect to an existing server."
+                                .to_string()
+                        })?;
+                        format!("http://127.0.0.1:{port}")
+                    };
 
                     let metadata = app_metadata.get(&tenant);
                     let resolver = |entity_or_set: &str| -> String {
@@ -331,11 +346,21 @@ impl RuntimeContext {
 /// Handle the `start_server` MCP-only method (spawns `temper serve`).
 async fn handle_start_server(
     server_port: &Arc<std::sync::OnceLock<u16>>,
+    server_url: &Option<String>,
     binary_path: &Option<std::path::PathBuf>,
     apps: &[crate::AppConfig],
 ) -> std::result::Result<Value, String> {
     use std::process::Stdio;
     use tokio::io::AsyncBufReadExt as _;
+
+    // When connected to a remote server via --url, spawning a local server
+    // is not supported — the remote server is already running.
+    if let Some(url) = server_url {
+        return Err(format!(
+            "Cannot start server — already connected to remote server at {url}. \
+             The remote server is managed externally."
+        ));
+    }
 
     if let Some(&port) = server_port.get() {
         let app_names: Vec<String> = apps.iter().map(|a| a.name.clone()).collect();

--- a/os-apps/project-management/Cargo.toml
+++ b/os-apps/project-management/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "project-management"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.92"
+publish = false
+description = "Bundled project management OS app for agent-driven issue tracking"
+
+[dev-dependencies]
+temper-jit = { path = "../../crates/temper-jit" }
+temper-runtime = { path = "../../crates/temper-runtime" }
+temper-server = { path = "../../crates/temper-server" }
+temper-store-postgres = { path = "../../crates/temper-store-postgres" }
+temper-verify = { path = "../../crates/temper-verify" }
+temper-spec = { path = "../../crates/temper-spec" }
+serde_json = { workspace = true }
+tokio = { workspace = true }

--- a/os-apps/project-management/specs/comment.ioa.toml
+++ b/os-apps/project-management/specs/comment.ioa.toml
@@ -1,0 +1,64 @@
+# Comment Entity — I/O Automaton Specification
+#
+# Discussion comment on an issue.
+
+[automaton]
+name = "Comment"
+states = ["Active", "Edited", "Deleted"]
+initial = "Active"
+
+# --- State Variables ---
+
+[[state]]
+name = "edit_count"
+type = "counter"
+initial = "0"
+
+[[state]]
+name = "issue_id"
+type = "string"
+initial = ""
+
+# --- Actions ---
+
+[[action]]
+name = "Create"
+kind = "input"
+from = ["Active"]
+params = ["issue_id", "body", "author_id"]
+hint = "Initialize comment fields when created on an issue."
+
+[[action]]
+name = "Edit"
+kind = "input"
+from = ["Active", "Edited"]
+to = "Edited"
+effect = "increment edit_count"
+params = ["body"]
+hint = "Edit the comment body."
+
+[[action]]
+name = "Delete"
+kind = "input"
+from = ["Active", "Edited"]
+to = "Deleted"
+hint = "Soft-delete the comment. Terminal state."
+
+[[action]]
+name = "React"
+kind = "input"
+from = ["Active", "Edited"]
+params = ["emoji", "reactor_id"]
+hint = "Add a reaction to the comment."
+
+# --- Safety Invariants ---
+
+[[invariant]]
+name = "DeletedIsFinal"
+when = ["Deleted"]
+assert = "no_further_transitions"
+
+[[invariant]]
+name = "EditedHasEdits"
+when = ["Edited"]
+assert = "edit_count > 0"

--- a/os-apps/project-management/specs/cycle.ioa.toml
+++ b/os-apps/project-management/specs/cycle.ioa.toml
@@ -1,0 +1,92 @@
+# Cycle Entity — I/O Automaton Specification
+#
+# Time-boxed sprint within a project.
+
+[automaton]
+name = "Cycle"
+states = ["Planning", "Active", "Completed"]
+initial = "Planning"
+
+# --- State Variables ---
+
+[[state]]
+name = "issue_count"
+type = "counter"
+initial = "0"
+
+[[state]]
+name = "completed_count"
+type = "counter"
+initial = "0"
+
+[[state]]
+name = "project_id"
+type = "string"
+initial = ""
+
+# --- Actions ---
+
+[[action]]
+name = "SetProject"
+kind = "input"
+from = ["Planning"]
+params = ["project_id"]
+hint = "Associate this cycle with a project."
+
+[[action]]
+name = "AddIssueToCycle"
+kind = "input"
+from = ["Planning", "Active"]
+effect = "increment issue_count"
+params = ["IssueId"]
+hint = "Add an issue to this cycle."
+
+[[action]]
+name = "Start"
+kind = "internal"
+from = ["Planning"]
+to = "Active"
+guard = "issue_count > 0"
+hint = "Start the cycle. Requires at least one issue."
+
+[[action]]
+name = "MarkIssueComplete"
+kind = "input"
+from = ["Active"]
+effect = "increment completed_count"
+params = ["IssueId"]
+hint = "Record that an issue within this cycle has been completed."
+
+[[action]]
+name = "Complete"
+kind = "internal"
+from = ["Active"]
+to = "Completed"
+hint = "Complete the cycle. Unfinished issues carry over."
+
+[[action]]
+name = "RemoveIssueFromCycle"
+kind = "input"
+from = ["Planning", "Active"]
+guard = "issue_count > 0"
+params = ["IssueId"]
+hint = "Remove an issue from this cycle."
+
+# --- Safety Invariants ---
+
+[[invariant]]
+name = "CompletedIsFinal"
+when = ["Completed"]
+assert = "no_further_transitions"
+
+[[invariant]]
+name = "ActiveRequiresIssues"
+when = ["Active"]
+assert = "issue_count > 0"
+
+# --- Liveness ---
+
+[[liveness]]
+name = "CycleEventuallyCompletes"
+from = ["Planning"]
+reaches = ["Completed"]

--- a/os-apps/project-management/specs/issue.ioa.toml
+++ b/os-apps/project-management/specs/issue.ioa.toml
@@ -1,0 +1,212 @@
+# Issue Entity — I/O Automaton Specification
+#
+# Core work item for project management. Models issue lifecycle from
+# backlog triage through development, review, completion, and archival.
+
+[automaton]
+name = "Issue"
+states = ["Backlog", "Triage", "Todo", "InProgress", "InReview", "Done", "Cancelled", "Archived"]
+initial = "Backlog"
+
+# --- State Variables ---
+
+[[state]]
+name = "assignee_set"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "priority"
+type = "counter"
+initial = "0"
+
+[[state]]
+name = "label_count"
+type = "counter"
+initial = "0"
+
+[[state]]
+name = "comment_count"
+type = "counter"
+initial = "0"
+
+[[state]]
+name = "review_cycles"
+type = "counter"
+initial = "0"
+
+[[state]]
+name = "has_description"
+type = "bool"
+initial = "false"
+
+# --- Actions: Issue Lifecycle ---
+
+[[action]]
+name = "SetDescription"
+kind = "input"
+from = ["Backlog", "Triage", "Todo", "InProgress", "InReview"]
+effect = "set has_description true"
+params = ["description"]
+hint = "Set or update the issue description. Can be done in any non-terminal state."
+
+[[action]]
+name = "SetPriority"
+kind = "input"
+from = ["Backlog", "Triage", "Todo", "InProgress"]
+effect = "increment priority"
+params = ["level"]
+hint = "Set priority level (1=urgent, 2=high, 3=medium, 4=low). Must be set before moving to Todo."
+
+[[action]]
+name = "AddLabel"
+kind = "input"
+from = ["Backlog", "Triage", "Todo", "InProgress", "InReview"]
+effect = "increment label_count"
+params = ["LabelId"]
+hint = "Attach a label to the issue for categorization."
+
+[[action]]
+name = "Assign"
+kind = "input"
+from = ["Backlog", "Triage", "Todo", "InProgress"]
+effect = "set assignee_set true"
+params = ["AgentId"]
+hint = "Assign an agent or person to the issue. Required before starting work."
+
+[[action]]
+name = "Unassign"
+kind = "input"
+from = ["Backlog", "Triage", "Todo"]
+effect = "set assignee_set false"
+hint = "Remove the current assignee from the issue."
+
+[[action]]
+name = "MoveToTriage"
+kind = "internal"
+from = ["Backlog"]
+to = "Triage"
+hint = "Move issue from backlog into triage for prioritization and scoping."
+
+[[action]]
+name = "MoveToTodo"
+kind = "internal"
+from = ["Triage"]
+to = "Todo"
+guard = "priority > 0"
+hint = "Accept the issue into the todo queue. Requires a priority to be set."
+
+[[action]]
+name = "StartWork"
+kind = "internal"
+from = ["Todo"]
+to = "InProgress"
+guard = "is_true assignee_set"
+hint = "Begin active work on the issue. Requires an assignee."
+
+[[action]]
+name = "SubmitForReview"
+kind = "internal"
+from = ["InProgress"]
+to = "InReview"
+hint = "Submit completed work for code review or verification."
+
+[[action]]
+name = "RequestChanges"
+kind = "input"
+from = ["InReview"]
+to = "InProgress"
+effect = "increment review_cycles"
+params = ["feedback"]
+hint = "Reviewer requests changes. Sends issue back to in-progress with feedback."
+
+[[action]]
+name = "ApproveReview"
+kind = "internal"
+from = ["InReview"]
+to = "Done"
+effect = "increment review_cycles"
+hint = "Reviewer approves the work. Issue moves to done."
+
+[[action]]
+name = "Reopen"
+kind = "input"
+from = ["Done"]
+to = "InProgress"
+hint = "Reopen a completed issue for further work."
+
+[[action]]
+name = "Cancel"
+kind = "input"
+from = ["Backlog", "Triage", "Todo", "InProgress"]
+to = "Cancelled"
+params = ["reason"]
+hint = "Cancel the issue. Can be cancelled from any active state before review completes."
+
+[[action]]
+name = "Archive"
+kind = "internal"
+from = ["Done", "Cancelled"]
+to = "Archived"
+hint = "Archive a completed or cancelled issue. Terminal state."
+
+[[action]]
+name = "AddComment"
+kind = "input"
+from = ["Backlog", "Triage", "Todo", "InProgress", "InReview", "Done"]
+effect = "increment comment_count"
+params = ["CommentId"]
+hint = "Add a comment to the issue."
+
+# --- Output Actions ---
+
+[[action]]
+name = "IssueCompletedEvent"
+kind = "output"
+hint = "Emitted when issue transitions to Done."
+
+[[action]]
+name = "IssueCancelledEvent"
+kind = "output"
+hint = "Emitted when issue is cancelled."
+
+# --- Safety Invariants ---
+
+[[invariant]]
+name = "ArchivedIsFinal"
+when = ["Archived"]
+assert = "no_further_transitions"
+
+[[invariant]]
+name = "InProgressRequiresAssignee"
+when = ["InProgress", "InReview", "Done"]
+assert = "assignee_set"
+
+[[invariant]]
+name = "TodoRequiresPriority"
+when = ["Todo", "InProgress", "InReview", "Done"]
+assert = "priority > 0"
+
+# --- Liveness Properties ---
+
+[[liveness]]
+name = "IssueEventuallyResolved"
+from = ["Backlog"]
+reaches = ["Done", "Cancelled", "Archived"]
+
+# --- Integrations ---
+
+[[integration]]
+name = "notify_assignee"
+trigger = "Assign"
+type = "webhook"
+
+[[integration]]
+name = "notify_review_requested"
+trigger = "SubmitForReview"
+type = "webhook"
+
+[[integration]]
+name = "notify_completed"
+trigger = "ApproveReview"
+type = "webhook"

--- a/os-apps/project-management/specs/label.ioa.toml
+++ b/os-apps/project-management/specs/label.ioa.toml
@@ -1,0 +1,45 @@
+# Label Entity — I/O Automaton Specification
+#
+# Categorization tag for issues.
+
+[automaton]
+name = "Label"
+states = ["Active", "Archived"]
+initial = "Active"
+
+# --- State Variables ---
+
+[[state]]
+name = "usage_count"
+type = "counter"
+initial = "0"
+
+# --- Actions ---
+
+[[action]]
+name = "Create"
+kind = "input"
+from = ["Active"]
+params = ["name", "color", "description"]
+hint = "Initialize label with name, color, and optional description."
+
+[[action]]
+name = "IncrementUsage"
+kind = "input"
+from = ["Active"]
+effect = "increment usage_count"
+hint = "Increment usage count when label is attached to an issue."
+
+[[action]]
+name = "Archive"
+kind = "input"
+from = ["Active"]
+to = "Archived"
+hint = "Archive the label. Terminal state."
+
+# --- Safety Invariants ---
+
+[[invariant]]
+name = "ArchivedIsFinal"
+when = ["Archived"]
+assert = "no_further_transitions"

--- a/os-apps/project-management/specs/model.csdl.xml
+++ b/os-apps/project-management/specs/model.csdl.xml
@@ -1,0 +1,452 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Temper Project Management OS App
+  OData v4 data model for issues, projects, cycles, comments, and labels.
+-->
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+
+    <Schema Namespace="Temper.Vocab" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <Term Name="StateMachine.States" Type="Collection(Edm.String)" AppliesTo="EntityType"/>
+      <Term Name="StateMachine.InitialState" Type="Edm.String" AppliesTo="EntityType"/>
+      <Term Name="StateMachine.ValidFromStates" Type="Collection(Edm.String)" AppliesTo="Action"/>
+      <Term Name="StateMachine.TargetState" Type="Edm.String" AppliesTo="Action"/>
+      <Term Name="Agent.Hint" Type="Edm.String" AppliesTo="Action Function EntityType"/>
+      <Term Name="Agent.CommonPattern" Type="Edm.String" AppliesTo="Action Function"/>
+      <Term Name="ShardKey" Type="Edm.String" AppliesTo="EntityType"/>
+      <Term Name="AuthZ.CedarPolicy" Type="Edm.String" AppliesTo="EntityType Action Function"/>
+    </Schema>
+
+    <Schema Namespace="Temper.ProjectManagement" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+
+      <!-- ============ Enums ============ -->
+
+      <EnumType Name="IssueStatus">
+        <Member Name="Backlog" Value="0"/>
+        <Member Name="Triage" Value="1"/>
+        <Member Name="Todo" Value="2"/>
+        <Member Name="InProgress" Value="3"/>
+        <Member Name="InReview" Value="4"/>
+        <Member Name="Done" Value="5"/>
+        <Member Name="Cancelled" Value="6"/>
+        <Member Name="Archived" Value="7"/>
+      </EnumType>
+
+      <EnumType Name="IssuePriority">
+        <Member Name="Urgent" Value="1"/>
+        <Member Name="High" Value="2"/>
+        <Member Name="Medium" Value="3"/>
+        <Member Name="Low" Value="4"/>
+      </EnumType>
+
+      <EnumType Name="ProjectStatus">
+        <Member Name="Planning" Value="0"/>
+        <Member Name="Active" Value="1"/>
+        <Member Name="Paused" Value="2"/>
+        <Member Name="Completed" Value="3"/>
+        <Member Name="Archived" Value="4"/>
+      </EnumType>
+
+      <EnumType Name="CycleStatus">
+        <Member Name="Planning" Value="0"/>
+        <Member Name="Active" Value="1"/>
+        <Member Name="Completed" Value="2"/>
+      </EnumType>
+
+      <EnumType Name="CommentStatus">
+        <Member Name="Active" Value="0"/>
+        <Member Name="Edited" Value="1"/>
+        <Member Name="Deleted" Value="2"/>
+      </EnumType>
+
+      <EnumType Name="LabelStatus">
+        <Member Name="Active" Value="0"/>
+        <Member Name="Archived" Value="1"/>
+      </EnumType>
+
+      <!-- ============ Entity Types ============ -->
+
+      <EntityType Name="Issue">
+        <Key><PropertyRef Name="Id"/></Key>
+        <Property Name="Id" Type="Edm.Guid" Nullable="false"/>
+        <Property Name="Title" Type="Edm.String" Nullable="false"/>
+        <Property Name="Description" Type="Edm.String"/>
+        <Property Name="Status" Type="Temper.ProjectManagement.IssueStatus" Nullable="false"/>
+        <Property Name="Priority" Type="Temper.ProjectManagement.IssuePriority"/>
+        <Property Name="AssigneeId" Type="Edm.String"/>
+        <Property Name="ProjectId" Type="Edm.Guid"/>
+        <Property Name="CycleId" Type="Edm.Guid"/>
+        <Property Name="ReviewCycles" Type="Edm.Int32" DefaultValue="0"/>
+        <Property Name="CommentCount" Type="Edm.Int32" DefaultValue="0"/>
+        <Property Name="LabelCount" Type="Edm.Int32" DefaultValue="0"/>
+        <Property Name="CreatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="UpdatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="CompletedAt" Type="Edm.DateTimeOffset"/>
+        <Property Name="CancelledAt" Type="Edm.DateTimeOffset"/>
+        <NavigationProperty Name="Project" Type="Temper.ProjectManagement.Project">
+          <ReferentialConstraint Property="ProjectId" ReferencedProperty="Id"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Cycle" Type="Temper.ProjectManagement.Cycle">
+          <ReferentialConstraint Property="CycleId" ReferencedProperty="Id"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Comments" Type="Collection(Temper.ProjectManagement.Comment)"/>
+        <Annotation Term="Temper.Vocab.StateMachine.States">
+          <Collection>
+            <String>Backlog</String><String>Triage</String><String>Todo</String>
+            <String>InProgress</String><String>InReview</String><String>Done</String>
+            <String>Cancelled</String><String>Archived</String>
+          </Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.InitialState" String="Backlog"/>
+        <Annotation Term="Temper.Vocab.ShardKey" String="Id"/>
+        <Annotation Term="Temper.Vocab.AuthZ.CedarPolicy" String="policies/issue.cedar"/>
+      </EntityType>
+
+      <EntityType Name="Project">
+        <Key><PropertyRef Name="Id"/></Key>
+        <Property Name="Id" Type="Edm.Guid" Nullable="false"/>
+        <Property Name="Name" Type="Edm.String" Nullable="false"/>
+        <Property Name="Description" Type="Edm.String"/>
+        <Property Name="Status" Type="Temper.ProjectManagement.ProjectStatus" Nullable="false"/>
+        <Property Name="IssueCount" Type="Edm.Int32" DefaultValue="0"/>
+        <Property Name="CycleCount" Type="Edm.Int32" DefaultValue="0"/>
+        <Property Name="MemberCount" Type="Edm.Int32" DefaultValue="0"/>
+        <Property Name="CreatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="UpdatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="CompletedAt" Type="Edm.DateTimeOffset"/>
+        <NavigationProperty Name="Issues" Type="Collection(Temper.ProjectManagement.Issue)"/>
+        <NavigationProperty Name="Cycles" Type="Collection(Temper.ProjectManagement.Cycle)"/>
+        <Annotation Term="Temper.Vocab.StateMachine.States">
+          <Collection>
+            <String>Planning</String><String>Active</String><String>Paused</String>
+            <String>Completed</String><String>Archived</String>
+          </Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.InitialState" String="Planning"/>
+        <Annotation Term="Temper.Vocab.ShardKey" String="Id"/>
+      </EntityType>
+
+      <EntityType Name="Cycle">
+        <Key><PropertyRef Name="Id"/></Key>
+        <Property Name="Id" Type="Edm.Guid" Nullable="false"/>
+        <Property Name="Name" Type="Edm.String" Nullable="false"/>
+        <Property Name="Status" Type="Temper.ProjectManagement.CycleStatus" Nullable="false"/>
+        <Property Name="ProjectId" Type="Edm.Guid"/>
+        <Property Name="IssueCount" Type="Edm.Int32" DefaultValue="0"/>
+        <Property Name="CompletedCount" Type="Edm.Int32" DefaultValue="0"/>
+        <Property Name="StartDate" Type="Edm.DateTimeOffset"/>
+        <Property Name="EndDate" Type="Edm.DateTimeOffset"/>
+        <Property Name="CreatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <NavigationProperty Name="Project" Type="Temper.ProjectManagement.Project">
+          <ReferentialConstraint Property="ProjectId" ReferencedProperty="Id"/>
+        </NavigationProperty>
+        <Annotation Term="Temper.Vocab.StateMachine.States">
+          <Collection>
+            <String>Planning</String><String>Active</String><String>Completed</String>
+          </Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.InitialState" String="Planning"/>
+        <Annotation Term="Temper.Vocab.ShardKey" String="ProjectId"/>
+      </EntityType>
+
+      <EntityType Name="Comment">
+        <Key><PropertyRef Name="Id"/></Key>
+        <Property Name="Id" Type="Edm.Guid" Nullable="false"/>
+        <Property Name="IssueId" Type="Edm.Guid" Nullable="false"/>
+        <Property Name="AuthorId" Type="Edm.String" Nullable="false"/>
+        <Property Name="Body" Type="Edm.String" Nullable="false"/>
+        <Property Name="Status" Type="Temper.ProjectManagement.CommentStatus" Nullable="false"/>
+        <Property Name="EditCount" Type="Edm.Int32" DefaultValue="0"/>
+        <Property Name="CreatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="UpdatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <NavigationProperty Name="Issue" Type="Temper.ProjectManagement.Issue" Nullable="false">
+          <ReferentialConstraint Property="IssueId" ReferencedProperty="Id"/>
+        </NavigationProperty>
+        <Annotation Term="Temper.Vocab.StateMachine.States">
+          <Collection>
+            <String>Active</String><String>Edited</String><String>Deleted</String>
+          </Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.InitialState" String="Active"/>
+      </EntityType>
+
+      <EntityType Name="Label">
+        <Key><PropertyRef Name="Id"/></Key>
+        <Property Name="Id" Type="Edm.Guid" Nullable="false"/>
+        <Property Name="Name" Type="Edm.String" Nullable="false"/>
+        <Property Name="Color" Type="Edm.String"/>
+        <Property Name="Description" Type="Edm.String"/>
+        <Property Name="Status" Type="Temper.ProjectManagement.LabelStatus" Nullable="false"/>
+        <Property Name="UsageCount" Type="Edm.Int32" DefaultValue="0"/>
+        <Property Name="CreatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Annotation Term="Temper.Vocab.StateMachine.States">
+          <Collection><String>Active</String><String>Archived</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.InitialState" String="Active"/>
+      </EntityType>
+
+      <!-- ============ Bound Actions ============ -->
+
+      <!-- Issue Actions -->
+      <Action Name="SetDescription" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
+        <Parameter Name="description" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Temper.ProjectManagement.Issue"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String><String>InProgress</String><String>InReview</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.Agent.Hint" String="Set or update the issue description."/>
+      </Action>
+
+      <Action Name="SetPriority" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
+        <Parameter Name="level" Type="Edm.Int32" Nullable="false"/>
+        <ReturnType Type="Temper.ProjectManagement.Issue"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String><String>InProgress</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.Agent.Hint" String="Set priority (1=urgent, 2=high, 3=medium, 4=low). Required before MoveToTodo."/>
+      </Action>
+
+      <Action Name="Assign" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
+        <Parameter Name="AgentId" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Temper.ProjectManagement.Issue"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String><String>InProgress</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.Agent.Hint" String="Assign an agent to this issue. Required before StartWork."/>
+      </Action>
+
+      <Action Name="Unassign" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
+        <ReturnType Type="Temper.ProjectManagement.Issue"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String></Collection>
+        </Annotation>
+      </Action>
+
+      <Action Name="MoveToTriage" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
+        <ReturnType Type="Temper.ProjectManagement.Issue"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Backlog</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Triage"/>
+        <Annotation Term="Temper.Vocab.Agent.Hint" String="Move issue to triage for prioritization."/>
+      </Action>
+
+      <Action Name="MoveToTodo" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
+        <ReturnType Type="Temper.ProjectManagement.Issue"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Triage</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Todo"/>
+        <Annotation Term="Temper.Vocab.Agent.Hint" String="Accept issue into todo. Requires priority to be set first."/>
+      </Action>
+
+      <Action Name="StartWork" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
+        <ReturnType Type="Temper.ProjectManagement.Issue"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Todo</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="InProgress"/>
+        <Annotation Term="Temper.Vocab.Agent.Hint" String="Start working on the issue. Must have an assignee."/>
+        <Annotation Term="Temper.Vocab.Agent.CommonPattern" String="1. Assign agent. 2. SetPriority. 3. MoveToTriage. 4. MoveToTodo. 5. StartWork."/>
+      </Action>
+
+      <Action Name="SubmitForReview" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
+        <ReturnType Type="Temper.ProjectManagement.Issue"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>InProgress</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="InReview"/>
+      </Action>
+
+      <Action Name="RequestChanges" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
+        <Parameter Name="feedback" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Temper.ProjectManagement.Issue"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>InReview</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="InProgress"/>
+      </Action>
+
+      <Action Name="ApproveReview" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
+        <ReturnType Type="Temper.ProjectManagement.Issue"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>InReview</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Done"/>
+      </Action>
+
+      <Action Name="Reopen" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
+        <ReturnType Type="Temper.ProjectManagement.Issue"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Done</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="InProgress"/>
+      </Action>
+
+      <Action Name="Cancel" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
+        <Parameter Name="reason" Type="Edm.String"/>
+        <ReturnType Type="Temper.ProjectManagement.Issue"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String><String>InProgress</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Cancelled"/>
+      </Action>
+
+      <Action Name="Archive" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
+        <ReturnType Type="Temper.ProjectManagement.Issue"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Done</String><String>Cancelled</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Archived"/>
+      </Action>
+
+      <Action Name="AddComment" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
+        <Parameter Name="CommentId" Type="Edm.Guid" Nullable="false"/>
+        <ReturnType Type="Temper.ProjectManagement.Issue"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String><String>InProgress</String><String>InReview</String><String>Done</String></Collection>
+        </Annotation>
+      </Action>
+
+      <Action Name="AddLabel" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
+        <Parameter Name="LabelId" Type="Edm.Guid" Nullable="false"/>
+        <ReturnType Type="Temper.ProjectManagement.Issue"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String><String>InProgress</String><String>InReview</String></Collection>
+        </Annotation>
+      </Action>
+
+      <!-- Project Actions -->
+      <Action Name="ProjectSetDescription" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Project"/>
+        <Parameter Name="description" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Temper.ProjectManagement.Project"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Planning</String><String>Active</String><String>Paused</String></Collection>
+        </Annotation>
+      </Action>
+
+      <Action Name="ProjectActivate" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Project"/>
+        <ReturnType Type="Temper.ProjectManagement.Project"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Planning</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Active"/>
+      </Action>
+
+      <Action Name="ProjectAddIssue" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Project"/>
+        <Parameter Name="IssueId" Type="Edm.Guid" Nullable="false"/>
+        <ReturnType Type="Temper.ProjectManagement.Project"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Active</String></Collection>
+        </Annotation>
+      </Action>
+
+      <Action Name="ProjectComplete" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Project"/>
+        <ReturnType Type="Temper.ProjectManagement.Project"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Active</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Completed"/>
+      </Action>
+
+      <Action Name="ProjectArchive" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Project"/>
+        <ReturnType Type="Temper.ProjectManagement.Project"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Completed</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Archived"/>
+      </Action>
+
+      <!-- Cycle Actions -->
+      <Action Name="CycleStart" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Cycle"/>
+        <ReturnType Type="Temper.ProjectManagement.Cycle"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Planning</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Active"/>
+      </Action>
+
+      <Action Name="CycleComplete" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Cycle"/>
+        <ReturnType Type="Temper.ProjectManagement.Cycle"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Active</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Completed"/>
+      </Action>
+
+      <!-- Comment Actions -->
+      <Action Name="CommentEdit" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Comment"/>
+        <Parameter Name="body" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Temper.ProjectManagement.Comment"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Active</String><String>Edited</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Edited"/>
+      </Action>
+
+      <Action Name="CommentDelete" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Comment"/>
+        <ReturnType Type="Temper.ProjectManagement.Comment"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Active</String><String>Edited</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Deleted"/>
+      </Action>
+
+      <!-- Label Actions -->
+      <Action Name="LabelArchive" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Label"/>
+        <ReturnType Type="Temper.ProjectManagement.Label"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Active</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Archived"/>
+      </Action>
+
+      <!-- ============ Entity Container ============ -->
+
+      <EntityContainer Name="ProjectManagementService">
+        <EntitySet Name="Issues" EntityType="Temper.ProjectManagement.Issue">
+          <NavigationPropertyBinding Path="Project" Target="Projects"/>
+          <NavigationPropertyBinding Path="Cycle" Target="Cycles"/>
+          <NavigationPropertyBinding Path="Comments" Target="Comments"/>
+        </EntitySet>
+        <EntitySet Name="Projects" EntityType="Temper.ProjectManagement.Project">
+          <NavigationPropertyBinding Path="Issues" Target="Issues"/>
+          <NavigationPropertyBinding Path="Cycles" Target="Cycles"/>
+        </EntitySet>
+        <EntitySet Name="Cycles" EntityType="Temper.ProjectManagement.Cycle">
+          <NavigationPropertyBinding Path="Project" Target="Projects"/>
+        </EntitySet>
+        <EntitySet Name="Comments" EntityType="Temper.ProjectManagement.Comment">
+          <NavigationPropertyBinding Path="Issue" Target="Issues"/>
+        </EntitySet>
+        <EntitySet Name="Labels" EntityType="Temper.ProjectManagement.Label"/>
+      </EntityContainer>
+
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/os-apps/project-management/specs/policies/issue.cedar
+++ b/os-apps/project-management/specs/policies/issue.cedar
@@ -1,0 +1,20 @@
+// Project Management — Issue Cedar Policies
+//
+// Default-deny posture. Policies are generated from human approval decisions.
+// This file provides initial bootstrap policies for common operations.
+
+// Allow any agent to create and read issues
+permit(
+  principal,
+  action in [Action::"create", Action::"read", Action::"list"],
+  resource is Issue
+);
+
+// Allow assignee to take work actions on their issues
+permit(
+  principal,
+  action in [Action::"StartWork", Action::"SubmitForReview"],
+  resource is Issue
+) when {
+  resource.AssigneeId == principal.id
+};

--- a/os-apps/project-management/specs/project.ioa.toml
+++ b/os-apps/project-management/specs/project.ioa.toml
@@ -1,0 +1,129 @@
+# Project Entity — I/O Automaton Specification
+#
+# Groups issues into a logical project with lifecycle tracking.
+
+[automaton]
+name = "Project"
+states = ["Planning", "Active", "Paused", "Completed", "Archived"]
+initial = "Planning"
+
+# --- State Variables ---
+
+[[state]]
+name = "issue_count"
+type = "counter"
+initial = "0"
+
+[[state]]
+name = "has_description"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "cycle_count"
+type = "counter"
+initial = "0"
+
+[[state]]
+name = "member_count"
+type = "counter"
+initial = "0"
+
+# --- Actions ---
+
+[[action]]
+name = "SetDescription"
+kind = "input"
+from = ["Planning", "Active", "Paused"]
+effect = "set has_description true"
+params = ["description"]
+hint = "Set or update the project description and goal."
+
+[[action]]
+name = "Activate"
+kind = "internal"
+from = ["Planning"]
+to = "Active"
+guard = "is_true has_description"
+hint = "Activate the project for work. Requires a description."
+
+[[action]]
+name = "AddIssue"
+kind = "input"
+from = ["Active"]
+effect = "increment issue_count"
+params = ["IssueId"]
+hint = "Associate an issue with this project."
+
+[[action]]
+name = "AddCycle"
+kind = "input"
+from = ["Active"]
+effect = "increment cycle_count"
+params = ["CycleId"]
+hint = "Create a new cycle (sprint) within this project."
+
+[[action]]
+name = "AddMember"
+kind = "input"
+from = ["Active", "Planning"]
+effect = "increment member_count"
+params = ["AgentId"]
+hint = "Add a team member to the project."
+
+[[action]]
+name = "Pause"
+kind = "input"
+from = ["Active"]
+to = "Paused"
+hint = "Pause the project."
+
+[[action]]
+name = "Resume"
+kind = "input"
+from = ["Paused"]
+to = "Active"
+hint = "Resume a paused project."
+
+[[action]]
+name = "Complete"
+kind = "internal"
+from = ["Active"]
+to = "Completed"
+guard = "issue_count > 0"
+hint = "Mark the project as completed. Requires at least one issue."
+
+[[action]]
+name = "Archive"
+kind = "internal"
+from = ["Completed"]
+to = "Archived"
+hint = "Archive a completed project. Terminal state."
+
+# --- Output Actions ---
+
+[[action]]
+name = "ProjectCompletedEvent"
+kind = "output"
+hint = "Emitted when project transitions to Completed."
+
+# --- Safety Invariants ---
+
+[[invariant]]
+name = "ArchivedIsFinal"
+when = ["Archived"]
+assert = "no_further_transitions"
+
+[[invariant]]
+name = "CompletedRequiresIssues"
+when = ["Completed", "Archived"]
+assert = "issue_count > 0"
+
+[[invariant]]
+name = "ActiveRequiresDescription"
+when = ["Active", "Paused", "Completed", "Archived"]
+assert = "has_description"
+
+# --- Liveness ---
+# No liveness property — projects can validly stay in Planning or Active
+# indefinitely. Completion is goal-driven, not guaranteed.

--- a/os-apps/project-management/src/lib.rs
+++ b/os-apps/project-management/src/lib.rs
@@ -1,0 +1,23 @@
+//! Project management OS app for the Temper platform.
+//!
+//! Bundled OS app for agents to track engineering work: issues, projects,
+//! cycles, comments, and labels. Distinct from platform Plan/Task entities
+//! which track agent execution — this tracks product/engineering work items.
+
+/// Issue entity IOA specification.
+pub const ISSUE_IOA: &str = include_str!("../specs/issue.ioa.toml");
+
+/// Project entity IOA specification.
+pub const PROJECT_IOA: &str = include_str!("../specs/project.ioa.toml");
+
+/// Cycle entity IOA specification.
+pub const CYCLE_IOA: &str = include_str!("../specs/cycle.ioa.toml");
+
+/// Comment entity IOA specification.
+pub const COMMENT_IOA: &str = include_str!("../specs/comment.ioa.toml");
+
+/// Label entity IOA specification.
+pub const LABEL_IOA: &str = include_str!("../specs/label.ioa.toml");
+
+/// CSDL data model.
+pub const MODEL_CSDL: &str = include_str!("../specs/model.csdl.xml");


### PR DESCRIPTION
## Summary

- **Project Management OS App**: Added `os-apps/project-management/` with 5 IOA entity specs (Issue, Project, Cycle, Comment, Label), OData CSDL data model, and Cedar authorization policies. All specs pass L0-L3 verification cascade.
- **Remote MCP `--url` flag**: Added `--url` option to `temper mcp` so it can connect to remote Temper servers (e.g., Railway deployments) instead of only localhost. Mutually exclusive with `--port`.
- **Clippy fix**: Collapsed nested `if let` in serve module.

## Test plan
- [x] `cargo check -p project-management` compiles
- [x] All 5 specs pass `temper verify` (L0-L3 cascade)
- [x] CLI arg parsing tests for `--url` and `--url`/`--port` conflict
- [ ] Manual test: `temper mcp --url https://remote-server` connects to remote

🤖 Generated with [Claude Code](https://claude.com/claude-code)