### PR TITLE
feat(pm): add Planning/Planned phase with role separation

### DIFF
--- a/os-apps/project-management/issue.ioa.toml
+++ b/os-apps/project-management/issue.ioa.toml
@@ -1,22 +1,31 @@
 # Issue Entity — I/O Automaton Specification
 #
 # Core work item for project management. Models issue lifecycle from
-# backlog triage through development, review, completion, and archival.
+# backlog triage through planning, execution, review, and archival.
 #
-# Designed for multi-agent coordination: CC agents, Codex agents, and human
-# operators share this board. Agent identity (AssigneeId + AgentType + SessionId)
-# tracks who is doing the work. Implementation fields (repo, branch, worktree,
-# PR URL) track where the work is happening.
+# Key design: Planning and execution are separated. One agent drafts the plan,
+# a supervisor approves it, and a (potentially different) agent executes it.
+# Cedar policies enforce role separation between planners, approvers, and implementers.
 
 [automaton]
 name = "Issue"
-states = ["Backlog", "Triage", "Todo", "InProgress", "InReview", "Done", "Cancelled", "Archived"]
+states = ["Backlog", "Triage", "Todo", "Planning", "Planned", "InProgress", "InReview", "Done", "Cancelled", "Archived"]
 initial = "Backlog"
 
 # --- State Variables ---
 
 [[state]]
 name = "assignee_set"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "planner_set"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "has_plan"
 type = "bool"
 initial = "false"
 
@@ -41,12 +50,12 @@ type = "counter"
 initial = "0"
 
 [[state]]
-name = "has_description"
-type = "bool"
-initial = "false"
+name = "plan_revision_count"
+type = "counter"
+initial = "0"
 
 [[state]]
-name = "has_branch"
+name = "has_description"
 type = "bool"
 initial = "false"
 
@@ -55,15 +64,15 @@ initial = "false"
 [[action]]
 name = "SetDescription"
 kind = "input"
-from = ["Backlog", "Triage", "Todo", "InProgress", "InReview"]
+from = ["Backlog", "Triage", "Todo", "Planning", "InProgress", "InReview"]
 effect = "set has_description true"
 params = ["description"]
-hint = "Set or update the issue description. Can be done in any non-terminal state."
+hint = "Set or update the issue description."
 
 [[action]]
 name = "SetPriority"
 kind = "input"
-from = ["Backlog", "Triage", "Todo", "InProgress"]
+from = ["Backlog", "Triage", "Todo", "Planning", "InProgress"]
 effect = "increment priority"
 params = ["level"]
 hint = "Set priority level (1=urgent, 2=high, 3=medium, 4=low). Must be set before moving to Todo."
@@ -71,7 +80,7 @@ hint = "Set priority level (1=urgent, 2=high, 3=medium, 4=low). Must be set befo
 [[action]]
 name = "AddLabel"
 kind = "input"
-from = ["Backlog", "Triage", "Todo", "InProgress", "InReview"]
+from = ["Backlog", "Triage", "Todo", "Planning", "InProgress", "InReview"]
 effect = "increment label_count"
 params = ["LabelId"]
 hint = "Attach a label to the issue for categorization."
@@ -79,10 +88,18 @@ hint = "Attach a label to the issue for categorization."
 [[action]]
 name = "Assign"
 kind = "input"
-from = ["Backlog", "Triage", "Todo", "InProgress"]
+from = ["Backlog", "Triage", "Todo", "Planning", "Planned", "InProgress"]
 effect = "set assignee_set true"
-params = ["AgentId", "AgentType", "SessionId"]
-hint = "Assign an agent to the issue. AgentType: claude-code, codex, haku, human. SessionId: the agent session identifier (e.g. cc-prop-048, codex-tmux-3). Required before starting work."
+params = ["AgentId"]
+hint = "Assign an implementer agent. Can be different from the planner."
+
+[[action]]
+name = "AssignPlanner"
+kind = "input"
+from = ["Backlog", "Triage", "Todo"]
+effect = "set planner_set true"
+params = ["AgentId"]
+hint = "Assign a planner agent to draft the implementation plan."
 
 [[action]]
 name = "Unassign"
@@ -106,30 +123,75 @@ to = "Todo"
 guard = "priority > 0"
 hint = "Accept the issue into the todo queue. Requires a priority to be set."
 
+# --- Planning Phase ---
+
+[[action]]
+name = "BeginPlanning"
+kind = "internal"
+from = ["Todo"]
+to = "Planning"
+guard = "is_true planner_set"
+hint = "Start planning phase. A planner agent drafts the approach."
+
+[[action]]
+name = "WritePlan"
+kind = "input"
+from = ["Planning"]
+effect = "set has_plan true"
+params = ["plan", "acceptance_criteria"]
+hint = "Draft or update the implementation plan. What to do, how, and what done looks like."
+
+[[action]]
+name = "RevisePlan"
+kind = "input"
+from = ["Planning"]
+effect = "increment plan_revision_count"
+params = ["feedback"]
+hint = "Request plan revision with feedback. Planner updates the plan."
+
+[[action]]
+name = "ApprovePlan"
+kind = "internal"
+from = ["Planning"]
+to = "Planned"
+guard = "is_true has_plan"
+hint = "Approve the plan. Only supervisors/humans. Requires a plan to exist."
+
+[[action]]
+name = "RejectPlan"
+kind = "input"
+from = ["Planned"]
+to = "Planning"
+effect = "increment plan_revision_count"
+params = ["reason"]
+hint = "Reject an approved plan and send it back for revision."
+
+# --- Execution Phase ---
+
 [[action]]
 name = "StartWork"
-kind = "input"
-from = ["Todo"]
+kind = "internal"
+from = ["Planned"]
 to = "InProgress"
 guard = "is_true assignee_set"
-effect = "set has_branch true"
 params = ["repo", "branch_name", "worktree_path"]
-hint = "Begin active work. Agent provides repo (e.g. rita-aga/deep-sci-fi), branch name, and worktree path. Requires an assignee."
+hint = "Begin implementation. Requires an assignee and an approved plan."
 
 [[action]]
 name = "UpdateImplementation"
 kind = "input"
 from = ["InProgress", "InReview"]
-params = ["implementation_notes"]
-hint = "Agent drops context about what it changed, what it found, or what is blocked. Append-style — each call adds to the record."
+effect = "increment comment_count"
+params = ["notes"]
+hint = "Agent drops implementation context -- progress notes, blockers, findings."
 
 [[action]]
 name = "SubmitForReview"
-kind = "input"
+kind = "internal"
 from = ["InProgress"]
 to = "InReview"
 params = ["pr_url"]
