### PR TITLE
fix: WASM HTTP host loads CA certs from secret store

### DIFF
--- a/crates/temper-wasm/src/host_trait.rs
+++ b/crates/temper-wasm/src/host_trait.rs
@@ -117,13 +117,33 @@ impl ProductionWasmHost {
     }
 
     /// Create with pre-loaded secrets and a custom HTTP request timeout.
+    ///
+    /// Secrets whose key starts with `ca_cert:` are treated as PEM-encoded
+    /// CA certificates and added as trusted roots to the HTTP client. This
+    /// lets operators provision private CA trust via the same secret store
+    /// that WASM modules already use, with no filesystem or env var coupling.
     pub fn with_timeout(secrets: BTreeMap<String, String>, timeout: std::time::Duration) -> Self {
+        let mut builder = reqwest::Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .timeout(timeout);
+
+        for (key, pem) in &secrets {
+            if !key.starts_with("ca_cert:") {
+                continue;
+            }
+            match reqwest::Certificate::from_pem(pem.as_bytes()) {
+                Ok(cert) => {
+                    tracing::info!(key, "loaded CA certificate from secret store");
+                    builder = builder.add_root_certificate(cert);
+                }
+                Err(e) => {
+                    tracing::warn!(key, error = %e, "failed to parse CA certificate from secret");
+                }
+            }
+        }
+
         Self {
-            client: reqwest::Client::builder()
-                .connect_timeout(std::time::Duration::from_secs(10))
-                .timeout(timeout)
-                .build()
-                .unwrap_or_default(),
+            client: builder.build().unwrap_or_default(),
             secrets,
             spec_evaluator: None,
             progress_emitter: None,


### PR DESCRIPTION
Cherry-pick of the fix from PR #95 onto current main.

Secrets with keys starting with `ca_cert:` are now parsed as PEM-encoded CA certificates and added as trusted roots to the reqwest HTTP client. Lets operators provision private CA trust (e.g., GKE internal CAs) via the Temper vault, with no filesystem or env var coupling.

Used by the k8s_provisioner WASM module to call the Kubernetes API server with the cluster CA certificate.

Original PR: #95 (CI passed: Compile & Lint, Integrity & DST Patterns, Spec Verification L0-L3, Tests, Verification Contract)