### PR TITLE
fix(cedar): fast-track policies for PM workflow

### DIFF
--- a/os-apps/project-management/policies/issue.cedar
+++ b/os-apps/project-management/policies/issue.cedar
@@ -71,3 +71,24 @@ permit(
 ) when {
   ["supervisor", "human"].contains(principal.agent_type)
 };
+
+// --- Fast-track: supervisor/human can perform role-gated and uncovered actions ---
+// Clears pending decisions for actions currently restricted to planner/assignee only,
+// and for hierarchy actions (SetParent, RemoveParent, AddSubIssue) with no prior policy.
+
+permit(
+  principal,
+  action in [
+    Action::"BeginPlanning",
+    Action::"WritePlan",
+    Action::"StartWork",
+    Action::"UpdateImplementation",
+    Action::"SubmitForReview",
+    Action::"SetParent",
+    Action::"RemoveParent",
+    Action::"AddSubIssue"
+  ],
+  resource is Issue
+) when {
+  ["supervisor", "human"].contains(principal.agent_type)
+};


### PR DESCRIPTION
## Problem
All PM issue state transitions for supervisor agents require Cedar approval, creating 72+ pending decisions that block the entire workflow. Specifically:
- `BeginPlanning` / `WritePlan` — restricted to `resource.PlannerId == principal.id` only
- `StartWork` / `UpdateImplementation` / `SubmitForReview` — restricted to `resource.AssigneeId == principal.id` only
- `SetParent` / `RemoveParent` / `AddSubIssue` — no policy at all (implicit deny)

## Fix
Added a single supervisor fast-track permit block covering the 8 uncovered actions. Existing role-specific policies are preserved (non-supervisor agents still require the planner/assignee match). `Archive` remains permitted for supervisors via the existing policy.

```cedar
permit(
  principal,
  action in [
    Action::"BeginPlanning", Action::"WritePlan",
    Action::"StartWork", Action::"UpdateImplementation", Action::"SubmitForReview",
    Action::"SetParent", Action::"RemoveParent", Action::"AddSubIssue"
  ],
  resource is Issue
) when {
  ["supervisor", "human"].contains(principal.agent_type)
};
```

## Verification
- Build: `cargo build --release` ✅
- Tests: `cargo test` ✅ (all 430+ tests pass)
- Clippy: clean ✅
- Fmt: clean ✅
- Pre-push gate: ALL GATES PASSED ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)