-hint = "Submit completed work for review. Agent provides the PR URL."
+hint = "Submit completed work for code review or verification."
 
 [[action]]
 name = "RequestChanges"
@@ -138,7 +200,7 @@ from = ["InReview"]
 to = "InProgress"
 effect = "increment review_cycles"
 params = ["feedback"]
-hint = "Reviewer requests changes. Sends issue back to in-progress with feedback."
+hint = "Reviewer requests changes. Sends issue back to in-progress."
 
 [[action]]
 name = "ApproveReview"
@@ -158,10 +220,10 @@ hint = "Reopen a completed issue for further work."
 [[action]]
 name = "Cancel"
 kind = "input"
-from = ["Backlog", "Triage", "Todo", "InProgress"]
+from = ["Backlog", "Triage", "Todo", "Planning", "Planned", "InProgress"]
 to = "Cancelled"
 params = ["reason"]
-hint = "Cancel the issue. Can be cancelled from any active state before review completes."
+hint = "Cancel the issue from any active state before review completes."
 
 [[action]]
 name = "Archive"
@@ -173,12 +235,22 @@ hint = "Archive a completed or cancelled issue. Terminal state."
 [[action]]
 name = "AddComment"
 kind = "input"
-from = ["Backlog", "Triage", "Todo", "InProgress", "InReview", "Done"]
+from = ["Backlog", "Triage", "Todo", "Planning", "Planned", "InProgress", "InReview", "Done"]
 effect = "increment comment_count"
 params = ["CommentId"]
 hint = "Add a comment to the issue."
 
 # --- Output Actions ---
+
+[[action]]
+name = "PlanReadyEvent"
+kind = "output"
+hint = "Emitted when a plan is written and ready for approval."
+
+[[action]]
+name = "PlanApprovedEvent"
+kind = "output"
+hint = "Emitted when a plan is approved. Implementation can begin."
 
 [[action]]
 name = "IssueCompletedEvent"
@@ -204,13 +276,18 @@ assert = "assignee_set"
 
 [[invariant]]
 name = "TodoRequiresPriority"
-when = ["Todo", "InProgress", "InReview", "Done"]
+when = ["Todo", "Planning", "Planned", "InProgress", "InReview", "Done"]
 assert = "priority > 0"
 
 [[invariant]]
-name = "InProgressRequiresBranch"
-when = ["InProgress", "InReview", "Done"]
-assert = "has_branch"
+name = "PlanningRequiresPlanner"
+when = ["Planning", "Planned"]
+assert = "planner_set"
+
+[[invariant]]
+name = "PlannedRequiresPlan"
+when = ["Planned", "InProgress", "InReview", "Done"]
+assert = "has_plan"
 
 # --- Liveness Properties ---
 
@@ -220,6 +297,21 @@ from = ["Backlog"]
 reaches = ["Done", "Cancelled", "Archived"]
 
 # --- Integrations ---
+
+[[integration]]
+name = "notify_planner_assigned"
+trigger = "AssignPlanner"
+type = "webhook"
+
+[[integration]]
+name = "notify_plan_ready"
+trigger = "WritePlan"
+type = "webhook"
+
+[[integration]]
+name = "notify_plan_approved"
+trigger = "ApprovePlan"
+type = "webhook"
 
 [[integration]]
 name = "notify_assignee"

--- a/os-apps/project-management/model.csdl.xml
+++ b/os-apps/project-management/model.csdl.xml
@@ -3,9 +3,7 @@
   Temper Project Management OS App
   OData v4 data model for issues, projects, cycles, comments, and labels.
   
-  Extended for multi-agent coordination: implementation tracking fields
-  (repo, branch, worktree, PR) and agent identity (type, session) on
-  Issue and Comment entities.
+  Planning phase: One agent plans, a supervisor approves, another agent implements.
 -->
 <edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
   <edmx:DataServices>
@@ -29,11 +27,13 @@
         <Member Name="Backlog" Value="0"/>
         <Member Name="Triage" Value="1"/>
         <Member Name="Todo" Value="2"/>
-        <Member Name="InProgress" Value="3"/>
-        <Member Name="InReview" Value="4"/>
-        <Member Name="Done" Value="5"/>
-        <Member Name="Cancelled" Value="6"/>
-        <Member Name="Archived" Value="7"/>
+        <Member Name="Planning" Value="3"/>
+        <Member Name="Planned" Value="4"/>
+        <Member Name="InProgress" Value="5"/>
+        <Member Name="InReview" Value="6"/>
+        <Member Name="Done" Value="7"/>
+        <Member Name="Cancelled" Value="8"/>
+        <Member Name="Archived" Value="9"/>
       </EnumType>
 
       <EnumType Name="IssuePriority">
@@ -41,6 +41,14 @@
         <Member Name="High" Value="2"/>
         <Member Name="Medium" Value="3"/>
         <Member Name="Low" Value="4"/>
+      </EnumType>
+
+      <EnumType Name="AgentType">
+        <Member Name="Human" Value="0"/>
+        <Member Name="Planner" Value="1"/>
+        <Member Name="Implementer" Value="2"/>
+        <Member Name="Reviewer" Value="3"/>
+        <Member Name="Supervisor" Value="4"/>
       </EnumType>
 
       <EnumType Name="ProjectStatus">
@@ -77,29 +85,28 @@
         <Property Name="Description" Type="Edm.String"/>
         <Property Name="Status" Type="Temper.ProjectManagement.IssueStatus" Nullable="false"/>
         <Property Name="Priority" Type="Temper.ProjectManagement.IssuePriority"/>
-        <!-- Agent identity -->
         <Property Name="AssigneeId" Type="Edm.String"/>
-        <Property Name="AgentType" Type="Edm.String"/>
+        <Property Name="AgentType" Type="Temper.ProjectManagement.AgentType"/>
+        <Property Name="PlannerId" Type="Edm.String"/>
+        <Property Name="Plan" Type="Edm.String"/>
+        <Property Name="AcceptanceCriteria" Type="Edm.String"/>
+        <Property Name="PlanRevisionCount" Type="Edm.Int32" DefaultValue="0"/>
         <Property Name="SessionId" Type="Edm.String"/>
-        <!-- Project/cycle association -->
-        <Property Name="ProjectId" Type="Edm.Guid"/>
-        <Property Name="CycleId" Type="Edm.Guid"/>
-        <!-- Implementation tracking -->
         <Property Name="Repo" Type="Edm.String"/>
         <Property Name="BranchName" Type="Edm.String"/>
         <Property Name="WorktreePath" Type="Edm.String"/>
         <Property Name="PrUrl" Type="Edm.String"/>
         <Property Name="ImplementationNotes" Type="Edm.String"/>
