### PR TITLE
chore(security): ignore local env secret files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,8 @@ Thumbs.db
 .env
 .env.local
 .env.*.local
-.env.railway
+.env.*
+!.env.example
 
 # Secrets
 *.pem
@@ -42,8 +43,6 @@ apps/scratch/
 .slop/
 .worktrees/
 .progress/
-.claude/worktrees/
-.claude/hooks/session-start-temper.sh
 
 # Node.js (observe UI)
 node_modules/
@@ -66,4 +65,5 @@ scripts/generate-graph-json.js
 .vercel
 .desloppify/
 scorecard.png
+.claude/hooks/session-start-temper.sh
 .claude/worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,8 @@ apps/scratch/
 .slop/
 .worktrees/
 .progress/
+.claude/worktrees/
+.claude/hooks/session-start-temper.sh
 
 # Node.js (observe UI)
 node_modules/


### PR DESCRIPTION
## Summary
- ignore all `.env.*` local env files by default
- keep `.env.example` tracked for templates
- ignore local Claude worktree artifacts and startup hook files
- ensure `.env.railway` remains local-only and cannot be accidentally committed

## Validation
- `git check-ignore -v .env.railway` resolves via `.gitignore`
