### PR TITLE
Extract platform improvements from feat/temper-claw

### DIFF
--- a/crates/temper-server/src/observe/entities.rs
+++ b/crates/temper-server/src/observe/entities.rs
@@ -253,12 +253,10 @@ pub(crate) async fn handle_entity_event_stream(
                 && event.seq > replay_high_water =>
         {
             let data = serde_json::to_string(&event.data).unwrap_or_default();
-            Some(Ok(
-                Event::default()
-                    .id(event.seq.to_string())
-                    .event(&event.event_name)
-                    .data(data),
-            ))
+            Some(Ok(Event::default()
+                .id(event.seq.to_string())
+                .event(&event.event_name)
+                .data(data)))
         }
         Ok(_) => None,
         Err(_) => None,

--- a/crates/temper-server/src/observe/entities.rs
+++ b/crates/temper-server/src/observe/entities.rs
@@ -219,7 +219,12 @@ pub(crate) async fn handle_entity_event_stream(
 ) -> Result<Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>>, StatusCode> {
     require_observe_auth(&state, &headers, "read_events", "Entity")?;
     let tenant = extract_tenant(&headers, &state).map_err(|(code, _)| code)?;
-    let since = params.since.unwrap_or(0);
+    let since = headers
+        .get("last-event-id")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok())
+        .or(params.since)
+        .unwrap_or(0);
     let rx = state.entity_observe_tx.subscribe();
     let replay_events = state
         .replay_entity_observe_events(tenant.as_str(), &entity_type, &entity_id, since)
@@ -228,7 +233,12 @@ pub(crate) async fn handle_entity_event_stream(
     let replay_high_water = replay_events.last().map(|event| event.seq).unwrap_or(since);
     let replay = replay_events.into_iter().map(|event| {
         let data = serde_json::to_string(&event.data).unwrap_or_default();
-        Ok::<Event, Infallible>(Event::default().event(&event.event_name).data(data))
+        Ok::<Event, Infallible>(
+            Event::default()
+                .id(event.seq.to_string())
+                .event(&event.event_name)
+                .data(data),
+        )
     });
     let replay_stream = tokio_stream::iter(replay);
 
@@ -243,7 +253,12 @@ pub(crate) async fn handle_entity_event_stream(
                 && event.seq > replay_high_water =>
         {
             let data = serde_json::to_string(&event.data).unwrap_or_default();
-            Some(Ok(Event::default().event(&event.event_name).data(data)))
+            Some(Ok(
+                Event::default()
+                    .id(event.seq.to_string())
+                    .event(&event.event_name)
+                    .data(data),
+            ))
         }
         Ok(_) => None,
         Err(_) => None,

--- a/crates/temper-server/src/observe/mod.rs
+++ b/crates/temper-server/src/observe/mod.rs
@@ -157,12 +157,12 @@ pub fn build_observe_router() -> Router<ServerState> {
             get(entities::handle_get_entity_history),
         )
         .route(
-            "/entities/{entity_type}/{entity_id}/wait",
-            get(entities::handle_wait_for_entity_state),
-        )
-        .route(
             "/entities/{entity_type}/{entity_id}/events",
             get(entities::handle_entity_event_stream),
+        )
+        .route(
+            "/entities/{entity_type}/{entity_id}/wait",
+            get(entities::handle_wait_for_entity_state),
         )
         .route("/events/stream", get(entities::handle_event_stream))
         .route(

--- a/crates/temper-wasm/src/host_trait.rs
+++ b/crates/temper-wasm/src/host_trait.rs
@@ -164,7 +164,7 @@ impl WasmHost for ProductionWasmHost {
         }
 
         if !body.is_empty() {
-            builder = builder.body(body.to_string());
+            builder = builder.body(encode_connect_json_frame(body));
         }
 
         let resp = builder

--- a/crates/temper-wasm/src/host_trait.rs
+++ b/crates/temper-wasm/src/host_trait.rs
@@ -164,7 +164,7 @@ impl WasmHost for ProductionWasmHost {
         }
 
         if !body.is_empty() {
-            builder = builder.body(encode_connect_json_frame(body));
+            builder = builder.body(body.to_string());
         }
 
         let resp = builder


### PR DESCRIPTION
## Summary
- cherry-pick the Connect protocol fixes needed for `connect_call` to work with envd and other Connect services
- extract replayable per-entity observe/progress infrastructure from `feat/temper-claw` without bringing over any Open Paw code
- extract Turso-backed blob storage and internal blob endpoints needed by platform-level file/blob handling

## Included
- `connect+json` content type fix
- Connect JSON request framing and raw HTTP vs framed Connect body handling
- `host_emit_progress` host plumbing across `temper-wasm`, `temper-wasm-sdk`, and the authorized host wrapper
- `EntityObserveEvent` sequencing/replay plumbing and `/observe/entities/{type}/{id}/events`
- sequence-aware server event wiring updates
- Turso blob schema/store support plus `/_internal/blobs/{*path}` server endpoints

## Intentionally not included
- `os-apps/temper-agent`
- `os-apps/temper-channels`
- `temper-transport`
- in-server Discord transport
- any Open Paw-specific agent, channel, or proof code

## Validation
- `cargo build`
- `cargo test`

## Notes
This PR is the platform-only slice needed so Open Paw can stop depending on `feat/temper-claw` and move toward `temper` `main`.