-        <!-- Counters -->
+        <Property Name="ProjectId" Type="Edm.Guid"/>
+        <Property Name="CycleId" Type="Edm.Guid"/>
         <Property Name="ReviewCycles" Type="Edm.Int32" DefaultValue="0"/>
         <Property Name="CommentCount" Type="Edm.Int32" DefaultValue="0"/>
         <Property Name="LabelCount" Type="Edm.Int32" DefaultValue="0"/>
-        <!-- Timestamps -->
         <Property Name="CreatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
         <Property Name="UpdatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="PlannedAt" Type="Edm.DateTimeOffset"/>
         <Property Name="CompletedAt" Type="Edm.DateTimeOffset"/>
         <Property Name="CancelledAt" Type="Edm.DateTimeOffset"/>
-        <!-- Navigation -->
         <NavigationProperty Name="Project" Type="Temper.ProjectManagement.Project">
           <ReferentialConstraint Property="ProjectId" ReferencedProperty="Id"/>
         </NavigationProperty>
@@ -107,10 +114,10 @@
           <ReferentialConstraint Property="CycleId" ReferencedProperty="Id"/>
         </NavigationProperty>
         <NavigationProperty Name="Comments" Type="Collection(Temper.ProjectManagement.Comment)"/>
-        <!-- Annotations -->
         <Annotation Term="Temper.Vocab.StateMachine.States">
           <Collection>
             <String>Backlog</String><String>Triage</String><String>Todo</String>
+            <String>Planning</String><String>Planned</String>
             <String>InProgress</String><String>InReview</String><String>Done</String>
             <String>Cancelled</String><String>Archived</String>
           </Collection>
@@ -118,6 +125,7 @@
         <Annotation Term="Temper.Vocab.StateMachine.InitialState" String="Backlog"/>
         <Annotation Term="Temper.Vocab.ShardKey" String="Id"/>
         <Annotation Term="Temper.Vocab.AuthZ.CedarPolicy" String="policies/issue.cedar"/>
+        <Annotation Term="Temper.Vocab.Agent.Hint" String="Work item with plan-then-execute lifecycle. Planner drafts approach, supervisor approves, implementer executes."/>
       </EntityType>
 
       <EntityType Name="Project">
@@ -172,8 +180,6 @@
         <Property Name="Id" Type="Edm.Guid" Nullable="false"/>
         <Property Name="IssueId" Type="Edm.Guid" Nullable="false"/>
         <Property Name="AuthorId" Type="Edm.String" Nullable="false"/>
-        <Property Name="AgentType" Type="Edm.String"/>
-        <Property Name="SessionId" Type="Edm.String"/>
         <Property Name="Body" Type="Edm.String" Nullable="false"/>
         <Property Name="Status" Type="Temper.ProjectManagement.CommentStatus" Nullable="false"/>
         <Property Name="EditCount" Type="Edm.Int32" DefaultValue="0"/>
@@ -213,9 +219,8 @@
         <Parameter Name="description" Type="Edm.String" Nullable="false"/>
         <ReturnType Type="Temper.ProjectManagement.Issue"/>
         <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
-          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String><String>InProgress</String><String>InReview</String></Collection>
+          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String><String>Planning</String><String>InProgress</String><String>InReview</String></Collection>
         </Annotation>
-        <Annotation Term="Temper.Vocab.Agent.Hint" String="Set or update the issue description."/>
       </Action>
 
       <Action Name="SetPriority" IsBound="true">
@@ -223,21 +228,28 @@
         <Parameter Name="level" Type="Edm.Int32" Nullable="false"/>
         <ReturnType Type="Temper.ProjectManagement.Issue"/>
         <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
-          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String><String>InProgress</String></Collection>
+          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String><String>Planning</String><String>InProgress</String></Collection>
         </Annotation>
-        <Annotation Term="Temper.Vocab.Agent.Hint" String="Set priority (1=urgent, 2=high, 3=medium, 4=low). Required before MoveToTodo."/>
       </Action>
 
       <Action Name="Assign" IsBound="true">
         <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
         <Parameter Name="AgentId" Type="Edm.String" Nullable="false"/>
-        <Parameter Name="AgentType" Type="Edm.String" Nullable="false"/>
-        <Parameter Name="SessionId" Type="Edm.String"/>
         <ReturnType Type="Temper.ProjectManagement.Issue"/>
         <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
-          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String><String>InProgress</String></Collection>
+          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String><String>Planning</String><String>Planned</String><String>InProgress</String></Collection>
         </Annotation>
-        <Annotation Term="Temper.Vocab.Agent.Hint" String="Assign an agent. AgentType: claude-code, codex, haku, human. SessionId: agent session trace."/>
+        <Annotation Term="Temper.Vocab.Agent.Hint" String="Assign an implementer agent. Can be different from the planner."/>
+      </Action>
+
+      <Action Name="AssignPlanner" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
+        <Parameter Name="AgentId" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Temper.ProjectManagement.Issue"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.Agent.Hint" String="Assign a planner agent to draft the implementation plan."/>
       </Action>
 
       <Action Name="Unassign" IsBound="true">
@@ -255,7 +267,6 @@
           <Collection><String>Backlog</String></Collection>
         </Annotation>
         <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Triage"/>
-        <Annotation Term="Temper.Vocab.Agent.Hint" String="Move issue to triage for prioritization."/>
       </Action>
 
       <Action Name="MoveToTodo" IsBound="true">
@@ -265,42 +276,89 @@
           <Collection><String>Triage</String></Collection>
         </Annotation>
         <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Todo"/>
-        <Annotation Term="Temper.Vocab.Agent.Hint" String="Accept issue into todo. Requires priority to be set first."/>
       </Action>
 
-      <Action Name="StartWork" IsBound="true">
+      <Action Name="BeginPlanning" IsBound="true">
         <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
-        <Parameter Name="repo" Type="Edm.String" Nullable="false"/>
-        <Parameter Name="branch_name" Type="Edm.String" Nullable="false"/>
-        <Parameter Name="worktree_path" Type="Edm.String"/>
         <ReturnType Type="Temper.ProjectManagement.Issue"/>
         <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
           <Collection><String>Todo</String></Collection>
         </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Planning"/>
