### PR TITLE
feat: WASI support + host_get_time_millis for WASM engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,6 +565,84 @@ checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
 dependencies = [
  "bytes",
  "either",
+]
+
+[[package]]
+name = "cap-fs-ext"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5528f85b1e134ae811704e41ef80930f56e795923f866813255bc342cc20654"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "io-lifetimes",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "cap-net-ext"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20a158160765c6a7d0d8c072a53d772e4cb243f38b04bfcf6b4939cfbe7482e7"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "rustix 1.1.4",
+ "smallvec",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6cf3aea8a5081171859ef57bc1606b1df6999df4f1110f8eef68b30098d1d3a"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes",
+ "ipnet",
+ "maybe-owned",
+ "rustix 1.1.4",
+ "rustix-linux-procfs",
+ "windows-sys 0.59.0",
+ "winx",
+]
+
+[[package]]
+name = "cap-rand"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8144c22e24bbcf26ade86cb6501a0916c46b7e4787abdb0045a467eb1645a1d"
+dependencies = [
+ "ambient-authority",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "cap-std"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6dc3090992a735d23219de5c204927163d922f42f575a0189b005c62d37549a"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "cap-time-ext"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "def102506ce40c11710a9b16e614af0cde8e76ae51b1f48c04b8d79f4b671a80"
+dependencies = [
+ "ambient-authority",
+ "cap-primitives",
+ "iana-time-zone",
+ "once_cell",
+ "rustix 1.1.4",
+ "winx",
 ]
 
 [[package]]
@@ -1446,11 +1530,31 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -1702,6 +1806,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1817,6 +1932,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes",
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2640,6 +2766,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
 
 [[package]]
+name = "io-extras"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
+dependencies = [
+ "io-lifetimes",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3212,6 +3354,12 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "md-5"
@@ -4646,6 +4794,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix 1.1.4",
+]
+
+[[package]]
 name = "rustls"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5009,6 +5167,15 @@ name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
+name = "shellexpand"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ccc8076840c4da029af4f87e4e8daeb0fca6b87bbb02e10cb60b791450e11e4"
+dependencies = [
+ "dirs 4.0.0",
+]
 
 [[package]]
 name = "shlex"
@@ -5495,6 +5662,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-interface"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc4592f674ce18521c2a81483873a49596655b179f71c5e05d10c1fe66c78745"
+dependencies = [
+ "bitflags 2.11.0",
+ "cap-fs-ext",
+ "cap-std",
+ "fd-lock",
+ "io-lifetimes",
+ "rustix 0.38.44",
+ "windows-sys 0.59.0",
+ "winx",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5524,7 +5707,7 @@ dependencies = [
  "clap",
  "console",
  "dialoguer",
- "dirs",
+ "dirs 6.0.0",
  "dotenvy",
  "indicatif",
  "open",
@@ -5926,6 +6109,7 @@ dependencies = [
  "tokio-test",
  "tracing",
  "wasmtime",
+ "wasmtime-wasi",
 ]
 
 [[package]]
@@ -7220,6 +7404,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtime-wasi"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d1be69bfcab1bdac74daa7a1f9695ab992b9c8e21b9b061e7d66434097e0ca4"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bitflags 2.11.0",
+ "bytes",
+ "cap-fs-ext",
+ "cap-net-ext",
+ "cap-rand",
+ "cap-std",
+ "cap-time-ext",
+ "fs-set-times",
+ "futures",
+ "io-extras",
+ "io-lifetimes",
+ "rustix 0.38.44",
+ "system-interface",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "trait-variant",
+ "url",
+ "wasmtime",
+ "wiggle",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "wasmtime-winch"
 version = "29.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7250,6 +7465,15 @@ dependencies = [
 
 [[package]]
 name = "wast"
+version = "35.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ef140f1b49946586078353a453a1d28ba90adfc54dde75710bc1931de204d68"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wast"
 version = "245.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28cf1149285569120b8ce39db8b465e8a2b55c34cbb586bd977e43e2bc7300bf"
@@ -7267,7 +7491,7 @@ version = "1.245.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd48d1679b6858988cb96b154dda0ec5bbb09275b71db46057be37332d5477be"
 dependencies = [
- "wast",
+ "wast 245.0.1",
 ]
 
 [[package]]
@@ -7328,6 +7552,48 @@ checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
 dependencies = [
  "libredox",
  "wasite",
+]
+
+[[package]]
+name = "wiggle"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9af35bc9629c52c261465320a9a07959164928b4241980ba1cf923b9e6751d"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bitflags 2.11.0",
+ "thiserror 1.0.69",
+ "tracing",
+ "wasmtime",
+ "wiggle-macro",
+]
+
+[[package]]
+name = "wiggle-generate"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cf267dd05673912c8138f4b54acabe6bd53407d9d1536f0fadb6520dd16e101"
+dependencies = [
+ "anyhow",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "shellexpand",
+ "syn",
+ "witx",
+]
+
+[[package]]
+name = "wiggle-macro"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c5c473d4198e6c2d377f3809f713ff0c110cab88a0805ae099a82119ee250c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wiggle-generate",
 ]
 
 [[package]]
@@ -7690,6 +7956,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags 2.11.0",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "wiremock"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7816,6 +8092,18 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "witx"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e366f27a5cabcddb2706a78296a40b8fcc451e1a6aba2fc1d94b4a01bdaaef4b"
+dependencies = [
+ "anyhow",
+ "log",
+ "thiserror 1.0.69",
+ "wast 35.0.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,7 @@ temper-transport = { path = "crates/temper-transport" }
 
 # WASM runtime
 wasmtime = { version = "29", features = ["component-model"] }
+wasmtime-wasi = "29"
 sha2 = "0.10"
 hostname = "0.4"
 aes-gcm = "0.10"

--- a/crates/temper-wasm-sdk/src/context.rs
+++ b/crates/temper-wasm-sdk/src/context.rs
@@ -105,6 +105,14 @@ impl Context {
         })
     }
 
