### PR TITLE
fix: wire Turso Cloud provisioning in serve bootstrap

### DIFF
--- a/crates/temper-cli/Cargo.toml
+++ b/crates/temper-cli/Cargo.toml
@@ -21,7 +21,7 @@ temper-runtime = { workspace = true }
 temper-jit = { workspace = true }
 temper-observe = { workspace = true }
 temper-store-postgres = { workspace = true }
-temper-store-turso = { workspace = true }
+temper-store-turso = { workspace = true, features = ["cloud"] }
 temper-store-redis = { workspace = true }
 temper-evolution = { workspace = true }
 temper-authz = { workspace = true }

--- a/crates/temper-cli/src/serve/bootstrap.rs
+++ b/crates/temper-cli/src/serve/bootstrap.rs
@@ -61,13 +61,22 @@ pub(super) async fn init_storage(
                     Some(format!("{home}/.local/share/temper/tenants"))
                 });
 
-                let router = TenantStoreRouter::new(
+                let mut router = TenantStoreRouter::new(
                     &platform_url,
                     platform_token.as_deref(),
                     local_base_dir,
                 )
                 .await
                 .map_err(|e| anyhow::anyhow!("Failed to create tenant store router: {e}"))?;
+
+                // Wire Turso Cloud provisioning when API credentials are available.
+                if let (Ok(api_token), Ok(org)) =
+                    (std::env::var("TURSO_API_TOKEN"), std::env::var("TURSO_ORG"))
+                {
+                    let group = std::env::var("TURSO_GROUP").ok();
+                    router = router.with_cloud_config(api_token, org, group);
+                    println!("  Cloud provisioning: enabled");
+                }
 
                 let tenant_count = router.connected_tenants().await.len();
                 println!(


### PR DESCRIPTION
## Problem
PR #19 enabled the `cloud` feature on `temper-store-turso`, but the CLI never called `with_cloud_config()` to pass `TURSO_API_TOKEN` and `TURSO_ORG` env vars to the tenant router. So `provision_database()` always fell through to local file mode, even with the feature compiled in.

## Fix
Read `TURSO_API_TOKEN` + `TURSO_ORG` from env during serve bootstrap, call `router.with_cloud_config()`. Also adds `cloud` feature to temper-cli's dep on temper-store-turso (workspace features don't auto-propagate to member crates).

## After merge
`install_os_app` on Railway will provision real Turso Cloud databases for tenants like `rita-agents`.