+        <Annotation Term="Temper.Vocab.Agent.Hint" String="Start planning phase. Requires a planner to be assigned."/>
+      </Action>
+
+      <Action Name="WritePlan" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
+        <Parameter Name="plan" Type="Edm.String" Nullable="false"/>
+        <Parameter Name="acceptance_criteria" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Temper.ProjectManagement.Issue"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Planning</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.Agent.Hint" String="Draft the implementation plan. What to do, how, and what done looks like."/>
+      </Action>
+
+      <Action Name="RevisePlan" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
+        <Parameter Name="feedback" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Temper.ProjectManagement.Issue"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Planning</String></Collection>
+        </Annotation>
+      </Action>
+
+      <Action Name="ApprovePlan" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
+        <ReturnType Type="Temper.ProjectManagement.Issue"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Planning</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Planned"/>
+        <Annotation Term="Temper.Vocab.Agent.Hint" String="Approve the plan. Supervisors/humans only."/>
+      </Action>
+
+      <Action Name="RejectPlan" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
+        <Parameter Name="reason" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Temper.ProjectManagement.Issue"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Planned</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Planning"/>
+      </Action>
+
+      <Action Name="StartWork" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
+        <Parameter Name="repo" Type="Edm.String"/>
+        <Parameter Name="branch_name" Type="Edm.String"/>
+        <Parameter Name="worktree_path" Type="Edm.String"/>
+        <ReturnType Type="Temper.ProjectManagement.Issue"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Planned</String></Collection>
+        </Annotation>
         <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="InProgress"/>
-        <Annotation Term="Temper.Vocab.Agent.Hint" String="Start working. Provide repo (e.g. rita-aga/deep-sci-fi), branch name, and optional worktree path."/>
-        <Annotation Term="Temper.Vocab.Agent.CommonPattern" String="1. Assign agent. 2. SetPriority. 3. MoveToTriage. 4. MoveToTodo. 5. StartWork."/>
+        <Annotation Term="Temper.Vocab.Agent.Hint" String="Begin implementation. Requires an assignee and an approved plan."/>
+        <Annotation Term="Temper.Vocab.Agent.CommonPattern" String="1. AssignPlanner. 2. BeginPlanning. 3. WritePlan. 4. ApprovePlan. 5. Assign implementer. 6. StartWork."/>
       </Action>
 
       <Action Name="UpdateImplementation" IsBound="true">
         <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
-        <Parameter Name="implementation_notes" Type="Edm.String" Nullable="false"/>
+        <Parameter Name="notes" Type="Edm.String" Nullable="false"/>
         <ReturnType Type="Temper.ProjectManagement.Issue"/>
         <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
           <Collection><String>InProgress</String><String>InReview</String></Collection>
         </Annotation>
-        <Annotation Term="Temper.Vocab.Agent.Hint" String="Drop implementation context: what changed, findings, blockers. Append-style."/>
       </Action>
 
       <Action Name="SubmitForReview" IsBound="true">
         <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
-        <Parameter Name="pr_url" Type="Edm.String" Nullable="false"/>
+        <Parameter Name="pr_url" Type="Edm.String"/>
         <ReturnType Type="Temper.ProjectManagement.Issue"/>
         <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
           <Collection><String>InProgress</String></Collection>
         </Annotation>
         <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="InReview"/>
-        <Annotation Term="Temper.Vocab.Agent.Hint" String="Submit for review with PR URL."/>
       </Action>
 
       <Action Name="RequestChanges" IsBound="true">
@@ -336,7 +394,7 @@
         <Parameter Name="reason" Type="Edm.String"/>
         <ReturnType Type="Temper.ProjectManagement.Issue"/>
         <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
-          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String><String>InProgress</String></Collection>
+          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String><String>Planning</String><String>Planned</String><String>InProgress</String></Collection>
         </Annotation>
         <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Cancelled"/>
       </Action>
@@ -355,7 +413,7 @@
         <Parameter Name="CommentId" Type="Edm.Guid" Nullable="false"/>
         <ReturnType Type="Temper.ProjectManagement.Issue"/>
         <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
-          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String><String>InProgress</String><String>InReview</String><String>Done</String></Collection>
+          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String><String>Planning</String><String>Planned</String><String>InProgress</String><String>InReview</String><String>Done</String></Collection>
         </Annotation>
       </Action>
 
@@ -364,7 +422,7 @@
         <Parameter Name="LabelId" Type="Edm.Guid" Nullable="false"/>
         <ReturnType Type="Temper.ProjectManagement.Issue"/>
         <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
-          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String><String>InProgress</String><String>InReview</String></Collection>
+          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String><String>Planning</String><String>InProgress</String><String>InReview</String></Collection>
         </Annotation>
       </Action>
 
@@ -434,19 +492,6 @@
       </Action>
 
       <!-- Comment Actions -->
-      <Action Name="CommentCreate" IsBound="true">
-        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Comment"/>
-        <Parameter Name="issue_id" Type="Edm.Guid" Nullable="false"/>
-        <Parameter Name="body" Type="Edm.String" Nullable="false"/>
-        <Parameter Name="author_id" Type="Edm.String" Nullable="false"/>
-        <Parameter Name="agent_type" Type="Edm.String"/>
-        <Parameter Name="session_id" Type="Edm.String"/>
-        <ReturnType Type="Temper.ProjectManagement.Comment"/>
-        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
-          <Collection><String>Active</String></Collection>
-        </Annotation>
-      </Action>
-
       <Action Name="CommentEdit" IsBound="true">
         <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Comment"/>
         <Parameter Name="body" Type="Edm.String" Nullable="false"/>

--- a/os-apps/project-management/policies/issue.cedar
+++ b/os-apps/project-management/policies/issue.cedar
@@ -1,41 +1,74 @@
 // Project Management — Issue Cedar Policies
 //
-// Default-deny posture. Agents can only act on issues assigned to them.
-// Supervisors (haku, human) have broader permissions.
+// Role separation: planners plan, supervisors approve, implementers execute.
+// No agent can both plan and approve the same issue.
 
-// Anyone can read and list issues
+// --- Universal: any agent can create, read, list, comment ---
+
 permit(
   principal,
-  action in [Action::"read", Action::"list"],
+  action in [Action::"create", Action::"read", Action::"list", Action::"AddComment", Action::"AddLabel"],
   resource is Issue
 );
 
-// Anyone can create issues and add to backlog
-permit(
-  principal,
-  action in [Action::"create", Action::"SetDescription", Action::"SetPriority",
-             Action::"AddLabel", Action::"MoveToTriage", Action::"MoveToTodo",
-             Action::"AddComment"],
-  resource is Issue
-);
+// --- Triage & Prioritization: supervisors and humans ---
 