+    /// Get current UTC time as milliseconds since Unix epoch.
+    ///
+    /// Useful for elapsed-time tracking in WASM modules where
+    /// `std::time::Instant` is not available.
+    pub fn get_time_millis() -> i64 {
+        unsafe { host::host_get_time_millis() }
+    }
+
     /// Make an HTTP GET request via the host.
     pub fn http_get(&self, url: &str) -> Result<HttpResponse, String> {
         self.http_call("GET", url, &[], "")

--- a/crates/temper-wasm-sdk/src/host.rs
+++ b/crates/temper-wasm-sdk/src/host.rs
@@ -80,6 +80,10 @@ unsafe extern "C" {
         result_buf_len: i32,
     ) -> i32;
 
+    /// Get current UTC time as milliseconds since Unix epoch.
+    /// Used for elapsed-time tracking in WASM modules (e.g., resource limiters).
+    pub fn host_get_time_millis() -> i64;
+
     /// Evaluate a single transition against an IOA spec on the host.
     /// Returns bytes written to result_buf (JSON), -1 on error, -2 if buf too small.
     pub fn host_evaluate_spec(

--- a/crates/temper-wasm/Cargo.toml
+++ b/crates/temper-wasm/Cargo.toml
@@ -8,6 +8,7 @@ description = "WASM sandboxed integration runtime for Temper"
 
 [dependencies]
 wasmtime = { workspace = true }
+wasmtime-wasi = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }

--- a/crates/temper-wasm/src/engine/host_functions.rs
+++ b/crates/temper-wasm/src/engine/host_functions.rs
@@ -575,6 +575,17 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
         )
         .map_err(|e| WasmError::Compilation(format!("failed to link host_get_time: {e}")))?;
 
+    // host_get_time_millis() -> i64
+    // Returns current UTC time as milliseconds since Unix epoch.
+    // Used by WASM modules that need elapsed-time tracking (e.g., resource limiters).
+    linker
+        .func_wrap(
+            "env",
+            "host_get_time_millis",
+            |_caller: Caller<'_, HostState>| -> i64 { chrono::Utc::now().timestamp_millis() },
+        )
+        .map_err(|e| WasmError::Compilation(format!("failed to link host_get_time_millis: {e}")))?;
+
     // host_evaluate_spec(ioa_ptr, ioa_len, state_ptr, state_len,
     //                    action_ptr, action_len, params_ptr, params_len,
     //                    result_buf_ptr, result_buf_len) -> i32

