### PR TITLE
fix: resolve Railway OOM crash loop from OTEL telemetry feedback spiral

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && apt-get install -y \
 
 COPY --from=builder /app/target/release/temper /usr/local/bin/temper
 
-ENV RUST_LOG=info,temper=debug
+ENV RUST_LOG=info,temper=info
 EXPOSE 3000
 
 # No ENTRYPOINT — Railway's startCommand provides the full command.

--- a/crates/temper-observe/src/otel.rs
+++ b/crates/temper-observe/src/otel.rs
@@ -16,6 +16,8 @@
 //! | `OTLP_ENDPOINT` | OTEL collector base URL (e.g. `http://localhost:4318`) |
 //! | `LOGFIRE_TOKEN` | Logfire write token — auto-sets endpoint + auth header |
 //! | `RUST_LOG` | Log level filter (default: `info`) |
+//! | `TEMPER_TRACE_QUEUE_SIZE` | Max buffered spans before drop (default: 2048, range: 128–32768) |
+//! | `TEMPER_LOG_QUEUE_SIZE` | Max buffered log records before drop (default: 2048, range: 128–32768) |
 
 use std::collections::HashMap;
 use std::time::Duration;
@@ -40,12 +42,23 @@ use tracing_subscriber::prelude::*;
 const LOGFIRE_ENDPOINT: &str = "https://logfire-us.pydantic.dev";
 const OTEL_EXPORTER_BUILD_RETRY_ATTEMPTS: usize = 3;
 const OTEL_EXPORTER_RETRY_BASE_DELAY_MS: u64 = 250;
-const TRACE_BATCH_MAX_QUEUE_SIZE: usize = 16_384;
-const TRACE_BATCH_MAX_EXPORT_BATCH_SIZE: usize = 1_024;
+const TRACE_BATCH_MAX_QUEUE_SIZE: usize = 2_048;
+const TRACE_BATCH_MAX_EXPORT_BATCH_SIZE: usize = 512;
 const TRACE_BATCH_SCHEDULE_DELAY_MS: u64 = 1_000;
-const LOG_BATCH_MAX_QUEUE_SIZE: usize = 16_384;
-const LOG_BATCH_MAX_EXPORT_BATCH_SIZE: usize = 1_024;
+const LOG_BATCH_MAX_QUEUE_SIZE: usize = 2_048;
+const LOG_BATCH_MAX_EXPORT_BATCH_SIZE: usize = 512;
 const LOG_BATCH_SCHEDULE_DELAY_MS: u64 = 1_000;
+
+/// Read an OTEL queue-size override from the environment, falling back to the
+/// compiled-in default.  Called once at startup so the `std::env::var` is
+/// acceptable (determinism-ok: read once at init).
+fn queue_size_from_env(var: &str, default: usize) -> usize {
+    std::env::var(var) // determinism-ok: startup config
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(default)
+        .clamp(128, 32_768)
+}
 
 #[derive(Clone, Copy, Debug)]
 enum EndpointSource {
@@ -289,8 +302,9 @@ pub fn init_tracing(
             .build()
     })?;
 
+    let trace_queue = queue_size_from_env("TEMPER_TRACE_QUEUE_SIZE", TRACE_BATCH_MAX_QUEUE_SIZE);
     let trace_batch_config = SpanBatchConfigBuilder::default()
-        .with_max_queue_size(TRACE_BATCH_MAX_QUEUE_SIZE)
+        .with_max_queue_size(trace_queue)
         .with_max_export_batch_size(TRACE_BATCH_MAX_EXPORT_BATCH_SIZE)
         .with_scheduled_delay(Duration::from_millis(TRACE_BATCH_SCHEDULE_DELAY_MS))
         .build();
@@ -334,8 +348,9 @@ pub fn init_tracing(
             .build()
     })?;
 
+    let log_queue = queue_size_from_env("TEMPER_LOG_QUEUE_SIZE", LOG_BATCH_MAX_QUEUE_SIZE);
     let log_batch_config = LogBatchConfigBuilder::default()
-        .with_max_queue_size(LOG_BATCH_MAX_QUEUE_SIZE)
+        .with_max_queue_size(log_queue)
         .with_max_export_batch_size(LOG_BATCH_MAX_EXPORT_BATCH_SIZE)
         .with_scheduled_delay(Duration::from_millis(LOG_BATCH_SCHEDULE_DELAY_MS))
         .build();