-// Supervisors (haku, human operators) can assign, cancel, approve, archive
 permit(
   principal,
-  action in [Action::"Assign", Action::"Unassign", Action::"Cancel",
-             Action::"ApproveReview", Action::"Archive", Action::"Reopen",
-             Action::"RequestChanges"],
+  action in [Action::"MoveToTriage", Action::"MoveToTodo", Action::"SetPriority", Action::"Assign", Action::"AssignPlanner", Action::"Unassign", Action::"Cancel"],
   resource is Issue
 ) when {
-  principal.agent_type == "haku" || principal.agent_type == "human"
+  principal.agent_type in ["supervisor", "human"]
 };
 
-// Assigned agent can start work, update implementation, submit for review
+// --- Planning: only the assigned planner ---
+
 permit(
   principal,
-  action in [Action::"StartWork", Action::"UpdateImplementation",
-             Action::"SubmitForReview"],
+  action in [Action::"BeginPlanning", Action::"WritePlan"],
+  resource is Issue
+) when {
+  resource.PlannerId == principal.id
+};
+
+// --- Plan Approval: supervisors and humans only, NOT the planner ---
+
+permit(
+  principal,
+  action in [Action::"ApprovePlan", Action::"RejectPlan", Action::"RevisePlan"],
+  resource is Issue
+) when {
+  principal.agent_type in ["supervisor", "human"] &&
+  resource.PlannerId != principal.id
+};
+
+// --- Implementation: only the assigned implementer ---
+
+permit(
+  principal,
+  action in [Action::"StartWork", Action::"UpdateImplementation", Action::"SubmitForReview"],
   resource is Issue
 ) when {
   resource.AssigneeId == principal.id
+};
+
+// --- Review: supervisors and humans, NOT the implementer ---
+
+permit(
+  principal,
+  action in [Action::"ApproveReview", Action::"RequestChanges"],
+  resource is Issue
+) when {
+  principal.agent_type in ["supervisor", "human"] &&
+  resource.AssigneeId != principal.id
+};
+
+// --- Reopen & Archive: supervisors and humans ---
+
+permit(
+  principal,
+  action in [Action::"Reopen", Action::"Archive"],
+  resource is Issue
+) when {
+  principal.agent_type in ["supervisor", "human"]
 };

--- a/os-apps/project-management/specs/issue.ioa.toml
+++ b/os-apps/project-management/specs/issue.ioa.toml
@@ -1,17 +1,31 @@
 # Issue Entity — I/O Automaton Specification
 #
 # Core work item for project management. Models issue lifecycle from
-# backlog triage through development, review, completion, and archival.
+# backlog triage through planning, execution, review, and archival.
+#
+# Key design: Planning and execution are separated. One agent drafts the plan,
+# a supervisor approves it, and a (potentially different) agent executes it.
+# Cedar policies enforce role separation between planners, approvers, and implementers.
 
 [automaton]
 name = "Issue"
-states = ["Backlog", "Triage", "Todo", "InProgress", "InReview", "Done", "Cancelled", "Archived"]
+states = ["Backlog", "Triage", "Todo", "Planning", "Planned", "InProgress", "InReview", "Done", "Cancelled", "Archived"]
 initial = "Backlog"
 
 # --- State Variables ---
 
 [[state]]
 name = "assignee_set"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "planner_set"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "has_plan"
 type = "bool"
 initial = "false"
 
@@ -36,6 +50,11 @@ type = "counter"
 initial = "0"
 
 [[state]]
+name = "plan_revision_count"
+type = "counter"
+initial = "0"
+
+[[state]]
 name = "has_description"
 type = "bool"
 initial = "false"
@@ -45,15 +64,15 @@ initial = "false"
 [[action]]
 name = "SetDescription"
 kind = "input"
-from = ["Backlog", "Triage", "Todo", "InProgress", "InReview"]
+from = ["Backlog", "Triage", "Todo", "Planning", "InProgress", "InReview"]
 effect = "set has_description true"
 params = ["description"]
-hint = "Set or update the issue description. Can be done in any non-terminal state."
+hint = "Set or update the issue description."
 
 [[action]]
 name = "SetPriority"
 kind = "input"
-from = ["Backlog", "Triage", "Todo", "InProgress"]
+from = ["Backlog", "Triage", "Todo", "Planning", "InProgress"]
 effect = "increment priority"
 params = ["level"]
 hint = "Set priority level (1=urgent, 2=high, 3=medium, 4=low). Must be set before moving to Todo."
@@ -61,7 +80,7 @@ hint = "Set priority level (1=urgent, 2=high, 3=medium, 4=low). Must be set befo
 [[action]]
 name = "AddLabel"
 kind = "input"
-from = ["Backlog", "Triage", "Todo", "InProgress", "InReview"]
+from = ["Backlog", "Triage", "Todo", "Planning", "InProgress", "InReview"]
 effect = "increment label_count"
 params = ["LabelId"]
 hint = "Attach a label to the issue for categorization."
@@ -69,10 +88,18 @@ hint = "Attach a label to the issue for categorization."
 [[action]]
 name = "Assign"
 kind = "input"
-from = ["Backlog", "Triage", "Todo", "InProgress"]
+from = ["Backlog", "Triage", "Todo", "Planning", "Planned", "InProgress"]
 effect = "set assignee_set true"
 params = ["AgentId"]
-hint = "Assign an agent or person to the issue. Required before starting work."
+hint = "Assign an implementer agent. Can be different from the planner."
+
+[[action]]
+name = "AssignPlanner"
+kind = "input"
+from = ["Backlog", "Triage", "Todo"]
+effect = "set planner_set true"
+params = ["AgentId"]
+hint = "Assign a planner agent to draft the implementation plan."
 
 [[action]]
 name = "Unassign"
@@ -96,19 +123,74 @@ to = "Todo"
 guard = "priority > 0"
 hint = "Accept the issue into the todo queue. Requires a priority to be set."
 
+# --- Planning Phase ---
+
+[[action]]
+name = "BeginPlanning"
+kind = "internal"
+from = ["Todo"]
+to = "Planning"
+guard = "is_true planner_set"
+hint = "Start planning phase. A planner agent drafts the approach."
+
+[[action]]
+name = "WritePlan"
+kind = "input"
+from = ["Planning"]
+effect = "set has_plan true"
+params = ["plan", "acceptance_criteria"]
+hint = "Draft or update the implementation plan. What to do, how, and what done looks like."
+
+[[action]]
+name = "RevisePlan"
+kind = "input"
+from = ["Planning"]
+effect = "increment plan_revision_count"
+params = ["feedback"]
+hint = "Request plan revision with feedback. Planner updates the plan."
+
+[[action]]
+name = "ApprovePlan"
+kind = "internal"
+from = ["Planning"]
+to = "Planned"
+guard = "is_true has_plan"
+hint = "Approve the plan. Only supervisors/humans. Requires a plan to exist."
+
+[[action]]
+name = "RejectPlan"
+kind = "input"
+from = ["Planned"]
+to = "Planning"
+effect = "increment plan_revision_count"
+params = ["reason"]
+hint = "Reject an approved plan and send it back for revision."
+
+# --- Execution Phase ---
+
 [[action]]
 name = "StartWork"
 kind = "internal"
