### PR TITLE
fix(observe): repair Logfire metrics export pipeline

### DIFF
--- a/crates/temper-cli/src/serve/mod.rs
+++ b/crates/temper-cli/src/serve/mod.rs
@@ -26,7 +26,6 @@ use temper_platform::router::build_platform_router;
 use temper_platform::state::PlatformState;
 use temper_runtime::tenant::TenantId;
 use temper_server::registry::{EntityLevelSummary, EntityVerificationResult, VerificationStatus};
-use temper_server::runtime_metrics::{init_runtime_metrics, spawn_runtime_metrics_sampler};
 use temper_server::state::DesignTimeEvent;
 use temper_verify::cascade::VerificationCascade;
 
@@ -63,7 +62,6 @@ pub async fn run(
     observe: bool,
 ) -> Result<()> {
     let _otel_guard = init_observability("temper-platform");
-    init_runtime_metrics();
     temper_authz::init_metrics();
     temper_store_turso::init_metrics();
     let api_key = std::env::var("ANTHROPIC_API_KEY").ok();
@@ -77,7 +75,6 @@ pub async fn run(
 
     // Assemble platform state
     let mut state = PlatformState::with_registry(registry, api_key);
-    spawn_runtime_metrics_sampler(state.server.clone());
     state.api_token = std::env::var("TEMPER_API_KEY").ok();
     if state.api_token.is_some() {
         println!("  API key: configured (Bearer token required)");

--- a/crates/temper-observe/src/otel.rs
+++ b/crates/temper-observe/src/otel.rs
@@ -28,11 +28,12 @@ use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::logs::{
     BatchConfigBuilder as LogBatchConfigBuilder, BatchLogProcessor, SdkLoggerProvider,
 };
-use opentelemetry_sdk::metrics::SdkMeterProvider;
+use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
 use opentelemetry_sdk::trace::{
     BatchConfigBuilder as SpanBatchConfigBuilder, BatchSpanProcessor, SdkTracerProvider,
 };
 use tracing_subscriber::EnvFilter;
+use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::prelude::*;
 
 /// Default OTLP endpoint for Logfire.
@@ -313,8 +314,13 @@ pub fn init_tracing(
             .build()
     })?;
 
+    // Export every 30 s so metrics are visible quickly and canary gauges stay fresh.
+    let metric_reader = PeriodicReader::builder(metric_exporter)
+        .with_interval(Duration::from_secs(30))
+        .build();
+
     let meter_provider = SdkMeterProvider::builder()
-        .with_periodic_exporter(metric_exporter)
+        .with_reader(metric_reader)
         .with_resource(resource.clone())
         .build();
 
@@ -357,7 +363,11 @@ pub fn init_tracing(
     let otel_trace_layer =
         tracing_opentelemetry::layer().with_tracer(tracer_provider.tracer("temper"));
 
-    let otel_log_layer = OpenTelemetryTracingBridge::new(&logger_provider);
+    // Restrict the log bridge to WARN+ to avoid flooding Logfire's /v1/logs
+    // endpoint with high-volume info events.  Traces already capture info-level
+    // spans via the otel_trace_layer, so no diagnostic value is lost.
+    let otel_log_layer =
+        OpenTelemetryTracingBridge::new(&logger_provider).with_filter(LevelFilter::WARN);
 
     tracing_subscriber::registry()
         .with(env_filter)

--- a/crates/temper-server/src/runtime_metrics.rs
+++ b/crates/temper-server/src/runtime_metrics.rs
@@ -1,4 +1,8 @@
 //! Runtime metrics exported via OpenTelemetry.
+//!
+//! This module provides metric recording helpers called from hot paths
+//! (entity actor replay, entity ops).  The periodic canary loop and
+//! sampler live in `state::runtime_metrics` via `spawn_runtime_metrics_loop`.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::OnceLock;
@@ -6,7 +10,6 @@ use std::time::Duration;
 
 use opentelemetry::metrics::{Gauge, Histogram};
 use opentelemetry::{KeyValue, global};
-use tokio::time::MissedTickBehavior;
 
 use crate::state::ServerState;
 
@@ -40,34 +43,6 @@ fn metrics() -> &'static RuntimeMetrics {
                 .build(),
         }
     })
