### PR TITLE
ci: cache target/ dir to speed up builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
+            target/
           key: ${{ runner.os }}-cargo-check-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-check-
 
@@ -111,6 +112,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
+            target/
           key: ${{ runner.os }}-cargo-integrity-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-integrity-
 
@@ -184,6 +186,7 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     needs: check
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
 
@@ -201,6 +204,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
+            target/
           key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-test-
 
@@ -231,6 +235,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
+            target/
           key: ${{ runner.os }}-cargo-verify-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-verify-
 


### PR DESCRIPTION
**Problem:** CI only caches cargo registry, not target/. Every run recompiles the entire workspace from scratch (~20 min compile + ~10 min tests = 30 min). PR #25 hit the 6-hour GitHub timeout due to a Cargo.lock cache miss.

**Fix:**
- Add target/ to all 4 cache blocks
- Add timeout-minutes: 45 to Tests job
- Expected: CI drops from ~30 min to ~10 min (cached incremental builds)

Co-authored-by: Claude Code <claude@anthropic.com>