-from = ["Todo"]
+from = ["Planned"]
 to = "InProgress"
 guard = "is_true assignee_set"
-hint = "Begin active work on the issue. Requires an assignee."
+params = ["repo", "branch_name", "worktree_path"]
+hint = "Begin implementation. Requires an assignee and an approved plan."
+
+[[action]]
+name = "UpdateImplementation"
+kind = "input"
+from = ["InProgress", "InReview"]
+effect = "increment comment_count"
+params = ["notes"]
+hint = "Agent drops implementation context -- progress notes, blockers, findings."
 
 [[action]]
 name = "SubmitForReview"
 kind = "internal"
 from = ["InProgress"]
 to = "InReview"
+params = ["pr_url"]
 hint = "Submit completed work for code review or verification."
 
 [[action]]
@@ -118,7 +200,7 @@ from = ["InReview"]
 to = "InProgress"
 effect = "increment review_cycles"
 params = ["feedback"]
-hint = "Reviewer requests changes. Sends issue back to in-progress with feedback."
+hint = "Reviewer requests changes. Sends issue back to in-progress."
 
 [[action]]
 name = "ApproveReview"
@@ -138,10 +220,10 @@ hint = "Reopen a completed issue for further work."
 [[action]]
 name = "Cancel"
 kind = "input"
-from = ["Backlog", "Triage", "Todo", "InProgress"]
+from = ["Backlog", "Triage", "Todo", "Planning", "Planned", "InProgress"]
 to = "Cancelled"
 params = ["reason"]
-hint = "Cancel the issue. Can be cancelled from any active state before review completes."
+hint = "Cancel the issue from any active state before review completes."
 
 [[action]]
 name = "Archive"
@@ -153,12 +235,22 @@ hint = "Archive a completed or cancelled issue. Terminal state."
 [[action]]
 name = "AddComment"
 kind = "input"
-from = ["Backlog", "Triage", "Todo", "InProgress", "InReview", "Done"]
+from = ["Backlog", "Triage", "Todo", "Planning", "Planned", "InProgress", "InReview", "Done"]
 effect = "increment comment_count"
 params = ["CommentId"]
 hint = "Add a comment to the issue."
 
 # --- Output Actions ---
+
+[[action]]
+name = "PlanReadyEvent"
+kind = "output"
+hint = "Emitted when a plan is written and ready for approval."
+
+[[action]]
+name = "PlanApprovedEvent"
+kind = "output"
+hint = "Emitted when a plan is approved. Implementation can begin."
 
 [[action]]
 name = "IssueCompletedEvent"
@@ -184,8 +276,18 @@ assert = "assignee_set"
 
 [[invariant]]
 name = "TodoRequiresPriority"
-when = ["Todo", "InProgress", "InReview", "Done"]
+when = ["Todo", "Planning", "Planned", "InProgress", "InReview", "Done"]
 assert = "priority > 0"
+
+[[invariant]]
+name = "PlanningRequiresPlanner"
+when = ["Planning", "Planned"]
+assert = "planner_set"
+
+[[invariant]]
+name = "PlannedRequiresPlan"
+when = ["Planned", "InProgress", "InReview", "Done"]
+assert = "has_plan"
 
 # --- Liveness Properties ---
 
@@ -195,6 +297,21 @@ from = ["Backlog"]
 reaches = ["Done", "Cancelled", "Archived"]
 
 # --- Integrations ---
+
+[[integration]]
+name = "notify_planner_assigned"
+trigger = "AssignPlanner"
+type = "webhook"
+
+[[integration]]
+name = "notify_plan_ready"
+trigger = "WritePlan"
+type = "webhook"
+
+[[integration]]
+name = "notify_plan_approved"
+trigger = "ApprovePlan"
+type = "webhook"
 
 [[integration]]
 name = "notify_assignee"

--- a/os-apps/project-management/specs/model.csdl.xml
+++ b/os-apps/project-management/specs/model.csdl.xml
@@ -2,6 +2,8 @@
 <!--
   Temper Project Management OS App
   OData v4 data model for issues, projects, cycles, comments, and labels.
+  
+  Planning phase: One agent plans, a supervisor approves, another agent implements.
 -->
 <edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
   <edmx:DataServices>
@@ -25,11 +27,13 @@
         <Member Name="Backlog" Value="0"/>
         <Member Name="Triage" Value="1"/>
         <Member Name="Todo" Value="2"/>
-        <Member Name="InProgress" Value="3"/>
-        <Member Name="InReview" Value="4"/>
-        <Member Name="Done" Value="5"/>
-        <Member Name="Cancelled" Value="6"/>
-        <Member Name="Archived" Value="7"/>
+        <Member Name="Planning" Value="3"/>
+        <Member Name="Planned" Value="4"/>
+        <Member Name="InProgress" Value="5"/>
+        <Member Name="InReview" Value="6"/>
+        <Member Name="Done" Value="7"/>
+        <Member Name="Cancelled" Value="8"/>
+        <Member Name="Archived" Value="9"/>
       </EnumType>
 
       <EnumType Name="IssuePriority">
@@ -37,6 +41,14 @@
         <Member Name="High" Value="2"/>
         <Member Name="Medium" Value="3"/>
         <Member Name="Low" Value="4"/>
+      </EnumType>
+
+      <EnumType Name="AgentType">
+        <Member Name="Human" Value="0"/>
+        <Member Name="Planner" Value="1"/>
+        <Member Name="Implementer" Value="2"/>
+        <Member Name="Reviewer" Value="3"/>
+        <Member Name="Supervisor" Value="4"/>
       </EnumType>
 
       <EnumType Name="ProjectStatus">
@@ -74,6 +86,17 @@
         <Property Name="Status" Type="Temper.ProjectManagement.IssueStatus" Nullable="false"/>
         <Property Name="Priority" Type="Temper.ProjectManagement.IssuePriority"/>
         <Property Name="AssigneeId" Type="Edm.String"/>
