### PR TITLE
fix: transactional spec persistence + symlink support + fuel config

### DIFF
--- a/crates/temper-platform/src/os_apps/mod.rs
+++ b/crates/temper-platform/src/os_apps/mod.rs
@@ -369,7 +369,7 @@ impl AppCatalog {
 
         let mut app_dirs: Vec<_> = read_dir
             .filter_map(|e| e.ok())
-            .filter(|e| e.file_type().map(|ft| ft.is_dir()).unwrap_or(false))
+            .filter(|e| e.path().is_dir())
             .collect();
         // Deterministic ordering.
         app_dirs.sort_by_key(|e| e.file_name());
@@ -563,7 +563,7 @@ fn find_wasm_modules(app_dir: &Path) -> BTreeMap<String, Vec<u8>> {
     };
     let mut dirs: Vec<_> = entries
         .filter_map(|e| e.ok())
-        .filter(|e| e.file_type().map(|ft| ft.is_dir()).unwrap_or(false))
+        .filter(|e| e.path().is_dir())
         .collect();
     dirs.sort_by_key(|e| e.file_name());
 
@@ -620,7 +620,7 @@ fn find_agents(app_dir: &Path) -> Vec<AgentDefinition> {
 
     let mut dirs: Vec<_> = entries
         .filter_map(|e| e.ok())
-        .filter(|e| e.file_type().map(|ft| ft.is_dir()).unwrap_or(false))
+        .filter(|e| e.path().is_dir())
         .collect();
     dirs.sort_by_key(|e| e.file_name());
 
@@ -691,7 +691,7 @@ fn find_app_skills(app_dir: &Path) -> Vec<AppSkillDefinition> {
 
     let mut dirs: Vec<_> = entries
         .filter_map(|e| e.ok())
-        .filter(|e| e.file_type().map(|ft| ft.is_dir()).unwrap_or(false))
+        .filter(|e| e.path().is_dir())
         .collect();
     dirs.sort_by_key(|e| e.file_name());
 
@@ -1045,7 +1045,11 @@ async fn install_os_app_without_dependencies(
             match registry.get_spec(&tenant_id, entity_type) {
                 Some(existing) => {
                     let existing_hash = temper_store_turso::spec_content_hash(&existing.ioa_source);
-                    if incoming_hash == existing_hash {
+                    let verified = registry
+                        .get_verification_status(&tenant_id, entity_type)
+                        .map(|s| s.is_passed())
+                        .unwrap_or(false);
+                    if incoming_hash == existing_hash && verified {
                         skipped.push(entity_type.to_string());
                     } else {
                         updated.push(entity_type.to_string());
@@ -1112,29 +1116,30 @@ async fn install_os_app_without_dependencies(
         }
 
         if let Some(ref merged) = merged_csdl {
-            for (entity_type, ioa_source) in spec_sources {
-                let hash = temper_store_turso::spec_content_hash(&ioa_source);
-                turso
-                    .upsert_spec(tenant, &entity_type, &ioa_source, merged, &hash)
-                    .await
-                    .map_err(|e| format!("Failed to persist spec {entity_type}: {e}"))?;
-            }
-        }
-        if let Some(ref policy_text) = combined_policy {
+            // Collect all specs with their content hashes for a single
+            // transactional write — eliminates the crash window between
+            // individual upserts (committed=0) and the commit step.
+            let owned: Vec<(String, String, String, String)> = spec_sources
+                .into_iter()
+                .map(|(et, ioa)| {
+                    let hash = temper_store_turso::spec_content_hash(&ioa);
+                    (et, ioa, merged.clone(), hash)
+                })
+                .collect();
+            let refs: Vec<(&str, &str, &str, &str)> = owned
+                .iter()
+                .map(|(et, ioa, csdl, h)| (et.as_str(), ioa.as_str(), csdl.as_str(), h.as_str()))
+                .collect();
             turso
-                .upsert_tenant_policy(tenant, policy_text)
+                .upsert_specs_and_commit(
+                    tenant,
+                    &refs,
+                    combined_policy.as_deref(),
+                    app_name,
+                )
                 .await
-                .map_err(|e| format!("Failed to persist Cedar policy: {e}"))?;
+                .map_err(|e| format!("Failed to persist and commit specs: {e}"))?;
         }
-        turso
-            .record_installed_app(tenant, app_name)
-            .await
-            .map_err(|e| format!("Failed to record os-app installation: {e}"))?;
-        // Commit all specs atomically after all writes succeed.
-        turso
-            .commit_specs(tenant)
-            .await
-            .map_err(|e| format!("Failed to commit specs: {e}"))?;
     } else if let Some(ref store) = state.server.event_store
         && let Some(ps) = store.platform_store()
     {

--- a/crates/temper-platform/src/os_apps/mod.rs
+++ b/crates/temper-platform/src/os_apps/mod.rs
@@ -1131,12 +1131,7 @@ async fn install_os_app_without_dependencies(
                 .map(|(et, ioa, csdl, h)| (et.as_str(), ioa.as_str(), csdl.as_str(), h.as_str()))
                 .collect();
             turso
-                .upsert_specs_and_commit(
-                    tenant,
-                    &refs,
-                    combined_policy.as_deref(),
-                    app_name,
-                )
+                .upsert_specs_and_commit(tenant, &refs, combined_policy.as_deref(), app_name)
                 .await
                 .map_err(|e| format!("Failed to persist and commit specs: {e}"))?;
         }

--- a/crates/temper-server/src/state/dispatch/wasm.rs
+++ b/crates/temper-server/src/state/dispatch/wasm.rs
@@ -342,9 +342,15 @@ impl crate::state::ServerState {
             .get("max_response_bytes")
             .and_then(|s| s.parse::<usize>().ok())
             .unwrap_or(WasmResourceLimits::default().max_response_bytes);
+        let max_fuel = integration
+            .config
+            .get("max_fuel")
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(WasmResourceLimits::default().max_fuel);
         let limits = WasmResourceLimits {
             max_duration: http_timeout,
             max_response_bytes,
+            max_fuel,
             ..WasmResourceLimits::default()
         };
 

--- a/crates/temper-store-turso/src/store/specs.rs
+++ b/crates/temper-store-turso/src/store/specs.rs
@@ -1,6 +1,6 @@
 //! Spec persistence: upsert, verification updates, and startup loading.
 
-use libsql::params;
+use libsql::{TransactionBehavior, params};
 use temper_runtime::persistence::{PersistenceError, storage_error};
 use tracing::instrument;
 
@@ -46,6 +46,78 @@ impl TursoEventStore {
         )
         .await
         .map_err(storage_error)?;
+        Ok(())
+    }
+
+    /// Atomically upsert multiple specs, record the app installation, optionally
+    /// write a Cedar policy, and mark all tenant specs as committed — all within
+    /// a single libsql transaction.
+    ///
+    /// This eliminates the crash-vulnerability window where individual upserts
+    /// leave specs with `committed=0` that get garbage-collected on restart.
+    #[instrument(skip_all, fields(tenant, app_name, otel.name = "turso.upsert_specs_and_commit"))]
+    pub async fn upsert_specs_and_commit(
+        &self,
+        tenant: &str,
+        specs: &[(&str, &str, &str, &str)], // (entity_type, ioa_source, csdl_xml, content_hash)
+        policy: Option<&str>,
+        app_name: &str,
+    ) -> Result<(), PersistenceError> {
+        let _query_timer = TursoQueryTimer::start("turso.upsert_specs_and_commit");
+        let conn = self.configured_connection().await?;
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .await
+            .map_err(storage_error)?;
+
+        for (entity_type, ioa_source, csdl_xml, content_hash) in specs {
+            tx.execute(
+                "INSERT INTO specs (tenant, entity_type, ioa_source, csdl_xml, content_hash, committed, version, verified, verification_status, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, 0, 1, 0, 'pending', datetime('now'))
+                 ON CONFLICT (tenant, entity_type) DO UPDATE SET
+                     ioa_source = excluded.ioa_source,
+                     csdl_xml = excluded.csdl_xml,
+                     content_hash = excluded.content_hash,
+                     committed = 0,
+                     version = specs.version + 1,
+                     verified = CASE WHEN specs.content_hash = excluded.content_hash THEN specs.verified ELSE 0 END,
+                     verification_status = CASE WHEN specs.content_hash = excluded.content_hash THEN specs.verification_status ELSE 'pending' END,
+                     levels_passed = CASE WHEN specs.content_hash = excluded.content_hash THEN specs.levels_passed ELSE NULL END,
+                     levels_total = CASE WHEN specs.content_hash = excluded.content_hash THEN specs.levels_total ELSE NULL END,
+                     verification_result = CASE WHEN specs.content_hash = excluded.content_hash THEN specs.verification_result ELSE NULL END,
+                     updated_at = datetime('now')",
+                params![tenant, entity_type, ioa_source, csdl_xml, content_hash],
+            )
+            .await
+            .map_err(storage_error)?;
+        }
+
+        if let Some(policy_text) = policy {
+            tx.execute(
+                "INSERT INTO tenant_policies (tenant, policy_text, updated_at) \
+                 VALUES (?1, ?2, datetime('now')) \
+                 ON CONFLICT(tenant) DO UPDATE SET policy_text = ?2, updated_at = datetime('now')",
+                params![tenant, policy_text],
+            )
+            .await
+            .map_err(storage_error)?;
+        }
+
+        tx.execute(
+            "INSERT OR IGNORE INTO tenant_installed_apps (tenant_id, app_name) VALUES (?1, ?2)",
+            params![tenant, app_name],
+        )
+        .await
+        .map_err(storage_error)?;
+
+        tx.execute(
+            "UPDATE specs SET committed = 1, updated_at = datetime('now') WHERE tenant = ?1",
+            params![tenant],
+        )
+        .await
+        .map_err(storage_error)?;
+
+        tx.commit().await.map_err(storage_error)?;
         Ok(())
     }
 

--- a/crates/temper-wasm/src/host_trait.rs
+++ b/crates/temper-wasm/src/host_trait.rs
@@ -340,7 +340,7 @@ impl WasmHost for ProductionWasmHost {
             .is_some_and(|ct| ct.contains("text/event-stream"));
         let request_asked_for_stream =
             body.contains("\"stream\":true") || body.contains("\"stream\": true");
-        let is_sse = ct_is_sse || (request_asked_for_stream && status >= 200 && status < 300);
+        let is_sse = ct_is_sse || (request_asked_for_stream && (200..300).contains(&status));
 
         let resp_body = if is_sse {
             // SSE streaming: read chunks with per-chunk stall timeout, strip SSE
@@ -373,13 +373,13 @@ impl WasmHost for ProductionWasmHost {
                             }
                         }
                         // Emit progress to keep heartbeats alive
-                        if chunk_count.is_multiple_of(20) {
-                            if let Some(ref emitter) = self.progress_emitter {
-                                let _ = emitter(&format!(
-                                    "{{\"kind\":\"streaming_progress\",\"chunks\":{chunk_count},\"data_bytes\":{}}}",
-                                    accumulated_data.len()
-                                ));
-                            }
+                        if chunk_count.is_multiple_of(20)
+                            && let Some(ref emitter) = self.progress_emitter
+                        {
+                            let _ = emitter(&format!(
+                                "{{\"kind\":\"streaming_progress\",\"chunks\":{chunk_count},\"data_bytes\":{}}}",
+                                accumulated_data.len()
+                            ));
                         }
                     }
                     Ok(Some(Err(e))) => {


### PR DESCRIPTION
## Summary
- Wrap spec upserts + commit in a single libsql transaction to prevent spec loss on crash between upsert (`committed=0`) and commit (`committed=1`)
- Follow symlinks in os-app discovery (`Path::is_dir` instead of `DirEntry::file_type`)
- Skip re-verification only when spec is already verified (not just content-matching)
- Allow WASM integrations to configure `max_fuel` via integration config
- Fix clippy warnings in temper-wasm SSE handler

## Test plan
- [x] All local tests pass (pre-push gate)
- [ ] Verify restart with existing DB preserves Channel/ChannelSession/AgentRoute specs
- [ ] Verify symlinked os-app directories are discovered

🤖 Generated with [Claude Code](https://claude.com/claude-code)