### PR TITLE
fix: additive OS app install with SHA-256 dedup

### DIFF
--- a/crates/temper-cli/src/serve/bootstrap.rs
+++ b/crates/temper-cli/src/serve/bootstrap.rs
@@ -502,17 +502,31 @@ pub(super) async fn bootstrap_installed_os_apps(state: &PlatformState, os_apps: 
             continue;
         }
         match temper_platform::install_os_app(state, &tenant, &app_name).await {
-            Ok(entities) => match source {
+            Ok(result) => match source {
                 OsAppBootstrapSource::Persisted => {
+                    let all: Vec<String> = result
+                        .added
+                        .iter()
+                        .chain(&result.updated)
+                        .chain(&result.skipped)
+                        .cloned()
+                        .collect();
                     println!(
                         "  Restored OS app '{app_name}' for '{tenant}': {}",
-                        entities.join(", ")
+                        all.join(", ")
                     );
                 }
                 OsAppBootstrapSource::Cli => {
+                    let all: Vec<String> = result
+                        .added
+                        .iter()
+                        .chain(&result.updated)
+                        .chain(&result.skipped)
+                        .cloned()
+                        .collect();
                     println!(
                         "  OS app '{app_name}' installed for '{tenant}': {}",
-                        entities.join(", ")
+                        all.join(", ")
                     );
                 }
             },

--- a/crates/temper-platform/src/lib.rs
+++ b/crates/temper-platform/src/lib.rs
@@ -31,6 +31,6 @@ pub use bootstrap::{
     bootstrap_agent_specs, bootstrap_system_tenant, persist_agent_verification,
     persist_system_verification,
 };
-pub use os_apps::{install_os_app, list_os_apps};
+pub use os_apps::{InstallResult, install_os_app, list_os_apps};
 pub use protocol::{PlatformEvent, VerifyStepStatus};
 pub use state::PlatformState;

--- a/crates/temper-platform/src/os_apps.rs
+++ b/crates/temper-platform/src/os_apps.rs
@@ -16,6 +16,17 @@ use temper_spec::csdl::{emit_csdl_xml, merge_csdl, parse_csdl};
 use crate::bootstrap;
 use crate::state::PlatformState;
 
+/// Result of an OS app installation, categorising each spec by what happened.
+#[derive(Debug, Clone, Serialize)]
+pub struct InstallResult {
+    /// Entity types registered for the first time.
+    pub added: Vec<String>,
+    /// Entity types that already existed but whose IOA source changed.
+    pub updated: Vec<String>,
+    /// Entity types whose IOA source was byte-for-byte identical — skipped.
+    pub skipped: Vec<String>,
+}
+
 // ── Project Management OS App ──────────────────────────────────────
 
 const PM_ISSUE_IOA: &str = include_str!("../../../os-apps/project-management/issue.ioa.toml");
@@ -158,10 +169,41 @@ pub async fn install_os_app(
     state: &PlatformState,
     tenant: &str,
     app_name: &str,
-) -> Result<Vec<String>, String> {
+) -> Result<InstallResult, String> {
     let bundle =
         get_os_app(app_name).ok_or_else(|| format!("OS app '{app_name}' not found in catalog"))?;
     let tenant_id = TenantId::new(tenant);
+
+    // Classify each bundle spec as added / updated / skipped based on the
+    // current in-memory registry state, using SHA-256 content hashes to
+    // detect whether the IOA source has actually changed.
+    let (mut added, mut updated, mut skipped): (Vec<String>, Vec<String>, Vec<String>) = {
+        let registry = state.registry.read().unwrap(); // ci-ok: infallible lock
+        let mut added = Vec::new();
+        let mut updated = Vec::new();
+        let mut skipped = Vec::new();
+        for (entity_type, ioa_source) in bundle.specs {
+            let incoming_hash = temper_store_turso::spec_content_hash(ioa_source);
+            match registry.get_spec(&tenant_id, entity_type) {
+                Some(existing) => {
+                    let existing_hash = temper_store_turso::spec_content_hash(&existing.ioa_source);
+                    if incoming_hash == existing_hash {
+                        skipped.push(entity_type.to_string());
+                    } else {
+                        updated.push(entity_type.to_string());
+                    }
+                }
+                None => {
+                    added.push(entity_type.to_string());
+                }
+            }
+        }
+        (added, updated, skipped)
+    };
+    // Sort for deterministic output.
+    added.sort();
+    updated.sort();
+    skipped.sort();
 
     // OS app installs must preserve existing tenant types.
     let merged_csdl = {
@@ -228,25 +270,36 @@ pub async fn install_os_app(
     }
 
     // ── Step 2: Bootstrap into memory (verification + registry). ────
-    let verified_cache = if let Some(ref store) = state.server.event_store
-        && let Some(turso) = store.platform_turso_store()
-    {
-        turso
-            .load_verification_cache(tenant)
-            .await
-            .unwrap_or_default()
-    } else {
-        std::collections::BTreeMap::new()
-    };
-    bootstrap::bootstrap_tenant_specs(
-        state,
-        tenant,
-        &merged_csdl,
-        bundle.specs,
-        true,
-        &format!("OS-App({app_name})"),
-        &verified_cache,
-    );
+    // Only process specs whose content has changed (added or updated);
+    // skipped specs are already loaded with identical content.
+    let specs_to_bootstrap: Vec<(&str, &str)> = bundle
+        .specs
+        .iter()
+        .filter(|(entity_type, _)| !skipped.contains(&entity_type.to_string()))
+        .map(|(et, src)| (*et, *src))
+        .collect();
+
+    if !specs_to_bootstrap.is_empty() {
+        let verified_cache = if let Some(ref store) = state.server.event_store
+            && let Some(turso) = store.platform_turso_store()
+        {
+            turso
+                .load_verification_cache(tenant)
+                .await
+                .unwrap_or_default()
+        } else {
+            std::collections::BTreeMap::new()
+        };
+        bootstrap::bootstrap_tenant_specs(
+            state,
+            tenant,
+            &merged_csdl,
+            &specs_to_bootstrap,
+            true,
+            &format!("OS-App({app_name})"),
+            &verified_cache,
+        );
+    }
 
     // ── Step 3: Load Cedar policies into memory. ────────────────────
     if let Some(ref policy_text) = combined_policy {
@@ -263,18 +316,19 @@ pub async fn install_os_app(
         }
     }
 
-    let entity_types = bundle
-        .specs
-        .iter()
-        .map(|(name, _)| name.to_string())
-        .collect();
-
     tracing::info!(
-        "Installed OS app '{app_name}' for tenant '{tenant}': {:?}",
-        bundle.specs.iter().map(|(t, _)| *t).collect::<Vec<_>>()
+        "Installed OS app '{app_name}' for tenant '{tenant}': \
+         added={:?} updated={:?} skipped={:?}",
+        added,
+        updated,
+        skipped,
     );
 
-    Ok(entity_types)
+    Ok(InstallResult {
+        added,
+        updated,
+        skipped,
+    })
 }
 
 #[cfg(test)]

--- a/crates/temper-platform/src/os_apps.rs
+++ b/crates/temper-platform/src/os_apps.rs
@@ -174,10 +174,9 @@ pub async fn install_os_app(
         get_os_app(app_name).ok_or_else(|| format!("OS app '{app_name}' not found in catalog"))?;
     let tenant_id = TenantId::new(tenant);
 
-    // Classify each bundle spec as added / updated / skipped based on the
-    // current in-memory registry state, using SHA-256 content hashes to
-    // detect whether the IOA source has actually changed.
-    let (mut added, mut updated, mut skipped): (Vec<String>, Vec<String>, Vec<String>) = {
+    // Classify each bundle spec as added / updated / skipped, and compute the
+    // merged CSDL — both require the registry read lock, so we do them together.
+    let (mut added, mut updated, mut skipped, merged_csdl) = {
         let registry = state.registry.read().unwrap(); // ci-ok: infallible lock
         let mut added = Vec::new();
         let mut updated = Vec::new();
@@ -198,24 +197,20 @@ pub async fn install_os_app(
                 }
             }
         }
-        (added, updated, skipped)
-    };
-    // Sort for deterministic output.
-    added.sort();
-    updated.sort();
-    skipped.sort();
-
-    // OS app installs must preserve existing tenant types.
-    let merged_csdl = {
-        let registry = state.registry.read().unwrap(); // ci-ok: infallible lock
-        if let Some(existing) = registry.get_tenant(&tenant_id) {
+        // OS app installs must preserve existing tenant types.
+        let merged_csdl = if let Some(existing) = registry.get_tenant(&tenant_id) {
             let incoming = parse_csdl(bundle.csdl)
                 .map_err(|e| format!("Failed to parse CSDL for OS app '{app_name}': {e}"))?;
             emit_csdl_xml(&merge_csdl(&existing.csdl, &incoming))
         } else {
             bundle.csdl.to_string()
-        }
+        };
+        (added, updated, skipped, merged_csdl)
     };
+    // Sort for deterministic output.
+    added.sort();
+    updated.sort();
+    skipped.sort();
 
     // Build the full Cedar policy text for this tenant (existing + new).
     let combined_policy = if !bundle.cedar_policies.is_empty() {

--- a/crates/temper-platform/src/os_apps/tests.rs
+++ b/crates/temper-platform/src/os_apps/tests.rs
@@ -134,13 +134,21 @@ async fn test_install_os_app_registers_entities() {
     let state = PlatformState::new(None);
     let result = install_os_app(&state, "test-pm", "project-management").await;
     assert!(result.is_ok());
-    let entities = result.unwrap();
-    assert_eq!(entities.len(), 5);
-    assert!(entities.contains(&"Issue".to_string()));
-    assert!(entities.contains(&"Project".to_string()));
-    assert!(entities.contains(&"Cycle".to_string()));
-    assert!(entities.contains(&"Comment".to_string()));
-    assert!(entities.contains(&"Label".to_string()));
+    let result = result.unwrap();
+    // Fresh tenant — all 5 specs should be new.
+    assert_eq!(
+        result.added.len(),
+        5,
+        "expected 5 added: {:?}",
+        result.added
+    );
+    assert!(result.updated.is_empty());
+    assert!(result.skipped.is_empty());
+    assert!(result.added.contains(&"Issue".to_string()));
+    assert!(result.added.contains(&"Project".to_string()));
+    assert!(result.added.contains(&"Cycle".to_string()));
+    assert!(result.added.contains(&"Comment".to_string()));
+    assert!(result.added.contains(&"Label".to_string()));
 
     // Verify entities are in the registry.
     let registry = state.registry.read().unwrap();
@@ -157,11 +165,18 @@ async fn test_install_agent_orchestration_registers_entities() {
     let state = PlatformState::new(None);
     let result = install_os_app(&state, "test-ao", "agent-orchestration").await;
     assert!(result.is_ok());
-    let entities = result.unwrap();
-    assert_eq!(entities.len(), 3);
-    assert!(entities.contains(&"HeartbeatRun".to_string()));
-    assert!(entities.contains(&"Organization".to_string()));
-    assert!(entities.contains(&"BudgetLedger".to_string()));
+    let result = result.unwrap();
+    assert_eq!(
+        result.added.len(),
+        3,
+        "expected 3 added: {:?}",
+        result.added
+    );
+    assert!(result.updated.is_empty());
+    assert!(result.skipped.is_empty());
+    assert!(result.added.contains(&"HeartbeatRun".to_string()));
+    assert!(result.added.contains(&"Organization".to_string()));
+    assert!(result.added.contains(&"BudgetLedger".to_string()));
 
     let registry = state.registry.read().unwrap();
     let tenant = TenantId::new("test-ao");
@@ -222,9 +237,24 @@ async fn test_install_multiple_os_apps_merges_and_is_idempotent() {
         );
     }
 
-    install_os_app(&state, "test-merge", "project-management")
+    let reinstall = install_os_app(&state, "test-merge", "project-management")
         .await
         .expect("reinstall project-management");
+
+    // Reinstall of identical specs should skip all 5.
+    assert!(
+        reinstall.added.is_empty(),
+        "no new entities expected on reinstall"
+    );
+    assert!(
+        reinstall.updated.is_empty(),
+        "no updates expected on reinstall of identical specs"
+    );
+    assert_eq!(
+        reinstall.skipped.len(),
+        5,
+        "all 5 PM specs should be skipped on identical reinstall"
+    );
 
     let registry = state.registry.read().unwrap(); // ci-ok: infallible lock
     let mut entity_types = registry
@@ -274,8 +304,8 @@ async fn test_os_app_install_survives_restart() {
 
     let result = install_os_app(&state, "test-ws", "project-management").await;
     assert!(result.is_ok(), "install failed: {:?}", result.err());
-    let entities = result.unwrap();
-    assert_eq!(entities.len(), 5);
+    let result = result.unwrap();
+    assert_eq!(result.added.len(), 5);
 
     // Verify specs are in the in-memory registry.
     {

--- a/crates/temper-platform/src/router.rs
+++ b/crates/temper-platform/src/router.rs
@@ -163,8 +163,11 @@ mod tests {
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(json["status"], "installed");
-        let entity_types = json["entity_types"].as_array().unwrap();
-        assert_eq!(entity_types.len(), 5);
+        // Fresh install — all 5 PM specs should be added.
+        let added = json["added"].as_array().unwrap();
+        assert_eq!(added.len(), 5);
+        assert!(json["updated"].as_array().unwrap().is_empty());
+        assert!(json["skipped"].as_array().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/crates/temper-platform/src/tenant_api.rs
+++ b/crates/temper-platform/src/tenant_api.rs
@@ -338,12 +338,14 @@ pub(crate) async fn install_os_app(
     }
 
     match crate::os_apps::install_os_app(&state, &req.tenant, &app_name).await {
-        Ok(entity_types) => (
+        Ok(result) => (
             StatusCode::OK,
             Json(serde_json::json!({
                 "app": app_name,
                 "tenant": req.tenant,
-                "entity_types": entity_types,
+                "added": result.added,
+                "updated": result.updated,
+                "skipped": result.skipped,
                 "status": "installed",
             })),
         ),


### PR DESCRIPTION
## Summary

- `POST /observe/os-apps/{app}/install` previously replaced ALL tenant specs; now it merges additively
- Incoming specs are classified by SHA-256 content hash: **added** (new), **updated** (changed), **skipped** (identical)
- Only added/updated specs go through the verification cascade — skipped specs are a no-op
- CSDL is merged with the existing tenant schema (existing entity types preserved)
- Response body now includes `added`, `updated`, `skipped` counts for idempotency verification

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test --workspace` — all tests pass (430+)
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo fmt --check` — clean
- [x] Pre-push gate: all 4 gates passed (fmt, clippy, readability ratchet, full test suite)
- [x] `test_install_multiple_os_apps_merges_and_is_idempotent` — verifies reinstall skips all 5 PM specs
- [x] `test_os_app_install_survives_restart` — verifies Turso persistence + registry restore cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)