+        <Property Name="AgentType" Type="Temper.ProjectManagement.AgentType"/>
+        <Property Name="PlannerId" Type="Edm.String"/>
+        <Property Name="Plan" Type="Edm.String"/>
+        <Property Name="AcceptanceCriteria" Type="Edm.String"/>
+        <Property Name="PlanRevisionCount" Type="Edm.Int32" DefaultValue="0"/>
+        <Property Name="SessionId" Type="Edm.String"/>
+        <Property Name="Repo" Type="Edm.String"/>
+        <Property Name="BranchName" Type="Edm.String"/>
+        <Property Name="WorktreePath" Type="Edm.String"/>
+        <Property Name="PrUrl" Type="Edm.String"/>
+        <Property Name="ImplementationNotes" Type="Edm.String"/>
         <Property Name="ProjectId" Type="Edm.Guid"/>
         <Property Name="CycleId" Type="Edm.Guid"/>
         <Property Name="ReviewCycles" Type="Edm.Int32" DefaultValue="0"/>
@@ -81,6 +104,7 @@
         <Property Name="LabelCount" Type="Edm.Int32" DefaultValue="0"/>
         <Property Name="CreatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
         <Property Name="UpdatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="PlannedAt" Type="Edm.DateTimeOffset"/>
         <Property Name="CompletedAt" Type="Edm.DateTimeOffset"/>
         <Property Name="CancelledAt" Type="Edm.DateTimeOffset"/>
         <NavigationProperty Name="Project" Type="Temper.ProjectManagement.Project">
@@ -93,6 +117,7 @@
         <Annotation Term="Temper.Vocab.StateMachine.States">
           <Collection>
             <String>Backlog</String><String>Triage</String><String>Todo</String>
+            <String>Planning</String><String>Planned</String>
             <String>InProgress</String><String>InReview</String><String>Done</String>
             <String>Cancelled</String><String>Archived</String>
           </Collection>
@@ -100,6 +125,7 @@
         <Annotation Term="Temper.Vocab.StateMachine.InitialState" String="Backlog"/>
         <Annotation Term="Temper.Vocab.ShardKey" String="Id"/>
         <Annotation Term="Temper.Vocab.AuthZ.CedarPolicy" String="policies/issue.cedar"/>
+        <Annotation Term="Temper.Vocab.Agent.Hint" String="Work item with plan-then-execute lifecycle. Planner drafts approach, supervisor approves, implementer executes."/>
       </EntityType>
 
       <EntityType Name="Project">
@@ -193,9 +219,8 @@
         <Parameter Name="description" Type="Edm.String" Nullable="false"/>
         <ReturnType Type="Temper.ProjectManagement.Issue"/>
         <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
-          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String><String>InProgress</String><String>InReview</String></Collection>
+          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String><String>Planning</String><String>InProgress</String><String>InReview</String></Collection>
         </Annotation>
-        <Annotation Term="Temper.Vocab.Agent.Hint" String="Set or update the issue description."/>
       </Action>
 
       <Action Name="SetPriority" IsBound="true">
@@ -203,9 +228,8 @@
         <Parameter Name="level" Type="Edm.Int32" Nullable="false"/>
         <ReturnType Type="Temper.ProjectManagement.Issue"/>
         <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
-          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String><String>InProgress</String></Collection>
+          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String><String>Planning</String><String>InProgress</String></Collection>
         </Annotation>
-        <Annotation Term="Temper.Vocab.Agent.Hint" String="Set priority (1=urgent, 2=high, 3=medium, 4=low). Required before MoveToTodo."/>
       </Action>
 
       <Action Name="Assign" IsBound="true">
@@ -213,9 +237,19 @@
         <Parameter Name="AgentId" Type="Edm.String" Nullable="false"/>
         <ReturnType Type="Temper.ProjectManagement.Issue"/>
         <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
-          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String><String>InProgress</String></Collection>
+          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String><String>Planning</String><String>Planned</String><String>InProgress</String></Collection>
         </Annotation>
-        <Annotation Term="Temper.Vocab.Agent.Hint" String="Assign an agent to this issue. Required before StartWork."/>
+        <Annotation Term="Temper.Vocab.Agent.Hint" String="Assign an implementer agent. Can be different from the planner."/>
+      </Action>
+
+      <Action Name="AssignPlanner" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
+        <Parameter Name="AgentId" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Temper.ProjectManagement.Issue"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.Agent.Hint" String="Assign a planner agent to draft the implementation plan."/>
       </Action>
 
       <Action Name="Unassign" IsBound="true">
@@ -233,7 +267,6 @@
           <Collection><String>Backlog</String></Collection>
         </Annotation>
         <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Triage"/>
-        <Annotation Term="Temper.Vocab.Agent.Hint" String="Move issue to triage for prioritization."/>
       </Action>
 
       <Action Name="MoveToTodo" IsBound="true">
@@ -243,22 +276,84 @@
           <Collection><String>Triage</String></Collection>
         </Annotation>
         <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Todo"/>
-        <Annotation Term="Temper.Vocab.Agent.Hint" String="Accept issue into todo. Requires priority to be set first."/>
       </Action>
 
-      <Action Name="StartWork" IsBound="true">
+      <Action Name="BeginPlanning" IsBound="true">
         <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
         <ReturnType Type="Temper.ProjectManagement.Issue"/>
         <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
           <Collection><String>Todo</String></Collection>
         </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Planning"/>
+        <Annotation Term="Temper.Vocab.Agent.Hint" String="Start planning phase. Requires a planner to be assigned."/>
+      </Action>
+
+      <Action Name="WritePlan" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
+        <Parameter Name="plan" Type="Edm.String" Nullable="false"/>
+        <Parameter Name="acceptance_criteria" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Temper.ProjectManagement.Issue"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Planning</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.Agent.Hint" String="Draft the implementation plan. What to do, how, and what done looks like."/>
+      </Action>
+
+      <Action Name="RevisePlan" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
+        <Parameter Name="feedback" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Temper.ProjectManagement.Issue"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Planning</String></Collection>
+        </Annotation>
+      </Action>
+
+      <Action Name="ApprovePlan" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
+        <ReturnType Type="Temper.ProjectManagement.Issue"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Planning</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Planned"/>
+        <Annotation Term="Temper.Vocab.Agent.Hint" String="Approve the plan. Supervisors/humans only."/>
+      </Action>
+
+      <Action Name="RejectPlan" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
+        <Parameter Name="reason" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Temper.ProjectManagement.Issue"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Planned</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Planning"/>
+      </Action>
+
+      <Action Name="StartWork" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
+        <Parameter Name="repo" Type="Edm.String"/>
+        <Parameter Name="branch_name" Type="Edm.String"/>
+        <Parameter Name="worktree_path" Type="Edm.String"/>
+        <ReturnType Type="Temper.ProjectManagement.Issue"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Planned</String></Collection>
+        </Annotation>
         <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="InProgress"/>