@@ -382,9 +397,9 @@ pub fn init_tracing(
     tracing::info!(
         endpoint,
         service_name,
-        trace_queue = TRACE_BATCH_MAX_QUEUE_SIZE,
+        trace_queue,
         trace_batch = TRACE_BATCH_MAX_EXPORT_BATCH_SIZE,
-        log_queue = LOG_BATCH_MAX_QUEUE_SIZE,
+        log_queue,
         log_batch = LOG_BATCH_MAX_EXPORT_BATCH_SIZE,
         "OTEL initialised (traces + metrics + logs)"
     );

--- a/crates/temper-server/src/observe/evolution/operations.rs
+++ b/crates/temper-server/src/observe/evolution/operations.rs
@@ -236,7 +236,7 @@ pub(crate) async fn handle_sentinel_check(
     headers: HeaderMap,
 ) -> Result<Json<serde_json::Value>, StatusCode> {
     require_observe_auth(&state, &headers, "run_sentinel", "Evolution")?;
-    let trajectory_entries = state.load_trajectory_entries(10_000).await;
+    let trajectory_entries = state.load_trajectory_entries(1_000).await;
     tracing::Span::current().record("trajectory_count", trajectory_entries.len());
     tracing::info!(
         trajectory_count = trajectory_entries.len(),
@@ -310,9 +310,9 @@ pub(crate) async fn handle_unmet_intents(
         );
     }
 
-    // Emit one detail span per intent for per-intent Logfire visibility.
+    // Per-intent detail at debug level to avoid OTEL span spam on every poll.
     for intent in &intents {
-        tracing::info!(
+        tracing::debug!(
             entity_type = %intent.entity_type,
             action = %intent.action,
             error_pattern = %intent.error_pattern,
@@ -344,7 +344,7 @@ pub(crate) async fn handle_feature_requests(
     let disposition_filter = params.get("disposition").map(|d| d.as_str());
 
     // Load trajectory entries for feature request generation.
-    let trajectory_entries = state.load_trajectory_entries(10_000).await;
+    let trajectory_entries = state.load_trajectory_entries(1_000).await;
 
     // Query Turso directly (single source of truth).
     let system_tenant = TenantId::new("temper-system");

--- a/ui/observe/app/(observe)/evolution/page.tsx
+++ b/ui/observe/app/(observe)/evolution/page.tsx
@@ -223,19 +223,19 @@ export default function EvolutionPage() {
 
   const recordsPoll = usePolling<EvolutionRecordsResponse>({
     fetcher: fetchEvolutionRecords,
-    interval: 10000,
+    interval: 30000,
     enabled: !initialLoading && !initialError,
   });
 
   const insightsPoll = usePolling<EvolutionInsightsResponse>({
     fetcher: fetchEvolutionInsights,
-    interval: 10000,
+    interval: 30000,
     enabled: !initialLoading && !initialError,
   });
 
   const unmetPoll = usePolling<UnmetIntentsResponse>({
     fetcher: fetchUnmetIntents,
-    interval: 10000,
+    interval: 30000,
     enabled: !initialLoading && !initialError,
   });
 

--- a/ui/observe/components/Sidebar.tsx
+++ b/ui/observe/components/Sidebar.tsx
@@ -114,7 +114,7 @@ export default function Sidebar() {
       } catch { /* ignore */ }
     };
     poll();
-    const interval = setInterval(poll, 15000);
+    const interval = setInterval(poll, 30000);
     return () => { mounted = false; clearInterval(interval); };
   }, []);
 


### PR DESCRIPTION
## Summary
- Reduce OTEL batch queue sizes from 16,384 to 2,048 entries (spans + logs) with env var overrides
- Reduce batch export sizes from 1,024 to 512
- Change default RUST_LOG from `info,temper=debug` to `info,temper=info`
- Reduce trajectory loading from 10,000 to 1,000 rows (sentinel + feature-requests handlers)
- Keep HEAD's aggregated `load_unmet_intent_rows_aggregated` approach for unmet-intents (no bulk-load regression)
- Downgrade per-intent detail logging from `info` to `debug` to avoid OTEL span spam on every poll
- Increase Observe UI polling intervals from 10-15s to 30s

## Root cause
The OOM was caused by a telemetry feedback loop: Observe UI polled every 10-15s, generating OTEL spans buffered in 16K-entry queues. When the Logfire exporter fell behind, queues consumed ~64-128MB, triggering Railway OOM kills every ~2 minutes.

## Test plan
- [x] `cargo check -p temper-server -p temper-observe` passes clean
- [ ] Deploy to Railway staging and verify memory stays under 512MB
- [ ] Confirm Observe UI still receives evolution data at 30s intervals

🤖 Generated with [Claude Code](https://claude.com/claude-code)