-}
-
-/// Register runtime metric instruments.
-pub fn init_runtime_metrics() {
-    let _ = metrics();
-}
-
-/// Spawn a periodic sampler that records process RSS and live actor/entity counts.
-pub fn spawn_runtime_metrics_sampler(state: ServerState) {
-    init_runtime_metrics();
-    tokio::spawn(async move {
-        // determinism-ok: runtime observability side-effect for production diagnostics
-        let interval_secs = std::env::var("TEMPER_RUNTIME_METRICS_INTERVAL_SECS")
-            .ok()
-            .and_then(|v| v.parse::<u64>().ok())
-            .unwrap_or(10)
-            .clamp(1, 86_400);
-        let mut ticker = tokio::time::interval(Duration::from_secs(interval_secs));
-        ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
-
-        loop {
-            ticker.tick().await;
-            record_server_state_metrics(&state);
-            if let Some(rss_bytes) = read_process_resident_memory_bytes() {
-                record_process_resident_memory_bytes(rss_bytes);
-            }
-        }
-    });
 }
 
 /// Record actor and entity counts from the current server state snapshot.
@@ -123,7 +98,7 @@ pub fn record_process_resident_memory_bytes(bytes: u64) {
 /// Read process resident memory (RSS) in bytes from Linux procfs.
 #[cfg(target_os = "linux")]
 pub fn read_process_resident_memory_bytes() -> Option<u64> {
-    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    let status = std::fs::read_to_string("/proc/self/status").ok()?; // determinism-ok: procfs RSS read for observability only
     let vm_rss_line = status.lines().find(|line| line.starts_with("VmRSS:"))?;
     let mut parts = vm_rss_line.split_whitespace();
     let _label = parts.next()?;

--- a/crates/temper-server/src/state/runtime_metrics.rs
+++ b/crates/temper-server/src/state/runtime_metrics.rs
@@ -8,6 +8,8 @@ use opentelemetry::metrics::Gauge;
 use super::ServerState;
 
 struct RuntimeMetricInstruments {
+    /// Canary: always 1; confirms the metric export pipeline is alive.
+    up: Gauge<u64>,
     process_resident_memory_bytes: Gauge<u64>,
     active_actors: Gauge<u64>,
     active_entities: Gauge<u64>,
@@ -17,6 +19,12 @@ impl RuntimeMetricInstruments {
     fn new() -> Self {
         let meter = global::meter("temper-runtime");
         Self {
+            up: meter
+                .u64_gauge("temper_up")
+                .with_description(
+                    "Always 1 — canary confirming the metric export pipeline is alive.",
+                )
+                .build(),
             process_resident_memory_bytes: meter
                 .u64_gauge("process_resident_memory_bytes")
                 .with_unit("By")
@@ -34,6 +42,7 @@ impl RuntimeMetricInstruments {
     }
 
     fn record(&self, state: &ServerState) {
+        self.up.record(1, &[]);
         if let Some(rss) = read_process_resident_memory_bytes() {
             self.process_resident_memory_bytes.record(rss, &[]);
         }


### PR DESCRIPTION
## Summary

- **Remove duplicate metric sampler**: `spawn_runtime_metrics_sampler` in the old `runtime_metrics` module raced with `spawn_runtime_metrics_loop` in `state::runtime_metrics`; the old sampler is removed, leaving the `ServerState` method as the single canonical loop
- **Fix zero-metrics bug**: `SdkMeterProvider` was built with `.with_periodic_exporter()` which did not register the reader correctly; replaced with an explicit `PeriodicReader::builder(...).with_interval(30s).build()` + `.with_reader()` — this is the root cause of zero metrics arriving at Logfire
- **Add `temper_up` canary gauge**: always records `1` on each tick so the metrics pipeline is immediately verifiable in Logfire dashboards
- **Fix `BatchLogProcessor.ExportError`**: restricted the `OpenTelemetryTracingBridge` to `WARN+` events; traces already capture info-level spans via `otel_trace_layer`, so no diagnostic value is lost while eliminating the high-volume info events that were overwhelming `/v1/logs` and causing HTTP rejections

## Files changed

| File | Change |
|------|--------|
| `crates/temper-server/src/runtime_metrics.rs` | Removed `init_runtime_metrics` + `spawn_runtime_metrics_sampler` (dead code post-fix) |
| `crates/temper-server/src/state/runtime_metrics.rs` | Added `temper_up` canary gauge, kept `spawn_runtime_metrics_loop` as the single sampler |
| `crates/temper-observe/src/otel.rs` | Fixed `PeriodicReader` registration; restricted log bridge to `WARN+` |
| `crates/temper-cli/src/serve/mod.rs` | Removed import + calls to deleted sampler functions |

## Test plan

- [x] `cargo check -p temper-server -p temper-observe -p temper-cli` — clean
- [x] `cargo test -p temper-server -p temper-observe` — all pass
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt --check` — clean
- [x] Pre-push gate: all 4 gates passed (rustfmt, clippy, readability ratchet, full 430+ test suite)
- [ ] Watch CI — do NOT merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)