### PR TITLE
fix: push-only Observe UI + stop trajectory junk writes (OOM fix)

### DIFF
--- a/crates/temper-server/src/api/decisions.rs
+++ b/crates/temper-server/src/api/decisions.rs
@@ -172,6 +172,9 @@ pub(crate) async fn handle_approve_decision(
     if let Err(e) = state.persist_pending_decision(&approved_decision).await {
         tracing::warn!(id = %id, error = %e, "failed to persist approved decision");
     }
+    let _ = state
+        .observe_refresh_tx
+        .send(crate::state::ObserveRefreshHint::Decisions);
 
     // Create D-Record for the approval (evolution audit trail).
     // Link to the A-Record via derived_from for O-A-D chain tracing.
@@ -291,6 +294,10 @@ pub(crate) async fn handle_deny_decision(
     // Persist updated decision to Turso synchronously.
     if let Err(e) = state.persist_pending_decision(&denied_decision).await {
         tracing::warn!(error = %e, "failed to persist denied decision");
+    }
+    let _ = state
+        .observe_refresh_tx
+        .send(crate::state::ObserveRefreshHint::Decisions);
     }
 
     (

--- a/crates/temper-server/src/api/decisions.rs
+++ b/crates/temper-server/src/api/decisions.rs
@@ -298,7 +298,6 @@ pub(crate) async fn handle_deny_decision(
     let _ = state
         .observe_refresh_tx
         .send(crate::state::ObserveRefreshHint::Decisions);
-    }
 
     (
         StatusCode::OK,

--- a/crates/temper-server/src/api/policies.rs
+++ b/crates/temper-server/src/api/policies.rs
@@ -109,6 +109,10 @@ pub(crate) async fn handle_put_policies(
 
     persist_and_activate_policy(&state, &tenant, "primary", &policy_text, "api").await;
 
+    let _ = state
+        .observe_refresh_tx
+        .send(crate::state::ObserveRefreshHint::Policies);
+
     (
         StatusCode::OK,
         axum::Json(serde_json::json!({"tenant": tenant, "status": "loaded"})),
@@ -170,6 +174,10 @@ pub(crate) async fn handle_add_policy_rule(
     }
 
     persist_and_activate_policy(&state, &tenant, "primary", &new_tenant_text, "api").await;
+
+    let _ = state
+        .observe_refresh_tx
+        .send(crate::state::ObserveRefreshHint::Policies);
 
     (
         StatusCode::OK,
@@ -341,6 +349,10 @@ pub(crate) async fn handle_create_policy(
         policies.insert(tenant.clone(), prospective);
     }
 
+    let _ = state
+        .observe_refresh_tx
+        .send(crate::state::ObserveRefreshHint::Policies);
+
     (
         StatusCode::CREATED,
         axum::Json(serde_json::json!({
@@ -443,6 +455,10 @@ pub(crate) async fn handle_patch_policy(
     // Reload tenant policies from Turso to update in-memory state.
     reload_tenant_from_turso(&state, &tenant).await;
 
+    let _ = state
+        .observe_refresh_tx
+        .send(crate::state::ObserveRefreshHint::Policies);
+
     (
         StatusCode::OK,
         axum::Json(serde_json::json!({
@@ -486,6 +502,10 @@ pub(crate) async fn handle_delete_policy_entry(
 
     // Reload tenant policies from Turso to update in-memory state.
     reload_tenant_from_turso(&state, &tenant).await;
+
+    let _ = state
+        .observe_refresh_tx
+        .send(crate::state::ObserveRefreshHint::Policies);
 
     (
         StatusCode::OK,

--- a/crates/temper-server/src/observe/evolution/operations.rs
+++ b/crates/temper-server/src/observe/evolution/operations.rs
@@ -262,6 +262,20 @@ pub(crate) async fn handle_sentinel_check(
     tracing::info!(insights_count = insights.len(), "evolution.insight");
     let insight_results = persist_insights(&state, &insights).await;
 
+    // Notify Observe UI that evolution data changed.
+    let _ = state
+        .observe_refresh_tx
+        .send(crate::state::ObserveRefreshHint::EvolutionRecords);
+    let _ = state
+        .observe_refresh_tx
+        .send(crate::state::ObserveRefreshHint::EvolutionInsights);
+    let _ = state
+        .observe_refresh_tx
+        .send(crate::state::ObserveRefreshHint::UnmetIntents);
+    let _ = state
+        .observe_refresh_tx
+        .send(crate::state::ObserveRefreshHint::FeatureRequests);
+
     Ok(Json(serde_json::json!({
         "alerts_count": alerts.len(),
         "alerts": results,
@@ -480,6 +494,10 @@ pub(crate) async fn handle_update_feature_request(
             tracing::error!(error = %e, "failed to update feature request");
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
+
+    let _ = state
+        .observe_refresh_tx
+        .send(crate::state::ObserveRefreshHint::FeatureRequests);
 
     Ok(Json(serde_json::json!({
         "id": id,

--- a/crates/temper-server/src/observe/mod.rs
+++ b/crates/temper-server/src/observe/mod.rs
@@ -7,6 +7,7 @@ mod agents;
 mod entities;
 pub(crate) mod evolution;
 mod metrics;
+mod refresh;
 pub(crate) mod specs;
 mod specs_helpers;
 pub mod subprocess_verify;
@@ -204,6 +205,7 @@ pub fn build_observe_router() -> Router<ServerState> {
             patch(evolution::handle_update_feature_request),
         )
         .route("/evolution/stream", get(evolution::handle_evolution_stream))
+        .route("/refresh/stream", get(refresh::handle_refresh_stream))
 }
 
 #[cfg(test)]

--- a/crates/temper-server/src/observe/refresh.rs
+++ b/crates/temper-server/src/observe/refresh.rs
@@ -1,0 +1,37 @@
+//! SSE endpoint for observe UI refresh hints.
+//!
+//! The frontend subscribes to `/observe/refresh/stream` and re-fetches
+//! the relevant REST endpoint when it receives a matching hint.
+
+use std::convert::Infallible;
+
+use axum::extract::State;
+use axum::response::sse::{Event, KeepAlive, Sse};
+use tokio_stream::StreamExt;
+use tokio_stream::wrappers::BroadcastStream;
+
+use crate::state::ServerState;
+
+/// GET /observe/refresh/stream -- SSE stream of refresh hints.
+///
+/// Each event has `event: refresh` and `data: {"kind": "Specs"}` (or whichever
+/// variant changed). The frontend uses these to selectively re-fetch data.
+pub(crate) async fn handle_refresh_stream(
+    State(state): State<ServerState>,
+) -> Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>> {
+    let rx = state.observe_refresh_tx.subscribe();
+    let stream = BroadcastStream::new(rx).filter_map(|result| match result {
+        Ok(hint) => {
+            let data = serde_json::to_string(&serde_json::json!({"kind": format!("{:?}", hint)}))
+                .unwrap_or_default();
+            Some(Ok(Event::default().event("refresh").data(data)))
+        }
+        // Lagged receiver: skip missed events and continue.
+        Err(_) => None,
+    });
+    Sse::new(stream).keep_alive(
+        KeepAlive::new()
+            .interval(std::time::Duration::from_secs(15))
+            .text(""),
+    )
+}

--- a/crates/temper-server/src/odata/read_support.rs
+++ b/crates/temper-server/src/odata/read_support.rs
@@ -2,11 +2,9 @@
 
 use std::sync::OnceLock;
 
-use temper_runtime::scheduler::sim_now;
 use temper_runtime::tenant::TenantId;
 
 use crate::state::ServerState;
-use crate::state::trajectory::{TrajectoryEntry, TrajectorySource};
 
 fn env_usize(name: &str, default: usize) -> usize {
     std::env::var(name) // determinism-ok: read once at startup
@@ -99,33 +97,10 @@ pub(super) fn resolve_entity_set_name(
 /// Record a trajectory entry for an EntitySetNotFound error.
 pub(super) async fn record_entity_set_not_found(state: &ServerState, tenant: &str, set_name: &str) {
     tracing::warn!(tenant = %tenant, entity_set = %set_name, "entity set not found");
-    let entry = TrajectoryEntry {
-        timestamp: sim_now().to_rfc3339(),
-        tenant: tenant.to_string(),
-        entity_type: set_name.to_string(),
-        entity_id: "".to_string(),
-        action: "EntitySetLookup".to_string(),
-        success: false,
-        from_status: None,
-        to_status: None,
-        error: Some(format!(
-            "EntitySetNotFound: entity set '{}' not found",
-            set_name
-        )),
-        agent_id: None,
-        session_id: None,
-        authz_denied: None,
-        denied_resource: None,
-        denied_module: None,
-        source: Some(TrajectorySource::Platform),
-        spec_governed: None,
-        agent_type: None,
-        request_body: None,
-        intent: None,
-    };
-    if let Err(e) = state.persist_trajectory_entry(&entry).await {
-        tracing::error!(error = %e, "failed to persist entity-set-not-found trajectory");
-    }
+    // Intentionally no trajectory write: read-only operations must not write to the database.
+    // Previously this wrote a TrajectoryEntry on every failed EntitySetLookup, creating
+    // unbounded junk rows (4,269 rows, 83% of all trajectories) from phantom entity polling.
+    let _ = state; // suppress unused warning
 }
 
 #[cfg(test)]

--- a/crates/temper-server/src/state/dispatch/effects.rs
+++ b/crates/temper-server/src/state/dispatch/effects.rs
@@ -118,6 +118,15 @@ impl crate::state::ServerState {
         });
         let cache_key = format!("{}:{}:{}", ctx.tenant, ctx.entity_type, ctx.entity_id);
         self.cache_entity_status(cache_key, response.state.status.clone());
+        let _ = self
+            .observe_refresh_tx
+            .send(crate::state::ObserveRefreshHint::Entities);
+        let _ = self
+            .observe_refresh_tx
+            .send(crate::state::ObserveRefreshHint::Trajectories);
+        let _ = self
+            .observe_refresh_tx
+            .send(crate::state::ObserveRefreshHint::Agents);
     }
 
     /// Fire webhooks for the trajectory entry (non-blocking).
@@ -170,8 +179,7 @@ impl crate::state::ServerState {
                     "unmet_intent"
                 );
             }
-            tokio::spawn(async move {
-                // determinism-ok: external side-effect, no simulation-visible state
+            tokio::spawn(async move { // determinism-ok: external side-effect, no simulation-visible state
                 dispatcher.dispatch(&entry);
             });
         }
@@ -197,9 +205,8 @@ impl crate::state::ServerState {
             let action = sched.action.clone();
             let ctx = agent_ctx.clone();
             let delay = std::time::Duration::from_secs(sched.delay_seconds);
-            tokio::spawn(
+            tokio::spawn( // determinism-ok: timer delivery is a background side-effect
                 async move {
-                    // determinism-ok: timer delivery is a background side-effect
                     tokio::time::sleep(delay).await; // determinism-ok: scheduled delay
                     let _ = state
                         .dispatch_tenant_action(

--- a/crates/temper-server/src/state/dispatch/effects.rs
+++ b/crates/temper-server/src/state/dispatch/effects.rs
@@ -179,7 +179,8 @@ impl crate::state::ServerState {
                     "unmet_intent"
                 );
             }
-            tokio::spawn(async move { // determinism-ok: external side-effect, no simulation-visible state
+            tokio::spawn(async move {
+                // determinism-ok: external side-effect, no simulation-visible state
                 dispatcher.dispatch(&entry);
             });
         }
@@ -205,7 +206,8 @@ impl crate::state::ServerState {
             let action = sched.action.clone();
             let ctx = agent_ctx.clone();
             let delay = std::time::Duration::from_secs(sched.delay_seconds);
-            tokio::spawn( // determinism-ok: timer delivery is a background side-effect
+            tokio::spawn(
+                // determinism-ok: timer delivery is a background side-effect
                 async move {
                     tokio::time::sleep(delay).await; // determinism-ok: scheduled delay
                     let _ = state

--- a/crates/temper-server/src/state/mod.rs
+++ b/crates/temper-server/src/state/mod.rs
@@ -73,6 +73,27 @@ pub struct AgentProgressEvent {
     pub timestamp: String,
 }
 
+/// Lightweight hint broadcast for the Observe UI SSE refresh stream.
+///
+/// Each variant signals that a particular domain's data has changed.
+/// The frontend subscribes to `/observe/refresh/stream` and re-fetches
+/// the relevant REST endpoint when it receives a matching hint.
+#[derive(Clone, Debug, serde::Serialize)]
+pub enum ObserveRefreshHint {
+    Specs,
+    Entities,
+    Verification,
+    Trajectories,
+    Agents,
+    Policies,
+    EvolutionRecords,
+    EvolutionInsights,
+    UnmetIntents,
+    FeatureRequests,
+    OsApps,
+    Decisions,
+}
+
 /// A design-time event emitted during spec loading and verification.
 ///
 /// These events are broadcast via SSE so the observe UI can show
@@ -213,6 +234,9 @@ pub struct ServerState {
     /// Broadcast channel for agent progress events (SSE subscriptions).
     /// // determinism-ok: broadcast channel for external observation only
     pub agent_progress_tx: Arc<tokio::sync::broadcast::Sender<AgentProgressEvent>>,
+    /// Broadcast channel for observe UI refresh hints (SSE push).
+    /// // determinism-ok: broadcast channel for external observation only
+    pub observe_refresh_tx: Arc<tokio::sync::broadcast::Sender<ObserveRefreshHint>>,
     /// Listening port for HTTP REPL self-referencing calls.
     pub listen_port: Arc<std::sync::OnceLock<u16>>,
     /// When true, missing `X-Tenant-Id` headers fall back to the first
@@ -251,6 +275,7 @@ impl ServerState {
         let (design_time_tx, _) = tokio::sync::broadcast::channel(256); // determinism-ok: broadcast for external observation
         let (pending_decision_tx, _) = tokio::sync::broadcast::channel(256); // determinism-ok: broadcast for external observation
         let (agent_progress_tx, _) = tokio::sync::broadcast::channel(256); // determinism-ok: broadcast for external observation
+        let (observe_refresh_tx, _) = tokio::sync::broadcast::channel(64); // determinism-ok: broadcast for external observation
         let state = Self {
             actor_system: Arc::new(system),
             csdl: Arc::new(csdl),
@@ -290,6 +315,7 @@ impl ServerState {
             tenant_policies: Arc::new(RwLock::new(BTreeMap::new())),
             secrets_vault: None,
             agent_progress_tx: Arc::new(agent_progress_tx), // determinism-ok: broadcast for external observation
+            observe_refresh_tx: Arc::new(observe_refresh_tx), // determinism-ok: broadcast for external observation
             listen_port: Arc::new(std::sync::OnceLock::new()),
             single_tenant_mode: true,
             suggestion_engine: Arc::new(RwLock::new(PolicySuggestionEngine::new())),
@@ -389,6 +415,7 @@ impl ServerState {
         let (design_time_tx, _) = tokio::sync::broadcast::channel(256); // determinism-ok: broadcast for external observation
         let (pending_decision_tx, _) = tokio::sync::broadcast::channel(256); // determinism-ok: broadcast for external observation
         let (agent_progress_tx, _) = tokio::sync::broadcast::channel(256); // determinism-ok: broadcast for external observation
+        let (observe_refresh_tx, _) = tokio::sync::broadcast::channel(64); // determinism-ok: broadcast for external observation
         let state = Self {
             actor_system: Arc::new(system),
             csdl: Arc::new(CsdlDocument {
@@ -431,6 +458,7 @@ impl ServerState {
             tenant_policies: Arc::new(RwLock::new(BTreeMap::new())),
             secrets_vault: None,
             agent_progress_tx: Arc::new(agent_progress_tx), // determinism-ok: broadcast for external observation
+            observe_refresh_tx: Arc::new(observe_refresh_tx), // determinism-ok: broadcast for external observation
             listen_port: Arc::new(std::sync::OnceLock::new()),
             single_tenant_mode: false,
             suggestion_engine: Arc::new(RwLock::new(PolicySuggestionEngine::new())),

--- a/crates/temper-server/src/state/persistence/logs_and_secrets.rs
+++ b/crates/temper-server/src/state/persistence/logs_and_secrets.rs
@@ -30,6 +30,16 @@ impl ServerState {
         }
         // Broadcast via SSE (keep for real-time UI).
         let _ = self.design_time_tx.send(event);
+        // Emit observe refresh hints for specs/verification changes.
+        let _ = self
+            .observe_refresh_tx
+            .send(crate::state::ObserveRefreshHint::Specs);
+        let _ = self
+            .observe_refresh_tx
+            .send(crate::state::ObserveRefreshHint::Verification);
+        let _ = self
+            .observe_refresh_tx
+            .send(crate::state::ObserveRefreshHint::OsApps);
         Ok(())
     }
 

--- a/docs/adrs/0034-push-only-observe-ui.md
+++ b/docs/adrs/0034-push-only-observe-ui.md
@@ -1,0 +1,88 @@
+# ADR-0034: Push-Only Observe UI
+
+- Status: Accepted
+- Date: 2026-03-18
+- Deciders: Temper core maintainers
+- Related:
+  - `crates/temper-server/src/observe/` (all observe handlers)
+  - `crates/temper-server/src/odata/read_support.rs` (trajectory writes on read ops)
+  - `crates/temper-server/src/state/mod.rs` (broadcast channels)
+  - `ui/observe/` (frontend polling infrastructure)
+
+## Context
+
+The Observe UI polls every backend endpoint on intervals (2s–30s). Each poll generates OTEL spans via `TraceLayer::new_for_http()` and `#[instrument]` handlers. Additionally, `EntitySetLookup` failures (phantom entity types like `CodexSessions`, `Issues` plural, `Projects` plural) write trajectory rows to Turso on every failed OData GET — 4,269 junk rows, 83% of all trajectories. The unmet intents endpoint then scans all these rows on every 30s poll, amplifying memory pressure. This feedback loop caused a Railway OOM crash on 2026-03-18.
+
+The SSE infrastructure already exists — four broadcast channels (`event_tx`, `design_time_tx`, `pending_decision_tx`, `agent_progress_tx`), six SSE endpoints, and a reconnecting `EventSource` factory on the frontend — but the UI doesn't use it. Only the Activity page and DecisionNotifier subscribe to SSE streams.
+
+## Decision
+
+### Sub-Decision 1: Eliminate all polling from the Observe UI
+
+Replace every `usePolling` / `setInterval` call with SSE-driven data refresh. No data-fetching intervals anywhere in `ui/observe/`.
+
+**Why this approach**: Polling creates O(pages × interval) HTTP requests per minute regardless of whether data changed. SSE pushes only when state actually mutates. This eliminates the OTEL span amplification that caused the OOM.
+
+### Sub-Decision 2: Add a single `ObserveRefreshHint` broadcast channel
+
+Instead of adding a broadcast channel per observe domain (specs, policies, agents, evolution, etc.), add one `observe_refresh_tx: broadcast::Sender<ObserveRefreshHint>` channel that carries typed hint variants. Backend mutation points emit hints; a single SSE endpoint (`GET /observe/refresh/stream`) streams them to the frontend.
+
+**Why this approach**: Keeps the broadcast surface minimal. The frontend already does HTTP GETs for full data — the hint just tells it *when* to refetch, not *what* changed. This avoids duplicating serialization logic between broadcast payloads and REST responses.
+
+### Sub-Decision 3: Stop writing trajectories for EntitySetLookup failures
+
+Read-only OData collection lookups (`GET /odata/{tenant}/{EntitySet}`) should never write to the database. Remove the `persist_trajectory_entry()` call from `record_entity_set_not_found()`. Keep the `tracing::warn!` for debugging.
+
+**Why this approach**: A read operation that writes on every failure creates unbounded growth. Trajectory data should capture meaningful user/agent actions, not infrastructure polling artifacts.
+
+### Sub-Decision 4: SSE auth via Next.js proxy
+
+The `EventSource` browser API doesn't support custom headers. However, the Observe UI's Next.js middleware already injects `Authorization`, `X-Temper-Principal-Id`, and `X-Temper-Principal-Kind` headers on all proxied requests. Since SSE URLs use relative paths through the Next.js rewrite, auth headers are applied automatically. The existing `DecisionNotifier` comment claiming "SSE can't send admin headers" is incorrect — the fallback polling can be removed.
+
+**Why this approach**: No new auth mechanism needed. The proxy already solves this.
+
+## Rollout Plan
+
+1. **Phase 0 (This PR)** — All five phases ship together:
+   - Fix trajectory writes (backend)
+   - Add `ObserveRefreshHint` broadcast + SSE endpoint (backend)
+   - Create `useSSERefresh` hook + `SSERefreshProvider` (frontend)
+   - Migrate all pages, remove `usePolling`
+   - Update tests
+   - Clean up 4,269 junk trajectory rows from Turso (one-time SQL)
+
+2. **Phase 1 (Post-merge)** — Monitor Railway logs for span volume reduction and memory stability.
+
+## Consequences
+
+### Positive
+- Eliminates OTEL span amplification from polling (the OOM root cause)
+- Data updates appear instantly on mutations instead of after interval delay
+- Reduces Turso row reads by ~83% (no more junk trajectory scans)
+- Single SSE connection per browser tab instead of 10+ concurrent polling intervals
+
+### Negative
+- SSE connections are long-lived; Railway/proxy must not aggressively timeout them
+- If the SSE connection drops, data goes stale until reconnection (mitigated by `createReconnectingEventSource` with exponential backoff + full refetch on reconnect)
+
+### Risks
+- Browser SSE connection limit (6 per domain): With refresh stream + existing entity/design-time/decision streams = ~4 connections. Safe margin.
+- Next.js rewrite and SSE: Already proven working by existing SSE endpoints in production.
+
+### DST Compliance
+- `observe_refresh_tx` is a broadcast channel for external observation only. Does not affect actor state transitions or deterministic simulation.
+- Annotated with `// determinism-ok: broadcast channel for external observation only`.
+
+## Non-Goals
+
+- Replacing the OData REST API with a streaming protocol (entities are still fetched via HTTP GET)
+- Server-push of full data payloads (hints only; frontend refetches via existing HTTP endpoints)
+- Addressing the `CodexSessions` polling source (temper-mcp npm package) — tracked separately
+
+## Alternatives Considered
+
+1. **Unified multiplexed SSE stream** — One endpoint that sends all observe data (specs, entities, trajectories, etc.) as typed events. Rejected: forces every client to receive all events; adds serialization complexity; existing REST endpoints already work well for full data.
+
+2. **WebSocket instead of SSE** — Bidirectional communication. Rejected: observe is read-only; SSE is simpler, has automatic reconnection, works through proxies without upgrade negotiation, and is already implemented.
+
+3. **Longer polling intervals** — Increase from 2-30s to 60-120s. Rejected: doesn't fix the fundamental feedback loop; still writes junk trajectories; just delays the OOM.

--- a/ui/observe/__tests__/lib/hooks.test.ts
+++ b/ui/observe/__tests__/lib/hooks.test.ts
@@ -1,10 +1,33 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
-import { usePolling, useRelativeTime } from "@/lib/hooks";
 
-describe("usePolling", () => {
+// Mock the SSE context before importing hooks
+vi.mock("@/lib/sse-context", () => {
+  let capturedCallback: (() => void) | null = null;
+  return {
+    useSSERefreshSubscribe: vi.fn((kinds: string[], callback: () => void) => {
+      capturedCallback = callback;
+    }),
+    useSSEConnected: vi.fn().mockReturnValue(true),
+    // Helper for tests to trigger the captured callback
+    __triggerSSE: () => { if (capturedCallback) capturedCallback(); },
+    __resetCapture: () => { capturedCallback = null; },
+  };
+});
+
+import { useSSERefresh, useRelativeTime } from "@/lib/hooks";
+
+// Access the test helpers
+const sseContextMock = await import("@/lib/sse-context") as unknown as {
+  useSSERefreshSubscribe: ReturnType<typeof vi.fn>;
+  __triggerSSE: () => void;
+  __resetCapture: () => void;
+};
+
+describe("useSSERefresh", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    sseContextMock.__resetCapture();
   });
 
   afterEach(() => {
@@ -14,7 +37,7 @@ describe("usePolling", () => {
   it("fetches data on mount", async () => {
     const fetcher = vi.fn().mockResolvedValue(["a", "b"]);
     const { result } = renderHook(() =>
-      usePolling({ fetcher, interval: 5000 }),
+      useSSERefresh({ fetcher, sseKinds: ["Test"] }),
     );
 
     expect(result.current.loading).toBe(true);
@@ -31,27 +54,34 @@ describe("usePolling", () => {
     expect(fetcher).toHaveBeenCalledTimes(1);
   });
 
-  it("polls at the specified interval", async () => {
-    const fetcher = vi.fn().mockResolvedValue([]);
-    renderHook(() => usePolling({ fetcher, interval: 3000 }));
+  it("refetches when SSE callback is triggered", async () => {
+    let callCount = 0;
+    const fetcher = vi.fn().mockImplementation(() => {
+      callCount++;
+      return Promise.resolve([`call-${callCount}`]);
+    });
+    const { result } = renderHook(() =>
+      useSSERefresh({ fetcher, sseKinds: ["Test"] }),
+    );
 
     // Initial fetch
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
     });
-    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(result.current.data).toEqual(["call-1"]);
 
-    // Advance past first interval
+    // Trigger SSE callback
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(3000);
+      sseContextMock.__triggerSSE();
+      await vi.advanceTimersByTimeAsync(0);
     });
-    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(result.current.data).toEqual(["call-2"]);
   });
 
   it("does not fetch when disabled", async () => {
     const fetcher = vi.fn().mockResolvedValue([]);
     const { result } = renderHook(() =>
-      usePolling({ fetcher, interval: 5000, enabled: false }),
+      useSSERefresh({ fetcher, sseKinds: ["Test"], enabled: false }),
     );
 
     await act(async () => {
@@ -65,7 +95,7 @@ describe("usePolling", () => {
   it("sets error on fetch failure", async () => {
     const fetcher = vi.fn().mockRejectedValue(new Error("API down"));
     const { result } = renderHook(() =>
-      usePolling({ fetcher, interval: 5000 }),
+      useSSERefresh({ fetcher, sseKinds: ["Test"] }),
     );
 
     await act(async () => {
@@ -84,7 +114,7 @@ describe("usePolling", () => {
       return Promise.resolve([`call-${callCount}`]);
     });
     const { result } = renderHook(() =>
-      usePolling({ fetcher, interval: 5000 }),
+      useSSERefresh({ fetcher, sseKinds: ["Test"] }),
     );
 
     await act(async () => {

--- a/ui/observe/__tests__/pages/activity.test.tsx
+++ b/ui/observe/__tests__/pages/activity.test.tsx
@@ -9,8 +9,13 @@ vi.mock("@/lib/api", () => ({
 }));
 
 vi.mock("@/lib/hooks", () => ({
-  usePolling: vi.fn(),
+  useSSERefresh: vi.fn(),
   useRelativeTime: vi.fn(),
+}));
+
+vi.mock("@/lib/sse-context", () => ({
+  useSSERefreshSubscribe: vi.fn(),
+  useSSEConnected: vi.fn().mockReturnValue(true),
 }));
 
 vi.mock("next/link", () => ({
@@ -20,10 +25,10 @@ vi.mock("next/link", () => ({
 }));
 
 import { fetchTrajectories } from "@/lib/api";
-import { usePolling, useRelativeTime } from "@/lib/hooks";
+import { useSSERefresh, useRelativeTime } from "@/lib/hooks";
 
 const mockFetchTrajectories = vi.mocked(fetchTrajectories);
-const mockUsePolling = vi.mocked(usePolling);
+const mockUseSSERefresh = vi.mocked(useSSERefresh);
 const mockUseRelativeTime = vi.mocked(useRelativeTime);
 
 const sampleTrajectoryData = {
@@ -57,7 +62,7 @@ const sampleTrajectoryData = {
   ],
 };
 
-function setPollingReturn(trajectoryData: unknown, opts?: { error?: string; entities?: unknown[] }) {
+function setSSERefreshReturn(trajectoryData: unknown, opts?: { error?: string; entities?: unknown[] }) {
   let callIndex = 0;
   const results = [
     {
@@ -75,7 +80,7 @@ function setPollingReturn(trajectoryData: unknown, opts?: { error?: string; enti
       refresh: vi.fn(),
     },
   ];
-  mockUsePolling.mockImplementation(() => {
+  mockUseSSERefresh.mockImplementation(() => {
     const result = results[callIndex % 2];
     callIndex++;
     return result;
@@ -85,13 +90,13 @@ function setPollingReturn(trajectoryData: unknown, opts?: { error?: string; enti
 beforeEach(() => {
   vi.clearAllMocks();
   mockUseRelativeTime.mockReturnValue("5s ago");
-  setPollingReturn(sampleTrajectoryData);
+  setSSERefreshReturn(sampleTrajectoryData);
 });
 
 describe("Activity page", () => {
   it("shows loading skeleton initially", () => {
     mockFetchTrajectories.mockReturnValue(new Promise(() => {}));
-    setPollingReturn(null);
+    setSSERefreshReturn(null);
     const { container } = render(<ActivityPage />);
     expect(container.querySelector(".animate-pulse")).toBeTruthy();
   });
@@ -139,7 +144,7 @@ describe("Activity page", () => {
 
   it("shows error state when API fails", async () => {
     mockFetchTrajectories.mockRejectedValue(new Error("Network error"));
-    setPollingReturn(null);
+    setSSERefreshReturn(null);
     render(<ActivityPage />);
     await waitFor(() => {
       expect(screen.getByText("Cannot load activity")).toBeInTheDocument();

--- a/ui/observe/__tests__/pages/dashboard.test.tsx
+++ b/ui/observe/__tests__/pages/dashboard.test.tsx
@@ -11,8 +11,13 @@ vi.mock("@/lib/api", () => ({
 }));
 
 vi.mock("@/lib/hooks", () => ({
-  usePolling: vi.fn(),
+  useSSERefresh: vi.fn(),
   useRelativeTime: vi.fn(),
+}));
+
+vi.mock("@/lib/sse-context", () => ({
+  useSSERefreshSubscribe: vi.fn(),
+  useSSEConnected: vi.fn().mockReturnValue(true),
 }));
 
 vi.mock("next/link", () => ({
@@ -26,19 +31,19 @@ vi.mock("next/navigation", () => ({
 }));
 
 import { fetchSpecs } from "@/lib/api";
-import { usePolling, useRelativeTime } from "@/lib/hooks";
+import { useSSERefresh, useRelativeTime } from "@/lib/hooks";
 
 const mockFetchSpecs = vi.mocked(fetchSpecs);
-const mockUsePolling = vi.mocked(usePolling);
+const mockUseSSERefresh = vi.mocked(useSSERefresh);
 const mockUseRelativeTime = vi.mocked(useRelativeTime);
 
 const emptyVerifyStatus = { pending: 0, running: 0, passed: 0, failed: 0, partial: 0, entities: [] };
 
 /**
- * Set up the 3 usePolling calls: specs, entities, verification status.
+ * Set up the 3 useSSERefresh calls: specs, entities, verification status.
  * Uses mockImplementation with a counter that cycles through the 3 return values.
  */
-function setPollingReturns(
+function setSSERefreshReturns(
   specs: unknown[] | null,
   entities: unknown[] | null,
   opts?: { error?: string; loading?: boolean },
@@ -67,7 +72,7 @@ function setPollingReturns(
       refresh: vi.fn(),
     },
   ];
-  mockUsePolling.mockImplementation(() => {
+  mockUseSSERefresh.mockImplementation(() => {
     const result = results[callIndex % 3];
     callIndex++;
     return result;
@@ -77,20 +82,20 @@ function setPollingReturns(
 beforeEach(() => {
   vi.clearAllMocks();
   mockUseRelativeTime.mockReturnValue("5s ago");
-  setPollingReturns([], []);
+  setSSERefreshReturns([], []);
 });
 
 describe("Dashboard page", () => {
   it("shows loading skeleton initially", () => {
     mockFetchSpecs.mockReturnValue(new Promise(() => {}));
-    setPollingReturns(null, null, { loading: true });
+    setSSERefreshReturns(null, null, { loading: true });
     const { container } = render(<Dashboard />);
     expect(container.querySelector(".animate-pulse")).toBeTruthy();
   });
 
   it("shows empty state when no data", async () => {
     mockFetchSpecs.mockResolvedValue([]);
-    setPollingReturns([], []);
+    setSSERefreshReturns([], []);
     render(<Dashboard />);
     await waitFor(() => {
       expect(screen.getByText("No specs loaded")).toBeInTheDocument();
@@ -101,7 +106,7 @@ describe("Dashboard page", () => {
     mockFetchSpecs.mockResolvedValue([
       { entity_type: "Ticket", states: ["Open", "Closed"], actions: ["close"], initial_state: "Open" },
     ]);
-    setPollingReturns(
+    setSSERefreshReturns(
       [{ entity_type: "Ticket", states: ["Open", "Closed"], actions: ["close"], initial_state: "Open" }],
       [{ entity_type: "Ticket", entity_id: "TKT-001", actor_status: "active", current_state: "Open" }],
     );
@@ -118,7 +123,7 @@ describe("Dashboard page", () => {
 
   it("shows error state when API fails", async () => {
     mockFetchSpecs.mockRejectedValue(new Error("Network error"));
-    setPollingReturns([], []);
+    setSSERefreshReturns([], []);
     render(<Dashboard />);
     await waitFor(() => {
       expect(screen.getByText("Cannot load dashboard")).toBeInTheDocument();
@@ -131,7 +136,7 @@ describe("Dashboard page", () => {
     mockFetchSpecs.mockResolvedValue([
       { entity_type: "Ticket", states: ["Open"], actions: [], initial_state: "Open" },
     ]);
-    setPollingReturns(
+    setSSERefreshReturns(
       [{ entity_type: "Ticket", states: ["Open"], actions: [], initial_state: "Open" }],
       [{ entity_type: "Ticket", entity_id: "TKT-001", actor_status: "active", current_state: "Open" }],
     );

--- a/ui/observe/__tests__/pages/evolution.test.tsx
+++ b/ui/observe/__tests__/pages/evolution.test.tsx
@@ -16,8 +16,13 @@ vi.mock("@/lib/api", async (importOriginal) => {
 });
 
 vi.mock("@/lib/hooks", () => ({
-  usePolling: vi.fn(),
+  useSSERefresh: vi.fn(),
   useRelativeTime: vi.fn(),
+}));
+
+vi.mock("@/lib/sse-context", () => ({
+  useSSERefreshSubscribe: vi.fn(),
+  useSSEConnected: vi.fn().mockReturnValue(true),
 }));
 
 vi.mock("next/link", () => ({
@@ -27,11 +32,11 @@ vi.mock("next/link", () => ({
 }));
 
 import { fetchEvolutionRecords, triggerSentinelCheck } from "@/lib/api";
-import { usePolling, useRelativeTime } from "@/lib/hooks";
+import { useSSERefresh, useRelativeTime } from "@/lib/hooks";
 
 const mockFetchRecords = vi.mocked(fetchEvolutionRecords);
 const mockTriggerSentinel = vi.mocked(triggerSentinelCheck);
-const mockUsePolling = vi.mocked(usePolling);
+const mockUseSSERefresh = vi.mocked(useSSERefresh);
 const mockUseRelativeTime = vi.mocked(useRelativeTime);
 
 const sampleRecords = {
@@ -63,7 +68,7 @@ const sampleInsights = {
 
 const sampleUnmetIntents = { intents: [], open_count: 0, resolved_count: 0 };
 
-function setPollingReturns(records: unknown, insights: unknown, unmet?: unknown) {
+function setSSERefreshReturns(records: unknown, insights: unknown, unmet?: unknown) {
   let callIndex = 0;
   const results = [
     {
@@ -88,7 +93,7 @@ function setPollingReturns(records: unknown, insights: unknown, unmet?: unknown)
       refresh: vi.fn(),
     },
   ];
-  mockUsePolling.mockImplementation(() => {
+  mockUseSSERefresh.mockImplementation(() => {
     const result = results[callIndex % results.length];
     callIndex++;
     return result;
@@ -98,13 +103,13 @@ function setPollingReturns(records: unknown, insights: unknown, unmet?: unknown)
 beforeEach(() => {
   vi.clearAllMocks();
   mockUseRelativeTime.mockReturnValue("5s ago");
-  setPollingReturns(sampleRecords, sampleInsights);
+  setSSERefreshReturns(sampleRecords, sampleInsights);
 });
 
 describe("Evolution page", () => {
   it("shows loading skeleton initially", () => {
     mockFetchRecords.mockReturnValue(new Promise(() => {}));
-    setPollingReturns(null, null);
+    setSSERefreshReturns(null, null);
     const { container } = render(<EvolutionPage />);
     expect(container.querySelector(".animate-pulse")).toBeTruthy();
   });
@@ -161,7 +166,7 @@ describe("Evolution page", () => {
 
   it("shows empty state when no records", async () => {
     mockFetchRecords.mockResolvedValue(sampleRecords);
-    setPollingReturns(
+    setSSERefreshReturns(
       { records: [], total_observations: 0, total_problems: 0, total_analyses: 0, total_decisions: 0, total_insights: 0 },
       { insights: [], total: 0 },
     );
@@ -173,7 +178,7 @@ describe("Evolution page", () => {
 
   it("shows error state when API fails", async () => {
     mockFetchRecords.mockRejectedValue(new Error("Server error"));
-    setPollingReturns(null, null);
+    setSSERefreshReturns(null, null);
     render(<EvolutionPage />);
     await waitFor(() => {
       expect(screen.getByText("Cannot load evolution data")).toBeInTheDocument();

--- a/ui/observe/app/(observe)/activity/page.tsx
+++ b/ui/observe/app/(observe)/activity/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useMemo, useCallback, useRef } from "react";
 import Link from "next/link";
 import { fetchTrajectories, fetchEntities, subscribeEntityEvents } from "@/lib/api";
-import { usePolling, useRelativeTime } from "@/lib/hooks";
+import { useSSERefresh, useRelativeTime } from "@/lib/hooks";
 import type { TrajectoryResponse, EntityStateChange, EntitySummary } from "@/lib/types";
 import ErrorDisplay from "@/components/ErrorDisplay";
 import StatCard from "@/components/StatCard";
@@ -49,9 +49,9 @@ export default function ActivityPage() {
     loadInitial();
   }, [loadInitial]);
 
-  const trajectoryPoll = usePolling<TrajectoryResponse>({
+  const trajectoryPoll = useSSERefresh<TrajectoryResponse>({
     fetcher: () => fetchTrajectories(filterType !== "all" ? { entity_type: filterType } : undefined),
-    interval: 5000,
+    sseKinds: ["Trajectories"],
     enabled: !initialLoading && !initialError,
   });
 
@@ -91,10 +91,10 @@ export default function ActivityPage() {
     return Array.from(set).sort();
   }, [data]);
 
-  // Entity polling
-  const entityPoll = usePolling<EntitySummary[]>({
+  // Entity refresh via SSE
+  const entityPoll = useSSERefresh<EntitySummary[]>({
     fetcher: fetchEntities,
-    interval: 5000,
+    sseKinds: ["Entities"],
     enabled: !initialLoading && !initialError,
   });
 

--- a/ui/observe/app/(observe)/agents/[id]/page.tsx
+++ b/ui/observe/app/(observe)/agents/[id]/page.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import { fetchAgentHistory } from "@/lib/api";
-import { usePolling, useRelativeTime } from "@/lib/hooks";
+import { useSSERefresh, useRelativeTime } from "@/lib/hooks";
 import type { AgentHistoryResponse } from "@/lib/types";
 import ErrorDisplay from "@/components/ErrorDisplay";
 import StatCard from "@/components/StatCard";
@@ -14,13 +14,13 @@ export default function AgentDetailPage() {
   const agentId = decodeURIComponent(params.id as string);
   const [entityTypeFilter, setEntityTypeFilter] = useState<string>("all");
 
-  const historyPoll = usePolling<AgentHistoryResponse>({
+  const historyPoll = useSSERefresh<AgentHistoryResponse>({
     fetcher: () =>
       fetchAgentHistory(agentId, {
         entity_type: entityTypeFilter !== "all" ? entityTypeFilter : undefined,
         limit: 200,
       }),
-    interval: 5000,
+    sseKinds: ["Agents"],
     enabled: true,
   });
 

--- a/ui/observe/app/(observe)/agents/page.tsx
+++ b/ui/observe/app/(observe)/agents/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { fetchAgents } from "@/lib/api";
-import { usePolling, useRelativeTime } from "@/lib/hooks";
+import { useSSERefresh, useRelativeTime } from "@/lib/hooks";
 import type { AgentsResponse } from "@/lib/types";
 import ErrorDisplay from "@/components/ErrorDisplay";
 import StatCard from "@/components/StatCard";
@@ -29,9 +29,9 @@ export default function AgentsPage() {
     }
   }, []);
 
-  const agentsPoll = usePolling<AgentsResponse>({
+  const agentsPoll = useSSERefresh<AgentsResponse>({
     fetcher: () => fetchAgents(),
-    interval: 5000,
+    sseKinds: ["Agents"],
     enabled: !initialError,
   });
 

--- a/ui/observe/app/(observe)/dashboard/page.tsx
+++ b/ui/observe/app/(observe)/dashboard/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback, useMemo, useRef } from "react";
 import { fetchSpecs, fetchEntities, fetchVerificationStatus, subscribeDesignTimeEvents, subscribeEntityEvents } from "@/lib/api";
-import { usePolling, useRelativeTime } from "@/lib/hooks";
+import { useSSERefresh, useRelativeTime } from "@/lib/hooks";
 import type { SpecSummary, EntitySummary, AllVerificationStatus } from "@/lib/types";
 import SpecCard from "@/components/SpecCard";
 import ErrorDisplay from "@/components/ErrorDisplay";
@@ -151,27 +151,27 @@ export default function Dashboard() {
 
   const [tenantFilter, setTenantFilter] = useState<string>("all");
 
-  // Poll specs every 3s during build to pick up verification_status updates
-  const specPoll = usePolling<SpecSummary[]>({
+  // SSE-driven spec refresh
+  const specPoll = useSSERefresh<SpecSummary[]>({
     fetcher: fetchSpecs,
-    interval: 3000,
+    sseKinds: ["Specs"],
     enabled: !initialLoading && !initialError,
   });
   const specs = useMemo(() => specPoll.data ?? [], [specPoll.data]);
 
-  // Auto-refresh entities every 5s
-  const entityPoll = usePolling<EntitySummary[]>({
+  // SSE-driven entity refresh
+  const entityPoll = useSSERefresh<EntitySummary[]>({
     fetcher: fetchEntities,
-    interval: 5000,
+    sseKinds: ["Entities"],
     enabled: !initialLoading && !initialError,
   });
   const entities = useMemo(() => entityPoll.data ?? [], [entityPoll.data]);
   const lastUpdated = useRelativeTime(entityPoll.lastUpdated);
 
-  // Poll verification status every 2s during build
-  const verifyPoll = usePolling<AllVerificationStatus>({
+  // SSE-driven verification status refresh
+  const verifyPoll = useSSERefresh<AllVerificationStatus>({
     fetcher: fetchVerificationStatus,
-    interval: 2000,
+    sseKinds: ["Verification"],
     enabled: !initialLoading && !initialError,
   });
   const verificationStatus = verifyPoll.data;

--- a/ui/observe/app/(observe)/decisions/page.tsx
+++ b/ui/observe/app/(observe)/decisions/page.tsx
@@ -10,7 +10,7 @@ import {
   subscribeAllPendingDecisions,
   fetchSpecs,
 } from "@/lib/api";
-import { usePolling, useRelativeTime } from "@/lib/hooks";
+import { useSSERefresh, useRelativeTime } from "@/lib/hooks";
 import type {
   DecisionsResponse,
   PendingDecision,
@@ -264,7 +264,7 @@ export default function DecisionsPage() {
     loadInitial();
   }, [loadInitial]);
 
-  const decisionsPoll = usePolling<DecisionsResponse>({
+  const decisionsPoll = useSSERefresh<DecisionsResponse>({
     fetcher: () =>
       tenant === ALL_TENANTS
         ? fetchAllDecisions(
@@ -274,7 +274,7 @@ export default function DecisionsPage() {
             tenant,
             statusFilter !== "all" ? { status: statusFilter } : undefined,
           ),
-    interval: 5000,
+    sseKinds: ["Decisions"],
     enabled: !initialLoading && !initialError,
   });
 

--- a/ui/observe/app/(observe)/evolution/page.tsx
+++ b/ui/observe/app/(observe)/evolution/page.tsx
@@ -9,7 +9,7 @@ import {
   fetchRecordDetail,
   subscribeEvolutionEvents,
 } from "@/lib/api";
-import { usePolling } from "@/lib/hooks";
+import { useSSERefresh } from "@/lib/hooks";
 import type {
   EvolutionRecordsResponse,
   EvolutionInsightsResponse,
@@ -221,21 +221,21 @@ export default function EvolutionPage() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const recordsPoll = usePolling<EvolutionRecordsResponse>({
+  const recordsPoll = useSSERefresh<EvolutionRecordsResponse>({
     fetcher: fetchEvolutionRecords,
-    interval: 30000,
+    sseKinds: ["EvolutionRecords"],
     enabled: !initialLoading && !initialError,
   });
 
-  const insightsPoll = usePolling<EvolutionInsightsResponse>({
+  const insightsPoll = useSSERefresh<EvolutionInsightsResponse>({
     fetcher: fetchEvolutionInsights,
-    interval: 30000,
+    sseKinds: ["EvolutionInsights"],
     enabled: !initialLoading && !initialError,
   });
 
-  const unmetPoll = usePolling<UnmetIntentsResponse>({
+  const unmetPoll = useSSERefresh<UnmetIntentsResponse>({
     fetcher: fetchUnmetIntents,
-    interval: 30000,
+    sseKinds: ["UnmetIntents"],
     enabled: !initialLoading && !initialError,
   });
 

--- a/ui/observe/app/(observe)/feature-requests/page.tsx
+++ b/ui/observe/app/(observe)/feature-requests/page.tsx
@@ -5,7 +5,7 @@ import {
   fetchFeatureRequests,
   updateFeatureRequest,
 } from "@/lib/api";
-import { usePolling, useRelativeTime } from "@/lib/hooks";
+import { useSSERefresh, useRelativeTime } from "@/lib/hooks";
 import type {
   FeatureRequest,
   FeatureRequestDisposition,
@@ -178,9 +178,9 @@ export default function FeatureRequestsPage() {
   const [activeTab, setActiveTab] = useState<FilterTab>("all");
   const [acting, setActing] = useState(false);
 
-  const featuresPoll = usePolling<FeatureRequest[]>({
+  const featuresPoll = useSSERefresh<FeatureRequest[]>({
     fetcher: fetchFeatureRequests,
-    interval: 10000,
+    sseKinds: ["FeatureRequests"],
   });
 
   const lastUpdated = useRelativeTime(featuresPoll.lastUpdated);

--- a/ui/observe/app/(observe)/integrations/page.tsx
+++ b/ui/observe/app/(observe)/integrations/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo, useCallback, useEffect } from "react";
 import { fetchWasmModules, fetchWasmInvocations } from "@/lib/api";
-import { usePolling, useRelativeTime } from "@/lib/hooks";
+import { useSSERefresh, useRelativeTime } from "@/lib/hooks";
 import type { WasmModulesResponse, WasmInvocationsResponse } from "@/lib/types";
 import ErrorDisplay from "@/components/ErrorDisplay";
 import StatCard from "@/components/StatCard";
@@ -30,18 +30,18 @@ export default function IntegrationsPage() {
     loadInitial();
   }, [loadInitial]);
 
-  const modulesPoll = usePolling<WasmModulesResponse>({
+  const modulesPoll = useSSERefresh<WasmModulesResponse>({
     fetcher: fetchWasmModules,
-    interval: 5000,
+    sseKinds: ["Entities"],
     enabled: !initialLoading && !initialError,
   });
 
-  const invocationsPoll = usePolling<WasmInvocationsResponse>({
+  const invocationsPoll = useSSERefresh<WasmInvocationsResponse>({
     fetcher: () =>
       fetchWasmInvocations(
         moduleFilter !== "all" ? { module_name: moduleFilter, limit: 100 } : { limit: 100 },
       ),
-    interval: 5000,
+    sseKinds: ["Entities"],
     enabled: !initialLoading && !initialError,
   });
 

--- a/ui/observe/app/(observe)/layout.tsx
+++ b/ui/observe/app/(observe)/layout.tsx
@@ -3,6 +3,7 @@ import ErrorBoundary from "@/components/ErrorBoundary";
 import Providers from "@/components/Providers";
 import { ConnectionProvider } from "@/lib/connection";
 import { DecisionNotifierProvider } from "@/lib/decision-notifier";
+import { SSERefreshProvider } from "@/lib/sse-context";
 export default function ObserveLayout({
   children,
 }: Readonly<{
@@ -10,6 +11,7 @@ export default function ObserveLayout({
 }>) {
   return (
     <Providers>
+      <SSERefreshProvider>
       <ConnectionProvider>
         <DecisionNotifierProvider>
           <div className="flex h-screen overflow-hidden">
@@ -25,6 +27,7 @@ export default function ObserveLayout({
           </div>
         </DecisionNotifierProvider>
       </ConnectionProvider>
+      </SSERefreshProvider>
     </Providers>
   );
 }

--- a/ui/observe/app/(observe)/os-apps/page.tsx
+++ b/ui/observe/app/(observe)/os-apps/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useEffect, useMemo } from "react";
 import { fetchOsApps, installOsApp, fetchSpecs } from "@/lib/api";
-import { usePolling } from "@/lib/hooks";
+import { useSSERefresh } from "@/lib/hooks";
 import type { OsAppsResponse, SpecSummary } from "@/lib/types";
 import ErrorDisplay from "@/components/ErrorDisplay";
 import StatCard from "@/components/StatCard";
@@ -29,15 +29,15 @@ export default function OsAppsPage() {
     loadInitial();
   }, [loadInitial]);
 
-  const appsPoll = usePolling<OsAppsResponse>({
+  const appsPoll = useSSERefresh<OsAppsResponse>({
     fetcher: fetchOsApps,
-    interval: 10000,
+    sseKinds: ["OsApps"],
     enabled: !initialLoading && !initialError,
   });
 
-  const specsPoll = usePolling<SpecSummary[]>({
+  const specsPoll = useSSERefresh<SpecSummary[]>({
     fetcher: fetchSpecs,
-    interval: 10000,
+    sseKinds: ["Specs"],
     enabled: !initialLoading && !initialError,
   });
 

--- a/ui/observe/app/(observe)/policies/page.tsx
+++ b/ui/observe/app/(observe)/policies/page.tsx
@@ -10,7 +10,7 @@ import {
   createPolicy,
   fetchSpecs,
 } from "@/lib/api";
-import { usePolling } from "@/lib/hooks";
+import { useSSERefresh } from "@/lib/hooks";
 import type {
   PolicyEntry,
   PoliciesResponse,
@@ -68,12 +68,12 @@ export default function PoliciesPage() {
   }, [loadInitial]);
 
   // Fetch policies for current view
-  const policiesPoll = usePolling<PoliciesResponse | AllPoliciesResponse>({
+  const policiesPoll = useSSERefresh<PoliciesResponse | AllPoliciesResponse>({
     fetcher: () =>
       tenant === ALL_TENANTS
         ? fetchAllPolicies()
         : fetchPoliciesList(tenant),
-    interval: 5000,
+    sseKinds: ["Policies"],
     enabled: !initialLoading && !initialError,
   });
 

--- a/ui/observe/app/(observe)/workflows/[tenant]/page.tsx
+++ b/ui/observe/app/(observe)/workflows/[tenant]/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useMemo, useCallback } from "react";
 import { useParams } from "next/navigation";
 import { fetchWorkflows, fetchVerificationStatus, subscribeDesignTimeEvents } from "@/lib/api";
-import { usePolling } from "@/lib/hooks";
+import { useSSERefresh } from "@/lib/hooks";
 import type { WorkflowsResponse, AppWorkflow, DesignTimeEvent } from "@/lib/types";
 import WorkflowTimeline from "@/components/WorkflowTimeline";
 import type { StepDetailsMap } from "@/components/WorkflowTimeline";
@@ -64,9 +64,9 @@ export default function WorkflowDetailPage() {
   const [initialError, setInitialError] = useState<string | null>(null);
   const [liveEvents, setLiveEvents] = useState<DesignTimeEvent[]>([]);
 
-  const poll = usePolling<WorkflowsResponse>({
+  const poll = useSSERefresh<WorkflowsResponse>({
     fetcher: fetchWorkflows,
-    interval: 2000,
+    sseKinds: ["Specs"],
     enabled: !initialLoading && !initialError,
   });
 

--- a/ui/observe/app/(observe)/workflows/page.tsx
+++ b/ui/observe/app/(observe)/workflows/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useMemo } from "react";
 import { fetchWorkflows, deleteTenant } from "@/lib/api";
-import { usePolling } from "@/lib/hooks";
+import { useSSERefresh } from "@/lib/hooks";
 import type { WorkflowsResponse, AppWorkflow } from "@/lib/types";
 import ErrorDisplay from "@/components/ErrorDisplay";
 import Link from "next/link";
@@ -130,9 +130,9 @@ export default function WorkflowsPage() {
   const [initialError, setInitialError] = useState<string | null>(null);
   const [deleting, setDeleting] = useState<string | null>(null);
 
-  const poll = usePolling<WorkflowsResponse>({
+  const poll = useSSERefresh<WorkflowsResponse>({
     fetcher: fetchWorkflows,
-    interval: 2000,
+    sseKinds: ["Specs"],
     enabled: !initialLoading && !initialError,
   });
   const workflows = useMemo(() => poll.data?.workflows ?? [], [poll.data]);

--- a/ui/observe/lib/connection.tsx
+++ b/ui/observe/lib/connection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { createContext, useContext, useEffect, useState, useCallback } from "react";
-import { checkConnection } from "./api";
+import { createContext, useContext } from "react";
+import { useSSEConnected } from "./sse-context";
 
 interface ConnectionState {
   connected: boolean;
@@ -11,18 +11,12 @@ interface ConnectionState {
 const ConnectionContext = createContext<ConnectionState>({ connected: true, checking: true });
 
 export function ConnectionProvider({ children }: { children: React.ReactNode }) {
-  const [state, setState] = useState<ConnectionState>({ connected: true, checking: true });
+  const sseConnected = useSSEConnected();
 
-  const check = useCallback(async () => {
-    const ok = await checkConnection();
-    setState({ connected: ok, checking: false });
-  }, []);
-
-  useEffect(() => {
-    check();
-    const id = setInterval(check, 10000);
-    return () => clearInterval(id);
-  }, [check]);
+  const state: ConnectionState = {
+    connected: sseConnected,
+    checking: false,
+  };
 
   return (
     <ConnectionContext.Provider value={state}>{children}</ConnectionContext.Provider>

--- a/ui/observe/lib/decision-notifier.tsx
+++ b/ui/observe/lib/decision-notifier.tsx
@@ -164,17 +164,15 @@ export function DecisionNotifierProvider({
     return () => clearInterval(interval);
   }, [toasts.length]);
 
-  // Poll for pending count (SSE can't send admin headers so it fails with 403)
+  // Initial fetch for pending count
   useEffect(() => {
-    const poll = async () => {
+    const fetchInitial = async () => {
       try {
         const data = await fetchAllDecisions({ status: "pending" });
         setPendingCount(data.pending_count ?? data.decisions.length);
       } catch { /* ignore fetch errors */ }
     };
-    poll();
-    const interval = setInterval(poll, 5000);
-    return () => clearInterval(interval);
+    fetchInitial();
   }, []);
 
   // SSE subscription (best-effort — may fail without admin headers)

--- a/ui/observe/lib/hooks.ts
+++ b/ui/observe/lib/hooks.ts
@@ -1,14 +1,9 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from "react";
+import { useSSERefreshSubscribe } from "./sse-context";
 
-interface UsePollingOptions<T> {
-  fetcher: () => Promise<T>;
-  interval: number;
-  enabled?: boolean;
-}
-
-interface UsePollingResult<T> {
+export interface UsePollingResult<T> {
   data: T | null;
   error: string | null;
   loading: boolean;
@@ -16,56 +11,60 @@ interface UsePollingResult<T> {
   refresh: () => Promise<void>;
 }
 
-export function usePolling<T>({
+interface UseSSERefreshOptions<T> {
+  fetcher: () => Promise<T>;
+  sseKinds: string[];
+  enabled?: boolean;
+}
+
+export function useSSERefresh<T>({
   fetcher,
-  interval,
+  sseKinds,
   enabled = true,
-}: UsePollingOptions<T>): UsePollingResult<T> {
+}: UseSSERefreshOptions<T>): UsePollingResult<T> {
   const [data, setData] = useState<T | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const fetcherRef = useRef(fetcher);
   const abortRef = useRef<AbortController | null>(null);
   fetcherRef.current = fetcher;
 
-  const doFetch = useCallback(async (showLoading = false) => {
-    // Cancel any in-flight request
+  const doFetch = useCallback(async (isInitial: boolean) => {
     abortRef.current?.abort();
     const controller = new AbortController();
     abortRef.current = controller;
-
-    if (showLoading) setLoading(true);
     try {
+      if (isInitial) setLoading(true);
       const result = await fetcherRef.current();
       if (!controller.signal.aborted) {
         setData(result);
         setError(null);
         setLastUpdated(new Date());
+        if (isInitial) setLoading(false);
       }
     } catch (err) {
       if (!controller.signal.aborted) {
-        setError(err instanceof Error ? err.message : "Unknown error");
-      }
-    } finally {
-      if (!controller.signal.aborted) {
-        setLoading(false);
+        setError(err instanceof Error ? err.message : String(err));
+        if (isInitial) setLoading(false);
       }
     }
   }, []);
 
+  // Initial fetch
   useEffect(() => {
     if (!enabled) return;
     doFetch(true);
-    intervalRef.current = setInterval(() => doFetch(false), interval);
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-      abortRef.current?.abort();
-    };
-  }, [doFetch, interval, enabled]);
+    return () => { abortRef.current?.abort(); };
+  }, [enabled, doFetch]);
 
-  const refresh = useCallback(() => doFetch(false), [doFetch]);
+  // SSE-driven refetch
+  useSSERefreshSubscribe(
+    enabled ? sseKinds : [],
+    () => { if (enabled) doFetch(false); }
+  );
+
+  const refresh = useCallback(async () => { await doFetch(false); }, [doFetch]);
 
   return { data, error, loading, lastUpdated, refresh };
 }

--- a/ui/observe/lib/hooks.ts
+++ b/ui/observe/lib/hooks.ts
@@ -70,7 +70,7 @@ export function usePolling<T>({
   return { data, error, loading, lastUpdated, refresh };
 }
 
-export function useRelativeTime(date: Date | null): string {
+export function useRelativeTime(date: Date | string | null): string {
   const [now, setNow] = useState(() => Date.now());
 
   useEffect(() => {
@@ -96,7 +96,9 @@ export function useRelativeTime(date: Date | null): string {
   }, []);
 
   if (!date) return "";
-  const seconds = Math.floor((now - date.getTime()) / 1000);
+  const d = typeof date === "string" ? new Date(date) : date;
+  if (isNaN(d.getTime())) return "";
+  const seconds = Math.floor((now - d.getTime()) / 1000);
   if (seconds < 5) return "just now";
   if (seconds < 60) return `${seconds}s ago`;
   const minutes = Math.floor(seconds / 60);

--- a/ui/observe/lib/sse-context.tsx
+++ b/ui/observe/lib/sse-context.tsx
@@ -1,0 +1,86 @@
+"use client";
+import { createContext, useContext, useEffect, useRef, useState, useCallback, type ReactNode } from "react";
+
+type Listener = { kinds: string[]; callback: () => void };
+
+interface SSERefreshContextValue {
+  subscribe: (kinds: string[], callback: () => void) => () => void;
+  connected: boolean;
+}
+
+const SSERefreshContext = createContext<SSERefreshContextValue | null>(null);
+
+export function SSERefreshProvider({ children }: { children: ReactNode }) {
+  const listenersRef = useRef<Set<Listener>>(new Set());
+  const [connected, setConnected] = useState(false);
+  const sourceRef = useRef<EventSource | null>(null);
+  const closedRef = useRef(false);
+  const retryDelayRef = useRef(1000);
+
+  useEffect(() => {
+    closedRef.current = false;
+
+    function connect() {
+      if (closedRef.current) return;
+      const source = new EventSource("/observe/refresh/stream");
+      sourceRef.current = source;
+
+      source.addEventListener("refresh", (e) => {
+        retryDelayRef.current = 1000;
+        try {
+          const { kind } = JSON.parse((e as MessageEvent).data);
+          for (const listener of listenersRef.current) {
+            if (listener.kinds.includes(kind)) {
+              listener.callback();
+            }
+          }
+        } catch { /* ignore parse errors */ }
+      });
+
+      source.onopen = () => setConnected(true);
+      source.onerror = () => {
+        setConnected(false);
+        source.close();
+        if (!closedRef.current) {
+          setTimeout(connect, retryDelayRef.current);
+          retryDelayRef.current = Math.min(retryDelayRef.current * 2, 30000);
+        }
+      };
+    }
+
+    connect();
+    return () => {
+      closedRef.current = true;
+      sourceRef.current?.close();
+      setConnected(false);
+    };
+  }, []);
+
+  const subscribe = useCallback((kinds: string[], callback: () => void) => {
+    const listener: Listener = { kinds, callback };
+    listenersRef.current.add(listener);
+    return () => { listenersRef.current.delete(listener); };
+  }, []);
+
+  return (
+    <SSERefreshContext.Provider value={{ subscribe, connected }}>
+      {children}
+    </SSERefreshContext.Provider>
+  );
+}
+
+export function useSSERefreshSubscribe(kinds: string[], callback: () => void) {
+  const ctx = useContext(SSERefreshContext);
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+
+  useEffect(() => {
+    if (!ctx) return;
+    return ctx.subscribe(kinds, () => callbackRef.current());
+  }, [ctx, kinds.join(",")]); // eslint-disable-line react-hooks/exhaustive-deps
+}
+
+export function useSSEConnected(): boolean {
+  const ctx = useContext(SSERefreshContext);
+  return ctx?.connected ?? false;
+}


### PR DESCRIPTION
## Summary

- **Root cause fix**: Observe UI polling (2-30s intervals) generated OTEL spans on every request, and `EntitySetLookup` failures wrote trajectory rows to Turso on every failed OData GET — 4,269 junk rows (83% of all trajectories). This feedback loop caused the Railway OOM crash on 2026-03-18.
- **Replace all polling with SSE push**: Added `ObserveRefreshHint` broadcast channel + `/observe/refresh/stream` SSE endpoint. Migrated all 12 Observe pages from `usePolling` to `useSSERefresh`. Zero polling intervals remain.
- **Stop trajectory writes for read-only ops**: `EntitySetLookup` failures no longer persist trajectory entries. Cleaned up 4,269 junk rows from Turso.

## Test plan

- [x] `cargo check -p temper-server` compiles clean
- [x] TypeScript compilation passes (no new errors)
- [x] All pre-push gates pass (fmt, clippy, readability, tests)
- [x] SSE endpoint verified: `curl` receives `{"kind":"Entities"}` and `{"kind":"Trajectories"}` events on entity dispatch
- [x] Local Observe UI tested: Dashboard, Evolution, Activity, Policies pages all load correctly with SSE-driven data
- [x] `grep -r "usePolling" ui/observe/` returns zero matches in source files
- [x] ADR-0034 documents all architectural decisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)