### PR TITLE
docs: replace 'skills' with 'capabilities'

### DIFF
--- a/docs/PAPER.md
+++ b/docs/PAPER.md
@@ -21,10 +21,10 @@ separation.
 Temper follows this pattern for autonomous agents.  The kernel is the constructor:
 it reads specifications -- I/O Automaton state machines, CSDL data models, Cedar
 authorization policies, WASM integration declarations -- and builds a running
-system from them.  Skills are the descriptions: each one bundles a verified state
-machine, data model, policies, and integrations into a deployable capability.
-Agents create new skills and operate through existing ones.  The GEPA (Guided
-Evolution of Pareto-optimal Artifacts) observes how skills are used, clusters
+system from them.  Capabilities are the descriptions: each one bundles a verified state
+machine, data model, policies, and integrations into a deployable unit.
+Agents create new capabilities and operate through existing ones.  The GEPA (Guided
+Evolution of Pareto-optimal Artifacts) observes how capabilities are used, clusters
 failure patterns, and proposes specification changes.  The descriptions evolve.
 The constructor stays stable.
 
@@ -36,7 +36,7 @@ human for approval.  Policies accumulate as agents work.  Every transition is
 recorded with agent identity, before/after state, and the authorization decision.
 
 The system is implemented as a 25-crate Rust workspace with 950+ tests.  Three
-pre-built skills ship with the platform (project management, filesystem, agent
+pre-built capabilities ship with the platform (project management, filesystem, agent
 orchestration).  A reference e-commerce application demonstrates the full
 development flow across three verified entity types.  A pre-built rule index
 yields sub-30ns action evaluation; end-to-end benchmarks through the full HTTP
@@ -75,11 +75,11 @@ description and builds what it encodes).  Evolution happens by mutating
 descriptions, not the constructor.  The constructor stays stable.
 
 In Temper, the kernel is the constructor.  It reads specifications and builds
-running systems from them.  Skills are the descriptions.  Each skill bundles
+running systems from them.  Capabilities are the descriptions.  Each capability bundles
 a verified state machine, a data model, authorization policies, and integration
-declarations.  Agents create skills by describing what they need.  The GEPA
-(Guided Evolution of Pareto-optimal Artifacts) observes how skills are used and
-proposes specification changes.  Agents also create new skills when they encounter
+declarations.  Agents create capabilities by describing what they need.  The GEPA
+(Guided Evolution of Pareto-optimal Artifacts) observes how capabilities are used and
+proposes specification changes.  Agents also create new capabilities when they encounter
 gaps.  Both paths -- mutation and creation -- go through a four-level verification
 cascade and require human approval.
 
@@ -103,7 +103,7 @@ Four challenges motivate this architecture:
    action recorded with agent identity), and evolvable (new permissions
    granted as needs arise, not anticipated upfront).
 
-4. **Interpretability under evolution.**  When skills evolve through use,
+4. **Interpretability under evolution.**  When capabilities evolve through use,
    a human must be able to read the specification and understand what the
    system does, trace why any change was made, and verify that the change
    is sound.  The specification is the system's behavior, complete and
@@ -896,9 +896,9 @@ at scale.  Temper uses Amazon Cedar <sup>[2]</sup>; Section 3.3 discusses the ra
 **Agent operating systems.**  AgentOS <sup>[23]</sup> proposes a skill-based architecture
 where agents discover, compose, and execute modular capabilities rather than
 monolithic applications.  Their skills are natural language contracts parsed
-into intent specifications and capability constraints.  Temper's skills share
+into intent specifications and capability constraints.  Temper's capabilities share
 the modularity and composability but differ in the contract representation:
-Temper skills are formally verified state machines with mathematical proofs
+Temper capabilities are formally verified state machines with mathematical proofs
 of correctness, not natural language intent specifications.  AgentOS's
 semantic firewall for intent verification, trajectory mining for pattern
 learning, and state rollback mechanisms have parallels in Temper's Cedar
@@ -907,8 +907,8 @@ authorization, GEPA trajectory analysis, and event-sourced state recovery.
 **Self-replicating machines.**  Von Neumann's universal constructor <sup>[21, 22]</sup>
 established the separation between description (blueprint) and constructor
 (universal builder) as a prerequisite for open-ended evolution.  Temper's
-kernel/skill architecture follows this separation: the kernel is the
-constructor that interprets any specification, and skills are the
+kernel/capability architecture follows this separation: the kernel is the
+constructor that interprets any specification, and capabilities are the
 descriptions that agents create, mutate, and evolve.  The GEPA serves
 as the copy-and-mutate mechanism, proposing description changes based on
 observed usage patterns.
@@ -1210,7 +1210,7 @@ As described in Section 9.3, the write path is backend-agnostic via
 Temper makes the following contributions:
 
 1. A constructor/description architecture where the kernel (constructor) interprets
-   any specification fed to it, and skills (descriptions) are the evolving artifacts
+   any specification fed to it, and capabilities (descriptions) are the evolving artifacts
    that agents create, operate through, and improve.  The kernel stays stable.  The
    descriptions evolve.
 