-        <Annotation Term="Temper.Vocab.Agent.Hint" String="Start working on the issue. Must have an assignee."/>
-        <Annotation Term="Temper.Vocab.Agent.CommonPattern" String="1. Assign agent. 2. SetPriority. 3. MoveToTriage. 4. MoveToTodo. 5. StartWork."/>
+        <Annotation Term="Temper.Vocab.Agent.Hint" String="Begin implementation. Requires an assignee and an approved plan."/>
+        <Annotation Term="Temper.Vocab.Agent.CommonPattern" String="1. AssignPlanner. 2. BeginPlanning. 3. WritePlan. 4. ApprovePlan. 5. Assign implementer. 6. StartWork."/>
+      </Action>
+
+      <Action Name="UpdateImplementation" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
+        <Parameter Name="notes" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Temper.ProjectManagement.Issue"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>InProgress</String><String>InReview</String></Collection>
+        </Annotation>
       </Action>
 
       <Action Name="SubmitForReview" IsBound="true">
         <Parameter Name="bindingParameter" Type="Temper.ProjectManagement.Issue"/>
+        <Parameter Name="pr_url" Type="Edm.String"/>
         <ReturnType Type="Temper.ProjectManagement.Issue"/>
         <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
           <Collection><String>InProgress</String></Collection>
@@ -299,7 +394,7 @@
         <Parameter Name="reason" Type="Edm.String"/>
         <ReturnType Type="Temper.ProjectManagement.Issue"/>
         <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
-          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String><String>InProgress</String></Collection>
+          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String><String>Planning</String><String>Planned</String><String>InProgress</String></Collection>
         </Annotation>
         <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Cancelled"/>
       </Action>
@@ -318,7 +413,7 @@
         <Parameter Name="CommentId" Type="Edm.Guid" Nullable="false"/>
         <ReturnType Type="Temper.ProjectManagement.Issue"/>
         <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
-          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String><String>InProgress</String><String>InReview</String><String>Done</String></Collection>
+          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String><String>Planning</String><String>Planned</String><String>InProgress</String><String>InReview</String><String>Done</String></Collection>
         </Annotation>
       </Action>
 
@@ -327,7 +422,7 @@
         <Parameter Name="LabelId" Type="Edm.Guid" Nullable="false"/>
         <ReturnType Type="Temper.ProjectManagement.Issue"/>
         <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
-          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String><String>InProgress</String><String>InReview</String></Collection>
+          <Collection><String>Backlog</String><String>Triage</String><String>Todo</String><String>Planning</String><String>InProgress</String><String>InReview</String></Collection>
         </Annotation>
       </Action>
 

--- a/os-apps/project-management/specs/policies/issue.cedar
+++ b/os-apps/project-management/specs/policies/issue.cedar
@@ -1,20 +1,74 @@
 // Project Management — Issue Cedar Policies
 //
-// Default-deny posture. Policies are generated from human approval decisions.
-// This file provides initial bootstrap policies for common operations.
+// Role separation: planners plan, supervisors approve, implementers execute.
+// No agent can both plan and approve the same issue.
 
-// Allow any agent to create and read issues
+// --- Universal: any agent can create, read, list, comment ---
+
 permit(
   principal,
-  action in [Action::"create", Action::"read", Action::"list"],
+  action in [Action::"create", Action::"read", Action::"list", Action::"AddComment", Action::"AddLabel"],
   resource is Issue
 );
 
-// Allow assignee to take work actions on their issues
+// --- Triage & Prioritization: supervisors and humans ---
+
 permit(
   principal,
-  action in [Action::"StartWork", Action::"SubmitForReview"],
+  action in [Action::"MoveToTriage", Action::"MoveToTodo", Action::"SetPriority", Action::"Assign", Action::"AssignPlanner", Action::"Unassign", Action::"Cancel"],
+  resource is Issue
+) when {
+  principal.agent_type in ["supervisor", "human"]
+};
+
+// --- Planning: only the assigned planner ---
+
+permit(
+  principal,
+  action in [Action::"BeginPlanning", Action::"WritePlan"],
+  resource is Issue
+) when {
+  resource.PlannerId == principal.id
+};
+
+// --- Plan Approval: supervisors and humans only, NOT the planner ---
+
+permit(
+  principal,
+  action in [Action::"ApprovePlan", Action::"RejectPlan", Action::"RevisePlan"],
+  resource is Issue
+) when {
+  principal.agent_type in ["supervisor", "human"] &&
+  resource.PlannerId != principal.id
+};
+
+// --- Implementation: only the assigned implementer ---
+
+permit(
+  principal,
+  action in [Action::"StartWork", Action::"UpdateImplementation", Action::"SubmitForReview"],
   resource is Issue
 ) when {
   resource.AssigneeId == principal.id
+};
+
+// --- Review: supervisors and humans, NOT the implementer ---
+
+permit(
+  principal,
+  action in [Action::"ApproveReview", Action::"RequestChanges"],
+  resource is Issue
+) when {
+  principal.agent_type in ["supervisor", "human"] &&
+  resource.AssigneeId != principal.id
+};
+
+// --- Reopen & Archive: supervisors and humans ---
+
+permit(
+  principal,
+  action in [Action::"Reopen", Action::"Archive"],
+  resource is Issue
+) when {
+  principal.agent_type in ["supervisor", "human"]
 };


### PR DESCRIPTION
## Planning Phase for Multi-Agent Coordination

Adds a plan-then-execute lifecycle to issues. One agent plans, a supervisor approves, a different agent implements.

### New States
```
Backlog → Triage → Todo → Planning → Planned → InProgress → InReview → Done → Archived
```

### New Actions
- **AssignPlanner** — assign a planner agent (separate from implementer)
- **BeginPlanning** — enter planning phase (requires planner)
- **WritePlan** — planner drafts approach + acceptance criteria
- **RevisePlan** — feedback loop on the plan
- **ApprovePlan** — supervisor/human approves (requires plan to exist)
- **RejectPlan** — send approved plan back to planning

### New Invariants
- `PlanningRequiresPlanner` — can't be in Planning/Planned without a planner
- `PlannedRequiresPlan` — can't start work without an approved plan

### Cedar Role Separation
- Planners can `WritePlan` but not `StartWork`
- Supervisors can `ApprovePlan` but not if they're the planner
- Implementers can `StartWork` but not `ApproveReview`
- No agent can both plan and approve the same issue