### PR TITLE
feat: add host_get_time WASM host function

### DIFF
--- a/crates/temper-wasm/Cargo.toml
+++ b/crates/temper-wasm/Cargo.toml
@@ -16,6 +16,7 @@ tokio = { workspace = true }
 reqwest = { workspace = true }
 sha2 = { workspace = true }
 async-trait = { workspace = true }
+chrono = { workspace = true }
 
 [features]
 test-helpers = []

--- a/crates/temper-wasm/src/engine/host_functions.rs
+++ b/crates/temper-wasm/src/engine/host_functions.rs
@@ -550,6 +550,31 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
         )
         .map_err(|e| WasmError::Compilation(format!("failed to link host_hash_stream: {e}")))?;
 
+    // host_get_time(buf_ptr, buf_len) -> i32
+    // Writes the current UTC time as "YYYYMMDDTHHMMSSz" (Sig V4 format) into buf.
+    // Returns bytes written, or -1 on error.
+    linker
+        .func_wrap(
+            "env",
+            "host_get_time",
+            |mut caller: Caller<'_, HostState>, buf_ptr: i32, buf_len: i32| -> i32 {
+                let memory = caller.get_export("memory").and_then(|e| e.into_memory());
+                let Some(memory) = memory else {
+                    return -1;
+                };
+
+                let now = chrono::Utc::now();
+                let formatted = now.format("%Y%m%dT%H%M%SZ").to_string();
+                let bytes = formatted.as_bytes();
+                if bytes.len() > buf_len as usize {
+                    return -1;
+                }
+                let _ = memory.write(&mut caller, buf_ptr as usize, bytes);
+                bytes.len() as i32
+            },
+        )
+        .map_err(|e| WasmError::Compilation(format!("failed to link host_get_time: {e}")))?;
+
     // host_evaluate_spec(ioa_ptr, ioa_len, state_ptr, state_len,
     //                    action_ptr, action_len, params_ptr, params_len,
     //                    result_buf_ptr, result_buf_len) -> i32


### PR DESCRIPTION
## Summary
- Adds `host_get_time(buf_ptr, buf_len) -> i32` host function to the WASM runtime
- Returns current UTC time in `YYYYMMDDTHHMMSSz` format (Sig V4 compatible)
- WASM guest modules need this for AWS Signature V4 signing against S3-compatible blob stores (GCS interoperability)
- Adds `chrono` workspace dependency to `temper-wasm`

## Test plan
- [x] All 52 temper-wasm unit + e2e tests pass
- [x] Full pre-push gate passed (rustfmt, clippy, readability ratchet, full test suite including DST)

🤖 Generated with [Claude Code](https://claude.com/claude-code)