--- a/crates/temper-wasm/src/engine/mod.rs
+++ b/crates/temper-wasm/src/engine/mod.rs
@@ -12,6 +12,8 @@ use std::sync::{Arc, RwLock};
 
 use sha2::{Digest, Sha256};
 use wasmtime::{Config, Engine, Linker, Module, ResourceLimiter, Store};
+use wasmtime_wasi::preview1::WasiP1Ctx;
+use wasmtime_wasi::{WasiCtxBuilder, preview1};
 
 use crate::host_trait::WasmHost;
 use crate::stream::StreamRegistry;
@@ -110,6 +112,10 @@ pub(crate) struct HostState {
     /// Stream registry for binary data transfer between host and WASM guest.
     /// Bytes never enter WASM memory — WASM references them by stream ID.
     pub(crate) streams: Arc<RwLock<StreamRegistry>>,
+    /// WASI context for modules compiled with wasm32-wasi target.
+    /// None for wasm32-unknown-unknown modules. When present, WASI
+    /// syscalls (clock_time_get, random_get, etc.) are available.
+    pub(crate) wasi_ctx: Option<WasiP1Ctx>,
 }
 
 /// WASM engine: compile, cache, invoke modules.
@@ -215,6 +221,20 @@ impl WasmEngine {
             .map_err(|e| WasmError::Invocation(format!("failed to serialize context: {e}")))?;
 
         // Create a fresh store with fuel budget and memory limiter
+        // Check if the module imports wasi_snapshot_preview1 (wasm32-wasi target).
+        let needs_wasi = cached
+            .module
+            .imports()
+            .any(|imp| imp.module() == "wasi_snapshot_preview1");
+
+        let wasi_ctx = if needs_wasi {
+            // Minimal WASI context: clock + random, no filesystem or network.
+            let wasi = WasiCtxBuilder::new().build_p1();
+            Some(wasi)
+        } else {
+            None
+        };
+
         let host_state = HostState {
             context_json: context_json.clone(),
             result_json: None,
@@ -223,6 +243,7 @@ impl WasmEngine {
                 max_memory: limits.max_memory,
             },
             streams,
+            wasi_ctx,
         };
         let mut store = Store::new(&self.engine, host_state);
         store
@@ -260,6 +281,19 @@ impl WasmEngine {
         // Link host functions
         let mut linker = Linker::new(&self.engine);
         host_functions::link_host_functions(&mut linker)?;
+
+        // Link WASI imports for wasm32-wasi modules (clock, random, etc.).
+        // Non-WASI modules skip this — their imports are fully satisfied by
+        // the custom host functions above.
+        if needs_wasi {
+            preview1::add_to_linker_sync(&mut linker, |state: &mut HostState| {
+                state
+                    .wasi_ctx
+                    .as_mut()
+                    .expect("wasi_ctx must be Some when needs_wasi is true")
+            })
+            .map_err(|e| WasmError::Compilation(format!("failed to link WASI: {e}")))?;
+        }
 
         // Instantiate
         let instance = linker


### PR DESCRIPTION
## Summary
- Add `host_get_time_millis()` host function returning UTC milliseconds since epoch
- Add optional WASI preview1 support to the WASM engine
- Engine auto-detects `wasm32-wasi` modules (checks for `wasi_snapshot_preview1` imports)
- Creates minimal `WasiP1Ctx` (clock + random only, no filesystem/network)
- Existing `wasm32-unknown-unknown` modules are completely unaffected

## Why
OpenPaw is embedding Pydantic's Monty Python sandbox as a WASM module for agent tool execution (ADR-0008). Monty compiles to `wasm32-wasi` (proven by `monty-js`), which requires WASI syscalls for `std::time::Instant`, `getrandom`, and `LazyLock`. Adding WASI support to the engine is cleaner than forking Monty.

## Test plan
- [x] `cargo test -p temper-wasm` — 4/4 pass (existing modules unaffected)
- [x] `cargo check -p temper-wasm -p temper-wasm-sdk` — clean
- [ ] Integration: build monty_repl as wasm32-wasip1, run through Temper engine

🤖 Generated with [Claude Code](https://claude.com/claude-code)