### PR TITLE
[codex] Normalize temper.list filter inputs

### DIFF
--- a/crates/temper-sandbox/src/dispatch.rs
+++ b/crates/temper-sandbox/src/dispatch.rs
@@ -142,7 +142,7 @@ async fn dispatch_entity(
     match method {
         "list" => {
             let entity = expect_string_arg(args, 0, "entity_type", method)?;
-            let filter = optional_string_arg(args, 1);
+            let filter = optional_string_arg(args, 1).map(|f| normalize_odata_filter(&f));
             let set = ctx.resolve_set(&entity);
             let path = match filter {
                 Some(f) => {
@@ -287,6 +287,14 @@ async fn dispatch_entity(
         }
         _ => unreachable!("dispatch_entity called with non-entity method"),
     }
+}
+
+fn normalize_odata_filter(filter: &str) -> String {
+    filter
+        .trim()
+        .strip_prefix("$filter=")
+        .unwrap_or(filter.trim())
+        .to_string()
 }
 
 /// Dispatch spec management methods.


### PR DESCRIPTION
## What changed
- normalize `temper.list()` filter arguments by stripping a leading `"$filter="` prefix before building the OData path

## Why it changed
OpenPaw Probe sessions were emitting `temper.list("Entity", "$filter=...")`. The old sandbox dispatch logic turned that into malformed URLs like `?$filter=$filter=...`.

This is not the primary memory fix by itself, but it keeps the sandbox-side `temper.*` interface aligned with the OpenPaw `monty_repl` fix and makes the agent-facing API more forgiving.

## Impact
- accepts both raw filter expressions and `"$filter=..."` inputs
- keeps sandbox and OpenPaw dispatch behavior in sync
- removes a malformed request shape from agent sessions

## Validation
- `cargo check -p temper-sandbox`
- full repo pre-push pipeline passed, including rustfmt, clippy, readability ratchet, and the full test suite
