### PR TITLE
fix: enable cloud feature for turso tenant provisioning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ temper-authz = { path = "crates/temper-authz" }
 temper-observe = { path = "crates/temper-observe" }
 temper-verify = { path = "crates/temper-verify" }
 temper-store-postgres = { path = "crates/temper-store-postgres" }
-temper-store-turso = { path = "crates/temper-store-turso" }
+temper-store-turso = { path = "crates/temper-store-turso", features = ["cloud"] }
 temper-store-redis = { path = "crates/temper-store-redis" }
 temper-store-sim = { path = "crates/temper-store-sim" }
 temper-server = { path = "crates/temper-server" }

--- a/crates/temper-platform/src/tenant_api.rs
+++ b/crates/temper-platform/src/tenant_api.rs
@@ -320,18 +320,18 @@ pub(crate) async fn install_os_app(
     Json(req): Json<InstallOsAppRequest>,
 ) -> impl IntoResponse {
     // Ensure tenant exists in persistence before loading specs.
-    if let Some(ref store) = state.server.event_store {
-        if let Some(router) = store.tenant_router() {
-            if let Err(e) = router.ensure_tenant(&req.tenant).await {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({
-                        "error": format!("failed to ensure tenant in persistence: {e}"),
-                    })),
-                );
-            }
-        }
+    if let Some(ref store) = state.server.event_store
+        && let Some(router) = store.tenant_router()
+        && let Err(e) = router.ensure_tenant(&req.tenant).await
+    {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({
+                "error": format!("failed to ensure tenant in persistence: {e}"),
+            })),
+        );
     }
+
 
     match crate::os_apps::install_os_app(&state, &req.tenant, &app_name) {
         Ok(entity_types) => (

--- a/crates/temper-platform/src/tenant_api.rs
+++ b/crates/temper-platform/src/tenant_api.rs
@@ -332,7 +332,6 @@ pub(crate) async fn install_os_app(
         );
     }
 
-
     match crate::os_apps::install_os_app(&state, &req.tenant, &app_name) {
         Ok(entity_types) => (
             StatusCode::OK,


### PR DESCRIPTION
## Problem
On Railway, `install_os_app` creates per-tenant databases as local SQLite files (`/root/.local/share/temper/tenants/{tenant}.db`). Railway's filesystem is ephemeral — on redeploy, these files vanish and all tenant state is lost.

## Root Cause
`temper-store-turso` has a `cloud` feature that enables Turso Cloud API provisioning, but it wasn't enabled in the workspace dependency. The Dockerfile builds without `--features cloud`, so `provision_database()` always falls through to local file mode even though `TURSO_API_TOKEN` and `TURSO_ORG` are set on Railway.

## Fix
Enable `cloud` feature at workspace level in `Cargo.toml`. When `TURSO_API_TOKEN` + `TURSO_ORG` env vars are present, tenant DBs are provisioned via Turso Cloud API and persist across redeploys.

## Impact
- Fixes: tenant data loss on Railway redeploy
- Fixes: `install_os_app` failing with `Unable to open connection to local database`
- Fixes: entity actors failing to hydrate (`failed to read events for replay — starting fresh`)