@@ -1219,14 +1219,14 @@ Temper makes the following contributions:
    deterministic simulation with fault injection, and property-based testing.
    Every description passes this cascade before deployment.
 
-3. A skill system where each skill bundles a verified state machine, data model,
+3. A capability system where each capability bundles a verified state machine, data model,
    authorization policies, and integration declarations into a deployable
-   capability.  Three pre-built skills ship with the platform; agents create
+   unit.  Three pre-built capabilities ship with the platform; agents create
    new ones at runtime.
 
 4. GEPA (Guided Evolution of Pareto-optimal Artifacts): a trajectory-driven
-   evolution engine that observes how skills are used, clusters failure patterns,
-   and proposes specification changes.  Combined with agent-initiated skill
+   evolution engine that observes how capabilities are used, clusters failure patterns,
+   and proposes specification changes.  Combined with agent-initiated capability
    creation, this provides two paths for capability evolution -- mutation
    of existing descriptions and creation of new ones -- both gated by
    verification and human approval.
@@ -1238,7 +1238,7 @@ Temper makes the following contributions:
    workarounds) from agent execution traces.
 
 7. A three-tier JIT execution model with atomic hot-swap and shadow testing for
-   zero-downtime skill evolution.
+   zero-downtime capability evolution.
 
 8. A DST-first development methodology where actor-level simulation tests
    validate state machine behavior before HTTP wiring, catching guard

--- a/docs/POSITIONING.md
+++ b/docs/POSITIONING.md
@@ -1,4 +1,4 @@
-# Temper: From Agent-Built Tools to Verified Skills 
+# Temper: From Agent-Built Tools to Verified Capabilities
 
 ## 1. Agents Are Starting to Build Their Own Tools
 
@@ -32,10 +32,10 @@ Temper follows this separation. The kernel is the constructor. It reads specific
 
 An agent that needs a project tracker writes a description of a project tracker. The kernel verifies the description, deploys it, and the agent operates through it. An agent that needs sprint planning writes a description of sprint planning. Same kernel, different description.
 
-We call a verified, deployed description a *skill*. A skill bundles:
+We call a verified, deployed description a *capability*. A capability bundles:
 
 - A natural language description of the capability ("issue tracking with projects, cycles, labels, and comments") for discovery and indexing
-- Guidance for agents on how to use the skill: patterns, examples, constraints
+- Guidance for agents on how to use the capability: patterns, examples, constraints
 - One or more state machine specifications defining statuses, transitions, guards, and invariants
 - A data model defining the entity schema
 - Authorization policies defining who can do what
@@ -43,27 +43,27 @@ We call a verified, deployed description a *skill*. A skill bundles:
 
 The natural language description and guidance are what agents and humans read. The specifications are what the kernel verifies and executes.
 
-## 4. Verified Skills Still Need Governance
+## 4. Verified Capabilities Still Need Governance
 
-A verified skill is correct: its state machine does what the description says. But the agent operating through it can still do things it should not. It can reassign every issue to itself. It can access another agent's project. It can call an external API through an integration without anyone approving that access.
+A verified capability is correct: its state machine does what the description says. But the agent operating through it can still do things it should not. It can reassign every issue to itself. It can access another agent's project. It can call an external API through an integration without anyone approving that access.
 
-Verification handles correctness. It does not handle who can use the skill, or how.
+Verification handles correctness. It does not handle who can use the capability, or how.
 
 Temper uses a default-deny authorization posture. When an agent attempts an action that no policy permits, the denial surfaces to the human: "Your agent tried to reassign issues in Project X. Allow?" The human approves with a scope: narrow (this agent, this action, this resource), medium (this agent, this action, any resource of this type), or broad (this agent, any action on this resource type). Temper generates the authorization policy and hot-loads it.
 
 The human does not write policies from scratch or anticipate what the agent will need. The human responds as needs arise. Over time, the policy set converges on what the agent requires.
 
-## 5. Skills Must Evolve
+## 5. Capabilities Must Evolve
 
-An agent described a project tracker last week. This week the team needs sprint planning. The tracker's state machine does not cover it. Someone has to write a new description, re-verify, redeploy. Next month the team wants labels and priorities. Another description. The skills the agent built are frozen at the moment of creation.
+An agent described a project tracker last week. This week the team needs sprint planning. The tracker's state machine does not cover it. Someone has to write a new description, re-verify, redeploy. Next month the team wants labels and priorities. Another description. The capabilities the agent built are frozen at the moment of creation.
 
 Two paths address this.
 
-**Agents create new skills.** When an agent encounters a problem the current skill set does not cover, it writes a new description. The kernel verifies and deploys it. An agent that needs sprint planning describes sprint planning.
+**Agents create new capabilities.** When an agent encounters a problem the current capability set does not cover, it writes a new description. The kernel verifies and deploys it. An agent that needs sprint planning describes sprint planning.
 
