### PR TITLE
feat: enrich OTel spans with HTTP semantic conventions and GenAI attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5916,6 +5916,7 @@ name = "temper-wasm"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "chrono",
  "reqwest",
  "serde",
  "serde_json",

--- a/crates/temper-server/src/router.rs
+++ b/crates/temper-server/src/router.rs
@@ -97,7 +97,27 @@ pub fn build_router(state: ServerState) -> Router {
         ]);
 
     router
-        .layer(TraceLayer::new_for_http())
+        .layer(
+            TraceLayer::new_for_http()
+                .make_span_with(|request: &axum::http::Request<_>| {
+                    tracing::info_span!(
+                        "http.request",
+                        otel.name = %format!("{} {}", request.method(), request.uri().path()),
+                        http.method = %request.method(),
+                        http.route = %request.uri().path(),
+                        http.status_code = tracing::field::Empty,
+                        otel.kind = "server",
+                    )
+                })
+                .on_response(|response: &axum::http::Response<_>, latency: std::time::Duration, span: &tracing::Span| {
+                    span.record("http.status_code", response.status().as_u16());
+                    tracing::info!(
+                        latency_ms = latency.as_millis() as u64,
+                        status = response.status().as_u16(),
+                        "response"
+                    );
+                }),
+        )
         .layer(cors)
         .with_state(state)
 }

--- a/crates/temper-server/src/router.rs
+++ b/crates/temper-server/src/router.rs
@@ -109,14 +109,18 @@ pub fn build_router(state: ServerState) -> Router {
                         otel.kind = "server",
                     )
                 })
-                .on_response(|response: &axum::http::Response<_>, latency: std::time::Duration, span: &tracing::Span| {
-                    span.record("http.status_code", response.status().as_u16());
-                    tracing::info!(
-                        latency_ms = latency.as_millis() as u64,
-                        status = response.status().as_u16(),
-                        "response"
-                    );
-                }),
+                .on_response(
+                    |response: &axum::http::Response<_>,
+                     latency: std::time::Duration,
+                     span: &tracing::Span| {
+                        span.record("http.status_code", response.status().as_u16());
+                        tracing::info!(
+                            latency_ms = latency.as_millis() as u64,
+                            status = response.status().as_u16(),
+                            "response"
+                        );
+                    },
+                ),
         )
         .layer(cors)
         .with_state(state)

