### PR TITLE
feat: add schedule_at effect type

### DIFF
--- a/crates/temper-jit/src/table/builder.rs
+++ b/crates/temper-jit/src/table/builder.rs
@@ -124,6 +124,7 @@ fn convert_effect(effect: ResolvedEffect) -> Effect {
             action,
             delay_seconds,
         },
+        ResolvedEffect::ScheduleAt { action, field } => Effect::ScheduleAtAction { action, field },
         ResolvedEffect::Spawn {
             entity_type,
             entity_id_source,

--- a/crates/temper-jit/src/table/types.rs
+++ b/crates/temper-jit/src/table/types.rs
@@ -133,6 +133,8 @@ pub enum Effect {
     Custom(String),
     /// Schedule a delayed action (timer fires after delay_seconds).
     ScheduleAction { action: String, delay_seconds: u64 },
+    /// Schedule an action at an absolute timestamp read from an entity field.
+    ScheduleAtAction { action: String, field: String },
     /// Spawn a child entity as a post-transition effect.
     SpawnEntity {
         entity_type: String,

--- a/crates/temper-server/src/entity_actor/actor.rs
+++ b/crates/temper-server/src/entity_actor/actor.rs
@@ -305,12 +305,16 @@ impl EntityActor {
                                 if result.success {
                                     // Shared effect application — same code as handle() and simulation.
                                     let from_status = event.from_status.clone();
-                                    let (_custom_effects, _scheduled_actions, _spawn_requests) =
-                                        super::effects::apply_effects(
-                                            state,
-                                            &result.effects,
-                                            &event.params,
-                                        );
+                                    let (
+                                        _custom_effects,
+                                        _scheduled_actions,
+                                        _spawn_requests,
+                                        _schedule_at_requests,
+                                    ) = super::effects::apply_effects(
+                                        state,
+                                        &result.effects,
+                                        &event.params,
+                                    );
                                     super::effects::apply_new_state_fallback(
                                         state,
                                         &from_status,

--- a/crates/temper-server/src/entity_actor/effects.rs
+++ b/crates/temper-server/src/entity_actor/effects.rs
@@ -38,6 +38,18 @@ pub struct SpawnRequest {
     pub store_id_in: Option<String>,
 }
 
+/// A deferred schedule-at request — resolved after `sync_fields`.
+///
+/// Unlike `ScheduledAction` (fixed delay), a `ScheduleAtRequest` reads an absolute
+/// ISO 8601 timestamp from an entity field and computes the delay at resolution time.
+#[derive(Debug, Clone)]
+pub struct ScheduleAtRequest {
+    /// The action name to dispatch.
+    pub action: String,
+    /// The entity field containing the ISO 8601 timestamp.
+    pub field: String,
+}
+
 /// Maximum cross-entity lookups per transition (TigerStyle budget).
 pub const MAX_CROSS_ENTITY_LOOKUPS: usize = 4;
 /// Maximum entity spawns per transition (TigerStyle budget).
@@ -149,10 +161,14 @@ pub fn process_action_with_xref(
             let from_status = state.status.clone();
             let to_status = transition_result.new_state.clone();
 
-            let (custom_effects, scheduled_actions, spawn_requests) =
+            let (custom_effects, scheduled_actions, spawn_requests, schedule_at_requests) =
                 apply_effects(state, &transition_result.effects, params);
             apply_new_state_fallback(state, &from_status, &to_status);
             sync_fields(state, params);
+
+            // Resolve deferred schedule_at requests now that fields are synced
+            let mut all_scheduled = scheduled_actions;
+            all_scheduled.extend(resolve_schedule_at_requests(state, &schedule_at_requests));
 
             let event = EntityEvent {
                 action: action.to_string(),
@@ -166,7 +182,7 @@ pub fn process_action_with_xref(
                 success: true,
                 event: Some(event),
                 custom_effects,
-                scheduled_actions,
+                scheduled_actions: all_scheduled,
                 spawn_requests,
                 error: None,
             }
@@ -205,15 +221,21 @@ pub fn process_action_with_xref(
 /// - `params` — The action parameters (needed for `ListAppend` / `ListRemoveAt`).
 ///
 /// # Returns
-/// A tuple of (custom effect names, scheduled actions).
+/// A tuple of (custom effect names, scheduled actions, spawn requests, schedule-at requests).
 pub fn apply_effects(
     state: &mut EntityState,
     effects: &[Effect],
     params: &serde_json::Value,
-) -> (Vec<String>, Vec<ScheduledAction>, Vec<SpawnRequest>) {
+) -> (
+    Vec<String>,
+    Vec<ScheduledAction>,
+    Vec<SpawnRequest>,
+    Vec<ScheduleAtRequest>,
+) {
     let mut custom_effects = Vec::new();
     let mut scheduled_actions = Vec::new();
     let mut spawn_requests = Vec::new();
+    let mut schedule_at_requests = Vec::new();
 
     for effect in effects {
         match effect {
@@ -340,10 +362,72 @@ pub fn apply_effects(
                     "spawn entity request"
                 );
             }
+            Effect::ScheduleAtAction { action, field } => {
+                schedule_at_requests.push(ScheduleAtRequest {
+                    action: action.clone(),
+                    field: field.clone(),
+                });
+                tracing::info!(
+                    entity_type = %state.entity_type,
+                    entity_id = %state.entity_id,
+                    scheduled_action = %action,
+                    field = %field,
+                    "schedule_at request (deferred until field resolution)"
+                );
+            }
         }
     }
 
-    (custom_effects, scheduled_actions, spawn_requests)
+    (
+        custom_effects,
+        scheduled_actions,
+        spawn_requests,
+        schedule_at_requests,
+    )
+}
+
+/// Resolve deferred `schedule_at` requests into [`ScheduledAction`]s.
+///
+/// Must be called AFTER [`sync_fields`] so that entity fields contain
+/// the latest param values. Reads the named field as an ISO 8601
+/// timestamp, computes `delay = target - now` (clamped to 0 if past).
+pub fn resolve_schedule_at_requests(
+    state: &EntityState,
+    requests: &[ScheduleAtRequest],
+) -> Vec<ScheduledAction> {
+    if requests.is_empty() {
+        return Vec::new();
+    }
+    let now = sim_now();
+    requests
+        .iter()
+        .filter_map(|req| {
+            let field_value = state.fields.get(&req.field).and_then(|v| v.as_str())?;
+            let target = chrono::DateTime::parse_from_rfc3339(field_value)
+                .ok()
+                .map(|dt| dt.with_timezone(&chrono::Utc))
+                .or_else(|| {
+                    // Fallback: try parsing without timezone suffix (assume UTC)
+                    chrono::NaiveDateTime::parse_from_str(field_value, "%Y-%m-%dT%H:%M:%S")
+                        .ok()
+                        .map(|ndt| ndt.and_utc())
+                })?;
+            let delay_seconds = (target - now).num_seconds().max(0) as u64;
+            tracing::info!(
+                entity_type = %state.entity_type,
+                entity_id = %state.entity_id,
+                action = %req.action,
+                field = %req.field,
+                target = %target,
+                delay_seconds,
+                "schedule_at resolved"
+            );
+            Some(ScheduledAction {
+                action: req.action.clone(),
+                delay_seconds,
+            })
+        })
+        .collect()
 }
 
 /// Apply the `new_state` fallback from a TransitionResult.
@@ -480,7 +564,7 @@ effect = [{ type = "schedule", action = "Refresh", delay_seconds = 2700 }]
             sequence_nr: 0,
         };
 
-        let (custom, scheduled, _spawns) =
+        let (custom, scheduled, _spawns, _schedule_at) =
             apply_effects(&mut state, &effects, &serde_json::json!({}));
 
         assert!(custom.is_empty());
@@ -597,5 +681,152 @@ guard = [
             "should succeed with cross-entity boolean = true"
         );
         assert_eq!(state.status, "Deployed");
+    }
+
+    #[test]
+    fn test_schedule_at_resolves_from_field_after_sync() {
+        let _guard = temper_runtime::scheduler::install_deterministic_context(42);
+
+        let spec = r#"
+[automaton]
+name = "CronJob"
+states = ["Active"]
+initial = "Active"
+
+[[state]]
+name = "next_run_at"
+type = "string"
+initial = ""
+
+[[action]]
+name = "TriggerComplete"
+from = ["Active"]
+params = ["next_run_at"]
+effect = [{ type = "schedule_at", field = "next_run_at", action = "Trigger" }]
+"#;
+
+        let table = temper_jit::table::TransitionTable::from_ioa_source(spec);
+        let mut state = EntityState {
+            entity_type: "CronJob".into(),
+            entity_id: "cron-1".into(),
+            status: "Active".into(),
+            item_count: 0,
+            counters: std::collections::BTreeMap::new(),
+            booleans: std::collections::BTreeMap::new(),
+            lists: std::collections::BTreeMap::new(),
+            fields: serde_json::json!({}),
+            events: std::collections::VecDeque::new(),
+            total_event_count: 0,
+            sequence_nr: 0,
+        };
+
+        // Provide next_run_at as a param (simulates WASM callback)
+        let future_time = sim_now() + chrono::Duration::seconds(300);
+        let future_iso = future_time.to_rfc3339();
+        let params = serde_json::json!({ "next_run_at": future_iso });
+
+        let result = process_action(&mut state, &table, "TriggerComplete", &params);
+
+        assert!(result.success, "action should succeed");
+        assert_eq!(
+            result.scheduled_actions.len(),
+            1,
+            "should have one scheduled action"
+        );
+        assert_eq!(result.scheduled_actions[0].action, "Trigger");
+        // Delay should be ~300 seconds (sim_now is deterministic)
+        assert_eq!(result.scheduled_actions[0].delay_seconds, 300);
+    }
+
+    #[test]
+    fn test_schedule_at_past_timestamp_fires_immediately() {
+        let _guard = temper_runtime::scheduler::install_deterministic_context(42);
+
+        let spec = r#"
+[automaton]
+name = "CronJob"
+states = ["Active"]
+initial = "Active"
+
+[[state]]
+name = "next_run_at"
+type = "string"
+initial = ""
+
+[[action]]
+name = "TriggerComplete"
+from = ["Active"]
+params = ["next_run_at"]
+effect = [{ type = "schedule_at", field = "next_run_at", action = "Trigger" }]
+"#;
+
+        let table = temper_jit::table::TransitionTable::from_ioa_source(spec);
+        let mut state = EntityState {
+            entity_type: "CronJob".into(),
+            entity_id: "cron-1".into(),
+            status: "Active".into(),
+            item_count: 0,
+            counters: std::collections::BTreeMap::new(),
+            booleans: std::collections::BTreeMap::new(),
+            lists: std::collections::BTreeMap::new(),
+            fields: serde_json::json!({}),
+            events: std::collections::VecDeque::new(),
+            total_event_count: 0,
+            sequence_nr: 0,
+        };
+
+        // Provide a timestamp in the past
+        let past_time = sim_now() - chrono::Duration::seconds(60);
+        let past_iso = past_time.to_rfc3339();
+        let params = serde_json::json!({ "next_run_at": past_iso });
+
+        let result = process_action(&mut state, &table, "TriggerComplete", &params);
+
+        assert!(result.success);
+        assert_eq!(result.scheduled_actions.len(), 1);
+        assert_eq!(
+            result.scheduled_actions[0].delay_seconds, 0,
+            "past timestamp should fire immediately"
+        );
+    }
+
+    #[test]
+    fn test_schedule_at_missing_field_skips() {
+        let _guard = temper_runtime::scheduler::install_deterministic_context(42);
+
+        let spec = r#"
+[automaton]
+name = "CronJob"
+states = ["Active"]
+initial = "Active"
+
+[[action]]
+name = "Complete"
+from = ["Active"]
+effect = [{ type = "schedule_at", field = "next_run_at", action = "Trigger" }]
+"#;
+
+        let table = temper_jit::table::TransitionTable::from_ioa_source(spec);
+        let mut state = EntityState {
+            entity_type: "CronJob".into(),
+            entity_id: "cron-1".into(),
+            status: "Active".into(),
+            item_count: 0,
+            counters: std::collections::BTreeMap::new(),
+            booleans: std::collections::BTreeMap::new(),
+            lists: std::collections::BTreeMap::new(),
+            fields: serde_json::json!({}),
+            events: std::collections::VecDeque::new(),
+            total_event_count: 0,
+            sequence_nr: 0,
+        };
+
+        let result = process_action(&mut state, &table, "Complete", &serde_json::json!({}));
+
+        assert!(result.success);
+        assert!(
+            result.scheduled_actions.is_empty(),
+            "missing field should produce no scheduled actions"
+        );
     }
 }

--- a/crates/temper-spec/src/automaton/lint.rs
+++ b/crates/temper-spec/src/automaton/lint.rs
@@ -367,6 +367,7 @@ fn effect_var(effect: &Effect) -> Option<&str> {
         Effect::ListRemoveAt { var } => Some(var.as_str()),
         Effect::Trigger { .. } => None,
         Effect::Schedule { .. } => None,
+        Effect::ScheduleAt { .. } => None,
         Effect::Spawn { .. } => None,
     }
 }
@@ -406,6 +407,7 @@ fn render_effect(effect: &Effect) -> String {
             action,
             delay_seconds,
         } => format!("schedule {action} {delay_seconds}s"),
+        Effect::ScheduleAt { action, field } => format!("schedule_at {field} {action}"),
         Effect::Spawn {
             entity_type,
             entity_id_source,

--- a/crates/temper-spec/src/automaton/parser.rs
+++ b/crates/temper-spec/src/automaton/parser.rs
@@ -152,6 +152,9 @@ fn format_effects(effects: &[Effect]) -> String {
             } => format!("Schedule(\"{action}\", {delay_seconds})"),
             Effect::ListAppend { var } => format!("ListAppend({var})"),
             Effect::ListRemoveAt { var } => format!("ListRemoveAt({var})"),
+            Effect::ScheduleAt { action, field } => {
+                format!("ScheduleAt(\"{action}\", {field})")
+            }
             Effect::Spawn {
                 entity_type,
                 entity_id_source,

--- a/crates/temper-spec/src/automaton/toml_parser/effects.rs
+++ b/crates/temper-spec/src/automaton/toml_parser/effects.rs
@@ -59,6 +59,15 @@ fn parse_effect_fields(
                 })
             }
         }
+        "schedule_at" => {
+            let action = fields.get("action").cloned().unwrap_or_default();
+            let field = fields.get("field").cloned().unwrap_or_default();
+            if action.is_empty() || field.is_empty() {
+                None
+            } else {
+                Some(Effect::ScheduleAt { action, field })
+            }
+        }
         "increment" => fields
             .get("var")
             .cloned()
@@ -122,6 +131,16 @@ fn parse_legacy_effect(value: &str) -> Option<Effect> {
 
     if let Some(event) = parse_prefixed_identifier(value, "emit ") {
         return Some(Effect::Emit { event });
+    }
+
+    if let Some(rest) = value.strip_prefix("schedule_at ") {
+        let parts: Vec<&str> = rest.splitn(2, ' ').collect();
+        if parts.len() == 2 && !parts[0].is_empty() && !parts[1].is_empty() {
+            return Some(Effect::ScheduleAt {
+                field: parts[0].to_string(),
+                action: parts[1].to_string(),
+            });
+        }
     }
 
     parse_prefixed_identifier(value, "trigger ").map(|name| Effect::Trigger { name })

--- a/crates/temper-spec/src/automaton/translate.rs
+++ b/crates/temper-spec/src/automaton/translate.rs
@@ -73,6 +73,8 @@ pub enum ResolvedEffect {
     Trigger(String),
     /// Schedule a delayed action.
     Schedule { action: String, delay_seconds: u64 },
+    /// Schedule an action at an absolute timestamp from an entity field.
+    ScheduleAt { action: String, field: String },
     /// Spawn a child entity.
     Spawn {
         entity_type: String,
@@ -85,7 +87,7 @@ pub enum ResolvedEffect {
 impl ResolvedEffect {
     /// Returns true if this effect modifies verifiable state (counters, booleans, lists).
     ///
-    /// Runtime-only effects (Emit, Trigger, Schedule, Spawn) return false.
+    /// Runtime-only effects (Emit, Trigger, Schedule, ScheduleAt, Spawn) return false.
     pub fn is_verifiable(&self) -> bool {
         matches!(
             self,
@@ -255,6 +257,10 @@ fn translate_single_effect(effect: &Effect) -> ResolvedEffect {
         } => ResolvedEffect::Schedule {
             action: action.clone(),
             delay_seconds: *delay_seconds,
+        },
+        Effect::ScheduleAt { action, field } => ResolvedEffect::ScheduleAt {
+            action: action.clone(),
+            field: field.clone(),
         },
         Effect::Spawn {
             entity_type,

--- a/crates/temper-spec/src/automaton/types.rs
+++ b/crates/temper-spec/src/automaton/types.rs
@@ -163,6 +163,9 @@ pub enum Effect {
     /// Schedule a delayed action on the same entity.
     #[serde(rename = "schedule")]
     Schedule { action: String, delay_seconds: u64 },
+    /// Schedule an action at an absolute timestamp read from an entity field.
+    #[serde(rename = "schedule_at")]
+    ScheduleAt { action: String, field: String },
     /// Spawn a child entity as a post-transition effect.
     #[serde(rename = "spawn")]
     Spawn {

--- a/crates/temper-verify/src/model/builder.rs
+++ b/crates/temper-verify/src/model/builder.rs
@@ -137,6 +137,7 @@ fn convert_effect(effect: ResolvedEffect) -> ModelEffect {
         ResolvedEffect::Emit(_)
         | ResolvedEffect::Trigger(_)
         | ResolvedEffect::Schedule { .. }
+        | ResolvedEffect::ScheduleAt { .. }
         | ResolvedEffect::Spawn { .. } => {
             unreachable!("runtime-only effect should have been filtered")
         }

--- a/docs/adrs/0012-oauth2-enablement-webhooks-timers-secret-templates.md
+++ b/docs/adrs/0012-oauth2-enablement-webhooks-timers-secret-templates.md
@@ -96,6 +96,26 @@ Recurring timers are achieved through a self-scheduling spec pattern — each su
 
 **Why this approach**: No new infrastructure (no separate timer service, no cron, no database table). Timers are just delayed messages through the existing dispatch pipeline. The self-scheduling pattern eliminates the need for a recurring timer primitive while remaining verifiable.
 
+### Sub-Decision 3b: Schedule-At (Absolute Timestamp Timer)
+
+A `schedule_at` effect type reads an absolute ISO 8601 timestamp from an entity field and schedules an action at that time:
+
+```toml
+[[action]]
+name = "TriggerComplete"
+from = ["Active"]
+params = ["last_session_id", "last_result", "next_run_at"]
+effect = [{ type = "schedule_at", field = "next_run_at", action = "Trigger" }]
+```
+
+Computed as `delay = target - now` (clamped to 0 if the timestamp is in the past). Reuses the same `ScheduledAction` dispatch path as `schedule`.
+
+**Key design detail**: `schedule_at` is a *deferred effect* — it is collected during `apply_effects()` but resolved AFTER `sync_fields()` in `process_action_with_xref()`. This ensures that WASM-provided params (like a computed `next_run_at`) are available in entity state when the timestamp field is read.
+
+**Motivation**: Enables self-scheduling entities where the next run time is computed by WASM integrations (e.g., cron expression parsing). Eliminates the need for polling infrastructure — no external cron trigger, no heartbeat hacks, no scheduler entities.
+
+**DST compliance**: Uses `sim_now()` for timestamp comparison, so simulation tests see deterministic scheduling. Same non-durable timer model as `schedule` — reconstructed from event replay on restart.
+
 ## Rollout Plan
 
 1. **Phase 0 (This ADR)** — Document decisions before any code.


### PR DESCRIPTION
## Summary
- Adds `schedule_at` effect that reads an ISO 8601 timestamp from an entity field and schedules an action at that time
- Deferred resolution pattern: collected during `apply_effects()`, resolved after `sync_fields()` so WASM-provided params are available
- Reuses existing `ScheduledAction` dispatch path — no new infrastructure
- Amends ADR-0012 with Sub-Decision 3b

## Changes across the effect pipeline
1. **temper-spec**: `Effect::ScheduleAt` variant + TOML parser + translation to `ResolvedEffect::ScheduleAt`
2. **temper-jit**: `Effect::ScheduleAtAction` variant + builder mapping
3. **temper-server**: `ScheduleAtRequest` struct, deferred resolution in `process_action_with_xref`, ISO 8601 parsing via chrono
4. **temper-verify**: non-verifiable filter updated

## Test plan
- [x] 3 new tests: future timestamp (delay=300), past timestamp (delay=0), missing field (skip)
- [x] All 468 existing tests pass across temper-spec, temper-jit, temper-server, temper-verify
- [x] Pre-push pipeline passes (rustfmt, clippy, readability ratchet, full test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)