-**Existing skills evolve through use.** The kernel records every agent action as an entity transition. Separately, the MCP bridge captures each agent's full execution trace: what the agent tried to do, what succeeded, what failed, what it gave up on. The GEPA (Guided Evolution of Pareto-optimal Artifacts) replays these execution traces against the current specs, clusters failure patterns, and proposes changes to existing descriptions. Agents keep trying to assign issues to teams, but the tracker only supports individual assignees? The GEPA produces a spec diff that adds team assignment. The change goes through the verification cascade before it takes effect.
+**Existing capabilities evolve through use.** The kernel records every agent action as an entity transition. Separately, the MCP bridge captures each agent's full execution trace: what the agent tried to do, what succeeded, what failed, what it gave up on. The GEPA (Guided Evolution of Pareto-optimal Artifacts) replays these execution traces against the current specs, clusters failure patterns, and proposes changes to existing descriptions. Agents keep trying to assign issues to teams, but the tracker only supports individual assignees? The GEPA produces a spec diff that adds team assignment. The change goes through the verification cascade before it takes effect.
 
-Both paths are evolution in Von Neumann's sense: changes to the descriptions, not the constructor. The kernel stays stable. The skills change.
+Both paths are evolution in Von Neumann's sense: changes to the descriptions, not the constructor. The kernel stays stable. The capabilities change.
 
 ## 6. Evolution Needs a Trust Gradient
 
@@ -89,7 +89,7 @@ A system that evolves its own descriptions raises a concern: changes humans cann
 
 **Evolution changes are traceable.** The O-P-A-D-I record chain (Observation, Problem, Analysis, Decision, Impact) connects every spec change back to the observation that motivated it. You can ask "why does this state exist?" and trace the answer: an observation from agent execution traces, the problem the GEPA identified, the analysis it performed, the decision a human approved, and the measured impact after deployment.
 
-**The Temper-native agent takes this further.** When agents run as entities inside Temper, their state machines, budgets, and lifecycle are governed by the same kernel. Every agent action is an event. You can pause an agent, resume it from any point in its history, or replay its entire execution. The agent becomes as inspectable as the skills it operates through.
+**The Temper-native agent takes this further.** When agents run as entities inside Temper, their state machines, budgets, and lifecycle are governed by the same kernel. Every agent action is an event. You can pause an agent, resume it from any point in its history, or replay its entire execution. The agent becomes as inspectable as the capabilities it operates through.
 
 ## 8. Where This Stands
 
@@ -97,7 +97,7 @@ Temper is version 0.1.0. The constructor works. The description format is stabil
 
 **The constructor can do this today.** Parse a description (I/O Automaton spec + data model + authorization policies). Run a four-level verification cascade. Deploy it as a live actor with event sourcing, a generated API, and authorization enforcement. Hot-reload when the description changes. Record every entity transition. Capture full agent execution traces through the MCP bridge. Run the GEPA against those traces to propose description changes. Enforce cross-entity invariants (both hard constraints and eventual consistency with bounded convergence). Surface denied actions to the human for approval.
 
-**Three pre-built skills ship with the platform:** project management (5 entity types), filesystem (4 entity types), agent orchestration (3 entity types). Agents can install them, operate through them, and propose changes. Agents can also submit new descriptions.
+**Three pre-built capabilities ship with the platform:** project management (5 entity types), filesystem (4 entity types), agent orchestration (3 entity types). Agents can install them, operate through them, and propose changes. Agents can also submit new descriptions.
 
 **The constructor cannot do this yet.** No floating-point state variables (prices live in payload fields, not state). No conditional effects ("if items > 5 then discount" requires decomposing into separate guarded actions). Single-node only (Redis traits are designed but not wired). No temporal guards ("if idle > 30 days" requires scheduled actions or integration engine cron triggers). Some of these are fundamental to finite automata. Others are engineering work.
 
@@ -110,7 +110,7 @@ Temper is version 0.1.0. The constructor works. The description format is stabil
 | **4. Harness Composition** | Agents describe harnesses as specs. | In Progress |
 | **3. Integration Framework** | External APIs as sandboxed WASM modules, governed by authorization. | In Progress |
 | **2. Temper as Filesystem** | Entity persistence replaces markdown files and JSON blobs. | In Progress |
-| **1. Skills** | Agents write descriptions. The kernel verifies and deploys them. Others consume them through the generated API. | Done |
+| **1. Capabilities** | Agents write descriptions. The kernel verifies and deploys them. Others consume them through the generated API. | Done |
 | **Foundation: Kernel** | Spec interpreter, verification cascade, actor runtime, authorization, event sourcing, evolution engine. | Done |
 
 Today, agents interact with Temper through an MCP bridge. The next layers close that gap: agents as first-class entities inside the constructor, then agents that compose harnesses as descriptions, then agents whose only tool is Temper itself. Whether this pattern holds across a broader set of real-world agent deployments is the next thing to find out.


### PR DESCRIPTION
## Summary
- Replaces all Temper-specific uses of "skills" with "capabilities" in PAPER.md and POSITIONING.md
- Avoids confusion with Anthropic's `skill.md` convention
- AgentOS references to their own "skill-based architecture" left as-is (their terminology)

🤖 Generated with [Claude Code](https://claude.com/claude-code)