--- a/crates/temper-server/src/state/dispatch/actions.rs
+++ b/crates/temper-server/src/state/dispatch/actions.rs
@@ -16,7 +16,7 @@ impl crate::state::ServerState {
     /// parameters explicit (especially tenant) and avoids the previous
     /// three-layer wrapper chain.
     #[instrument(skip_all, fields(
-        otel.name = "dispatch.dispatch",
+        otel.name = %format_args!("{}.{}", cmd.entity_type, cmd.action),
         tenant = %cmd.tenant,
         entity_type = cmd.entity_type,
         entity_id = cmd.entity_id,
@@ -51,7 +51,7 @@ impl crate::state::ServerState {
     ///
     /// Callers that need integration await or other options should use
     /// `dispatch(DispatchCommand { .. })` directly.
-    #[instrument(skip_all, fields(otel.name = "dispatch.dispatch_tenant_action", tenant = %tenant, entity_type, entity_id, action_name = action))]
+    #[instrument(skip_all, fields(otel.name = %format_args!("{}.{}", entity_type, action), tenant = %tenant, entity_type, entity_id, action_name = action))]
     pub async fn dispatch_tenant_action(
         &self,
         tenant: &TenantId,
@@ -74,7 +74,7 @@ impl crate::state::ServerState {
     }
 
     /// Convenience wrapper around [`dispatch`](Self::dispatch) with full options.
-    #[instrument(skip_all, fields(otel.name = "dispatch.dispatch_tenant_action_ext", tenant = %tenant, entity_type, entity_id, action_name = action))]
+    #[instrument(skip_all, fields(otel.name = %format_args!("{}.{}", entity_type, action), tenant = %tenant, entity_type, entity_id, action_name = action))]
     pub async fn dispatch_tenant_action_ext(
         &self,
         tenant: &TenantId,
@@ -97,7 +97,7 @@ impl crate::state::ServerState {
     }
 
     /// Typed variant of [`dispatch_tenant_action_ext`](Self::dispatch_tenant_action_ext).
-    #[instrument(skip_all, fields(otel.name = "dispatch.dispatch_tenant_action_ext_typed", tenant = %tenant, entity_type, entity_id, action_name = action))]
+    #[instrument(skip_all, fields(otel.name = %format_args!("{}.{}", entity_type, action), tenant = %tenant, entity_type, entity_id, action_name = action))]
     pub async fn dispatch_tenant_action_ext_typed(
         &self,
         tenant: &TenantId,

--- a/crates/temper-server/src/state/dispatch/wasm.rs
+++ b/crates/temper-server/src/state/dispatch/wasm.rs
@@ -444,10 +444,18 @@ impl crate::state::ServerState {
         {
             Ok(result) if result.success => {
                 // Record GenAI token usage from callback params (if present)
-                if let Some(input) = result.callback_params.get("input_tokens").and_then(|v| v.as_i64()) {
+                if let Some(input) = result
+                    .callback_params
+                    .get("input_tokens")
+                    .and_then(|v| v.as_i64())
+                {
                     tracing::Span::current().record("gen_ai.usage.input_tokens", input);
                 }
-                if let Some(output) = result.callback_params.get("output_tokens").and_then(|v| v.as_i64()) {
+                if let Some(output) = result
+                    .callback_params
+                    .get("output_tokens")
+                    .and_then(|v| v.as_i64())
+                {
                     tracing::Span::current().record("gen_ai.usage.output_tokens", output);
                 }
 

--- a/crates/temper-server/src/state/dispatch/wasm.rs
+++ b/crates/temper-server/src/state/dispatch/wasm.rs
@@ -44,7 +44,7 @@ fn is_http_call_authz_denial(error: &str) -> bool {
 }
 
 impl crate::state::ServerState {
-    #[instrument(skip_all, fields(otel.name = "dispatch.dispatch_wasm_integrations_internal", tenant = %req.tenant, entity_type = req.entity_type, entity_id = req.entity_id, action_name = req.action))]
+    #[instrument(skip_all, fields(otel.name = %format_args!("{}.{}.integrations", req.entity_type, req.action), tenant = %req.tenant, entity_type = req.entity_type, entity_id = req.entity_id, action_name = req.action))]
     pub(crate) async fn dispatch_wasm_integrations_internal(
         &self,
         req: &WasmDispatchRequest<'_>,
@@ -96,7 +96,15 @@ impl crate::state::ServerState {
     }
 
     /// Dispatch a single WASM integration: resolve module, invoke, handle result.
-    #[instrument(skip_all, fields(otel.name = "dispatch.dispatch_single_integration", integration = %integration.name))]
+    #[instrument(skip_all, fields(
+        otel.name = tracing::field::Empty,
+        integration = %integration.name,
+        wasm.module = tracing::field::Empty,
+        gen_ai.system = tracing::field::Empty,
+        gen_ai.request.model = tracing::field::Empty,
+        gen_ai.usage.input_tokens = tracing::field::Empty,
+        gen_ai.usage.output_tokens = tracing::field::Empty,
+    ))]
     async fn dispatch_single_integration(
         &self,
         ctx: &WasmDispatchCtx<'_>,
@@ -115,6 +123,17 @@ impl crate::state::ServerState {
             );
             return Ok(None);
         };
+
+        // Set dynamic span name and GenAI attributes
+        let span = tracing::Span::current();
+        span.record("otel.name", format!("wasm:{module_name}").as_str());
+        span.record("wasm.module", module_name.as_str());
+        if module_name == "llm_caller" {
+            span.record("gen_ai.system", "anthropic");
+            if let Some(model) = entity_state.fields.get("model").and_then(|v| v.as_str()) {
+                span.record("gen_ai.request.model", model);
+            }
+        }
 
         let module_hash = {
             let wasm_reg = self.wasm_module_registry.read().unwrap(); // ci-ok: infallible lock
@@ -424,6 +443,14 @@ impl crate::state::ServerState {
             .await
         {
             Ok(result) if result.success => {
+                // Record GenAI token usage from callback params (if present)
+                if let Some(input) = result.callback_params.get("input_tokens").and_then(|v| v.as_i64()) {
+                    tracing::Span::current().record("gen_ai.usage.input_tokens", input);
+                }
+                if let Some(output) = result.callback_params.get("output_tokens").and_then(|v| v.as_i64()) {
+                    tracing::Span::current().record("gen_ai.usage.output_tokens", output);
+                }
+
                 let complete_seq = self.next_entity_event_sequence(
                     ctx.entity_ref.tenant.as_str(),
                     ctx.entity_ref.entity_type,

--- a/crates/temper-server/src/webhooks/receiver.rs
+++ b/crates/temper-server/src/webhooks/receiver.rs
@@ -25,7 +25,12 @@ use temper_spec::automaton::Webhook;
 /// The handler looks up the webhook configuration from the tenant's spec
 /// registry, validates the HTTP method, extracts the entity ID and action
 /// parameters, then dispatches the configured action to the target entity.
-#[instrument(skip_all, fields(tenant, webhook_path, otel.name = "GET|POST /webhooks/{tenant}/{*path}"))]
+#[instrument(skip_all, fields(
+    otel.name = %format_args!("{} /webhooks/{}/{}", method, tenant_str, webhook_path),
+    tenant = %tenant_str,
+    webhook_path = %webhook_path,
+    http.method = %method,
+))]
 pub async fn handle_webhook(
     method: Method,
     State(state): State<ServerState>,


### PR DESCRIPTION
## Summary
- Custom MakeSpan on TraceLayer adds `http.method`, `http.route`, `http.status_code` to all HTTP spans
- Entity dispatch spans use dynamic names: `Agent.Provision`, `AlertCycle.Open` instead of generic `dispatch.dispatch`
- WASM integration spans named `wasm:{module}` with GenAI semantic conventions (`gen_ai.system`, `gen_ai.request.model`, `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`)
- Fixed unbound fields bug in webhook handler

## Test plan
- [x] All existing tests pass (700+ tests, 0 failures)
- [ ] Start OpenPaw with OTel enabled → verify Datadog APM shows readable span names
- [ ] Verify HTTP spans have type `web` in Datadog
- [ ] Verify LLM calls show GenAI attributes in Datadog LLM Observability

🤖 Generated with [Claude Code](https://claude.com/claude-code)