### PR TITLE
feat(pm): ResolveDone action + Reopen from Cancelled

### DIFF
--- a/os-apps/project-management/issue.ioa.toml
+++ b/os-apps/project-management/issue.ioa.toml
@@ -248,9 +248,17 @@ hint = "Reviewer approves the work. Issue moves to done."
 [[action]]
 name = "Reopen"
 kind = "input"
-from = ["Done"]
+from = ["Done", "Cancelled"]
 to = "InProgress"
-hint = "Reopen a completed issue for further work."
+hint = "Reopen a completed or cancelled issue for further work."
+
+[[action]]
+name = "ResolveDone"
+kind = "input"
+from = ["Backlog", "Triage", "Todo", "Planning", "Planned", "InProgress", "InReview", "Cancelled"]
+to = "Done"
+params = ["Resolution"]
+hint = "Resolve an issue as done from any state. For verified fixes, admin fast-track, or bulk triage."
 
 [[action]]
 name = "Cancel"

--- a/os-apps/project-management/policies/issue.cedar
+++ b/os-apps/project-management/policies/issue.cedar
@@ -62,6 +62,16 @@ permit(
   ["supervisor", "human"].contains(principal.agent_type)
 };
 
+// --- Resolve Done: supervisors and humans can fast-track ---
+
+permit(
+  principal,
+  action in [Action::"ResolveDone"],
+  resource is Issue
+) when {
+  ["supervisor", "human"].contains(principal.agent_type)
+};
+
 // --- Reopen & Archive: supervisors and humans ---
 
 permit(


### PR DESCRIPTION
Adds ResolveDone (any state → Done, supervisor/human only) and extends Reopen to work from Cancelled.