### PR TITLE
feat: fix tenant database isolation in TenantRouted mode (ADR-0033)

### DIFF
--- a/crates/temper-cli/src/serve/bootstrap.rs
+++ b/crates/temper-cli/src/serve/bootstrap.rs
@@ -415,13 +415,14 @@ pub(super) async fn recover_wasm_modules(state: &PlatformState) {
 
 /// Load the verification cache from Turso for a tenant (hash + verified status).
 ///
+/// Routes to the per-tenant store in TenantRouted mode.
 /// Returns an empty map if no Turso store is available.
 async fn load_verified_cache(
     state: &PlatformState,
     tenant: &str,
 ) -> std::collections::BTreeMap<String, (String, bool)> {
     if let Some(ref store) = state.server.event_store
-        && let Some(turso) = store.platform_turso_store()
+        && let Some(turso) = store.turso_for_tenant(tenant).await
     {
         match turso.load_verification_cache(tenant).await {
             Ok(cache) => cache,
@@ -438,32 +439,32 @@ async fn load_verified_cache(
 /// Phase 8: Bootstrap system tenant and agent specs.
 ///
 /// After verifying (or skipping via cache), persists spec hashes and
-/// verification status to Turso so subsequent boots skip the cascade.
+/// verification status to the per-tenant Turso store so subsequent boots
+/// skip the cascade.
 pub(super) async fn bootstrap_tenants(state: &PlatformState, apps: &[(String, String)]) {
-    // Resolve the Turso store once for persisting verification results.
-    let turso = state
-        .server
-        .event_store
-        .as_ref()
-        .and_then(|s| s.platform_turso_store());
-
     let sys_cache = load_verified_cache(state, "temper-system").await;
     let sys_hashes = temper_platform::bootstrap_system_tenant(state, &sys_cache);
-    if let Some(turso) = turso {
-        temper_platform::persist_system_verification(turso, &sys_hashes).await;
+    if let Some(ref store) = state.server.event_store
+        && let Some(turso) = store.turso_for_tenant("temper-system").await
+    {
+        temper_platform::persist_system_verification(&turso, &sys_hashes).await;
     }
 
     let default_cache = load_verified_cache(state, "default").await;
     let default_hashes = temper_platform::bootstrap_agent_specs(state, "default", &default_cache);
-    if let Some(turso) = turso {
-        temper_platform::persist_agent_verification(turso, "default", &default_hashes).await;
+    if let Some(ref store) = state.server.event_store
+        && let Some(turso) = store.turso_for_tenant("default").await
+    {
+        temper_platform::persist_agent_verification(&turso, "default", &default_hashes).await;
     }
 
     for (tenant, _dir) in apps {
         let cache = load_verified_cache(state, tenant).await;
         let hashes = temper_platform::bootstrap_agent_specs(state, tenant, &cache);
-        if let Some(turso) = turso {
-            temper_platform::persist_agent_verification(turso, tenant, &hashes).await;
+        if let Some(ref store) = state.server.event_store
+            && let Some(turso) = store.turso_for_tenant(tenant).await
+        {
+            temper_platform::persist_agent_verification(&turso, tenant, &hashes).await;
         }
     }
     // In TenantRouted mode, bootstrap agent specs for all registered tenants.
@@ -476,8 +477,8 @@ pub(super) async fn bootstrap_tenants(state: &PlatformState, apps: &[(String, St
         for tenant in tenant_router.connected_tenants().await {
             let cache = load_verified_cache(state, &tenant).await;
             let hashes = temper_platform::bootstrap_agent_specs(state, &tenant, &cache);
-            if let Some(turso) = turso {
-                temper_platform::persist_agent_verification(turso, &tenant, &hashes).await;
+            if let Some(turso) = store.turso_for_tenant(&tenant).await {
+                temper_platform::persist_agent_verification(&turso, &tenant, &hashes).await;
             }
         }
     }

--- a/crates/temper-platform/src/os_apps.rs
+++ b/crates/temper-platform/src/os_apps.rs
@@ -229,39 +229,44 @@ pub async fn install_os_app(
 
     // ── Step 1: Persist to Turso FIRST (if available). ──────────────
     // If any write fails, bail before touching in-memory state.
-    if let Some(ref store) = state.server.event_store
-        && let Some(turso) = store.platform_turso_store()
-    {
-        let mut spec_sources: BTreeMap<String, String> = turso
-            .load_specs()
-            .await
-            .map_err(|e| format!("Failed to load existing specs for tenant '{tenant}': {e}"))?
-            .into_iter()
-            .filter(|row| row.tenant == tenant)
-            .map(|row| (row.entity_type, row.ioa_source))
-            .collect();
-
-        for (entity_type, ioa_source) in bundle.specs {
-            spec_sources.insert((*entity_type).to_string(), (*ioa_source).to_string());
-        }
-
-        for (entity_type, ioa_source) in spec_sources {
-            let hash = temper_store_turso::spec_content_hash(&ioa_source);
-            turso
-                .upsert_spec(tenant, &entity_type, &ioa_source, &merged_csdl, &hash)
+    // Specs and policies go to the per-tenant store; the app installation
+    // record goes to the platform store (cross-tenant boot index).
+    if let Some(ref store) = state.server.event_store {
+        if let Some(tenant_turso) = store.turso_for_tenant(tenant).await {
+            let mut spec_sources: BTreeMap<String, String> = tenant_turso
+                .load_specs()
                 .await
-                .map_err(|e| format!("Failed to persist spec {entity_type}: {e}"))?;
+                .map_err(|e| format!("Failed to load existing specs for tenant '{tenant}': {e}"))?
+                .into_iter()
+                .filter(|row| row.tenant == tenant)
+                .map(|row| (row.entity_type, row.ioa_source))
+                .collect();
+
+            for (entity_type, ioa_source) in bundle.specs {
+                spec_sources.insert((*entity_type).to_string(), (*ioa_source).to_string());
+            }
+
+            for (entity_type, ioa_source) in spec_sources {
+                let hash = temper_store_turso::spec_content_hash(&ioa_source);
+                tenant_turso
+                    .upsert_spec(tenant, &entity_type, &ioa_source, &merged_csdl, &hash)
+                    .await
+                    .map_err(|e| format!("Failed to persist spec {entity_type}: {e}"))?;
+            }
+            if let Some(ref policy_text) = combined_policy {
+                tenant_turso
+                    .upsert_tenant_policy(tenant, policy_text)
+                    .await
+                    .map_err(|e| format!("Failed to persist Cedar policy: {e}"))?;
+            }
         }
-        if let Some(ref policy_text) = combined_policy {
-            turso
-                .upsert_tenant_policy(tenant, policy_text)
+        // App installation record stays on platform store (cross-tenant boot index).
+        if let Some(platform_turso) = store.platform_turso_store() {
+            platform_turso
+                .record_installed_app(tenant, app_name)
                 .await
-                .map_err(|e| format!("Failed to persist Cedar policy: {e}"))?;
+                .map_err(|e| format!("Failed to record app installation: {e}"))?;
         }
-        turso
-            .record_installed_app(tenant, app_name)
-            .await
-            .map_err(|e| format!("Failed to record app installation: {e}"))?;
     }
 
     // ── Step 2: Bootstrap into memory (verification + registry). ────
@@ -276,7 +281,7 @@ pub async fn install_os_app(
 
     if !specs_to_bootstrap.is_empty() {
         let verified_cache = if let Some(ref store) = state.server.event_store
-            && let Some(turso) = store.platform_turso_store()
+            && let Some(turso) = store.turso_for_tenant(tenant).await
         {
             turso
                 .load_verification_cache(tenant)

--- a/crates/temper-server/src/api/decisions.rs
+++ b/crates/temper-server/src/api/decisions.rs
@@ -49,7 +49,7 @@ pub(crate) async fn handle_list_decisions(
     if let Some(resp) = require_policy_auth(&state, &headers, &tenant).await {
         return resp;
     }
-    if let Some(turso) = state.persistent_store() {
+    if let Some(turso) = state.persistent_store_for_tenant(&tenant).await {
         match turso
             .query_decisions(&tenant, params.status.as_deref())
             .await
@@ -86,7 +86,7 @@ pub(crate) async fn handle_approve_decision(
 
     // Read decision from Turso (single source of truth).
     let mut decision: PendingDecision = {
-        let Some(turso) = state.persistent_store() else {
+        let Some(turso) = state.persistent_store_for_tenant(&tenant).await else {
             tracing::error!("Turso backend not configured for approve decision");
             return (
                 StatusCode::SERVICE_UNAVAILABLE,
@@ -146,7 +146,7 @@ pub(crate) async fn handle_approve_decision(
     }
 
     // Persist to Turso FIRST — if fails, roll back Cedar engine and return 500.
-    if let Some(turso) = state.persistent_store()
+    if let Some(turso) = state.persistent_store_for_tenant(&tenant).await
         && let Err(e) = turso.upsert_tenant_policy(&tenant, &new_tenant_text).await
     {
         // Roll back: reload engine from current HashMap (without the new policy).
@@ -219,8 +219,8 @@ pub(crate) async fn handle_approve_decision(
         verification_results: None,
         implementation: None,
     };
-    // Persist D-Record to Turso.
-    if let Some(turso) = state.persistent_store() {
+    // Persist D-Record to Turso (evolution records stay on platform DB).
+    if let Some(turso) = state.platform_persistent_store() {
         let data_json = serde_json::to_string(&d_record).unwrap_or_default();
         if let Err(e) = turso
             .insert_evolution_record(
@@ -268,7 +268,7 @@ pub(crate) async fn handle_deny_decision(
 
     // Read decision from Turso (single source of truth).
     let mut decision: PendingDecision = {
-        let Some(turso) = state.persistent_store() else {
+        let Some(turso) = state.persistent_store_for_tenant(&tenant).await else {
             tracing::error!("Turso backend not configured for deny decision");
             return (
                 StatusCode::SERVICE_UNAVAILABLE,
@@ -371,13 +371,19 @@ pub(crate) async fn handle_list_all_decisions(
     if let Err(status) = require_observe_auth(&state, &headers, "manage_policies", "PolicySet") {
         return (status, "Authorization required for cross-tenant access").into_response();
     }
-    if let Some(turso) = state.persistent_store() {
+    // Fan-out across all tenant stores to aggregate decisions.
+    let stores = state.collect_all_turso_stores().await;
+    let mut all_data = Vec::new();
+    for turso in &stores {
         match turso.query_all_decisions(params.status.as_deref()).await {
-            Ok(data_strings) => return format_decision_list(data_strings),
+            Ok(data_strings) => all_data.extend(data_strings),
             Err(e) => {
-                tracing::warn!(error = %e, "failed to query all decisions from Turso");
+                tracing::warn!(error = %e, "failed to query decisions from a Turso store");
             }
         }
+    }
+    if !all_data.is_empty() {
+        return format_decision_list(all_data);
     }
     empty_decision_list()
 }

--- a/crates/temper-server/src/authz/policy_persistence.rs
+++ b/crates/temper-server/src/authz/policy_persistence.rs
@@ -30,7 +30,7 @@ use crate::state::ServerState;
 /// Returns `true` if the policy was written (content changed or new entry),
 /// `false` when the hash matched and no write was needed.
 /// Returns `false` silently (with a `tracing::debug` log) when no Turso store
-/// is configured — callers that need to know should check `state.persistent_store()`.
+/// is configured — callers that need to know should check `state.platform_persistent_store()`.
 #[instrument(skip_all, fields(tenant, policy_id, otel.name = "authz.persist_and_activate_policy"))]
 pub async fn persist_and_activate_policy(
     state: &ServerState,
@@ -39,7 +39,7 @@ pub async fn persist_and_activate_policy(
     cedar_text: &str,
     created_by: &str,
 ) -> bool {
-    let Some(turso) = state.persistent_store() else {
+    let Some(turso) = state.persistent_store_for_tenant(tenant).await else {
         tracing::debug!(
             tenant,
             policy_id,
@@ -70,6 +70,7 @@ pub async fn persist_and_activate_policy(
         let now = sim_now().to_rfc3339();
         if let Err(e) = turso
             .persist_trajectory(TursoTrajectoryInsert {
+
                 tenant,
                 entity_type: "_cedar",
                 entity_id: tenant,

--- a/crates/temper-server/src/authz/policy_persistence.rs
+++ b/crates/temper-server/src/authz/policy_persistence.rs
@@ -70,7 +70,6 @@ pub async fn persist_and_activate_policy(
         let now = sim_now().to_rfc3339();
         if let Err(e) = turso
             .persist_trajectory(TursoTrajectoryInsert {
-
                 tenant,
                 entity_type: "_cedar",
                 entity_id: tenant,

--- a/crates/temper-server/src/observe/agents.rs
+++ b/crates/temper-server/src/observe/agents.rs
@@ -91,13 +91,22 @@ pub(crate) async fn handle_list_agents(
         .as_ref()
         .map(|t| t.as_str().to_string())
         .or(params.tenant);
-    // Query Turso directly (single source of truth).
-    if let Some(turso) = state.persistent_store() {
-        match turso.query_agent_summaries(tenant_filter.as_deref()).await {
-            Ok(summaries) => {
-                let agents: Vec<AgentSummary> = summaries
-                    .into_iter()
-                    .map(|s| AgentSummary {
+    // Determine which stores to query: tenant-scoped or fan-out.
+    let stores = if let Some(ref tf) = tenant_filter {
+        match state.persistent_store_for_tenant(tf).await {
+            Some(turso) => vec![turso],
+            None => Vec::new(),
+        }
+    } else {
+        state.collect_all_turso_stores().await
+    };
+
+    if !stores.is_empty() {
+        let mut all_agents: Vec<AgentSummary> = Vec::new();
+        for turso in &stores {
+            match turso.query_agent_summaries(tenant_filter.as_deref()).await {
+                Ok(summaries) => {
+                    all_agents.extend(summaries.into_iter().map(|s| AgentSummary {
                         agent_id: s.agent_id,
                         total_actions: s.total_actions as usize,
                         success_count: s.success_count as usize,
@@ -107,19 +116,50 @@ pub(crate) async fn handle_list_agents(
                         last_active_at: Some(s.last_active_at),
                         entity_types: Vec::new(),
                         tenants: Vec::new(),
-                    })
-                    .collect();
-                let total = agents.len();
-                return Ok(Json(serde_json::json!({
-                    "agents": agents,
-                    "total": total,
-                })));
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, "failed to query agent summaries from Turso");
-                return Err(StatusCode::SERVICE_UNAVAILABLE);
+                    }));
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to query agent summaries from Turso");
+                }
             }
         }
+        // Deduplicate agents by agent_id (merge stats across stores).
+        let mut merged: std::collections::BTreeMap<String, AgentSummary> =
+            std::collections::BTreeMap::new();
+        for agent in all_agents {
+            let entry = merged.entry(agent.agent_id.clone()).or_insert(AgentSummary {
+                agent_id: agent.agent_id.clone(),
+                total_actions: 0,
+                success_count: 0,
+                error_count: 0,
+                denial_count: 0,
+                success_rate: 0.0,
+                last_active_at: None,
+                entity_types: Vec::new(),
+                tenants: Vec::new(),
+            });
+            entry.total_actions += agent.total_actions;
+            entry.success_count += agent.success_count;
+            entry.error_count += agent.error_count;
+            entry.denial_count += agent.denial_count;
+            if agent.last_active_at > entry.last_active_at {
+                entry.last_active_at = agent.last_active_at;
+            }
+        }
+        // Recompute success rates.
+        for agent in merged.values_mut() {
+            agent.success_rate = if agent.total_actions > 0 {
+                agent.success_count as f64 / agent.total_actions as f64
+            } else {
+                0.0
+            };
+        }
+        let agents: Vec<AgentSummary> = merged.into_values().collect();
+        let total = agents.len();
+        return Ok(Json(serde_json::json!({
+            "agents": agents,
+            "total": total,
+        })));
     }
 
     // No persistent store configured — return empty.
@@ -144,8 +184,17 @@ pub(crate) async fn handle_get_agent_history(
         .or(params.tenant);
     let limit = params.limit.unwrap_or(100).min(500);
 
-    // Query Turso directly (single source of truth).
-    if let Some(turso) = state.persistent_store() {
+    // Query the tenant-scoped or fan-out stores.
+    let stores = if let Some(ref tf) = tenant_filter {
+        match state.persistent_store_for_tenant(tf).await {
+            Some(turso) => vec![turso],
+            None => Vec::new(),
+        }
+    } else {
+        state.collect_all_turso_stores().await
+    };
+
+    for turso in &stores {
         match turso
             .query_trajectories_by_agent(
                 &agent_id,

--- a/crates/temper-server/src/observe/agents.rs
+++ b/crates/temper-server/src/observe/agents.rs
@@ -230,7 +230,7 @@ pub(crate) async fn handle_get_agent_history(
 
     // Sort by timestamp descending and truncate to limit.
     all_history.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
-    all_history.truncate(limit as usize);
+    all_history.truncate(limit);
     let total = all_history.len();
     Ok(Json(serde_json::json!({
         "agent_id": agent_id,

--- a/crates/temper-server/src/observe/agents.rs
+++ b/crates/temper-server/src/observe/agents.rs
@@ -127,17 +127,19 @@ pub(crate) async fn handle_list_agents(
         let mut merged: std::collections::BTreeMap<String, AgentSummary> =
             std::collections::BTreeMap::new();
         for agent in all_agents {
-            let entry = merged.entry(agent.agent_id.clone()).or_insert(AgentSummary {
-                agent_id: agent.agent_id.clone(),
-                total_actions: 0,
-                success_count: 0,
-                error_count: 0,
-                denial_count: 0,
-                success_rate: 0.0,
-                last_active_at: None,
-                entity_types: Vec::new(),
-                tenants: Vec::new(),
-            });
+            let entry = merged
+                .entry(agent.agent_id.clone())
+                .or_insert(AgentSummary {
+                    agent_id: agent.agent_id.clone(),
+                    total_actions: 0,
+                    success_count: 0,
+                    error_count: 0,
+                    denial_count: 0,
+                    success_rate: 0.0,
+                    last_active_at: None,
+                    entity_types: Vec::new(),
+                    tenants: Vec::new(),
+                });
             entry.total_actions += agent.total_actions;
             entry.success_count += agent.success_count;
             entry.error_count += agent.error_count;

--- a/crates/temper-server/src/observe/agents.rs
+++ b/crates/temper-server/src/observe/agents.rs
@@ -196,6 +196,7 @@ pub(crate) async fn handle_get_agent_history(
         state.collect_all_turso_stores().await
     };
 
+    let mut all_history: Vec<AgentHistoryEntry> = Vec::new();
     for turso in &stores {
         match turso
             .query_trajectories_by_agent(
@@ -207,40 +208,33 @@ pub(crate) async fn handle_get_agent_history(
             .await
         {
             Ok(rows) => {
-                let history: Vec<AgentHistoryEntry> = rows
-                    .into_iter()
-                    .map(|r| AgentHistoryEntry {
-                        timestamp: r.created_at,
-                        tenant: r.tenant,
-                        entity_type: r.entity_type,
-                        entity_id: r.entity_id,
-                        action: r.action,
-                        success: r.success,
-                        from_status: r.from_status,
-                        to_status: r.to_status,
-                        error: r.error,
-                        authz_denied: r.authz_denied.unwrap_or(false),
-                        denied_resource: r.denied_resource,
-                    })
-                    .collect();
-                let total = history.len();
-                return Ok(Json(serde_json::json!({
-                    "agent_id": agent_id,
-                    "history": history,
-                    "total": total,
-                })));
+                all_history.extend(rows.into_iter().map(|r| AgentHistoryEntry {
+                    timestamp: r.created_at,
+                    tenant: r.tenant,
+                    entity_type: r.entity_type,
+                    entity_id: r.entity_id,
+                    action: r.action,
+                    success: r.success,
+                    from_status: r.from_status,
+                    to_status: r.to_status,
+                    error: r.error,
+                    authz_denied: r.authz_denied.unwrap_or(false),
+                    denied_resource: r.denied_resource,
+                }));
             }
             Err(e) => {
                 tracing::warn!(error = %e, "failed to query agent history from Turso");
-                return Err(StatusCode::SERVICE_UNAVAILABLE);
             }
         }
     }
 
-    // No persistent store configured — return empty.
+    // Sort by timestamp descending and truncate to limit.
+    all_history.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    all_history.truncate(limit as usize);
+    let total = all_history.len();
     Ok(Json(serde_json::json!({
         "agent_id": agent_id,
-        "history": [],
-        "total": 0,
+        "history": all_history,
+        "total": total,
     })))
 }

--- a/crates/temper-server/src/observe/evolution/operations.rs
+++ b/crates/temper-server/src/observe/evolution/operations.rs
@@ -28,7 +28,7 @@ async fn persist_evolution_record(
     derived_from: Option<&str>,
     data_json: &str,
 ) -> Result<(), String> {
-    let Some(turso) = state.persistent_store() else {
+    let Some(turso) = state.platform_persistent_store() else {
         tracing::debug!(
             record_id,
             record_type,
@@ -348,7 +348,7 @@ pub(crate) async fn handle_feature_requests(
 
     // Query Turso directly (single source of truth).
     let system_tenant = TenantId::new("temper-system");
-    if let Some(turso) = state.persistent_store() {
+    if let Some(turso) = state.platform_persistent_store() {
         // First, generate and upsert fresh feature requests from trajectory data.
         let generated = insight_generator::generate_feature_requests(&trajectory_entries);
         for fr in &generated {
@@ -469,7 +469,7 @@ pub(crate) async fn handle_update_feature_request(
         }
     }
 
-    let Some(turso) = state.persistent_store() else {
+    let Some(turso) = state.platform_persistent_store() else {
         return Err(StatusCode::SERVICE_UNAVAILABLE);
     };
 

--- a/crates/temper-server/src/observe/evolution/trajectories.rs
+++ b/crates/temper-server/src/observe/evolution/trajectories.rs
@@ -39,33 +39,79 @@ pub(crate) async fn handle_trajectories(
     let failed_limit = params.failed_limit.unwrap_or(50).min(500);
     let success_filter: Option<bool> = params.success.as_deref().map(|s| s == "true");
 
-    // Query Turso directly (single source of truth).
-    if let Some(turso) = state.persistent_store() {
-        let _tenant_str = tenant_scope.as_ref().map(|t| t.as_str().to_string());
-        match turso
-            .query_trajectory_stats(
-                params.entity_type.as_deref(),
-                params.action.as_deref(),
-                success_filter,
-                failed_limit as i64,
-            )
+    // Determine which stores to query: tenant-scoped or fan-out.
+    let stores = if let Some(ref scope) = tenant_scope {
+        match state
+            .persistent_store_for_tenant(scope.as_str())
             .await
         {
-            Ok(stats) => {
-                return Ok(Json(serde_json::json!({
-                    "total": stats.total,
-                    "success_count": stats.success_count,
-                    "error_count": stats.error_count,
-                    "success_rate": stats.success_rate,
-                    "by_action": stats.by_action,
-                    "failed_intents": stats.failed_intents,
-                })));
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, "failed to query trajectories from Turso");
-                return Err(StatusCode::SERVICE_UNAVAILABLE);
+            Some(turso) => vec![turso],
+            None => Vec::new(),
+        }
+    } else {
+        state.collect_all_turso_stores().await
+    };
+
+    if !stores.is_empty() {
+        // Aggregate stats across all queried stores.
+        let mut total: u64 = 0;
+        let mut success_count: u64 = 0;
+        let mut error_count: u64 = 0;
+        let mut by_action: std::collections::BTreeMap<String, temper_store_turso::ActionStats> =
+            std::collections::BTreeMap::new();
+        let mut failed_intents = Vec::new();
+
+        for turso in &stores {
+            match turso
+                .query_trajectory_stats(
+                    params.entity_type.as_deref(),
+                    params.action.as_deref(),
+                    success_filter,
+                    failed_limit as i64,
+                )
+                .await
+            {
+                Ok(stats) => {
+                    total += stats.total;
+                    success_count += stats.success_count;
+                    error_count += stats.error_count;
+                    for (action, action_stats) in stats.by_action {
+                        let entry = by_action.entry(action).or_insert(
+                            temper_store_turso::ActionStats {
+                                total: 0,
+                                success: 0,
+                                error: 0,
+                            },
+                        );
+                        entry.total += action_stats.total;
+                        entry.success += action_stats.success;
+                        entry.error += action_stats.error;
+                    }
+                    failed_intents.extend(stats.failed_intents);
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to query trajectories from Turso");
+                }
             }
         }
+
+        let success_rate = if total > 0 {
+            success_count as f64 / total as f64
+        } else {
+            0.0
+        };
+        // Sort and limit failed intents
+        failed_intents.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        failed_intents.truncate(failed_limit);
+
+        return Ok(Json(serde_json::json!({
+            "total": total,
+            "success_count": success_count,
+            "error_count": error_count,
+            "success_rate": success_rate,
+            "by_action": by_action,
+            "failed_intents": failed_intents,
+        })));
     }
 
     // Fallback: empty response when no Turso configured.

--- a/crates/temper-server/src/observe/evolution/trajectories.rs
+++ b/crates/temper-server/src/observe/evolution/trajectories.rs
@@ -41,10 +41,7 @@ pub(crate) async fn handle_trajectories(
 
     // Determine which stores to query: tenant-scoped or fan-out.
     let stores = if let Some(ref scope) = tenant_scope {
-        match state
-            .persistent_store_for_tenant(scope.as_str())
-            .await
-        {
+        match state.persistent_store_for_tenant(scope.as_str()).await {
             Some(turso) => vec![turso],
             None => Vec::new(),
         }
@@ -76,13 +73,14 @@ pub(crate) async fn handle_trajectories(
                     success_count += stats.success_count;
                     error_count += stats.error_count;
                     for (action, action_stats) in stats.by_action {
-                        let entry = by_action.entry(action).or_insert(
-                            temper_store_turso::ActionStats {
-                                total: 0,
-                                success: 0,
-                                error: 0,
-                            },
-                        );
+                        let entry =
+                            by_action
+                                .entry(action)
+                                .or_insert(temper_store_turso::ActionStats {
+                                    total: 0,
+                                    success: 0,
+                                    error: 0,
+                                });
                         entry.total += action_stats.total;
                         entry.success += action_stats.success;
                         entry.error += action_stats.error;

--- a/crates/temper-server/src/observe/mod_test.rs
+++ b/crates/temper-server/src/observe/mod_test.rs
@@ -282,7 +282,7 @@ async fn test_approve_decision_reload_failure_keeps_pending_and_policies_unchang
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 
     // Verify decision status unchanged in Turso.
-    let turso = state.persistent_store().expect("turso configured");
+    let turso = state.platform_persistent_store().expect("turso configured");
     let data_str = turso
         .get_pending_decision(&decision_id)
         .await
@@ -820,7 +820,7 @@ async fn test_evolution_decide_creates_d_record() {
     };
     let data_json = serde_json::to_string(&obs).unwrap();
     state
-        .persistent_store()
+        .platform_persistent_store()
         .expect("turso configured")
         .insert_evolution_record(
             &obs.header.id,
@@ -1139,7 +1139,7 @@ async fn test_load_dir_emits_design_time_events() {
         .unwrap();
 
     // Check that design-time events were persisted to Turso.
-    let turso = state.persistent_store().expect("turso configured");
+    let turso = state.platform_persistent_store().expect("turso configured");
     let events = turso
         .list_design_time_events(None, 1000)
         .await

--- a/crates/temper-server/src/observe/specs/load_inline.rs
+++ b/crates/temper-server/src/observe/specs/load_inline.rs
@@ -101,8 +101,8 @@ pub(crate) async fn handle_load_inline(
             }),
         };
         let o_id = o_record.header.id.clone();
-        // Persist observation to Turso.
-        if let Some(turso) = state.persistent_store() {
+        // Persist observation to Turso (evolution records stay on platform).
+        if let Some(turso) = state.platform_persistent_store() {
             let data_json = serde_json::to_string(&o_record).unwrap_or_default();
             let _ = turso
                 .insert_evolution_record(
@@ -140,8 +140,8 @@ pub(crate) async fn handle_load_inline(
             recommendation: Some(0),
         };
         let a_record_id = a_record.header.id.clone();
-        // Persist analysis to Turso.
-        if let Some(turso) = state.persistent_store() {
+        // Persist analysis to Turso (evolution records stay on platform).
+        if let Some(turso) = state.platform_persistent_store() {
             let data_json = serde_json::to_string(&a_record).unwrap_or_default();
             let _ = turso
                 .insert_evolution_record(
@@ -156,9 +156,9 @@ pub(crate) async fn handle_load_inline(
         }
 
         // Link the PendingDecision to the A-Record for O-A-D chain tracing.
-        // Decisions are persisted to Turso; the evolution_record_id link will be
-        // available when the decision is read back from Turso.
-        if let Some(turso) = state.persistent_store() {
+        // Decisions are persisted to the tenant store; the evolution_record_id
+        // link will be available when the decision is read back from Turso.
+        if let Some(turso) = state.persistent_store_for_tenant(&tenant).await {
             for decision_id in &decision_ids {
                 if let Ok(Some(data_str)) = turso.get_pending_decision(decision_id).await
                     && let Ok(mut pd) =

--- a/crates/temper-server/src/observe/verification/workflow.rs
+++ b/crates/temper-server/src/observe/verification/workflow.rs
@@ -105,12 +105,13 @@ async fn fetch_event_log(state: &ServerState) -> Vec<crate::state::DesignTimeEve
         }
     }
 
-    // Turso fallback.
-    if let Some(turso) = state.persistent_store() {
+    // Turso fallback: fan-out across all tenant stores.
+    let stores = state.collect_all_turso_stores().await;
+    let mut all_events = Vec::new();
+    for turso in &stores {
         match turso.list_design_time_events(None, 10_000).await {
-            Ok(rows) => rows
-                .into_iter()
-                .map(|r| crate::state::DesignTimeEvent {
+            Ok(rows) => {
+                all_events.extend(rows.into_iter().map(|r| crate::state::DesignTimeEvent {
                     kind: r.kind,
                     entity_type: r.entity_type,
                     tenant: r.tenant,
@@ -120,16 +121,14 @@ async fn fetch_event_log(state: &ServerState) -> Vec<crate::state::DesignTimeEve
                     timestamp: r.created_at,
                     step_number: r.step_number.map(|n| n as u8),
                     total_steps: r.total_steps.map(|n| n as u8),
-                })
-                .collect(),
+                }));
+            }
             Err(e) => {
                 tracing::warn!(error = %e, "failed to read design_time_events from Turso");
-                Vec::new()
             }
         }
-    } else {
-        Vec::new()
     }
+    all_events
 }
 
 /// Fetch per-tenant trajectory counts from Turso using a SQL aggregate query.

--- a/crates/temper-server/src/observe/wasm.rs
+++ b/crates/temper-server/src/observe/wasm.rs
@@ -282,26 +282,25 @@ pub async fn handle_list_wasm_modules(
     require_observe_auth(&state, &headers, "read_wasm", "WasmModule")?;
     let tenant_scope = observe_tenant_scope(&state, &headers)?;
 
-    // Collect invocation stats — Turso is single source of truth but we
-    // aggregate from load_recent_wasm_invocations; for module list we
-    // just use an empty stats map if Turso is unavailable.
+    // Collect invocation stats via fan-out across all tenant stores.
     let invocation_stats: std::collections::BTreeMap<String, (usize, usize, Option<String>)> = {
         let mut stats: std::collections::BTreeMap<String, (usize, usize, Option<String>)> =
             std::collections::BTreeMap::new();
-        if let Some(turso) = state.persistent_store()
-            && let Ok(rows) = turso.load_recent_wasm_invocations(10_000).await
-        {
-            for row in rows {
-                let module = row.module_name.clone();
-                let success = row.success;
-                let ts = Some(row.created_at.clone());
-                let (total, s_count, last_ts) = stats.entry(module).or_insert((0, 0, None));
-                *total += 1;
-                if success {
-                    *s_count += 1;
-                }
-                if ts.is_some() {
-                    *last_ts = ts;
+        let stores = state.collect_all_turso_stores().await;
+        for turso in &stores {
+            if let Ok(rows) = turso.load_recent_wasm_invocations(10_000).await {
+                for row in rows {
+                    let module = row.module_name.clone();
+                    let success = row.success;
+                    let ts = Some(row.created_at.clone());
+                    let (total, s_count, last_ts) = stats.entry(module).or_insert((0, 0, None));
+                    *total += 1;
+                    if success {
+                        *s_count += 1;
+                    }
+                    if ts.is_some() {
+                        *last_ts = ts;
+                    }
                 }
             }
         }
@@ -368,8 +367,10 @@ pub async fn handle_list_wasm_invocations(
     require_observe_auth(&state, &headers, "read_wasm", "WasmModule")?;
     let limit = params.limit.unwrap_or(100).min(10_000);
 
-    // Query Turso directly (single source of truth).
-    if let Some(turso) = state.persistent_store() {
+    // Fan-out across all tenant stores.
+    let stores = state.collect_all_turso_stores().await;
+    let mut all_filtered: Vec<serde_json::Value> = Vec::new();
+    for turso in &stores {
         match turso.load_recent_wasm_invocations(limit as i64).await {
             Ok(rows) => {
                 let filtered: Vec<serde_json::Value> = rows
@@ -389,11 +390,7 @@ pub async fn handle_list_wasm_invocations(
                     })
                     .map(|e| serde_json::to_value(&e).unwrap_or_default())
                     .collect();
-                let total = filtered.len();
-                return Ok(Json(WasmInvocationResponse {
-                    invocations: filtered,
-                    total,
-                }));
+                all_filtered.extend(filtered);
             }
             Err(e) => {
                 tracing::warn!(error = %e, "failed to query WASM invocations from Turso");
@@ -401,9 +398,9 @@ pub async fn handle_list_wasm_invocations(
         }
     }
 
-    // Fallback: empty response when no Turso configured.
+    let total = all_filtered.len();
     Ok(Json(WasmInvocationResponse {
-        invocations: Vec::new(),
-        total: 0,
+        invocations: all_filtered,
+        total,
     }))
 }

--- a/crates/temper-server/src/state/evolution.rs
+++ b/crates/temper-server/src/state/evolution.rs
@@ -17,7 +17,7 @@ impl ServerState {
         status: Option<&str>,
     ) -> Result<Vec<EvolutionRecordRow>, String> {
         // Prefer Turso when available.
-        if let Some(turso) = self.persistent_store() {
+        if let Some(turso) = self.platform_persistent_store() {
             let rows = turso
                 .list_evolution_records(record_type, status)
                 .await
@@ -77,7 +77,7 @@ impl ServerState {
         &self,
         id: &str,
     ) -> Result<Option<EvolutionRecordRow>, String> {
-        if let Some(turso) = self.persistent_store() {
+        if let Some(turso) = self.platform_persistent_store() {
             let row = turso
                 .get_evolution_record(id)
                 .await
@@ -116,7 +116,7 @@ impl ServerState {
     /// List ranked insights (I-Records) from the first available backend.
     #[instrument(skip_all, fields(otel.name = "evolution.list_ranked_insights"))]
     pub async fn list_ranked_insights(&self) -> Result<Vec<EvolutionRecordRow>, String> {
-        if let Some(turso) = self.persistent_store() {
+        if let Some(turso) = self.platform_persistent_store() {
             let rows = turso.list_ranked_insights().await.map_err(|e| {
                 tracing::warn!(backend = "turso", error = %e, "evolution.store.read");
                 e.to_string()
@@ -154,7 +154,7 @@ impl ServerState {
         derived_from: Option<&str>,
         data_json: &str,
     ) -> Result<(), String> {
-        if let Some(turso) = self.persistent_store() {
+        if let Some(turso) = self.platform_persistent_store() {
             turso
                 .insert_evolution_record(
                     id,

--- a/crates/temper-server/src/state/mod.rs
+++ b/crates/temper-server/src/state/mod.rs
@@ -500,22 +500,41 @@ impl ServerState {
         }
     }
 
-    /// Get a reference to the Turso event store.
+    /// Get a reference to the platform Turso event store.
     ///
     /// Panics if the event store is not configured or is not a Turso backend.
     pub fn turso(&self) -> &temper_store_turso::TursoEventStore {
-        self.persistent_store()
+        self.platform_persistent_store()
             .expect("Turso event store is not configured")
     }
 
-    /// Get an optional reference to the persistent Turso event store.
+    /// Get an optional reference to the **platform** Turso event store.
+    ///
+    /// Only use for system-wide data that stays in the platform DB
+    /// (evolution records, feature requests, tenant registry).
+    /// For tenant-scoped data, use [`persistent_store_for_tenant`].
     ///
     /// Returns `None` when the server is running without Turso (e.g. in-memory
     /// mode or tests). Callers should degrade gracefully to empty results.
-    pub fn persistent_store(&self) -> Option<&temper_store_turso::TursoEventStore> {
+    pub fn platform_persistent_store(&self) -> Option<&temper_store_turso::TursoEventStore> {
         self.event_store
             .as_ref()
             .and_then(|store| store.platform_turso_store())
+    }
+
+    /// Get a Turso store for a specific tenant.
+    ///
+    /// In TenantRouted mode, routes to the per-tenant database.
+    /// In single-DB Turso mode, returns the shared store.
+    /// `temper-system` and `default` tenants route to the platform store.
+    ///
+    /// Returns `None` when the server is running without Turso.
+    pub async fn persistent_store_for_tenant(
+        &self,
+        tenant: &str,
+    ) -> Option<temper_store_turso::TursoEventStore> {
+        let store = self.event_store.as_ref()?;
+        store.turso_for_tenant(tenant).await
     }
 
     /// Find an entity spec by name across all tenants.
@@ -537,90 +556,139 @@ impl ServerState {
 
     /// Load aggregated unmet-intent failure groups from Turso.
     ///
-    /// Returns at most 100 rows (one per entity_type × error group) instead of
-    /// loading thousands of raw trajectory rows.  Returns an empty vec when
-    /// Turso is not configured.
+    /// Uses fan-out across all tenant stores in TenantRouted mode.
+    /// Returns an empty vec when Turso is not configured.
     pub async fn load_unmet_intent_rows_aggregated(
         &self,
     ) -> (
         Vec<temper_store_turso::UnmetIntentAggRow>,
         std::collections::BTreeMap<String, String>,
     ) {
-        let Some(turso) = self.persistent_store() else {
+        let stores = self.collect_all_turso_stores().await;
+        if stores.is_empty() {
             return (Vec::new(), std::collections::BTreeMap::new());
-        };
-        let failures = match turso.load_unmet_intent_rows().await {
-            Ok(rows) => rows,
-            Err(e) => {
-                tracing::warn!(error = %e, "failed to load unmet intent rows from Turso");
-                Vec::new()
+        }
+
+        let mut failures = Vec::new();
+        let mut submitted_specs = std::collections::BTreeMap::new();
+
+        for turso in &stores {
+            match turso.load_unmet_intent_rows().await {
+                Ok(rows) => failures.extend(rows),
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to load unmet intent rows from Turso");
+                }
             }
-        };
-        let submitted_specs = match turso.load_submit_spec_timestamps().await {
-            Ok(map) => map,
-            Err(e) => {
-                tracing::warn!(error = %e, "failed to load submit-spec timestamps from Turso");
-                std::collections::BTreeMap::new()
+            match turso.load_submit_spec_timestamps().await {
+                Ok(map) => submitted_specs.extend(map),
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to load submit-spec timestamps from Turso");
+                }
             }
-        };
+        }
         (failures, submitted_specs)
     }
 
-    /// Count trajectory rows per tenant using a single SQL aggregate query.
+    /// Count trajectory rows per tenant using fan-out across all stores.
     ///
     /// Returns an empty map when Turso is not configured.
     pub async fn count_trajectories_by_tenant(&self) -> std::collections::BTreeMap<String, u64> {
-        let Some(turso) = self.persistent_store() else {
+        let stores = self.collect_all_turso_stores().await;
+        if stores.is_empty() {
             return std::collections::BTreeMap::new();
-        };
-        match turso.count_trajectories_by_tenant().await {
-            Ok(counts) => counts,
-            Err(e) => {
-                tracing::warn!(error = %e, "failed to count trajectories by tenant from Turso");
-                std::collections::BTreeMap::new()
+        }
+
+        let mut counts = std::collections::BTreeMap::new();
+        for turso in &stores {
+            match turso.count_trajectories_by_tenant().await {
+                Ok(c) => {
+                    for (tenant, count) in c {
+                        *counts.entry(tenant).or_insert(0) += count;
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to count trajectories by tenant from Turso");
+                }
             }
         }
+        counts
     }
 
     /// Load trajectory entries from Turso, converting to domain TrajectoryEntry.
+    ///
+    /// Uses fan-out across all tenant stores in TenantRouted mode.
     pub async fn load_trajectory_entries(&self, limit: i64) -> Vec<TrajectoryEntry> {
-        let Some(turso) = self.persistent_store() else {
+        let stores = self.collect_all_turso_stores().await;
+        if stores.is_empty() {
             return Vec::new();
-        };
-        match turso.load_recent_trajectories(limit).await {
-            Ok(rows) => rows
-                .into_iter()
-                .map(|r| TrajectoryEntry {
-                    timestamp: r.created_at,
-                    tenant: r.tenant,
-                    entity_type: r.entity_type,
-                    entity_id: r.entity_id,
-                    action: r.action,
-                    success: r.success,
-                    from_status: r.from_status,
-                    to_status: r.to_status,
-                    error: r.error,
-                    agent_id: r.agent_id,
-                    session_id: r.session_id,
-                    authz_denied: r.authz_denied,
-                    denied_resource: r.denied_resource,
-                    denied_module: r.denied_module,
-                    source: r.source.as_deref().and_then(|s| match s {
-                        "Entity" => Some(TrajectorySource::Entity),
-                        "Platform" => Some(TrajectorySource::Platform),
-                        "Authz" => Some(TrajectorySource::Authz),
-                        _ => None,
-                    }),
-                    spec_governed: r.spec_governed,
-                    agent_type: None,
-                    request_body: r.request_body.and_then(|s| serde_json::from_str(&s).ok()),
-                    intent: r.intent,
-                })
-                .collect(),
-            Err(e) => {
-                tracing::warn!(error = %e, "failed to load trajectories from Turso");
-                Vec::new()
+        }
+
+        let mut all_entries = Vec::new();
+        for turso in &stores {
+            match turso.load_recent_trajectories(limit).await {
+                Ok(rows) => {
+                    all_entries.extend(rows.into_iter().map(|r| TrajectoryEntry {
+                        timestamp: r.created_at,
+                        tenant: r.tenant,
+                        entity_type: r.entity_type,
+                        entity_id: r.entity_id,
+                        action: r.action,
+                        success: r.success,
+                        from_status: r.from_status,
+                        to_status: r.to_status,
+                        error: r.error,
+                        agent_id: r.agent_id,
+                        session_id: r.session_id,
+                        authz_denied: r.authz_denied,
+                        denied_resource: r.denied_resource,
+                        denied_module: r.denied_module,
+                        source: r.source.as_deref().and_then(|s| match s {
+                            "Entity" => Some(TrajectorySource::Entity),
+                            "Platform" => Some(TrajectorySource::Platform),
+                            "Authz" => Some(TrajectorySource::Authz),
+                            _ => None,
+                        }),
+                        spec_governed: r.spec_governed,
+                        agent_type: None,
+                        request_body: r.request_body.and_then(|s| serde_json::from_str(&s).ok()),
+                        intent: r.intent,
+                    }));
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to load trajectories from Turso");
+                }
             }
         }
+        // Sort by timestamp descending and limit
+        all_entries.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        all_entries.truncate(limit as usize);
+        all_entries
+    }
+
+    /// Collect all Turso stores for fan-out reads.
+    ///
+    /// In single-DB mode, returns just the shared store.
+    /// In TenantRouted mode, returns the platform store + all connected tenant stores.
+    /// Returns an empty vec when Turso is not configured.
+    pub async fn collect_all_turso_stores(&self) -> Vec<temper_store_turso::TursoEventStore> {
+        let Some(store) = self.event_store.as_ref() else {
+            return Vec::new();
+        };
+
+        if let Some(turso) = store.turso_store() {
+            return vec![turso.clone()];
+        }
+
+        if let Some(router) = store.tenant_router() {
+            let mut stores = vec![router.platform_store().clone()];
+            for tid in router.connected_tenants().await {
+                if let Ok(s) = router.store_for_tenant(&tid).await {
+                    stores.push(s);
+                }
+            }
+            return stores;
+        }
+
+        Vec::new()
     }
 }

--- a/crates/temper-server/src/state/persistence/logs_and_secrets.rs
+++ b/crates/temper-server/src/state/persistence/logs_and_secrets.rs
@@ -147,12 +147,10 @@ impl ServerState {
                 .map_err(|e| format!("failed to upsert secret {tenant}/{key_name}: {e}"))?;
                 Ok(())
             }
-            TenantMetadataBackend::Turso(turso) => {
-                turso
-                    .upsert_secret(tenant, key_name, ciphertext, nonce)
-                    .await
-                    .map_err(|e| format!("failed to upsert secret {tenant}/{key_name} in turso: {e}"))
-            }
+            TenantMetadataBackend::Turso(turso) => turso
+                .upsert_secret(tenant, key_name, ciphertext, nonce)
+                .await
+                .map_err(|e| format!("failed to upsert secret {tenant}/{key_name} in turso: {e}")),
             TenantMetadataBackend::Redis => Err(Self::redis_ephemeral_error("Secret persistence")),
         }
     }
@@ -224,10 +222,9 @@ impl ServerState {
                 Ok(count)
             }
             TenantMetadataBackend::Turso(turso) => {
-                let rows = turso
-                    .load_secrets_for_tenant(tenant)
-                    .await
-                    .map_err(|e| format!("failed to load secrets for tenant {tenant} from turso: {e}"))?;
+                let rows = turso.load_secrets_for_tenant(tenant).await.map_err(|e| {
+                    format!("failed to load secrets for tenant {tenant} from turso: {e}")
+                })?;
 
                 let mut count = 0;
                 for (key_name, ciphertext, nonce) in &rows {

--- a/crates/temper-server/src/state/persistence/logs_and_secrets.rs
+++ b/crates/temper-server/src/state/persistence/logs_and_secrets.rs
@@ -2,13 +2,13 @@ use temper_store_turso::TursoTrajectoryInsert;
 
 use super::super::trajectory::TrajectoryEntry;
 use super::super::{DesignTimeEvent, ServerState};
-use super::MetadataBackend;
+use super::TenantMetadataBackend;
 
 impl ServerState {
-    /// Broadcast and persist a design-time event to Turso.
+    /// Broadcast and persist a design-time event to the tenant's store.
     pub async fn emit_design_time_event(&self, event: DesignTimeEvent) -> Result<(), String> {
-        // Persist to Turso.
-        if let Some(turso) = self.persistent_store() {
+        // Persist to the tenant's Turso store.
+        if let Some(turso) = self.persistent_store_for_tenant(&event.tenant).await {
             turso
                 .insert_design_time_event(
                     &event.kind,
@@ -33,9 +33,9 @@ impl ServerState {
         Ok(())
     }
 
-    /// Persist a trajectory entry to Turso (single source of truth).
+    /// Persist a trajectory entry to the tenant's Turso store.
     pub async fn persist_trajectory_entry(&self, entry: &TrajectoryEntry) -> Result<(), String> {
-        let Some(turso) = self.persistent_store() else {
+        let Some(turso) = self.persistent_store_for_tenant(&entry.tenant).await else {
             return Ok(());
         };
         let request_body_json = entry.request_body.as_ref().and_then(|v| {
@@ -86,34 +86,32 @@ impl ServerState {
         Ok(())
     }
 
-    /// Persist a pending decision to the storage backend (Turso only for now).
+    /// Persist a pending decision to the tenant's storage backend.
     pub async fn persist_pending_decision(
         &self,
         decision: &super::super::PendingDecision,
     ) -> Result<(), String> {
-        let Some(store) = self.event_store.as_ref() else {
+        let Some(turso) = self.persistent_store_for_tenant(&decision.tenant).await else {
             return Ok(());
         };
 
-        if let Some(turso) = store.platform_turso_store() {
-            let status_str = match decision.status {
-                super::super::DecisionStatus::Pending => "pending",
-                super::super::DecisionStatus::Approved => "approved",
-                super::super::DecisionStatus::Denied => "denied",
-                super::super::DecisionStatus::Expired => "expired",
-            };
-            let data_json = serde_json::to_string(decision)
-                .map_err(|e| format!("failed to serialize decision {}: {e}", decision.id))?;
-            turso
-                .upsert_pending_decision(&decision.id, &decision.tenant, status_str, &data_json)
-                .await
-                .map_err(|e| {
-                    format!(
-                        "failed to persist pending decision {} in turso: {e}",
-                        decision.id
-                    )
-                })?;
-        }
+        let status_str = match decision.status {
+            super::super::DecisionStatus::Pending => "pending",
+            super::super::DecisionStatus::Approved => "approved",
+            super::super::DecisionStatus::Denied => "denied",
+            super::super::DecisionStatus::Expired => "expired",
+        };
+        let data_json = serde_json::to_string(decision)
+            .map_err(|e| format!("failed to serialize decision {}: {e}", decision.id))?;
+        turso
+            .upsert_pending_decision(&decision.id, &decision.tenant, status_str, &data_json)
+            .await
+            .map_err(|e| {
+                format!(
+                    "failed to persist pending decision {} in turso: {e}",
+                    decision.id
+                )
+            })?;
 
         Ok(())
     }
@@ -126,12 +124,12 @@ impl ServerState {
         ciphertext: &[u8],
         nonce: &[u8],
     ) -> Result<(), String> {
-        let Some(backend) = self.metadata_backend() else {
+        let Some(backend) = self.metadata_backend_for_tenant(tenant).await else {
             return Ok(());
         };
 
         match backend {
-            MetadataBackend::Postgres(pool) => {
+            TenantMetadataBackend::Postgres(pool) => {
                 sqlx::query(
                     "INSERT INTO tenant_secrets (tenant, key_name, ciphertext, nonce, created_at, updated_at) \
                      VALUES ($1, $2, $3, $4, now(), now()) \
@@ -144,39 +142,43 @@ impl ServerState {
                 .bind(key_name)
                 .bind(ciphertext)
                 .bind(nonce)
-                .execute(pool)
+                .execute(&pool)
                 .await
                 .map_err(|e| format!("failed to upsert secret {tenant}/{key_name}: {e}"))?;
                 Ok(())
             }
-            MetadataBackend::Turso(_) => {
-                Err("secret persistence is not supported on turso backend yet".to_string())
+            TenantMetadataBackend::Turso(turso) => {
+                turso
+                    .upsert_secret(tenant, key_name, ciphertext, nonce)
+                    .await
+                    .map_err(|e| format!("failed to upsert secret {tenant}/{key_name} in turso: {e}"))
             }
-            MetadataBackend::Redis => Err(Self::redis_ephemeral_error("Secret persistence")),
+            TenantMetadataBackend::Redis => Err(Self::redis_ephemeral_error("Secret persistence")),
         }
     }
 
     /// Delete a secret from the persistence backend.
     pub async fn delete_secret(&self, tenant: &str, key_name: &str) -> Result<bool, String> {
-        let Some(backend) = self.metadata_backend() else {
+        let Some(backend) = self.metadata_backend_for_tenant(tenant).await else {
             return Ok(false);
         };
 
         match backend {
-            MetadataBackend::Postgres(pool) => {
+            TenantMetadataBackend::Postgres(pool) => {
                 let result =
                     sqlx::query("DELETE FROM tenant_secrets WHERE tenant = $1 AND key_name = $2")
                         .bind(tenant)
                         .bind(key_name)
-                        .execute(pool)
+                        .execute(&pool)
                         .await
                         .map_err(|e| format!("failed to delete secret {tenant}/{key_name}: {e}"))?;
                 Ok(result.rows_affected() > 0)
             }
-            MetadataBackend::Turso(_) => {
-                Err("secret deletion is not supported on turso backend yet".to_string())
-            }
-            MetadataBackend::Redis => Err(Self::redis_ephemeral_error("Secret deletion")),
+            TenantMetadataBackend::Turso(turso) => turso
+                .delete_secret(tenant, key_name)
+                .await
+                .map_err(|e| format!("failed to delete secret {tenant}/{key_name} in turso: {e}")),
+            TenantMetadataBackend::Redis => Err(Self::redis_ephemeral_error("Secret deletion")),
         }
     }
 
@@ -185,17 +187,17 @@ impl ServerState {
         let Some(vault) = self.secrets_vault.as_ref() else {
             return Ok(0);
         };
-        let Some(backend) = self.metadata_backend() else {
+        let Some(backend) = self.metadata_backend_for_tenant(tenant).await else {
             return Ok(0);
         };
 
         match backend {
-            MetadataBackend::Postgres(pool) => {
+            TenantMetadataBackend::Postgres(pool) => {
                 let rows: Vec<(String, Vec<u8>, Vec<u8>)> = sqlx::query_as(
                     "SELECT key_name, ciphertext, nonce FROM tenant_secrets WHERE tenant = $1",
                 )
                 .bind(tenant)
-                .fetch_all(pool)
+                .fetch_all(&pool)
                 .await
                 .map_err(|e| format!("failed to load secrets for tenant {tenant}: {e}"))?;
 
@@ -221,10 +223,35 @@ impl ServerState {
                 }
                 Ok(count)
             }
-            MetadataBackend::Turso(_) => {
-                Err("secret loading is not supported on turso backend yet".to_string())
+            TenantMetadataBackend::Turso(turso) => {
+                let rows = turso
+                    .load_secrets_for_tenant(tenant)
+                    .await
+                    .map_err(|e| format!("failed to load secrets for tenant {tenant} from turso: {e}"))?;
+
+                let mut count = 0;
+                for (key_name, ciphertext, nonce) in &rows {
+                    match vault.decrypt(ciphertext, nonce) {
+                        Ok(plaintext) => {
+                            let value = String::from_utf8(plaintext).map_err(|e| {
+                                format!("secret {key_name} is not valid UTF-8: {e}")
+                            })?;
+                            vault.cache_secret(tenant, key_name, value)?;
+                            count += 1;
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                tenant,
+                                key_name,
+                                error = %e,
+                                "failed to decrypt secret, skipping"
+                            );
+                        }
+                    }
+                }
+                Ok(count)
             }
-            MetadataBackend::Redis => Err(Self::redis_ephemeral_error("Secret loading")),
+            TenantMetadataBackend::Redis => Err(Self::redis_ephemeral_error("Secret loading")),
         }
     }
 }
@@ -248,7 +275,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn turso_secret_operations_are_explicitly_unsupported() {
+    async fn turso_secret_round_trip() {
         let db_path =
             std::env::temp_dir().join(format!("temper-secrets-{}.db", uuid::Uuid::new_v4())); // determinism-ok: test-only temp file
         let db_url = format!("file:{}", db_path.display());
@@ -262,23 +289,31 @@ mod tests {
         let vault = state.secrets_vault.as_ref().expect("vault configured");
         let (ciphertext, nonce) = vault.encrypt(b"secret-value").expect("encrypt");
 
-        let put_err = state
+        // Upsert secret.
+        state
             .upsert_secret("tenant-a", "API_KEY", &ciphertext, &nonce)
             .await
-            .expect_err("turso secret upsert should fail");
-        assert!(put_err.contains("not supported"));
+            .expect("turso secret upsert should succeed");
 
-        let del_err = state
-            .delete_secret("tenant-a", "API_KEY")
-            .await
-            .expect_err("turso secret delete should fail");
-        assert!(del_err.contains("not supported"));
-
-        let load_err = state
+        // Load and decrypt.
+        let loaded = state
             .load_tenant_secrets("tenant-a")
             .await
-            .expect_err("turso secret load should fail");
-        assert!(load_err.contains("not supported"));
+            .expect("turso secret load should succeed");
+        assert_eq!(loaded, 1, "should have loaded 1 secret");
+
+        // Verify the decrypted value is cached.
+        let cached = vault
+            .get_secret("tenant-a", "API_KEY")
+            .expect("secret should be cached");
+        assert_eq!(cached, "secret-value");
+
+        // Delete secret.
+        let deleted = state
+            .delete_secret("tenant-a", "API_KEY")
+            .await
+            .expect("turso secret delete should succeed");
+        assert!(deleted, "should have deleted 1 row");
 
         let _ = std::fs::remove_file(db_path); // determinism-ok: test-only cleanup
     }

--- a/crates/temper-server/src/state/persistence/mod.rs
+++ b/crates/temper-server/src/state/persistence/mod.rs
@@ -7,9 +7,24 @@ use temper_store_turso::{TursoEventStore, TursoWasmInvocationInsert};
 use super::ServerState;
 use super::wasm_invocation_log::WasmInvocationEntry;
 
+/// Borrowed metadata backend for platform-scoped operations.
+///
+/// Used only for system-wide data that stays in the platform DB
+/// (evolution records, feature requests). For tenant-scoped data,
+/// use [`TenantMetadataBackend`] via [`ServerState::metadata_backend_for_tenant`].
 enum MetadataBackend<'a> {
     Postgres(&'a PgPool),
     Turso(&'a TursoEventStore),
+    Redis,
+}
+
+/// Owned metadata backend for tenant-scoped operations.
+///
+/// `turso_for_tenant()` returns an owned `TursoEventStore` (Arc-based,
+/// clone is cheap), so tenant-scoped operations use this owned variant.
+pub(crate) enum TenantMetadataBackend {
+    Postgres(PgPool),
+    Turso(TursoEventStore),
     Redis,
 }
 
@@ -23,7 +38,11 @@ impl ServerState {
         )
     }
 
-    fn metadata_backend(&self) -> Option<MetadataBackend<'_>> {
+    /// Return the platform-scoped metadata backend.
+    ///
+    /// Only use for system-wide data (evolution records, feature requests).
+    /// For tenant-scoped data, use [`metadata_backend_for_tenant`].
+    fn platform_metadata_backend(&self) -> Option<MetadataBackend<'_>> {
         let store = self.event_store.as_ref()?;
         if let Some(pool) = store.postgres_pool() {
             return Some(MetadataBackend::Postgres(pool));
@@ -38,6 +57,29 @@ impl ServerState {
         }
     }
 
+    /// Return a tenant-scoped metadata backend.
+    ///
+    /// In TenantRouted mode, routes to the per-tenant database.
+    /// In single-DB Turso mode, returns the shared store.
+    /// In Postgres mode, returns the shared pool (RLS handles isolation).
+    pub(crate) async fn metadata_backend_for_tenant(
+        &self,
+        tenant: &str,
+    ) -> Option<TenantMetadataBackend> {
+        let store = self.event_store.as_ref()?;
+        if let Some(pool) = store.postgres_pool() {
+            return Some(TenantMetadataBackend::Postgres(pool.clone()));
+        }
+        if let Some(turso) = store.turso_for_tenant(tenant).await {
+            return Some(TenantMetadataBackend::Turso(turso));
+        }
+        if store.redis_store().is_some() {
+            Some(TenantMetadataBackend::Redis)
+        } else {
+            None
+        }
+    }
+
     /// Upsert a WASM module in the persistence backend (Postgres or Turso).
     pub async fn upsert_wasm_module(
         &self,
@@ -46,12 +88,12 @@ impl ServerState {
         wasm_bytes: &[u8],
         sha256_hash: &str,
     ) -> Result<(), String> {
-        let Some(backend) = self.metadata_backend() else {
+        let Some(backend) = self.metadata_backend_for_tenant(tenant).await else {
             return Ok(());
         };
 
         match backend {
-            MetadataBackend::Postgres(pool) => {
+            TenantMetadataBackend::Postgres(pool) => {
                 sqlx::query(
                     "INSERT INTO wasm_modules (tenant, module_name, wasm_bytes, sha256_hash, version, size_bytes, updated_at) \
                      VALUES ($1, $2, $3, $4, 1, $5, now()) \
@@ -67,18 +109,18 @@ impl ServerState {
                 .bind(wasm_bytes)
                 .bind(sha256_hash)
                 .bind(wasm_bytes.len() as i32)
-                .execute(pool)
+                .execute(&pool)
                 .await
                 .map(|_| ())
                 .map_err(|e| format!("failed to upsert WASM module {tenant}/{module_name}: {e}"))
             }
-            MetadataBackend::Turso(turso) => turso
+            TenantMetadataBackend::Turso(turso) => turso
                 .upsert_wasm_module(tenant, module_name, wasm_bytes, sha256_hash)
                 .await
                 .map_err(|e| {
                     format!("failed to upsert WASM module {tenant}/{module_name} in turso: {e}")
                 }),
-            MetadataBackend::Redis => Err(Self::redis_ephemeral_error("WASM module persistence")),
+            TenantMetadataBackend::Redis => Err(Self::redis_ephemeral_error("WASM module persistence")),
         }
     }
 
@@ -88,30 +130,30 @@ impl ServerState {
         tenant: &str,
         module_name: &str,
     ) -> Result<bool, String> {
-        let Some(backend) = self.metadata_backend() else {
+        let Some(backend) = self.metadata_backend_for_tenant(tenant).await else {
             return Ok(false);
         };
 
         match backend {
-            MetadataBackend::Postgres(pool) => {
+            TenantMetadataBackend::Postgres(pool) => {
                 let result =
                     sqlx::query("DELETE FROM wasm_modules WHERE tenant = $1 AND module_name = $2")
                         .bind(tenant)
                         .bind(module_name)
-                        .execute(pool)
+                        .execute(&pool)
                         .await
                         .map_err(|e| {
                             format!("failed to delete WASM module {tenant}/{module_name}: {e}")
                         })?;
                 Ok(result.rows_affected() > 0)
             }
-            MetadataBackend::Turso(turso) => turso
+            TenantMetadataBackend::Turso(turso) => turso
                 .delete_wasm_module(tenant, module_name)
                 .await
                 .map_err(|e| {
                     format!("failed to delete WASM module {tenant}/{module_name} in turso: {e}")
                 }),
-            MetadataBackend::Redis => Err(Self::redis_ephemeral_error("WASM module deletion")),
+            TenantMetadataBackend::Redis => Err(Self::redis_ephemeral_error("WASM module deletion")),
         }
     }
 
@@ -154,8 +196,8 @@ impl ServerState {
             return Ok(());
         }
 
-        // Turso path.
-        if let Some(turso) = store.platform_turso_store() {
+        // Turso path (tenant-routed).
+        if let Some(turso) = store.turso_for_tenant(&entry.tenant).await {
             turso
                 .persist_wasm_invocation(&TursoWasmInvocationInsert {
                     tenant: &entry.tenant,

--- a/crates/temper-server/src/state/persistence/mod.rs
+++ b/crates/temper-server/src/state/persistence/mod.rs
@@ -7,17 +7,6 @@ use temper_store_turso::{TursoEventStore, TursoWasmInvocationInsert};
 use super::ServerState;
 use super::wasm_invocation_log::WasmInvocationEntry;
 
-/// Borrowed metadata backend for platform-scoped operations.
-///
-/// Used only for system-wide data that stays in the platform DB
-/// (evolution records, feature requests). For tenant-scoped data,
-/// use [`TenantMetadataBackend`] via [`ServerState::metadata_backend_for_tenant`].
-enum MetadataBackend<'a> {
-    Postgres(&'a PgPool),
-    Turso(&'a TursoEventStore),
-    Redis,
-}
-
 /// Owned metadata backend for tenant-scoped operations.
 ///
 /// `turso_for_tenant()` returns an owned `TursoEventStore` (Arc-based,
@@ -36,25 +25,6 @@ impl ServerState {
         format!(
             "{operation} is not supported on redis backend (explicit ephemeral mode: metadata is in-memory only)"
         )
-    }
-
-    /// Return the platform-scoped metadata backend.
-    ///
-    /// Only use for system-wide data (evolution records, feature requests).
-    /// For tenant-scoped data, use [`metadata_backend_for_tenant`].
-    fn platform_metadata_backend(&self) -> Option<MetadataBackend<'_>> {
-        let store = self.event_store.as_ref()?;
-        if let Some(pool) = store.postgres_pool() {
-            return Some(MetadataBackend::Postgres(pool));
-        }
-        if let Some(turso) = store.platform_turso_store() {
-            return Some(MetadataBackend::Turso(turso));
-        }
-        if store.redis_store().is_some() {
-            Some(MetadataBackend::Redis)
-        } else {
-            None
-        }
     }
 
     /// Return a tenant-scoped metadata backend.

--- a/crates/temper-server/src/state/persistence/mod.rs
+++ b/crates/temper-server/src/state/persistence/mod.rs
@@ -153,7 +153,9 @@ impl ServerState {
                 .map_err(|e| {
                     format!("failed to delete WASM module {tenant}/{module_name} in turso: {e}")
                 }),
-            TenantMetadataBackend::Redis => Err(Self::redis_ephemeral_error("WASM module deletion")),
+            TenantMetadataBackend::Redis => {
+                Err(Self::redis_ephemeral_error("WASM module deletion"))
+            }
         }
     }
 

--- a/crates/temper-server/src/state/persistence/spec_metadata.rs
+++ b/crates/temper-server/src/state/persistence/spec_metadata.rs
@@ -2,7 +2,7 @@ use sqlx::types::Json;
 use temper_store_turso::TursoSpecVerificationUpdate;
 
 use super::super::ServerState;
-use super::MetadataBackend;
+use super::TenantMetadataBackend;
 use crate::registry::EntityVerificationResult;
 
 impl ServerState {
@@ -14,12 +14,12 @@ impl ServerState {
         ioa_source: &str,
         csdl_xml: &str,
     ) -> Result<(), String> {
-        let Some(backend) = self.metadata_backend() else {
+        let Some(backend) = self.metadata_backend_for_tenant(tenant).await else {
             return Ok(());
         };
 
         match backend {
-            MetadataBackend::Postgres(pool) => {
+            TenantMetadataBackend::Postgres(pool) => {
                 sqlx::query(
                     "INSERT INTO specs \
                      (tenant, entity_type, ioa_source, csdl_xml, version, verified, verification_status, updated_at) \
@@ -39,19 +39,19 @@ impl ServerState {
                 .bind(entity_type)
                 .bind(ioa_source)
                 .bind(csdl_xml)
-                .execute(pool)
+                .execute(&pool)
                 .await
                 .map(|_| ())
                 .map_err(|e| format!("failed to upsert spec {tenant}/{entity_type} in postgres: {e}"))
             }
-            MetadataBackend::Turso(turso) => {
+            TenantMetadataBackend::Turso(turso) => {
                 let hash = temper_store_turso::spec_content_hash(ioa_source);
                 turso
                     .upsert_spec(tenant, entity_type, ioa_source, csdl_xml, &hash)
                     .await
                     .map_err(|e| format!("failed to upsert spec {tenant}/{entity_type} in turso: {e}"))
             }
-            MetadataBackend::Redis => Err(Self::redis_ephemeral_error("Spec source persistence")),
+            TenantMetadataBackend::Redis => Err(Self::redis_ephemeral_error("Spec source persistence")),
         }
     }
 
@@ -61,12 +61,12 @@ impl ServerState {
         tenant: &str,
         cross_invariants_toml: Option<&str>,
     ) -> Result<(), String> {
-        let Some(backend) = self.metadata_backend() else {
+        let Some(backend) = self.metadata_backend_for_tenant(tenant).await else {
             return Ok(());
         };
 
         match backend {
-            MetadataBackend::Postgres(pool) => {
+            TenantMetadataBackend::Postgres(pool) => {
                 if let Some(source) = cross_invariants_toml {
                     sqlx::query(
                         "INSERT INTO tenant_constraints (tenant, cross_invariants_toml, version, updated_at) \
@@ -78,13 +78,13 @@ impl ServerState {
                     )
                     .bind(tenant)
                     .bind(source)
-                    .execute(pool)
+                    .execute(&pool)
                     .await
                     .map_err(|e| format!("failed to upsert tenant constraints for {tenant}: {e}"))?;
                 } else {
                     sqlx::query("DELETE FROM tenant_constraints WHERE tenant = $1")
                         .bind(tenant)
-                        .execute(pool)
+                        .execute(&pool)
                         .await
                         .map_err(|e| {
                             format!("failed to clear tenant constraints for {tenant}: {e}")
@@ -92,7 +92,7 @@ impl ServerState {
                 }
                 Ok(())
             }
-            MetadataBackend::Turso(turso) => {
+            TenantMetadataBackend::Turso(turso) => {
                 if let Some(source) = cross_invariants_toml {
                     turso
                         .upsert_tenant_constraints(tenant, source)
@@ -109,7 +109,7 @@ impl ServerState {
                 }
                 Ok(())
             }
-            MetadataBackend::Redis => {
+            TenantMetadataBackend::Redis => {
                 Err(Self::redis_ephemeral_error("Tenant constraint persistence"))
             }
         }
@@ -123,7 +123,7 @@ impl ServerState {
         status: &str,
         result: Option<&EntityVerificationResult>,
     ) -> Result<(), String> {
-        let Some(backend) = self.metadata_backend() else {
+        let Some(backend) = self.metadata_backend_for_tenant(tenant).await else {
             return Ok(());
         };
 
@@ -138,7 +138,7 @@ impl ServerState {
         };
 
         match backend {
-            MetadataBackend::Postgres(pool) => {
+            TenantMetadataBackend::Postgres(pool) => {
                 sqlx::query(
                     "UPDATE specs SET \
                          verified = $3, \
@@ -156,7 +156,7 @@ impl ServerState {
                 .bind(levels_passed)
                 .bind(levels_total)
                 .bind(verification_result.map(Json))
-                .execute(pool)
+                .execute(&pool)
                 .await
                 .map(|_| ())
                 .map_err(|e| {
@@ -165,7 +165,7 @@ impl ServerState {
                     )
                 })
             }
-            MetadataBackend::Turso(turso) => {
+            TenantMetadataBackend::Turso(turso) => {
                 let result_json = verification_result
                     .as_ref()
                     .and_then(|v| serde_json::to_string(v).ok());
@@ -188,7 +188,7 @@ impl ServerState {
                         )
                     })
             }
-            MetadataBackend::Redis => Err(Self::redis_ephemeral_error("Spec verification persistence")),
+            TenantMetadataBackend::Redis => Err(Self::redis_ephemeral_error("Spec verification persistence")),
         }
     }
 }

--- a/crates/temper-server/tests/wasm_dispatch.rs
+++ b/crates/temper-server/tests/wasm_dispatch.rs
@@ -160,7 +160,7 @@ fn install_non_wasm_policy(state: &ServerState) {
 /// 3. A WASM invocation entry recording the failed invocation
 async fn assert_wasm_authz_denial_artifacts(state: &ServerState, entity_id: &str) {
     let turso = state
-        .persistent_store()
+        .platform_persistent_store()
         .expect("Turso backend required for authz denial artifact verification");
 
     // 1. Verify PendingDecision was persisted.

--- a/crates/temper-store-turso/src/lib.rs
+++ b/crates/temper-store-turso/src/lib.rs
@@ -69,7 +69,7 @@ pub struct TursoWasmInvocationInsert<'a> {
 pub use metrics::init_metrics;
 pub use router::{TenantRegistryRow, TenantStoreRouter, TenantUserRow};
 pub use store::{
-    AgentSummary, DesignTimeEventRow, EvolutionRecordRow, FeatureRequestRow, PolicyRow,
-    TursoEventStore, TursoSpecRow, TursoTenantConstraintRow, TursoTrajectoryRow,
+    ActionStats, AgentSummary, DesignTimeEventRow, EvolutionRecordRow, FeatureRequestRow,
+    PolicyRow, TursoEventStore, TursoSpecRow, TursoTenantConstraintRow, TursoTrajectoryRow,
     TursoWasmInvocationRow, TursoWasmModuleRow, UnmetIntentAggRow,
 };

--- a/crates/temper-store-turso/src/schema.rs
+++ b/crates/temper-store-turso/src/schema.rs
@@ -301,6 +301,22 @@ pub const CREATE_TENANT_USERS_USER_INDEX: &str = "\
 CREATE INDEX IF NOT EXISTS idx_tenant_users_user
     ON tenant_users(user_id);";
 
+/// Per-tenant encrypted secret storage.
+///
+/// Mirrors the Postgres `tenant_secrets` table. Ciphertext and nonce are stored
+/// as BLOBs (AES-256-GCM encrypted by [`SecretsVault`]).  Secrets are always
+/// stored in the per-tenant database for proper isolation.
+pub const CREATE_TENANT_SECRETS_TABLE: &str = "\
+CREATE TABLE IF NOT EXISTS tenant_secrets (
+    tenant TEXT NOT NULL,
+    key_name TEXT NOT NULL,
+    ciphertext BLOB NOT NULL,
+    nonce BLOB NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY(tenant, key_name)
+);";
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -330,6 +346,7 @@ mod tests {
         assert!(CREATE_EVOLUTION_RECORDS_STATUS_INDEX.contains("IF NOT EXISTS"));
         assert!(CREATE_DESIGN_TIME_EVENTS_TABLE.contains("IF NOT EXISTS"));
         assert!(CREATE_DESIGN_TIME_EVENTS_TENANT_INDEX.contains("IF NOT EXISTS"));
+        assert!(CREATE_TENANT_SECRETS_TABLE.contains("IF NOT EXISTS"));
     }
 
     #[test]

--- a/crates/temper-store-turso/src/store/mod.rs
+++ b/crates/temper-store-turso/src/store/mod.rs
@@ -21,6 +21,7 @@ mod constraints;
 mod event_store;
 mod instrumentation;
 mod policy;
+mod secrets;
 mod specs;
 mod trajectory;
 mod wasm;
@@ -185,6 +186,9 @@ impl TursoEventStore {
             .await
             .map_err(storage_error)?;
         conn.execute(schema::CREATE_DESIGN_TIME_EVENTS_TENANT_INDEX, ())
+            .await
+            .map_err(storage_error)?;
+        conn.execute(schema::CREATE_TENANT_SECRETS_TABLE, ())
             .await
             .map_err(storage_error)?;
 

--- a/crates/temper-store-turso/src/store/secrets.rs
+++ b/crates/temper-store-turso/src/store/secrets.rs
@@ -8,6 +8,9 @@ use temper_runtime::persistence::{PersistenceError, storage_error};
 use tracing::instrument;
 
 use super::TursoEventStore;
+
+/// A single encrypted secret row: `(key_name, ciphertext, nonce)`.
+pub type SecretRow = (String, Vec<u8>, Vec<u8>);
 use crate::metrics::TursoQueryTimer;
 
 impl TursoEventStore {
@@ -68,7 +71,7 @@ impl TursoEventStore {
     pub async fn load_secrets_for_tenant(
         &self,
         tenant: &str,
-    ) -> Result<Vec<(String, Vec<u8>, Vec<u8>)>, PersistenceError> {
+    ) -> Result<Vec<SecretRow>, PersistenceError> {
         let _query_timer = TursoQueryTimer::start("turso.load_secrets_for_tenant");
         let conn = self.configured_connection().await?;
         let mut rows = conn

--- a/crates/temper-store-turso/src/store/secrets.rs
+++ b/crates/temper-store-turso/src/store/secrets.rs
@@ -1,0 +1,91 @@
+//! Per-tenant encrypted secret storage.
+//!
+//! CRUD operations on the `tenant_secrets` table, storing AES-256-GCM
+//! encrypted ciphertext and nonce as BLOBs.
+
+use libsql::params;
+use temper_runtime::persistence::{PersistenceError, storage_error};
+use tracing::instrument;
+
+use super::TursoEventStore;
+use crate::metrics::TursoQueryTimer;
+
+impl TursoEventStore {
+    /// Upsert an encrypted secret for a tenant.
+    ///
+    /// If a row with the same `(tenant, key_name)` exists, both the ciphertext
+    /// and nonce are replaced and `updated_at` is refreshed.
+    #[instrument(skip_all, fields(tenant, key_name, otel.name = "turso.upsert_secret"))]
+    pub async fn upsert_secret(
+        &self,
+        tenant: &str,
+        key_name: &str,
+        ciphertext: &[u8],
+        nonce: &[u8],
+    ) -> Result<(), PersistenceError> {
+        let _query_timer = TursoQueryTimer::start("turso.upsert_secret");
+        let conn = self.configured_connection().await?;
+        conn.execute(
+            "INSERT INTO tenant_secrets (tenant, key_name, ciphertext, nonce, created_at, updated_at) \
+             VALUES (?1, ?2, ?3, ?4, datetime('now'), datetime('now')) \
+             ON CONFLICT (tenant, key_name) DO UPDATE SET \
+                 ciphertext = excluded.ciphertext, \
+                 nonce = excluded.nonce, \
+                 updated_at = datetime('now')",
+            params![tenant, key_name, ciphertext, nonce],
+        )
+        .await
+        .map_err(storage_error)?;
+        Ok(())
+    }
+
+    /// Delete a secret by `(tenant, key_name)`.
+    ///
+    /// Returns `true` if a row was deleted, `false` if no matching row existed.
+    #[instrument(skip_all, fields(tenant, key_name, otel.name = "turso.delete_secret"))]
+    pub async fn delete_secret(
+        &self,
+        tenant: &str,
+        key_name: &str,
+    ) -> Result<bool, PersistenceError> {
+        let _query_timer = TursoQueryTimer::start("turso.delete_secret");
+        let conn = self.configured_connection().await?;
+        let rows_affected = conn
+            .execute(
+                "DELETE FROM tenant_secrets WHERE tenant = ?1 AND key_name = ?2",
+                params![tenant, key_name],
+            )
+            .await
+            .map_err(storage_error)?;
+        Ok(rows_affected > 0)
+    }
+
+    /// Load all secrets for a tenant.
+    ///
+    /// Returns `(key_name, ciphertext, nonce)` triples.  Callers are responsible
+    /// for decrypting via [`SecretsVault`].
+    #[instrument(skip_all, fields(tenant, otel.name = "turso.load_secrets_for_tenant"))]
+    pub async fn load_secrets_for_tenant(
+        &self,
+        tenant: &str,
+    ) -> Result<Vec<(String, Vec<u8>, Vec<u8>)>, PersistenceError> {
+        let _query_timer = TursoQueryTimer::start("turso.load_secrets_for_tenant");
+        let conn = self.configured_connection().await?;
+        let mut rows = conn
+            .query(
+                "SELECT key_name, ciphertext, nonce FROM tenant_secrets WHERE tenant = ?1",
+                params![tenant],
+            )
+            .await
+            .map_err(storage_error)?;
+
+        let mut out = Vec::new();
+        while let Some(row) = rows.next().await.map_err(storage_error)? {
+            let key_name: String = row.get(0).map_err(storage_error)?;
+            let ciphertext: Vec<u8> = row.get(1).map_err(storage_error)?;
+            let nonce: Vec<u8> = row.get(2).map_err(storage_error)?;
+            out.push((key_name, ciphertext, nonce));
+        }
+        Ok(out)
+    }
+}

--- a/docs/adrs/0033-tenant-database-isolation.md
+++ b/docs/adrs/0033-tenant-database-isolation.md
@@ -1,0 +1,150 @@
+# ADR-0033: Tenant Database Isolation + Turso Secrets
+
+- Status: Accepted
+- Date: 2026-03-17
+- Deciders: Temper core maintainers
+- Related:
+  - ADR-0032: Granular Cedar policy storage (same hash-gating pattern)
+  - `crates/temper-server/src/state/persistence/mod.rs`
+  - `crates/temper-server/src/state/mod.rs`
+  - `crates/temper-server/src/event_store.rs`
+  - `crates/temper-store-turso/src/router.rs`
+
+## Context
+
+In TenantRouted mode (database-per-tenant via Turso), only events and snapshots are correctly routed to per-tenant databases via `TenantStoreRouter`. **All other metadata** — specs, trajectories, pending decisions, Cedar policies, WASM modules, design-time events — is incorrectly written to the **platform database**, defeating the purpose of tenant isolation.
+
+Additionally, secrets are not supported on the Turso backend at all (returns "not supported yet") despite no technical limitation — Turso supports BLOB storage (used for WASM modules), and the Postgres schema already has a `tenant_secrets` table with RLS policies.
+
+**Empirical proof** (verified locally with two tenants in TenantRouted mode):
+- Platform DB: 39 spec rows across all tenants, all trajectories, all decisions, all policies
+- Tenant DBs: only events (2 each), everything else empty
+
+**Root cause**: Two methods on `ServerState` always delegate to the platform store:
+1. `metadata_backend()` calls `store.platform_turso_store()` — routes all Turso metadata to platform
+2. `persistent_store()` calls `store.platform_turso_store()` — routes all direct Turso reads to platform
+
+The correct routing method `ServerEventStore::turso_for_tenant()` already exists but is never called from metadata persistence paths.
+
+**Backend abstraction is sound**: `MetadataBackend` already has `Postgres` and `Turso` variants. Postgres uses RLS for isolation (single DB, `WHERE tenant=`). Turso TenantRouted uses separate DBs. Both go through the same persistence methods. The fix is routing — not restructuring.
+
+## Decision
+
+### Sub-Decision 1: New tenant-scoped routing methods
+
+Add `metadata_backend_for_tenant(tenant)` (async) and `persistent_store_for_tenant(tenant)` (async) that route to per-tenant stores in TenantRouted mode.
+
+Rename `metadata_backend()` → `platform_metadata_backend()` and `persistent_store()` → `platform_persistent_store()`. These are only used for system-wide analytics (evolution records, feature requests) that genuinely belong in the platform DB.
+
+The existing `turso_for_tenant()` on `ServerEventStore` handles the routing logic:
+- Single-DB Turso: returns the shared store (clone, Arc-cheap)
+- TenantRouted: returns per-tenant store via `router.store_for_tenant(tenant)`
+- `temper-system`/`default` automatically route to platform
+
+A new `TenantMetadataBackend` enum owns its store (vs the existing `MetadataBackend<'a>` which borrows) because `turso_for_tenant()` returns an owned `TursoEventStore`.
+
+**Why this approach**: Minimal API surface change. All tenant-scoped methods already receive `tenant` as a parameter — only the routing call changes. The backend abstraction (Postgres/Turso/Redis) is preserved.
+
+### Sub-Decision 2: Fix all metadata write paths
+
+Every persistence call that has a `tenant` parameter and currently uses `metadata_backend()` or `persistent_store()` switches to the tenant-scoped variant:
+- Spec persistence (`upsert_spec_source`, `upsert_tenant_constraints`, `persist_spec_verification`)
+- Trajectory persistence (`persist_trajectory_entry`)
+- Design-time events (`emit_design_time_event`)
+- Pending decisions (`persist_pending_decision`)
+- WASM modules (`upsert_wasm_module`, `delete_wasm_module`, `persist_wasm_invocation`)
+- Cedar policies (`persist_and_activate_policy`)
+
+**Why this approach**: Every method already has the tenant available. No new parameters needed — just a different routing call.
+
+### Sub-Decision 3: Fan-out for cross-tenant reads
+
+Observe layer endpoints that aggregate across tenants need a fan-out pattern when data is in per-tenant DBs. A `collect_from_tenant_stores` helper iterates platform + all connected tenant stores.
+
+Tenant-scoped reads (where tenant is in the URL/params) route directly to the tenant store. Cross-tenant reads (no tenant filter) fan out.
+
+**Why this approach**: Follows the existing pattern in `load_wasm_modules()` (lines 254-299 of persistence/mod.rs) which already implements fan-out correctly for TenantRouted mode.
+
+### Sub-Decision 4: Turso secrets implementation
+
+Add a `tenant_secrets` table mirroring the Postgres schema, with `ciphertext BLOB` and `nonce BLOB` columns. Implement CRUD on `TursoEventStore` and wire into the persistence layer, replacing the "not supported yet" errors.
+
+```sql
+CREATE TABLE IF NOT EXISTS tenant_secrets (
+    tenant TEXT NOT NULL,
+    key_name TEXT NOT NULL,
+    ciphertext BLOB NOT NULL,
+    nonce BLOB NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY(tenant, key_name)
+);
+```
+
+**Why this approach**: No technical limitation exists. Turso supports BLOB (used for WASM modules already). Secrets are tenant-scoped and must go to per-tenant DBs for proper isolation.
+
+### Sub-Decision 5: Fix bootstrap paths
+
+Boot-time recovery functions that use `platform_turso_store()` switch to per-tenant routing:
+- `load_verified_cache(tenant)` → `turso_for_tenant(tenant)`
+- `bootstrap_tenants()` → resolve per-tenant inside each loop
+- `install_os_app()` → specs/policies to tenant store, `record_installed_app` stays on platform (cross-tenant boot index)
+
+**Why this approach**: Boot functions already have tenant as a parameter. The router handles `temper-system`/`default` automatically.
+
+## What Stays in Platform DB
+
+| Table | Reason |
+|---|---|
+| `tenant_registry` | Maps tenant IDs to DB URLs |
+| `tenant_users` | User-to-tenant access mappings |
+| `tenant_installed_apps` | Cross-tenant boot index |
+| `evolution_records` | System-wide analytics (O-P-A-D-I chain) |
+| `feature_requests` | System-wide analytics |
+| `temper-system` all data | System tenant by design |
+| `default` all data | Default tenant by design |
+
+## What Moves to Per-Tenant DBs
+
+| Table | Before | After |
+|---|---|---|
+| `specs` | Platform | Per-tenant |
+| `trajectories` | Platform | Per-tenant |
+| `pending_decisions` | Platform | Per-tenant |
+| `tenant_policies` / `policies` | Platform | Per-tenant |
+| `wasm_modules` | Platform | Per-tenant |
+| `wasm_invocation_logs` | Platform | Per-tenant |
+| `design_time_events` | Platform | Per-tenant |
+| `tenant_secrets` | Not in Turso | Per-tenant (new) |
+
+## Consequences
+
+### Positive
+- Complete tenant data isolation in TenantRouted mode — no cross-tenant data leakage.
+- Secrets fully functional on Turso backend with proper per-tenant isolation.
+- Backend-swappable architecture preserved — Postgres with RLS achieves the same isolation.
+- Fan-out reads maintain existing observe UI functionality across tenants.
+
+### Negative
+- Fan-out reads add latency proportional to number of connected tenants (mitigated by `connected_tenants()` returning only active stores).
+- All persistence methods become async (were sync for borrowed store access).
+
+### Risks
+- Missing a write path that still routes to platform. Mitigated by renaming `persistent_store()` → `platform_persistent_store()` which forces compiler errors at every call site.
+- Fan-out read performance with many tenants. Mitigated by SQL-level aggregation (existing pattern) and tenant-scoped query parameters.
+
+### DST Compliance
+- No new `HashMap`/`HashSet` usage; `BTreeMap` used throughout.
+- No `tokio::spawn`, `std::thread::spawn`, or multi-threaded patterns introduced.
+- `sim_now()` used for trajectory timestamps (existing pattern, unchanged).
+- Turso SQL layer uses `datetime('now')` for DB-level timestamps (existing precedent in all tables).
+
+## Non-Goals
+- Migrating existing platform DB data to per-tenant DBs. This is a clean fix — data written after deployment goes to the right place; old data in the platform DB is superseded.
+- Automatic data migration tooling. The two-pass boot recovery in `recover_cedar_policies` already handles coexistence.
+- Per-tenant RBAC for secrets. All secrets for a tenant are managed by anyone with tenant access.
+
+## Alternatives Considered
+
+1. **Add RLS-like WHERE clauses to Turso queries** — Would keep single-DB mode but doesn't provide true isolation. Rejected: defeats the purpose of database-per-tenant.
+2. **Abstract all metadata behind a `MetadataStore` trait** — Clean but requires major refactoring. Rejected: the existing enum dispatch (`MetadataBackend`) works; only the routing is broken.


### PR DESCRIPTION
## Summary

- **Fix tenant database isolation**: In TenantRouted mode (database-per-tenant via Turso), all metadata (specs, trajectories, decisions, policies, WASM modules, design-time events) was incorrectly written to the platform database instead of per-tenant databases. Root cause: `metadata_backend()` and `persistent_store()` always called `platform_turso_store()`.
- **Implement Turso secrets backend**: Replace "not supported yet" stub with full CRUD (schema, migration, upsert/delete/load) using AES-256-GCM encrypted BLOBs in a `tenant_secrets` table.
- **Add fan-out reads for Observe layer**: Cross-tenant queries (trajectories, agents, WASM invocations, decisions) now aggregate across all connected tenant stores via `collect_all_turso_stores()`.

### Key changes
- `TenantMetadataBackend` enum + `metadata_backend_for_tenant()` for tenant-scoped routing
- `persistent_store_for_tenant()` replaces `persistent_store()` for all tenant-scoped writes
- `collect_all_turso_stores()` for cross-tenant read aggregation
- Fixed bootstrap paths (`load_verified_cache`, `bootstrap_tenants`, `os_apps`) to resolve per-tenant
- Evolution records, feature requests, `tenant_registry`, and `tenant_installed_apps` correctly stay on platform DB

### What stays in platform DB vs moves to per-tenant DBs

| Platform DB | Per-Tenant DBs |
|---|---|
| tenant_registry, tenant_users | specs, trajectories |
| tenant_installed_apps | pending_decisions, policies |
| evolution_records, feature_requests | wasm_modules, wasm_invocation_logs |
| temper-system/default tenant data | design_time_events, tenant_secrets |

## Test plan

- [x] `cargo test --workspace` passes (430+ tests)
- [x] `cargo clippy --workspace` clean
- [x] E2E verification: two tenants confirmed isolated in separate databases
- [x] Observe API aggregation returns merged results across tenants
- [x] Server restart recovery loads specs/policies from per-tenant DBs
- [x] DST compliance review: PASS
- [x] Code quality review: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)