### PR TITLE
Fix app-tenant agent bootstrap merge behavior and align ecommerce shipment action naming

### DIFF
--- a/crates/temper-cli/src/serve/bootstrap.rs
+++ b/crates/temper-cli/src/serve/bootstrap.rs
@@ -451,7 +451,8 @@ pub(super) async fn bootstrap_tenants(state: &PlatformState, apps: &[(String, St
     }
 
     let default_cache = load_verified_cache(state, "default").await;
-    let default_hashes = temper_platform::bootstrap_agent_specs(state, "default", &default_cache);
+    let default_hashes =
+        temper_platform::bootstrap_agent_specs(state, "default", false, &default_cache);
     if let Some(ref store) = state.server.event_store
         && let Some(turso) = store.turso_for_tenant("default").await
     {
@@ -460,7 +461,9 @@ pub(super) async fn bootstrap_tenants(state: &PlatformState, apps: &[(String, St
 
     for (tenant, _dir) in apps {
         let cache = load_verified_cache(state, tenant).await;
-        let hashes = temper_platform::bootstrap_agent_specs(state, tenant, &cache);
+        // App tenants already have user specs loaded in Phase 2; merge the
+        // built-in agent OS entities so we do not replace their entity-set map.
+        let hashes = temper_platform::bootstrap_agent_specs(state, tenant, true, &cache);
         if let Some(ref store) = state.server.event_store
             && let Some(turso) = store.turso_for_tenant(tenant).await
         {
@@ -476,7 +479,7 @@ pub(super) async fn bootstrap_tenants(state: &PlatformState, apps: &[(String, St
     {
         for tenant in tenant_router.connected_tenants().await {
             let cache = load_verified_cache(state, &tenant).await;
-            let hashes = temper_platform::bootstrap_agent_specs(state, &tenant, &cache);
+            let hashes = temper_platform::bootstrap_agent_specs(state, &tenant, true, &cache);
             if let Some(turso) = store.turso_for_tenant(&tenant).await {
                 temper_platform::persist_agent_verification(&turso, &tenant, &hashes).await;
             }

--- a/crates/temper-platform/src/bootstrap.rs
+++ b/crates/temper-platform/src/bootstrap.rs
@@ -207,6 +207,7 @@ pub fn bootstrap_system_tenant(
 pub fn bootstrap_agent_specs(
     state: &PlatformState,
     tenant: &str,
+    merge: bool,
     verified_cache: &BTreeMap<String, (String, bool)>,
 ) -> Vec<(String, String)> {
     bootstrap_tenant_specs(
@@ -214,7 +215,7 @@ pub fn bootstrap_agent_specs(
         tenant,
         AGENT_CSDL,
         AGENT_SPECS,
-        false,
+        merge,
         "Agent",
         verified_cache,
     )
@@ -500,7 +501,7 @@ mod tests {
     #[test]
     fn test_bootstrap_agent_specs_registers_tenant() {
         let state = PlatformState::new(None);
-        bootstrap_agent_specs(&state, "test-agent", &BTreeMap::new());
+        bootstrap_agent_specs(&state, "test-agent", false, &BTreeMap::new());
         let registry = state.registry.read().unwrap();
         let tenant = TenantId::new("test-agent");
         assert!(registry.get_tenant(&tenant).is_some());
@@ -509,6 +510,61 @@ mod tests {
         assert!(registry.get_table(&tenant, "Plan").is_some());
         assert!(registry.get_table(&tenant, "Task").is_some());
         assert!(registry.get_table(&tenant, "ToolCall").is_some());
+    }
+
+    #[test]
+    fn test_bootstrap_agent_specs_merge_preserves_existing_app_entity_sets() {
+        let state = PlatformState::new(None);
+        let tenant = TenantId::new("app-tenant");
+        let custom_csdl = r#"<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx Version="4.0"
+  xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="Temper.Example"
+      xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="Widget">
+        <Key><PropertyRef Name="Id"/></Key>
+        <Property Name="Id" Type="Edm.Guid" Nullable="false"/>
+      </EntityType>
+      <EntityContainer Name="ExampleService">
+        <EntitySet Name="Widgets" EntityType="Temper.Example.Widget"/>
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>"#;
+        let custom_ioa = r#"
+[automaton]
+name = "Widget"
+states = ["Created"]
+initial = "Created"
+"#;
+
+        {
+            let mut registry = state.registry.write().unwrap();
+            registry.register_tenant(
+                tenant.clone(),
+                parse_csdl(custom_csdl).unwrap(),
+                custom_csdl.to_string(),
+                &[("Widget", custom_ioa)],
+            );
+        }
+
+        bootstrap_agent_specs(&state, "app-tenant", true, &BTreeMap::new());
+
+        let registry = state.registry.read().unwrap();
+        assert!(
+            registry.get_table(&tenant, "Widget").is_some(),
+            "custom app entity should survive merged agent bootstrap"
+        );
+        assert!(
+            registry.get_table(&tenant, "Agent").is_some(),
+            "agent entities should be added during merged bootstrap"
+        );
+        assert_eq!(
+            registry.resolve_entity_type(&tenant, "Widgets").as_deref(),
+            Some("Widget"),
+            "existing app entity-set mapping should survive merged bootstrap"
+        );
     }
 
     #[test]

--- a/crates/temper-platform/src/tenant_api.rs
+++ b/crates/temper-platform/src/tenant_api.rs
@@ -106,6 +106,7 @@ async fn create_tenant(
             crate::bootstrap_agent_specs(
                 &state,
                 &req.tenant_id,
+                false,
                 &std::collections::BTreeMap::new(),
             );
             (

--- a/reference-apps/ecommerce/specs/model.csdl.xml
+++ b/reference-apps/ecommerce/specs/model.csdl.xml
@@ -461,7 +461,7 @@
       </Action>
 
       <!-- Shipment Actions -->
-      <Action Name="ShipOrderShipment" IsBound="true">
+      <Action Name="ShipOrder" IsBound="true">
         <Parameter Name="bindingParameter" Type="Temper.Example.Shipment"/>
         <Parameter Name="Carrier" Type="Edm.String" Nullable="false"/>
         <Parameter Name="TrackingNumber" Type="Edm.String" Nullable="false"/>

--- a/reference-apps/ecommerce/tests/ecommerce_cascade.rs
+++ b/reference-apps/ecommerce/tests/ecommerce_cascade.rs
@@ -5,11 +5,13 @@
 //! - Level 2: Deterministic simulation with fault injection
 //! - Level 3: Property-based testing with random action sequences
 
+use temper_spec::csdl::parse_csdl;
 use temper_verify::cascade::{CascadeLevel, VerificationCascade};
 
 const ORDER_IOA: &str = include_str!("../specs/order.ioa.toml");
 const PAYMENT_IOA: &str = include_str!("../specs/payment.ioa.toml");
 const SHIPMENT_IOA: &str = include_str!("../specs/shipment.ioa.toml");
+const MODEL_CSDL: &str = include_str!("../specs/model.csdl.xml");
 
 #[test]
 fn cascade_order_all_levels_pass() {
@@ -132,4 +134,23 @@ fn cascade_shipment_all_levels_pass() {
         "L3 Property Tests should pass"
     );
     assert!(result.all_passed, "Shipment cascade should pass all levels");
+}
+
+#[test]
+fn shipment_bound_action_name_matches_runtime_action() {
+    let csdl = parse_csdl(MODEL_CSDL).expect("ecommerce CSDL should parse");
+    let schema = csdl
+        .schemas
+        .iter()
+        .find(|schema| schema.namespace == "Temper.Example")
+        .expect("Temper.Example schema should exist");
+
+    let action = schema
+        .action("ShipOrder")
+        .expect("shipment bound action should use the runtime action name");
+    assert!(action.is_bound, "shipment action should remain bound");
+    assert!(
+        schema.action("ShipOrderShipment").is_none(),
+        "legacy shipment action name should not reappear"
+    );
 }


### PR DESCRIPTION
  ## Summary

  This PR fixes two issues:

  1. App tenants could lose their existing entity-set mappings when built-in agent specs were bootstrapped after tenant/app specs had already been loaded.
  2. The ecommerce reference app exposed a shipment bound action name in CSDL that did not match the underlying Shipment IOA action, which caused runtime failures for shipment action calls.

  It also adds focused regression tests for both behaviors.

  ## What Changed

  ### 1. Make agent bootstrap support merge mode for existing tenants

  Files:

  - crates/temper-platform/src/bootstrap.rs
  - crates/temper-cli/src/serve/bootstrap.rs
  - crates/temper-platform/src/tenant_api.rs

  Changes:

  - bootstrap_agent_specs now takes an explicit merge: bool parameter.
  - Default/new-tenant bootstrap paths pass false.
  - Existing app-tenant/bootstrap restore paths pass true.

  Why:

  - App tenants may already have user/app specs loaded before the built-in agent entities are added.
  - Using replace semantics in that situation overwrites the tenant’s entity-set map and can effectively discard previously loaded app mappings.
  - Specifically, when testing the ecommerce app, after ecommerce specs are loaded, Phase 8 bootstraps agent specs into the same tenant with merge = false. That replaces the tenant’s CSDL/entity-set map and wipes out Orders, Payments, and
    Shipments from /tdata.
  - Merge semantics preserve existing app entities and entity-set mappings while adding the built-in agent OS entities.

  Behavior after this change:

  - Fresh tenant creation still uses replace semantics (merge = false), which is correct for a new tenant.
  - Existing tenants that already have app specs loaded now merge in agent entities (merge = true) instead of replacing tenant spec state.

  ### 2. Fix ecommerce shipment bound action name mismatch

  File:

  - reference-apps/ecommerce/specs/model.csdl.xml

  Change:

  - Renamed shipment bound action from ShipOrderShipment to ShipOrder.

  Why:

  - The Shipment IOA spec defines the runtime action as ShipOrder.
  - The CSDL previously exposed ShipOrderShipment.
  - OData path parsing strips the namespace but still dispatches the action by its declared action name, so the runtime attempted to execute ShipOrderShipment, which does not exist in the Shipment transition table.
  - This caused runtime errors like:
      - Unknown action: ShipOrderShipment

  Behavior after this change:

  - Shipment action calls using /Temper.Example.ShipOrder now resolve to the correct runtime action.

  ### 3. Add regression tests

  Files:

  - crates/temper-platform/src/bootstrap.rs
  - reference-apps/ecommerce/tests/ecommerce_cascade.rs

  Added tests:

  - test_bootstrap_agent_specs_merge_preserves_existing_app_entity_sets
      - Verifies merged agent bootstrap preserves an existing app tenant’s entity and entity-set mapping while adding agent entities.
  - shipment_bound_action_name_matches_runtime_action
      - Verifies ecommerce CSDL exposes ShipOrder and no longer exposes the old ShipOrderShipment action name.

  ## Why These Changes Are Needed

  Without the bootstrap change:

  - existing app tenants can be partially replaced when built-in agent specs are bootstrapped after app specs
  - app entity-set mappings may disappear, causing incorrect tenant registry state
  - in the ecommerce flow specifically, Orders, Payments, and Shipments can disappear from /tdata after Phase 8

  Without the ecommerce spec change:

  - shipment action calls fail at runtime even though the API appears to advertise the action
  - the reference app is internally inconsistent between CSDL and IOA
