### PR TITLE
fix: harden GovernanceDecision callbacks and inline spec loading

### DIFF
--- a/crates/temper-platform/src/hooks.rs
+++ b/crates/temper-platform/src/hooks.rs
@@ -16,9 +16,9 @@
 use std::sync::{Arc, RwLock};
 
 use temper_runtime::TenantId;
+use temper_server::ServerState;
 use temper_server::request_context::AgentContext;
 use temper_server::state::custom_effects::CustomEffectHandler;
-use temper_server::ServerState;
 
 use crate::deploy::{DeployInput, DeployPipeline, EntitySpecSource};
 use crate::state::PlatformState;
@@ -321,10 +321,7 @@ fn handle_generate_cedar_from_fields(
         .get("scope")
         .and_then(|v| v.as_str())
         .unwrap_or("narrow");
-    let tenant = fields
-        .get("tenant")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
+    let tenant = fields.get("tenant").and_then(|v| v.as_str()).unwrap_or("");
 
     if agent_id.is_empty() || action_name.is_empty() || resource_type.is_empty() {
         return Err(format!(
@@ -402,7 +399,10 @@ fn handle_generate_cedar_from_fields(
         }
     }
 
-    tracing::info!(entity_id, "GenerateCedarPolicy hook: policy loaded successfully");
+    tracing::info!(
+        entity_id,
+        "GenerateCedarPolicy hook: policy loaded successfully"
+    );
     Ok(())
 }
 
@@ -428,9 +428,7 @@ fn handle_dispatch_callback(
         .and_then(|v| v.as_str())
         .unwrap_or("");
 
-    if callback_tenant.is_empty()
-        || callback_entity_set.is_empty()
-        || callback_entity_id.is_empty()
+    if callback_tenant.is_empty() || callback_entity_set.is_empty() || callback_entity_id.is_empty()
     {
         tracing::debug!("DispatchCallback: no callback registered — skipping");
         return Ok(());

--- a/crates/temper-platform/src/hooks.rs
+++ b/crates/temper-platform/src/hooks.rs
@@ -13,6 +13,13 @@
 //!   transitions to Approved. Generates a Cedar permit policy from the
 //!   entity's fields and reloads the authz engine.
 
+use std::sync::{Arc, RwLock};
+
+use temper_runtime::TenantId;
+use temper_server::request_context::AgentContext;
+use temper_server::state::custom_effects::CustomEffectHandler;
+use temper_server::ServerState;
+
 use crate::deploy::{DeployInput, DeployPipeline, EntitySpecSource};
 use crate::state::PlatformState;
 
@@ -242,6 +249,269 @@ fn handle_generate_cedar_policy(
         entity_id = entity_id,
         "GenerateCedarPolicy hook: policy loaded successfully"
     );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Platform custom effect handler (registered on ServerState)
+// ---------------------------------------------------------------------------
+
+/// Platform-level custom effect handler.
+///
+/// Registered on `ServerState` during `PlatformState` construction to
+/// route custom effects from system entities to platform hooks.
+pub struct PlatformEffectHandler {
+    /// Spec store for DeploySpecs hook (future use).
+    pub spec_store: Arc<RwLock<crate::spec_store::SpecStore>>,
+}
+
+impl CustomEffectHandler for PlatformEffectHandler {
+    fn handle(
+        &self,
+        effect_name: &str,
+        entity_type: &str,
+        entity_id: &str,
+        entity_fields: &serde_json::Value,
+        server: &ServerState,
+    ) -> Result<(), String> {
+        match effect_name {
+            "GenerateCedarPolicy" => {
+                handle_generate_cedar_from_fields(entity_id, entity_fields, server)
+            }
+            "DispatchCallback" => handle_dispatch_callback(entity_fields, server),
+            _ => {
+                tracing::debug!(
+                    effect = effect_name,
+                    entity_type,
+                    entity_id,
+                    "Unknown custom effect — ignored"
+                );
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Generate Cedar policy from entity state fields.
+///
+/// Reads agent_id, action_name, resource_type, resource_id, scope, tenant,
+/// and scope_matrix from the GovernanceDecision entity's merged fields.
+fn handle_generate_cedar_from_fields(
+    entity_id: &str,
+    fields: &serde_json::Value,
+    server: &ServerState,
+) -> Result<(), String> {
+    let agent_id = fields
+        .get("agent_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let action_name = fields
+        .get("action_name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let resource_type = fields
+        .get("resource_type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let resource_id = fields
+        .get("resource_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let scope = fields
+        .get("scope")
+        .and_then(|v| v.as_str())
+        .unwrap_or("narrow");
+    let tenant = fields
+        .get("tenant")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    if agent_id.is_empty() || action_name.is_empty() || resource_type.is_empty() {
+        return Err(format!(
+            "GenerateCedarPolicy: missing required fields for entity '{entity_id}'"
+        ));
+    }
+
+    // Parse scope_matrix from fields, or build a default matrix based on the legacy scope string.
+    let matrix: temper_authz::PolicyScopeMatrix =
+        if let Some(matrix_val) = fields.get("scope_matrix") {
+            serde_json::from_value(matrix_val.clone()).map_err(|e| {
+                format!("GenerateCedarPolicy: invalid scope_matrix for entity '{entity_id}': {e}")
+            })?
+        } else {
+            match scope {
+                "narrow" => temper_authz::PolicyScopeMatrix {
+                    principal: temper_authz::PrincipalScope::ThisAgent,
+                    action: temper_authz::ActionScope::ThisAction,
+                    resource: temper_authz::ResourceScope::ThisResource,
+                    duration: temper_authz::DurationScope::Always,
+                    agent_type_value: None,
+                    role_value: None,
+                    session_id: None,
+                },
+                "broad" => temper_authz::PolicyScopeMatrix {
+                    principal: temper_authz::PrincipalScope::ThisAgent,
+                    action: temper_authz::ActionScope::AllActionsOnType,
+                    resource: temper_authz::ResourceScope::AnyOfType,
+                    duration: temper_authz::DurationScope::Always,
+                    agent_type_value: None,
+                    role_value: None,
+                    session_id: None,
+                },
+                _ => temper_authz::PolicyScopeMatrix::default_for(None),
+            }
+        };
+    temper_authz::validate_policy_scope_matrix(&matrix).map_err(|e| {
+        format!("GenerateCedarPolicy: invalid scope_matrix for entity '{entity_id}': {e}")
+    })?;
+    let principal_kind = fields
+        .get("principal_kind")
+        .and_then(|v| v.as_str())
+        .unwrap_or("Agent");
+    let generated_policy = temper_authz::generate_cedar_from_matrix(
+        agent_id,
+        principal_kind,
+        action_name,
+        resource_type,
+        resource_id,
+        &matrix,
+    );
+
+    tracing::info!(
+        entity_id,
+        tenant,
+        scope,
+        "GenerateCedarPolicy hook: generated policy, validating and loading"
+    );
+
+    // Validate and reload the per-tenant policy set.
+    {
+        let Ok(mut policies) = server.tenant_policies.write() else {
+            return Err("tenant_policies lock poisoned".to_string());
+        };
+        let entry = policies.entry(tenant.to_string()).or_default();
+        if !entry.is_empty() {
+            entry.push('\n');
+        }
+        entry.push_str(&generated_policy);
+
+        let tenant_text = entry.clone();
+        if let Err(e) = server.authz.reload_tenant_policies(tenant, &tenant_text) {
+            tracing::error!(error = %e, "GenerateCedarPolicy: failed to reload policies");
+            return Err(format!("Failed to reload policies: {e}"));
+        }
+    }
+
+    tracing::info!(entity_id, "GenerateCedarPolicy hook: policy loaded successfully");
+    Ok(())
+}
+
+/// Dispatch callback to a registered target entity.
+///
+/// Reads callback fields from GovernanceDecision entity state. If a callback
+/// is registered (callback_tenant is non-empty), dispatches the appropriate
+/// action on the target entity via cross-tenant dispatch.
+fn handle_dispatch_callback(
+    entity_fields: &serde_json::Value,
+    server: &ServerState,
+) -> Result<(), String> {
+    let callback_tenant = entity_fields
+        .get("callback_tenant")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let callback_entity_set = entity_fields
+        .get("callback_entity_set")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let callback_entity_id = entity_fields
+        .get("callback_entity_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    if callback_tenant.is_empty()
+        || callback_entity_set.is_empty()
+        || callback_entity_id.is_empty()
+    {
+        tracing::debug!("DispatchCallback: no callback registered — skipping");
+        return Ok(());
+    }
+
+    // Determine the callback action from the current entity status.
+    let status = entity_fields
+        .get("Status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let callback_action = match status {
+        "Approved" => entity_fields
+            .get("callback_on_approve")
+            .and_then(|v| v.as_str())
+            .unwrap_or(""),
+        "Denied" => entity_fields
+            .get("callback_on_deny")
+            .and_then(|v| v.as_str())
+            .unwrap_or(""),
+        _ => {
+            tracing::warn!(
+                status,
+                "DispatchCallback: unexpected status, skipping callback"
+            );
+            return Ok(());
+        }
+    };
+
+    if callback_action.is_empty() {
+        tracing::debug!(
+            status,
+            "DispatchCallback: no callback action for status — skipping"
+        );
+        return Ok(());
+    }
+
+    let params = if status == "Denied" {
+        serde_json::json!({"error_message": "Action denied by human reviewer"})
+    } else {
+        serde_json::json!({})
+    };
+
+    tracing::info!(
+        callback_tenant,
+        callback_entity_set,
+        callback_entity_id,
+        callback_action,
+        "DispatchCallback: dispatching callback"
+    );
+
+    let server = server.clone();
+    let tenant = callback_tenant.to_string();
+    let entity_set = callback_entity_set.to_string();
+    let entity_id = callback_entity_id.to_string();
+    let action = callback_action.to_string();
+
+    tokio::spawn(async move {
+        // determinism-ok: async callback dispatch for governance decision resolution
+        let tid = TenantId::new(&tenant);
+        if let Err(e) = server
+            .dispatch_tenant_action(
+                &tid,
+                &entity_set,
+                &entity_id,
+                &action,
+                params,
+                &AgentContext::system(),
+            )
+            .await
+        {
+            tracing::error!(
+                error = %e,
+                tenant,
+                entity_set,
+                entity_id,
+                action,
+                "DispatchCallback: failed to dispatch callback action"
+            );
+        }
+    });
+
     Ok(())
 }
 

--- a/crates/temper-platform/src/hooks.rs
+++ b/crates/temper-platform/src/hooks.rs
@@ -15,13 +15,14 @@
 
 use std::sync::{Arc, RwLock};
 
-use temper_runtime::TenantId;
 use temper_server::ServerState;
-use temper_server::request_context::AgentContext;
 use temper_server::state::custom_effects::CustomEffectHandler;
 
 use crate::deploy::{DeployInput, DeployPipeline, EntitySpecSource};
 use crate::state::PlatformState;
+
+mod generate_cedar;
+mod governance_callback;
 
 /// Dispatch a custom effect from a system entity transition.
 ///
@@ -276,9 +277,11 @@ impl CustomEffectHandler for PlatformEffectHandler {
     ) -> Result<(), String> {
         match effect_name {
             "GenerateCedarPolicy" => {
-                handle_generate_cedar_from_fields(entity_id, entity_fields, server)
+                generate_cedar::handle_generate_cedar_from_fields(entity_id, entity_fields, server)
             }
-            "DispatchCallback" => handle_dispatch_callback(entity_fields, server),
+            "DispatchCallback" => {
+                governance_callback::handle_dispatch_callback(entity_fields, server)
+            }
             _ => {
                 tracing::debug!(
                     effect = effect_name,
@@ -290,227 +293,6 @@ impl CustomEffectHandler for PlatformEffectHandler {
             }
         }
     }
-}
-
-/// Generate Cedar policy from entity state fields.
-///
-/// Reads agent_id, action_name, resource_type, resource_id, scope, tenant,
-/// and scope_matrix from the GovernanceDecision entity's merged fields.
-fn handle_generate_cedar_from_fields(
-    entity_id: &str,
-    fields: &serde_json::Value,
-    server: &ServerState,
-) -> Result<(), String> {
-    let agent_id = fields
-        .get("agent_id")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
-    let action_name = fields
-        .get("action_name")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
-    let resource_type = fields
-        .get("resource_type")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
-    let resource_id = fields
-        .get("resource_id")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
-    let scope = fields
-        .get("scope")
-        .and_then(|v| v.as_str())
-        .unwrap_or("narrow");
-    let tenant = fields.get("tenant").and_then(|v| v.as_str()).unwrap_or("");
-
-    if agent_id.is_empty() || action_name.is_empty() || resource_type.is_empty() {
-        return Err(format!(
-            "GenerateCedarPolicy: missing required fields for entity '{entity_id}'"
-        ));
-    }
-
-    // Parse scope_matrix from fields, or build a default matrix based on the legacy scope string.
-    let matrix: temper_authz::PolicyScopeMatrix =
-        if let Some(matrix_val) = fields.get("scope_matrix") {
-            serde_json::from_value(matrix_val.clone()).map_err(|e| {
-                format!("GenerateCedarPolicy: invalid scope_matrix for entity '{entity_id}': {e}")
-            })?
-        } else {
-            match scope {
-                "narrow" => temper_authz::PolicyScopeMatrix {
-                    principal: temper_authz::PrincipalScope::ThisAgent,
-                    action: temper_authz::ActionScope::ThisAction,
-                    resource: temper_authz::ResourceScope::ThisResource,
-                    duration: temper_authz::DurationScope::Always,
-                    agent_type_value: None,
-                    role_value: None,
-                    session_id: None,
-                },
-                "broad" => temper_authz::PolicyScopeMatrix {
-                    principal: temper_authz::PrincipalScope::ThisAgent,
-                    action: temper_authz::ActionScope::AllActionsOnType,
-                    resource: temper_authz::ResourceScope::AnyOfType,
-                    duration: temper_authz::DurationScope::Always,
-                    agent_type_value: None,
-                    role_value: None,
-                    session_id: None,
-                },
-                _ => temper_authz::PolicyScopeMatrix::default_for(None),
-            }
-        };
-    temper_authz::validate_policy_scope_matrix(&matrix).map_err(|e| {
-        format!("GenerateCedarPolicy: invalid scope_matrix for entity '{entity_id}': {e}")
-    })?;
-    let principal_kind = fields
-        .get("principal_kind")
-        .and_then(|v| v.as_str())
-        .unwrap_or("Agent");
-    let generated_policy = temper_authz::generate_cedar_from_matrix(
-        agent_id,
-        principal_kind,
-        action_name,
-        resource_type,
-        resource_id,
-        &matrix,
-    );
-
-    tracing::info!(
-        entity_id,
-        tenant,
-        scope,
-        "GenerateCedarPolicy hook: generated policy, validating and loading"
-    );
-
-    // Validate and reload the per-tenant policy set.
-    {
-        let Ok(mut policies) = server.tenant_policies.write() else {
-            return Err("tenant_policies lock poisoned".to_string());
-        };
-        let entry = policies.entry(tenant.to_string()).or_default();
-        if !entry.is_empty() {
-            entry.push('\n');
-        }
-        entry.push_str(&generated_policy);
-
-        let tenant_text = entry.clone();
-        if let Err(e) = server.authz.reload_tenant_policies(tenant, &tenant_text) {
-            tracing::error!(error = %e, "GenerateCedarPolicy: failed to reload policies");
-            return Err(format!("Failed to reload policies: {e}"));
-        }
-    }
-
-    tracing::info!(
-        entity_id,
-        "GenerateCedarPolicy hook: policy loaded successfully"
-    );
-    Ok(())
-}
-
-/// Dispatch callback to a registered target entity.
-///
-/// Reads callback fields from GovernanceDecision entity state. If a callback
-/// is registered (callback_tenant is non-empty), dispatches the appropriate
-/// action on the target entity via cross-tenant dispatch.
-fn handle_dispatch_callback(
-    entity_fields: &serde_json::Value,
-    server: &ServerState,
-) -> Result<(), String> {
-    let callback_tenant = entity_fields
-        .get("callback_tenant")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
-    let callback_entity_set = entity_fields
-        .get("callback_entity_set")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
-    let callback_entity_id = entity_fields
-        .get("callback_entity_id")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
-
-    if callback_tenant.is_empty() || callback_entity_set.is_empty() || callback_entity_id.is_empty()
-    {
-        tracing::debug!("DispatchCallback: no callback registered — skipping");
-        return Ok(());
-    }
-
-    // Determine the callback action from the current entity status.
-    let status = entity_fields
-        .get("Status")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
-    let callback_action = match status {
-        "Approved" => entity_fields
-            .get("callback_on_approve")
-            .and_then(|v| v.as_str())
-            .unwrap_or(""),
-        "Denied" => entity_fields
-            .get("callback_on_deny")
-            .and_then(|v| v.as_str())
-            .unwrap_or(""),
-        _ => {
-            tracing::warn!(
-                status,
-                "DispatchCallback: unexpected status, skipping callback"
-            );
-            return Ok(());
-        }
-    };
-
-    if callback_action.is_empty() {
-        tracing::debug!(
-            status,
-            "DispatchCallback: no callback action for status — skipping"
-        );
-        return Ok(());
-    }
-
-    let params = if status == "Denied" {
-        serde_json::json!({"error_message": "Action denied by human reviewer"})
-    } else {
-        serde_json::json!({})
-    };
-
-    tracing::info!(
-        callback_tenant,
-        callback_entity_set,
-        callback_entity_id,
-        callback_action,
-        "DispatchCallback: dispatching callback"
-    );
-
-    let server = server.clone();
-    let tenant = callback_tenant.to_string();
-    let entity_set = callback_entity_set.to_string();
-    let entity_id = callback_entity_id.to_string();
-    let action = callback_action.to_string();
-
-    tokio::spawn(async move {
-        // determinism-ok: async callback dispatch for governance decision resolution
-        let tid = TenantId::new(&tenant);
-        if let Err(e) = server
-            .dispatch_tenant_action(
-                &tid,
-                &entity_set,
-                &entity_id,
-                &action,
-                params,
-                &AgentContext::system(),
-            )
-            .await
-        {
-            tracing::error!(
-                error = %e,
-                tenant,
-                entity_set,
-                entity_id,
-                action,
-                "DispatchCallback: failed to dispatch callback action"
-            );
-        }
-    });
-
-    Ok(())
 }
 
 /// Generate a Cedar permit statement for the given scope.

--- a/crates/temper-platform/src/hooks/generate_cedar.rs
+++ b/crates/temper-platform/src/hooks/generate_cedar.rs
@@ -1,0 +1,113 @@
+use temper_server::ServerState;
+
+/// Generate Cedar policy from entity state fields.
+///
+/// Reads agent_id, action_name, resource_type, resource_id, scope, tenant,
+/// and scope_matrix from the GovernanceDecision entity's merged fields.
+pub(super) fn handle_generate_cedar_from_fields(
+    entity_id: &str,
+    fields: &serde_json::Value,
+    server: &ServerState,
+) -> Result<(), String> {
+    let agent_id = fields
+        .get("agent_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let action_name = fields
+        .get("action_name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let resource_type = fields
+        .get("resource_type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let resource_id = fields
+        .get("resource_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let scope = fields
+        .get("scope")
+        .and_then(|v| v.as_str())
+        .unwrap_or("narrow");
+    let tenant = fields.get("tenant").and_then(|v| v.as_str()).unwrap_or("");
+
+    if agent_id.is_empty() || action_name.is_empty() || resource_type.is_empty() {
+        return Err(format!(
+            "GenerateCedarPolicy: missing required fields for entity '{entity_id}'"
+        ));
+    }
+
+    let matrix: temper_authz::PolicyScopeMatrix =
+        if let Some(matrix_val) = fields.get("scope_matrix") {
+            serde_json::from_value(matrix_val.clone()).map_err(|e| {
+                format!("GenerateCedarPolicy: invalid scope_matrix for entity '{entity_id}': {e}")
+            })?
+        } else {
+            match scope {
+                "narrow" => temper_authz::PolicyScopeMatrix {
+                    principal: temper_authz::PrincipalScope::ThisAgent,
+                    action: temper_authz::ActionScope::ThisAction,
+                    resource: temper_authz::ResourceScope::ThisResource,
+                    duration: temper_authz::DurationScope::Always,
+                    agent_type_value: None,
+                    role_value: None,
+                    session_id: None,
+                },
+                "broad" => temper_authz::PolicyScopeMatrix {
+                    principal: temper_authz::PrincipalScope::ThisAgent,
+                    action: temper_authz::ActionScope::AllActionsOnType,
+                    resource: temper_authz::ResourceScope::AnyOfType,
+                    duration: temper_authz::DurationScope::Always,
+                    agent_type_value: None,
+                    role_value: None,
+                    session_id: None,
+                },
+                _ => temper_authz::PolicyScopeMatrix::default_for(None),
+            }
+        };
+    temper_authz::validate_policy_scope_matrix(&matrix).map_err(|e| {
+        format!("GenerateCedarPolicy: invalid scope_matrix for entity '{entity_id}': {e}")
+    })?;
+    let principal_kind = fields
+        .get("principal_kind")
+        .and_then(|v| v.as_str())
+        .unwrap_or("Agent");
+    let generated_policy = temper_authz::generate_cedar_from_matrix(
+        agent_id,
+        principal_kind,
+        action_name,
+        resource_type,
+        resource_id,
+        &matrix,
+    );
+
+    tracing::info!(
+        entity_id,
+        tenant,
+        scope,
+        "GenerateCedarPolicy hook: generated policy, validating and loading"
+    );
+
+    {
+        let Ok(mut policies) = server.tenant_policies.write() else {
+            return Err("tenant_policies lock poisoned".to_string());
+        };
+        let entry = policies.entry(tenant.to_string()).or_default();
+        if !entry.is_empty() {
+            entry.push('\n');
+        }
+        entry.push_str(&generated_policy);
+
+        let tenant_text = entry.clone();
+        if let Err(e) = server.authz.reload_tenant_policies(tenant, &tenant_text) {
+            tracing::error!(error = %e, "GenerateCedarPolicy: failed to reload policies");
+            return Err(format!("Failed to reload policies: {e}"));
+        }
+    }
+
+    tracing::info!(
+        entity_id,
+        "GenerateCedarPolicy hook: policy loaded successfully"
+    );
+    Ok(())
+}

--- a/crates/temper-platform/src/hooks/governance_callback.rs
+++ b/crates/temper-platform/src/hooks/governance_callback.rs
@@ -1,0 +1,435 @@
+use temper_runtime::TenantId;
+use temper_server::ServerState;
+use temper_server::request_context::AgentContext;
+
+/// Dispatch callback to a registered target entity.
+///
+/// Reads callback fields from GovernanceDecision entity state. If a callback
+/// is registered (callback_tenant is non-empty), dispatches the appropriate
+/// action on the target entity via cross-tenant dispatch.
+///
+/// This hook is also used for late callback registration: `RegisterCallback`
+/// now triggers `DispatchCallback`, so replaying callback wiring after a
+/// decision has already been approved or denied will immediately redeliver
+/// the resolution to the waiting target entity.
+pub(super) fn handle_dispatch_callback(
+    entity_fields: &serde_json::Value,
+    server: &ServerState,
+) -> Result<(), String> {
+    let callback_tenant = entity_fields
+        .get("callback_tenant")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let callback_entity_set = entity_fields
+        .get("callback_entity_set")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let callback_entity_id = entity_fields
+        .get("callback_entity_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    if callback_tenant.is_empty() || callback_entity_set.is_empty() || callback_entity_id.is_empty()
+    {
+        tracing::debug!("DispatchCallback: no callback registered — skipping");
+        return Ok(());
+    }
+
+    let status = entity_fields
+        .get("Status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let callback_action = match status {
+        "Approved" => entity_fields
+            .get("callback_on_approve")
+            .and_then(|v| v.as_str())
+            .unwrap_or(""),
+        "Denied" => entity_fields
+            .get("callback_on_deny")
+            .and_then(|v| v.as_str())
+            .unwrap_or(""),
+        "Pending" => {
+            tracing::debug!("DispatchCallback: decision still pending — skipping callback");
+            return Ok(());
+        }
+        _ => {
+            tracing::debug!(
+                status,
+                "DispatchCallback: decision not in a callback-emitting terminal state — skipping"
+            );
+            return Ok(());
+        }
+    };
+
+    if callback_action.is_empty() {
+        tracing::debug!(
+            status,
+            "DispatchCallback: no callback action for status — skipping"
+        );
+        return Ok(());
+    }
+
+    let params = if status == "Denied" {
+        serde_json::json!({"error_message": "Action denied by human reviewer"})
+    } else {
+        serde_json::json!({})
+    };
+
+    tracing::info!(
+        callback_tenant,
+        callback_entity_set,
+        callback_entity_id,
+        callback_action,
+        "DispatchCallback: dispatching callback"
+    );
+
+    let server = server.clone();
+    let tenant = callback_tenant.to_string();
+    let entity_set = callback_entity_set.to_string();
+    let entity_id = callback_entity_id.to_string();
+    let action = callback_action.to_string();
+
+    tokio::spawn(async move {
+        // determinism-ok: async callback dispatch for governance decision resolution
+        let tid = TenantId::new(&tenant);
+        let entity_type = resolve_callback_entity_type(&server, &tid, &entity_set);
+        if let Err(e) = server
+            .dispatch_tenant_action(
+                &tid,
+                &entity_type,
+                &entity_id,
+                &action,
+                params,
+                &AgentContext::system(),
+            )
+            .await
+        {
+            tracing::error!(
+                error = %e,
+                tenant,
+                entity_set,
+                entity_type,
+                entity_id,
+                action,
+                "DispatchCallback: failed to dispatch callback action"
+            );
+        } else {
+            tracing::info!(
+                tenant,
+                entity_set,
+                entity_type,
+                entity_id,
+                action,
+                "DispatchCallback: callback action dispatched successfully"
+            );
+        }
+    });
+
+    Ok(())
+}
+
+/// Resolve a callback target from an OData entity-set name to a governed entity type.
+///
+/// Callbacks are registered over HTTP and therefore store OData-facing entity set names
+/// like `Sessions`. The dispatch layer, however, expects governed entity type names like
+/// `Session`. If the callback already contains a type name, we preserve it.
+fn resolve_callback_entity_type(
+    server: &ServerState,
+    tenant: &TenantId,
+    entity_set_or_type: &str,
+) -> String {
+    {
+        let registry = match server.registry.read() {
+            Ok(registry) => registry,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if let Some(entity_type) = registry.resolve_entity_type(tenant, entity_set_or_type) {
+            return entity_type;
+        }
+        if registry.get_spec(tenant, entity_set_or_type).is_some() {
+            return entity_set_or_type.to_string();
+        }
+    }
+    server
+        .entity_set_map
+        .get(entity_set_or_type)
+        .cloned()
+        .or_else(|| {
+            server
+                .transition_tables
+                .contains_key(entity_set_or_type)
+                .then(|| entity_set_or_type.to_string())
+        })
+        .unwrap_or_else(|| entity_set_or_type.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::time::Duration;
+
+    use super::*;
+    use crate::bootstrap::{SYSTEM_TENANT, bootstrap_system_tenant};
+    use crate::state::PlatformState;
+    use temper_spec::csdl::{CsdlDocument, parse_csdl};
+
+    fn session_callback_csdl() -> (CsdlDocument, String) {
+        let xml = r#"<?xml version="1.0"?>
+        <edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+          <edmx:DataServices>
+            <Schema Namespace="OpenPaw.Test" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+              <EntityType Name="Session">
+                <Key><PropertyRef Name="Id"/></Key>
+                <Property Name="Id" Type="Edm.Guid" Nullable="false"/>
+              </EntityType>
+              <EntityContainer Name="OpenPawTestService">
+                <EntitySet Name="Sessions" EntityType="OpenPaw.Test.Session"/>
+              </EntityContainer>
+            </Schema>
+          </edmx:DataServices>
+        </edmx:Edmx>"#;
+        (parse_csdl(xml).unwrap(), xml.to_string())
+    }
+
+    const SESSION_IOA: &str = r#"
+[automaton]
+name = "Session"
+initial = "WaitingForApproval"
+states = ["WaitingForApproval", "Executing", "Failed"]
+
+[[action]]
+name = "ResumeAfterApproval"
+from = ["WaitingForApproval"]
+to = "Executing"
+kind = "input"
+
+[[action]]
+name = "Fail"
+from = ["WaitingForApproval"]
+to = "Failed"
+kind = "input"
+params = ["error_message"]
+"#;
+
+    #[test]
+    fn callback_entity_set_resolution_uses_registry_mapping() {
+        let state = PlatformState::new(None);
+        let (csdl, xml) = session_callback_csdl();
+        state.registry.write().unwrap().register_tenant(
+            "default",
+            csdl,
+            xml,
+            &[("Session", SESSION_IOA)],
+        );
+
+        let tenant = TenantId::new("default");
+        assert_eq!(
+            resolve_callback_entity_type(&state.server, &tenant, "Sessions"),
+            "Session"
+        );
+    }
+
+    #[test]
+    fn callback_entity_set_resolution_preserves_entity_type_inputs() {
+        let state = PlatformState::new(None);
+        let (csdl, xml) = session_callback_csdl();
+        state.registry.write().unwrap().register_tenant(
+            "default",
+            csdl,
+            xml,
+            &[("Session", SESSION_IOA)],
+        );
+
+        let tenant = TenantId::new("default");
+        assert_eq!(
+            resolve_callback_entity_type(&state.server, &tenant, "Session"),
+            "Session"
+        );
+    }
+
+    #[tokio::test]
+    async fn approved_governance_decision_dispatches_callback_registered_with_entity_set_name() {
+        let state = PlatformState::new(None);
+        bootstrap_system_tenant(&state, &BTreeMap::new());
+
+        let (csdl, xml) = session_callback_csdl();
+        state.registry.write().unwrap().register_tenant(
+            "default",
+            csdl,
+            xml,
+            &[("Session", SESSION_IOA)],
+        );
+
+        let system_tenant = TenantId::new(SYSTEM_TENANT);
+        let app_tenant = TenantId::new("default");
+        let decision_id = "gd-callback-test";
+        let session_id = "ss-callback-test";
+
+        state
+            .server
+            .dispatch_tenant_action(
+                &system_tenant,
+                "GovernanceDecision",
+                decision_id,
+                "CreateGovernanceDecision",
+                serde_json::json!({
+                    "tenant": "default",
+                    "agent_id": "bot-openpaw",
+                    "action_name": "temper.submit_specs",
+                    "resource_type": "Session",
+                    "resource_id": session_id,
+                    "denial_reason": "",
+                    "scope": "narrow",
+                    "pending_decision_id": decision_id,
+                }),
+                &AgentContext::system(),
+            )
+            .await
+            .expect("governance decision should be created");
+
+        state
+            .server
+            .dispatch_tenant_action(
+                &system_tenant,
+                "GovernanceDecision",
+                decision_id,
+                "RegisterCallback",
+                serde_json::json!({
+                    "callback_tenant": "default",
+                    "callback_entity_set": "Sessions",
+                    "callback_entity_id": session_id,
+                    "callback_on_approve": "ResumeAfterApproval",
+                    "callback_on_deny": "Fail",
+                }),
+                &AgentContext::system(),
+            )
+            .await
+            .expect("callback should register");
+
+        state
+            .server
+            .dispatch_tenant_action(
+                &system_tenant,
+                "GovernanceDecision",
+                decision_id,
+                "Approve",
+                serde_json::json!({
+                    "decided_by": "human-reviewer",
+                    "scope": "narrow",
+                    "generated_policy": "",
+                }),
+                &AgentContext::system(),
+            )
+            .await
+            .expect("approval should succeed");
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if let Ok(entity) = state
+                    .server
+                    .get_tenant_entity_state(&app_tenant, "Session", session_id)
+                    .await
+                    && entity.state.status == "Executing"
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        })
+        .await
+        .expect("callback should resume the target session");
+    }
+
+    #[tokio::test]
+    async fn late_callback_registration_replays_approved_governance_decision() {
+        let state = PlatformState::new(None);
+        bootstrap_system_tenant(&state, &BTreeMap::new());
+
+        let (csdl, xml) = session_callback_csdl();
+        state.registry.write().unwrap().register_tenant(
+            "default",
+            csdl,
+            xml,
+            &[("Session", SESSION_IOA)],
+        );
+
+        let system_tenant = TenantId::new(SYSTEM_TENANT);
+        let app_tenant = TenantId::new("default");
+        let decision_id = "gd-late-callback-test";
+        let session_id = "ss-late-callback-test";
+
+        state
+            .server
+            .dispatch_tenant_action(
+                &system_tenant,
+                "GovernanceDecision",
+                decision_id,
+                "CreateGovernanceDecision",
+                serde_json::json!({
+                    "tenant": "default",
+                    "agent_id": "bot-openpaw",
+                    "action_name": "temper.submit_specs",
+                    "resource_type": "Session",
+                    "resource_id": session_id,
+                    "denial_reason": "",
+                    "scope": "narrow",
+                    "pending_decision_id": decision_id,
+                }),
+                &AgentContext::system(),
+            )
+            .await
+            .expect("governance decision should be created");
+
+        state
+            .server
+            .dispatch_tenant_action(
+                &system_tenant,
+                "GovernanceDecision",
+                decision_id,
+                "Approve",
+                serde_json::json!({
+                    "decided_by": "human-reviewer",
+                    "scope": "narrow",
+                    "generated_policy": "",
+                }),
+                &AgentContext::system(),
+            )
+            .await
+            .expect("approval should succeed before callback registration");
+
+        state
+            .server
+            .dispatch_tenant_action(
+                &system_tenant,
+                "GovernanceDecision",
+                decision_id,
+                "RegisterCallback",
+                serde_json::json!({
+                    "callback_tenant": "default",
+                    "callback_entity_set": "Sessions",
+                    "callback_entity_id": session_id,
+                    "callback_on_approve": "ResumeAfterApproval",
+                    "callback_on_deny": "Fail",
+                }),
+                &AgentContext::system(),
+            )
+            .await
+            .expect("late callback registration should replay the approval callback");
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if let Ok(entity) = state
+                    .server
+                    .get_tenant_entity_state(&app_tenant, "Session", session_id)
+                    .await
+                    && entity.state.status == "Executing"
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        })
+        .await
+        .expect("late callback registration should resume the target session");
+    }
+}

--- a/crates/temper-platform/src/os_apps/mod.rs
+++ b/crates/temper-platform/src/os_apps/mod.rs
@@ -1398,34 +1398,34 @@ async fn install_os_app_without_dependencies(
             .filter(|(entity_type, _)| !skipped.contains(entity_type))
             .map(|(et, src)| (et.as_str(), src.as_str()))
             .collect();
+        let verified_cache = if let Some(ref store) = state.server.event_store
+            && let Some(turso) = store.platform_turso_store()
+        {
+            turso
+                .load_verification_cache(tenant)
+                .await
+                .unwrap_or_default()
+        } else if let Some(ref store) = state.server.event_store
+            && let Some(ps) = store.platform_store()
+        {
+            ps.load_verification_cache(tenant).await.unwrap_or_default()
+        } else {
+            std::collections::BTreeMap::new()
+        };
 
-        if !specs_to_bootstrap.is_empty() {
-            let verified_cache = if let Some(ref store) = state.server.event_store
-                && let Some(turso) = store.platform_turso_store()
-            {
-                turso
-                    .load_verification_cache(tenant)
-                    .await
-                    .unwrap_or_default()
-            } else if let Some(ref store) = state.server.event_store
-                && let Some(ps) = store.platform_store()
-            {
-                ps.load_verification_cache(tenant).await.unwrap_or_default()
-            } else {
-                std::collections::BTreeMap::new()
-            };
-
-            if let Some(ref merged) = merged_csdl {
-                bootstrap::bootstrap_tenant_specs(
-                    state,
-                    tenant,
-                    merged,
-                    &specs_to_bootstrap,
-                    true,
-                    &format!("OsApp({app_name})"),
-                    &verified_cache,
-                );
-            }
+        if let Some(ref merged) = merged_csdl {
+            // Even when every spec is byte-for-byte unchanged, we still need to
+            // merge the app's CSDL back into the in-memory registry so entity-set
+            // mappings survive partial restores and process restarts.
+            bootstrap::bootstrap_tenant_specs(
+                state,
+                tenant,
+                merged,
+                &specs_to_bootstrap,
+                true,
+                &format!("OsApp({app_name})"),
+                &verified_cache,
+            );
         }
     }
 

--- a/crates/temper-platform/src/os_apps/mod_test.rs
+++ b/crates/temper-platform/src/os_apps/mod_test.rs
@@ -4,6 +4,7 @@ use std::fs;
 
 use temper_authz::SecurityContext;
 use temper_runtime::tenant::TenantId;
+use temper_server::registry::{EntityLevelSummary, EntityVerificationResult, VerificationStatus};
 use temper_spec::automaton;
 use temper_spec::csdl::parse_csdl;
 use temper_verify::cascade::VerificationCascade;
@@ -468,6 +469,102 @@ async fn test_install_multiple_skills_merges_and_is_idempotent() {
             "Organization".to_string(),
             "Project".to_string(),
         ]
+    );
+}
+
+#[tokio::test]
+async fn test_reinstall_of_skipped_specs_repairs_entity_set_map() {
+    let state = PlatformState::new(None);
+    let tenant_name = "test-skipped-map-repair";
+    let tenant = TenantId::new(tenant_name);
+
+    install_skill(&state, tenant_name, "project-management")
+        .await
+        .expect("install project-management");
+
+    let bundle = get_os_app("project-management").expect("project-management app not found");
+    let mut broken_csdl = bundle.csdl.expect("project-management should have CSDL");
+    broken_csdl = broken_csdl.replace(
+        r#"        <EntitySet Name="Issues" EntityType="Temper.ProjectManagement.Issue">
+          <NavigationPropertyBinding Path="ParentIssue" Target="Issues"/>
+          <NavigationPropertyBinding Path="SubIssues" Target="Issues"/>
+          <NavigationPropertyBinding Path="Project" Target="Projects"/>
+          <NavigationPropertyBinding Path="Cycle" Target="Cycles"/>
+          <NavigationPropertyBinding Path="Comments" Target="Comments"/>
+        </EntitySet>
+"#,
+        "",
+    );
+
+    {
+        let mut registry = state.registry.write().unwrap(); // ci-ok: infallible lock
+        let parsed = parse_csdl(&broken_csdl).expect("broken CSDL should still parse");
+        let specs: Vec<(&str, &str)> = bundle
+            .specs
+            .iter()
+            .map(|(entity_type, ioa_source)| (entity_type.as_str(), ioa_source.as_str()))
+            .collect();
+        registry
+            .try_register_tenant_with_reactions_and_constraints(
+                tenant.clone(),
+                parsed,
+                broken_csdl,
+                &specs,
+                Vec::new(),
+                None,
+                false,
+            )
+            .expect("replace tenant config with a broken entity-set map");
+
+        let verified_at = temper_runtime::scheduler::sim_now().to_rfc3339();
+        for (entity_type, _) in &bundle.specs {
+            registry.set_verification_status(
+                &tenant,
+                entity_type,
+                VerificationStatus::Completed(EntityVerificationResult {
+                    all_passed: true,
+                    levels: vec![EntityLevelSummary {
+                        level: "Test".to_string(),
+                        passed: true,
+                        summary: "Preserved verification for skipped reinstall".to_string(),
+                        details: None,
+                    }],
+                    verified_at: verified_at.clone(),
+                }),
+            );
+        }
+    }
+
+    {
+        let registry = state.registry.read().unwrap(); // ci-ok: infallible lock
+        assert_eq!(
+            registry.resolve_entity_type(&tenant, "Issues").as_deref(),
+            None,
+            "test setup should remove the Issues entity-set mapping"
+        );
+        assert!(
+            registry.get_table(&tenant, "Issue").is_some(),
+            "Issue spec should still exist so reinstall is treated as skipped"
+        );
+    }
+
+    let reinstall = install_skill(&state, tenant_name, "project-management")
+        .await
+        .expect("reinstall project-management");
+
+    assert!(reinstall.added.is_empty());
+    assert!(reinstall.updated.is_empty());
+    assert_eq!(
+        reinstall.skipped.len(),
+        5,
+        "reinstall should still classify all project-management specs as skipped"
+    );
+
+    let registry = state.registry.read().unwrap(); // ci-ok: infallible lock
+    assert_eq!(
+        registry.resolve_entity_type(&tenant, "Issues").as_deref(),
+        Some("Issue"),
+        "identical reinstall should repair the entity-set map from the app CSDL"
     );
 }
 

--- a/crates/temper-platform/src/specs/GovernanceDecision.ioa.toml
+++ b/crates/temper-platform/src/specs/GovernanceDecision.ioa.toml
@@ -93,10 +93,11 @@ params = ["tenant", "agent_id", "action_name", "resource_type", "resource_id", "
 
 [[action]]
 name = "RegisterCallback"
-from = ["Pending"]
+from = ["Pending", "Approved", "Denied"]
 kind = "input"
 params = ["callback_tenant", "callback_entity_set", "callback_entity_id", "callback_on_approve", "callback_on_deny"]
-hint = "Register entity callback for decision resolution. Self-loop — does not change state."
+hint = "Register entity callback for decision resolution. Self-loop — does not change state. Late registration after approval/denial immediately replays DispatchCallback."
+effect = "trigger DispatchCallback"
 
 [[action]]
 name = "Approve"

--- a/crates/temper-platform/src/specs/GovernanceDecision.ioa.toml
+++ b/crates/temper-platform/src/specs/GovernanceDecision.ioa.toml
@@ -104,7 +104,7 @@ from = ["Pending"]
 to = "Approved"
 kind = "input"
 params = ["decided_by", "scope", "generated_policy"]
-effect = ["trigger GenerateCedarPolicy", "trigger DispatchCallback"]
+effect = '[{ type = "trigger", name = "GenerateCedarPolicy" }, { type = "trigger", name = "DispatchCallback" }]'
 
 [[action]]
 name = "Deny"

--- a/crates/temper-platform/src/specs/GovernanceDecision.ioa.toml
+++ b/crates/temper-platform/src/specs/GovernanceDecision.ioa.toml
@@ -3,12 +3,100 @@ name = "GovernanceDecision"
 initial = "Pending"
 states = ["Pending", "Approved", "Denied", "Expired"]
 
+# --- State Variables ---
+
+[[state]]
+name = "tenant"
+type = "string"
+initial = ""
+
+[[state]]
+name = "agent_id"
+type = "string"
+initial = ""
+
+[[state]]
+name = "action_name"
+type = "string"
+initial = ""
+
+[[state]]
+name = "resource_type"
+type = "string"
+initial = ""
+
+[[state]]
+name = "resource_id"
+type = "string"
+initial = ""
+
+[[state]]
+name = "denial_reason"
+type = "string"
+initial = ""
+
+[[state]]
+name = "scope"
+type = "string"
+initial = ""
+
+[[state]]
+name = "pending_decision_id"
+type = "string"
+initial = ""
+
+[[state]]
+name = "decided_by"
+type = "string"
+initial = ""
+
+[[state]]
+name = "generated_policy"
+type = "string"
+initial = ""
+
+# --- Callback Fields ---
+
+[[state]]
+name = "callback_tenant"
+type = "string"
+initial = ""
+
+[[state]]
+name = "callback_entity_set"
+type = "string"
+initial = ""
+
+[[state]]
+name = "callback_entity_id"
+type = "string"
+initial = ""
+
+[[state]]
+name = "callback_on_approve"
+type = "string"
+initial = ""
+
+[[state]]
+name = "callback_on_deny"
+type = "string"
+initial = ""
+
+# --- Actions ---
+
 [[action]]
 name = "CreateGovernanceDecision"
 from = []
 to = "Pending"
 kind = "input"
-params = ["tenant", "agent_id", "action_name", "resource_type", "resource_id", "denial_reason", "scope"]
+params = ["tenant", "agent_id", "action_name", "resource_type", "resource_id", "denial_reason", "scope", "pending_decision_id"]
+
+[[action]]
+name = "RegisterCallback"
+from = ["Pending"]
+kind = "input"
+params = ["callback_tenant", "callback_entity_set", "callback_entity_id", "callback_on_approve", "callback_on_deny"]
+hint = "Register entity callback for decision resolution. Self-loop — does not change state."
 
 [[action]]
 name = "Approve"
@@ -16,7 +104,7 @@ from = ["Pending"]
 to = "Approved"
 kind = "input"
 params = ["decided_by", "scope", "generated_policy"]
-effect = "trigger GenerateCedarPolicy"
+effect = ["trigger GenerateCedarPolicy", "trigger DispatchCallback"]
 
 [[action]]
 name = "Deny"
@@ -24,12 +112,15 @@ from = ["Pending"]
 to = "Denied"
 kind = "input"
 params = ["decided_by", "denial_reason"]
+effect = "trigger DispatchCallback"
 
 [[action]]
 name = "Expire"
 from = ["Pending"]
 to = "Expired"
 kind = "internal"
+
+# --- Invariants ---
 
 [[invariant]]
 name = "ApprovedIsTerminal"

--- a/crates/temper-platform/src/specs/model.csdl.xml
+++ b/crates/temper-platform/src/specs/model.csdl.xml
@@ -246,6 +246,12 @@
         <Property Name="GeneratedPolicy" Type="Edm.String" />
         <Property Name="DecidedBy" Type="Edm.String" />
         <Property Name="EvolutionRecordId" Type="Edm.String" />
+        <Property Name="PendingDecisionId" Type="Edm.String" Nullable="true"/>
+        <Property Name="CallbackTenant" Type="Edm.String" Nullable="true"/>
+        <Property Name="CallbackEntitySet" Type="Edm.String" Nullable="true"/>
+        <Property Name="CallbackEntityId" Type="Edm.String" Nullable="true"/>
+        <Property Name="CallbackOnApprove" Type="Edm.String" Nullable="true"/>
+        <Property Name="CallbackOnDeny" Type="Edm.String" Nullable="true"/>
       </EntityType>
       <Action Name="ApproveGovernanceDecision" IsBound="true">
         <Parameter Name="bindingParameter" Type="Temper.System.GovernanceDecision" />
@@ -255,6 +261,14 @@
       </Action>
       <Action Name="ExpireGovernanceDecision" IsBound="true">
         <Parameter Name="bindingParameter" Type="Temper.System.GovernanceDecision" />
+      </Action>
+      <Action Name="RegisterCallbackGovernanceDecision" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.System.GovernanceDecision"/>
+        <Parameter Name="CallbackTenant" Type="Edm.String" Nullable="true"/>
+        <Parameter Name="CallbackEntitySet" Type="Edm.String" Nullable="true"/>
+        <Parameter Name="CallbackEntityId" Type="Edm.String" Nullable="true"/>
+        <Parameter Name="CallbackOnApprove" Type="Edm.String" Nullable="true"/>
+        <Parameter Name="CallbackOnDeny" Type="Edm.String" Nullable="true"/>
       </Action>
 
       <EntityContainer Name="Container">

--- a/crates/temper-platform/src/specs/model.csdl.xml
+++ b/crates/temper-platform/src/specs/model.csdl.xml
@@ -262,7 +262,7 @@
       <Action Name="ExpireGovernanceDecision" IsBound="true">
         <Parameter Name="bindingParameter" Type="Temper.System.GovernanceDecision" />
       </Action>
-      <Action Name="RegisterCallbackGovernanceDecision" IsBound="true">
+      <Action Name="RegisterCallback" IsBound="true">
         <Parameter Name="bindingParameter" Type="Temper.System.GovernanceDecision"/>
         <Parameter Name="CallbackTenant" Type="Edm.String" Nullable="true"/>
         <Parameter Name="CallbackEntitySet" Type="Edm.String" Nullable="true"/>

--- a/crates/temper-platform/src/state.rs
+++ b/crates/temper-platform/src/state.rs
@@ -50,6 +50,25 @@ pub struct PlatformState {
 /// Default broadcast channel capacity.
 const BROADCAST_CAPACITY: usize = 256;
 
+/// Cedar policy for the temper-system tenant.
+///
+/// Platform entities (GovernanceDecision, etc.) live in the temper-system
+/// tenant but have no os-app to ship policies with. This baseline policy
+/// permits admin principals to manage governance decisions — needed so that
+/// WASM modules can register callbacks via HTTP (system principal is blocked
+/// from HTTP headers as a privilege-escalation safeguard).
+const SYSTEM_TENANT_POLICY: &str = r#"
+// Baseline policy for the temper-system tenant.
+// Admin principals get full access to all platform entities (GovernanceDecision,
+// Project, etc.). This matches the global fallback behavior — without it, loading
+// any tenant-specific policy would shadow the global set and deny unlisted actions.
+permit(
+  principal is Admin,
+  action,
+  resource
+);
+"#;
+
 #[allow(deprecated)] // RecordStore retained during migration to IOA entities (ADR-0025)
 impl PlatformState {
     /// Create a new platform state with an empty registry.
@@ -63,6 +82,14 @@ impl PlatformState {
         server.custom_effect_handler = Some(Arc::new(crate::hooks::PlatformEffectHandler {
             spec_store: spec_store.clone(),
         }));
+        // Load baseline Cedar policies for the temper-system tenant so that
+        // WASM modules can manage GovernanceDecision entities via HTTP.
+        if let Err(e) = server
+            .authz
+            .reload_tenant_policies("temper-system", SYSTEM_TENANT_POLICY)
+        {
+            tracing::warn!(error = %e, "failed to load temper-system Cedar policies");
+        }
         let (broadcast_tx, _) = broadcast::channel(BROADCAST_CAPACITY);
 
         Self {
@@ -88,6 +115,14 @@ impl PlatformState {
         server.custom_effect_handler = Some(Arc::new(crate::hooks::PlatformEffectHandler {
             spec_store: spec_store.clone(),
         }));
+        // Load baseline Cedar policies for the temper-system tenant so that
+        // WASM modules can manage GovernanceDecision entities via HTTP.
+        if let Err(e) = server
+            .authz
+            .reload_tenant_policies("temper-system", SYSTEM_TENANT_POLICY)
+        {
+            tracing::warn!(error = %e, "failed to load temper-system Cedar policies");
+        }
         let (broadcast_tx, _) = broadcast::channel(BROADCAST_CAPACITY);
 
         Self {

--- a/crates/temper-platform/src/state.rs
+++ b/crates/temper-platform/src/state.rs
@@ -56,7 +56,13 @@ impl PlatformState {
     pub fn new(api_key: Option<String>) -> Self {
         let system = ActorSystem::new("temper-platform");
         let registry = Arc::new(RwLock::new(SpecRegistry::new()));
-        let server = ServerState::from_registry_shared(system, registry.clone());
+        let spec_store = Arc::new(RwLock::new(SpecStore::new()));
+        let mut server = ServerState::from_registry_shared(system, registry.clone());
+        // Register platform custom effect handler so hooks.rs is called
+        // from the dispatch pipeline for system entity effects.
+        server.custom_effect_handler = Some(Arc::new(crate::hooks::PlatformEffectHandler {
+            spec_store: spec_store.clone(),
+        }));
         let (broadcast_tx, _) = broadcast::channel(BROADCAST_CAPACITY);
 
         Self {
@@ -66,7 +72,7 @@ impl PlatformState {
             record_store: RecordStore::new(),
             api_key,
             api_token: None,
-            spec_store: Arc::new(RwLock::new(SpecStore::new())),
+            spec_store,
             identity_resolver: Arc::new(IdentityResolver::new()),
         }
     }
@@ -75,7 +81,13 @@ impl PlatformState {
     pub fn with_registry(registry: SpecRegistry, api_key: Option<String>) -> Self {
         let system = ActorSystem::new("temper-platform");
         let registry = Arc::new(RwLock::new(registry));
-        let server = ServerState::from_registry_shared(system, registry.clone());
+        let spec_store = Arc::new(RwLock::new(SpecStore::new()));
+        let mut server = ServerState::from_registry_shared(system, registry.clone());
+        // Register platform custom effect handler so hooks.rs is called
+        // from the dispatch pipeline for system entity effects.
+        server.custom_effect_handler = Some(Arc::new(crate::hooks::PlatformEffectHandler {
+            spec_store: spec_store.clone(),
+        }));
         let (broadcast_tx, _) = broadcast::channel(BROADCAST_CAPACITY);
 
         Self {
@@ -85,7 +97,7 @@ impl PlatformState {
             record_store: RecordStore::new(),
             api_key,
             api_token: None,
-            spec_store: Arc::new(RwLock::new(SpecStore::new())),
+            spec_store,
             identity_resolver: Arc::new(IdentityResolver::new()),
         }
     }

--- a/crates/temper-platform/src/state.rs
+++ b/crates/temper-platform/src/state.rs
@@ -211,4 +211,11 @@ mod tests {
         assert!(rx1.try_recv().is_ok());
         assert!(rx2.try_recv().is_ok());
     }
+
+    #[test]
+    fn temper_system_csdl_uses_register_callback_action_name() {
+        let csdl = include_str!("specs/model.csdl.xml");
+        assert!(csdl.contains(r#"<Action Name="RegisterCallback" IsBound="true">"#));
+        assert!(!csdl.contains("RegisterCallbackGovernanceDecision"));
+    }
 }

--- a/crates/temper-server/src/api/decisions.rs
+++ b/crates/temper-server/src/api/decisions.rs
@@ -223,10 +223,7 @@ pub(crate) async fn handle_approve_decision(
     if let Some(ref gd_id) = approved_decision.governance_decision_id {
         let state_c = state.clone();
         let gd_id = gd_id.clone();
-        let decided_by = body
-            .decided_by
-            .clone()
-            .unwrap_or_else(|| "unknown".into());
+        let decided_by = body.decided_by.clone().unwrap_or_else(|| "unknown".into());
         let generated_policy = generated_policy.clone();
         tokio::spawn(async move {
             // determinism-ok: async callback dispatch for governance decision resolution

--- a/crates/temper-server/src/api/decisions.rs
+++ b/crates/temper-server/src/api/decisions.rs
@@ -16,8 +16,11 @@ use tokio_stream::StreamExt;
 use tokio_stream::wrappers::BroadcastStream;
 use tracing::instrument;
 
+use temper_runtime::tenant::TenantId;
+
 use super::{empty_decision_list, format_decision_list, require_policy_auth};
 use crate::authz::{persist_and_activate_policy, require_observe_auth};
+use crate::request_context::AgentContext;
 use crate::state::{DecisionStatus, PendingDecision, ServerState};
 
 /// Query parameters for listing decisions.
@@ -215,6 +218,41 @@ pub(crate) async fn handle_approve_decision(
         }
     }
 
+    // Dispatch GovernanceDecision.Approve — triggers DispatchCallback effect
+    // which resumes/fails the waiting Session via the registered callback.
+    if let Some(ref gd_id) = approved_decision.governance_decision_id {
+        let state_c = state.clone();
+        let gd_id = gd_id.clone();
+        let decided_by = body
+            .decided_by
+            .clone()
+            .unwrap_or_else(|| "unknown".into());
+        let generated_policy = generated_policy.clone();
+        tokio::spawn(async move {
+            // determinism-ok: async callback dispatch for governance decision resolution
+            let system_tenant = TenantId::new("temper-system");
+            if let Err(e) = state_c
+                .dispatch_tenant_action(
+                    &system_tenant,
+                    "GovernanceDecision",
+                    &gd_id,
+                    "Approve",
+                    serde_json::json!({
+                        "decided_by": decided_by,
+                        "scope": "narrow",
+                        "generated_policy": generated_policy,
+                    }),
+                    &AgentContext::system(),
+                )
+                .await
+            {
+                tracing::error!(
+                    error = %e, gd_id, "failed to dispatch GovernanceDecision.Approve"
+                );
+            }
+        });
+    }
+
     (
         StatusCode::OK,
         axum::Json(serde_json::json!({
@@ -298,6 +336,39 @@ pub(crate) async fn handle_deny_decision(
     let _ = state
         .observe_refresh_tx
         .send(crate::state::ObserveRefreshHint::Decisions);
+
+    // Dispatch GovernanceDecision.Deny — triggers DispatchCallback effect
+    // which fails the waiting Session via the registered callback.
+    if let Some(ref gd_id) = denied_decision.governance_decision_id {
+        let state_c = state.clone();
+        let gd_id = gd_id.clone();
+        let decided_by_val = denied_decision
+            .decided_by
+            .clone()
+            .unwrap_or_else(|| "unknown".into());
+        tokio::spawn(async move {
+            // determinism-ok: async callback dispatch for governance decision resolution
+            let system_tenant = TenantId::new("temper-system");
+            if let Err(e) = state_c
+                .dispatch_tenant_action(
+                    &system_tenant,
+                    "GovernanceDecision",
+                    &gd_id,
+                    "Deny",
+                    serde_json::json!({
+                        "decided_by": decided_by_val,
+                        "denial_reason": "Denied by human reviewer",
+                    }),
+                    &AgentContext::system(),
+                )
+                .await
+            {
+                tracing::error!(
+                    error = %e, gd_id, "failed to dispatch GovernanceDecision.Deny"
+                );
+            }
+        });
+    }
 
     (
         StatusCode::OK,

--- a/crates/temper-server/src/authz/helpers.rs
+++ b/crates/temper-server/src/authz/helpers.rs
@@ -224,6 +224,12 @@ pub(crate) async fn record_authz_denial(
             "failed to create GovernanceDecision entity for denial"
         );
     }
+    pd.governance_decision_id = Some(gd_id.clone());
+
+    // Re-persist with governance_decision_id link so approve/deny endpoints can find the GD.
+    if let Err(e) = state.persist_pending_decision(&pd).await {
+        tracing::warn!(error = %e, id = %pd.id, "failed to persist PD with governance_decision_id");
+    }
 
     // Record trajectory to Turso synchronously.
     let traj = TrajectoryEntry {

--- a/crates/temper-server/src/observe/mod_test.rs
+++ b/crates/temper-server/src/observe/mod_test.rs
@@ -97,11 +97,26 @@ permit(
 );
 "#;
 
+const ADMIN_SUBMIT_SPECS_POLICY: &str = r#"
+permit(
+  principal is Admin,
+  action == Action::"submit_specs",
+  resource is SpecRegistry
+);
+"#;
+
 fn install_admin_policy(state: &ServerState) {
     state
         .authz
         .reload_policies(ADMIN_MANAGE_POLICIES_POLICY)
         .expect("admin policy should parse");
+}
+
+fn install_admin_submit_specs_policy(state: &ServerState) {
+    state
+        .authz
+        .reload_policies(ADMIN_SUBMIT_SPECS_POLICY)
+        .expect("submit_specs policy should parse");
 }
 
 fn build_app_with_state(state: ServerState) -> Router {
@@ -160,6 +175,37 @@ async fn test_get_spec_detail_not_found() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_load_inline_supports_nested_paths() {
+    let state = test_state_with_registry();
+    install_admin_submit_specs_policy(&state);
+    let app = build_app_with_state(state.clone());
+
+    let response = app
+        .oneshot(system_post(
+            "/api/specs/load-inline",
+            &serde_json::json!({
+                "tenant": "nested-inline",
+                "specs": {
+                    "InlineProbe/model.csdl.xml": CSDL_XML,
+                    "InlineProbe/order.ioa.toml": ORDER_IOA
+                }
+            })
+            .to_string(),
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let registry = state.registry.read().unwrap();
+    let tenant = TenantId::new("nested-inline");
+    let spec = registry
+        .get_spec(&tenant, "Order")
+        .expect("nested inline load should register Order");
+    assert_eq!(spec.automaton.automaton.name, "Order");
 }
 
 #[tokio::test]

--- a/crates/temper-server/src/observe/specs/load_inline.rs
+++ b/crates/temper-server/src/observe/specs/load_inline.rs
@@ -1,3 +1,5 @@
+use std::path::{Path, PathBuf};
+
 use axum::extract::State;
 use axum::http::HeaderMap;
 use axum::http::StatusCode;
@@ -205,8 +207,19 @@ pub(crate) async fn handle_load_inline(
         )
     })?;
 
+    let specs_root = resolve_inline_specs_root(&tmp_dir, &body.specs)?;
+
     for (filename, content) in &body.specs {
         let path = tmp_dir.join(filename);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                // determinism-ok: HTTP handler creates temp subdirectories for nested inline specs
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Failed to create parent directory for {filename}: {e}"),
+                )
+            })?;
+        }
         std::fs::write(&path, content).map_err(|e| {
             // determinism-ok: HTTP handler writes specs
             (
@@ -217,7 +230,7 @@ pub(crate) async fn handle_load_inline(
     }
 
     if let Some(source) = body.cross_invariants_toml.as_deref() {
-        std::fs::write(tmp_dir.join("cross-invariants.toml"), source).map_err(|e| {
+        std::fs::write(specs_root.join("cross-invariants.toml"), source).map_err(|e| {
             // determinism-ok: HTTP handler writes cross-invariants
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -231,7 +244,7 @@ pub(crate) async fn handle_load_inline(
     let cedar_policies = body.cedar_policies.clone();
     let dir_request = LoadDirRequest {
         tenant: tenant.clone(),
-        specs_dir: tmp_dir.to_string_lossy().to_string(),
+        specs_dir: specs_root.to_string_lossy().to_string(),
         merge: true,
     };
     let result = handle_load_dir(State(state.clone()), Json(dir_request)).await;
@@ -351,6 +364,41 @@ fn extract_submitted_namespaces(specs: &std::collections::BTreeMap<String, Strin
         }
     }
     namespaces.into_iter().collect()
+}
+
+fn resolve_inline_specs_root(
+    tmp_dir: &Path,
+    specs: &std::collections::BTreeMap<String, String>,
+) -> Result<PathBuf, (StatusCode, String)> {
+    let model_paths: Vec<&str> = specs
+        .keys()
+        .filter_map(|path| path.ends_with("model.csdl.xml").then_some(path.as_str()))
+        .collect();
+
+    if model_paths.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "Inline spec submission must include model.csdl.xml".to_string(),
+        ));
+    }
+
+    if model_paths.len() > 1 {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "Inline spec submission must contain exactly one model.csdl.xml, found {}",
+                model_paths.len()
+            ),
+        ));
+    }
+
+    let model_path = Path::new(model_paths[0]);
+    let relative_root = model_path.parent().unwrap_or_else(|| Path::new(""));
+    Ok(if relative_root.as_os_str().is_empty() {
+        tmp_dir.to_path_buf()
+    } else {
+        tmp_dir.join(relative_root)
+    })
 }
 
 fn adr_candidate_paths(app_name: Option<&str>, namespaces: &[String]) -> Vec<String> {

--- a/crates/temper-server/src/state/custom_effects.rs
+++ b/crates/temper-server/src/state/custom_effects.rs
@@ -1,0 +1,31 @@
+//! Extension point for platform-level custom effects.
+//!
+//! Platform entities (temper-system) use `effect = "trigger Foo"` in their
+//! IOA specs. The dispatch pipeline calls this handler for each custom
+//! effect after WASM/adapter integration dispatch.
+//!
+//! This trait lives in `temper-server` so that `temper-platform` can implement
+//! it without introducing a circular dependency (platform depends on server,
+//! not the reverse).
+
+/// Handler for custom effects triggered by entity state machine transitions.
+///
+/// Implementations registered on [`ServerState::custom_effect_handler`] are
+/// called by the post-dispatch effects pipeline for every custom effect name.
+pub trait CustomEffectHandler: Send + Sync {
+    /// Handle a custom effect.
+    ///
+    /// - `effect_name`: the effect trigger name (e.g. "GenerateCedarPolicy")
+    /// - `entity_type`: the entity type that transitioned
+    /// - `entity_id`: the entity instance ID
+    /// - `entity_fields`: merged entity state fields (includes all params from all prior actions)
+    /// - `server`: server state for dispatch, authz, etc.
+    fn handle(
+        &self,
+        effect_name: &str,
+        entity_type: &str,
+        entity_id: &str,
+        entity_fields: &serde_json::Value,
+        server: &super::ServerState,
+    ) -> Result<(), String>;
+}

--- a/crates/temper-server/src/state/dispatch/effects.rs
+++ b/crates/temper-server/src/state/dispatch/effects.rs
@@ -384,23 +384,23 @@ impl crate::state::ServerState {
         if !response.custom_effects.is_empty()
             && let Some(handler) = &self.custom_effect_handler
         {
-                for effect_name in &response.custom_effects {
-                    if let Err(e) = handler.handle(
-                        effect_name,
-                        ctx.entity_type,
-                        ctx.entity_id,
-                        &response.state.fields,
-                        self,
-                    ) {
-                        tracing::error!(
-                            effect = %effect_name,
-                            entity_type = ctx.entity_type,
-                            entity_id = ctx.entity_id,
-                            error = %e,
-                            "custom effect handler failed"
-                        );
-                    }
+            for effect_name in &response.custom_effects {
+                if let Err(e) = handler.handle(
+                    effect_name,
+                    ctx.entity_type,
+                    ctx.entity_id,
+                    &response.state.fields,
+                    self,
+                ) {
+                    tracing::error!(
+                        effect = %effect_name,
+                        entity_type = ctx.entity_type,
+                        entity_id = ctx.entity_id,
+                        error = %e,
+                        "custom effect handler failed"
+                    );
                 }
+            }
         }
 
         // 6. Spawn requests

--- a/crates/temper-server/src/state/dispatch/effects.rs
+++ b/crates/temper-server/src/state/dispatch/effects.rs
@@ -376,6 +376,33 @@ impl crate::state::ServerState {
             }
         }
 
+        // 5b. Platform custom effect hooks
+        //
+        // For system-tenant entities whose specs declare custom effects
+        // but have no WASM/adapter integrations (e.g. GovernanceDecision),
+        // the handler routes effects to platform hooks (hooks.rs).
+        if !response.custom_effects.is_empty() {
+            if let Some(handler) = &self.custom_effect_handler {
+                for effect_name in &response.custom_effects {
+                    if let Err(e) = handler.handle(
+                        effect_name,
+                        ctx.entity_type,
+                        ctx.entity_id,
+                        &response.state.fields,
+                        self,
+                    ) {
+                        tracing::error!(
+                            effect = %effect_name,
+                            entity_type = ctx.entity_type,
+                            entity_id = ctx.entity_id,
+                            error = %e,
+                            "custom effect handler failed"
+                        );
+                    }
+                }
+            }
+        }
+
         // 6. Spawn requests
         if !response.spawn_requests.is_empty() {
             self.dispatch_spawn_requests(

--- a/crates/temper-server/src/state/dispatch/effects.rs
+++ b/crates/temper-server/src/state/dispatch/effects.rs
@@ -381,8 +381,9 @@ impl crate::state::ServerState {
         // For system-tenant entities whose specs declare custom effects
         // but have no WASM/adapter integrations (e.g. GovernanceDecision),
         // the handler routes effects to platform hooks (hooks.rs).
-        if !response.custom_effects.is_empty() {
-            if let Some(handler) = &self.custom_effect_handler {
+        if !response.custom_effects.is_empty()
+            && let Some(handler) = &self.custom_effect_handler
+        {
                 for effect_name in &response.custom_effects {
                     if let Err(e) = handler.handle(
                         effect_name,
@@ -400,7 +401,6 @@ impl crate::state::ServerState {
                         );
                     }
                 }
-            }
         }
 
         // 6. Spawn requests

--- a/crates/temper-server/src/state/mod.rs
+++ b/crates/temper-server/src/state/mod.rs
@@ -1,5 +1,6 @@
 //! Server state shared across all request handlers.
 
+pub mod custom_effects;
 mod dispatch;
 mod entity_ops;
 mod evolution;
@@ -286,6 +287,13 @@ pub struct ServerState {
     /// Each entity's IOA source is written to stdin; the result is read from stdout
     /// as JSON. A 30-second timeout is applied per entity.
     pub verify_subprocess_bin: Option<Arc<std::path::PathBuf>>,
+    /// Optional custom effect handler for platform-level hooks.
+    ///
+    /// When set, the post-dispatch pipeline calls this handler for each
+    /// custom effect triggered by entity transitions. This is the extension
+    /// point that `temper-platform` uses to wire `hooks.rs` into the
+    /// dispatch pipeline.
+    pub custom_effect_handler: Option<Arc<dyn custom_effects::CustomEffectHandler>>,
 }
 
 #[allow(deprecated)] // ADR-0025 Phase 4: RecordStore used until chain validation replaced
@@ -359,6 +367,7 @@ impl ServerState {
             single_tenant_mode: true,
             suggestion_engine: Arc::new(RwLock::new(PolicySuggestionEngine::new())),
             verify_subprocess_bin: None,
+            custom_effect_handler: None,
         };
 
         // Pre-register built-in WASM modules (http_fetch for generic HTTP integrations).
@@ -587,6 +596,7 @@ impl ServerState {
             single_tenant_mode: false,
             suggestion_engine: Arc::new(RwLock::new(PolicySuggestionEngine::new())),
             verify_subprocess_bin: None,
+            custom_effect_handler: None,
         };
         state.register_builtin_wasm_modules();
         state

--- a/crates/temper-server/src/state/pending_decisions.rs
+++ b/crates/temper-server/src/state/pending_decisions.rs
@@ -85,6 +85,9 @@ pub struct PendingDecision {
     /// Session ID at time of denial (for session-scoped approvals).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_id: Option<String>,
+    /// Linked GovernanceDecision entity ID (e.g. "GD-{uuid}") in temper-system tenant.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub governance_decision_id: Option<String>,
 }
 
 impl PendingDecision {
@@ -120,6 +123,7 @@ impl PendingDecision {
             agent_type: None,
             principal_kind: None,
             session_id: None,
+            governance_decision_id: None,
         }
     }
 

--- a/docs/adrs/0041-governance-decision-callbacks.md
+++ b/docs/adrs/0041-governance-decision-callbacks.md
@@ -74,8 +74,10 @@ Extend the GovernanceDecision IOA spec with callback registration:
 - **New state variables**: `callback_tenant`, `callback_entity_set`,
   `callback_entity_id`, `callback_on_approve`, `callback_on_deny`,
   `pending_decision_id`
-- **New action**: `RegisterCallback` (self-loop on Pending state) — allows
-  any caller to register a callback target before the decision is resolved
+- **New action**: `RegisterCallback` (self-loop on Pending/Approved/Denied) —
+  allows any caller to register a callback target before the decision is
+  resolved, and safely replay callback delivery if registration happens after
+  approval or denial
 - **New effect**: `DispatchCallback` on both `Approve` and `Deny` actions —
   when the decision is resolved, the handler reads the callback fields and
   dispatches the registered action on the target entity
@@ -105,7 +107,7 @@ mechanism through the entity effect pipeline.
 ### Sub-Decision 5: WASM Callback Registration
 
 The `request_approval` WASM module (triggered by `Session.PauseForApproval`)
-registers the callback after posting approval buttons:
+registers the callback before posting approval buttons:
 1. Queries GovernanceDecisions in `temper-system` by `pending_decision_id`
 2. Dispatches `RegisterCallback` with the Session entity as target
 

--- a/docs/adrs/0041-governance-decision-callbacks.md
+++ b/docs/adrs/0041-governance-decision-callbacks.md
@@ -1,0 +1,167 @@
+# ADR-0041: GovernanceDecision Callback Mechanism
+
+## Status
+
+Accepted
+
+## Context
+
+When an agent action is denied by Cedar authorization, the platform creates a
+`PendingDecision` (legacy, deprecated) and a `GovernanceDecision` entity in the
+`temper-system` tenant. A human can then approve or deny the decision via the
+Observe UI or channel buttons (Discord, Slack).
+
+The approval flow had accumulated several layers of custom plumbing:
+
+1. **Dead hooks**: `dispatch_custom_effect()` in `hooks.rs` handled
+   `GenerateCedarPolicy` and `DeploySpecs` effects, but was never called from
+   the dispatch pipeline. `effects.rs` routes custom effects through
+   WASM/adapter integration lookup only, and platform entities in
+   `temper-system` have no `[[integration]]` sections.
+
+2. **Transport-level orchestration**: Discord (`transport.rs:1219-1278`) and
+   Slack (`transport.rs:530-566`) each contained ~40-60 lines of business
+   logic querying Sessions by `pending_decision_id` and dispatching
+   `ResumeAfterApproval` or `Fail`. This logic was duplicated across both
+   transports and violated the Temper-Native rule (transports should be thin
+   protocol bridges, not orchestration engines).
+
+3. **Inline policy generation**: `handle_approve_decision` in `decisions.rs`
+   generated and loaded Cedar policies inline, duplicating what the
+   `GenerateCedarPolicy` hook was supposed to do.
+
+4. **GovernanceDecision entity bypassed**: The entity existed with proper
+   states (Pending → Approved/Denied/Expired) and a `GenerateCedarPolicy`
+   effect on Approve, but nobody dispatched entity actions on it from the
+   button/approval flow.
+
+5. **PendingDecision still primary**: Despite being marked deprecated, the
+   `PendingDecision` struct was still the primary approval path with no link
+   to the corresponding `GovernanceDecision` entity.
+
+## Decision
+
+### Sub-Decision 1: CustomEffectHandler Trait
+
+Add a `CustomEffectHandler` trait to `temper-server` that `temper-platform`
+implements. This respects the crate dependency direction (platform depends on
+server, not vice versa) and provides an extension point for platform-level
+custom effects.
+
+```rust
+// temper-server/src/state/custom_effects.rs
+pub trait CustomEffectHandler: Send + Sync {
+    fn handle(
+        &self,
+        effect_name: &str,
+        entity_type: &str,
+        entity_id: &str,
+        entity_fields: &serde_json::Value,
+        server: &ServerState,
+    ) -> Result<(), String>;
+}
+```
+
+The dispatch pipeline in `effects.rs` calls this handler after the
+WASM/adapter integration block. `PlatformEffectHandler` captures only
+`spec_store: Arc<RwLock<SpecStore>>` (not `PlatformState`) to avoid circular
+references, and receives `&ServerState` as a parameter when invoked.
+
+### Sub-Decision 2: GovernanceDecision Callback Fields
+
+Extend the GovernanceDecision IOA spec with callback registration:
+
+- **New state variables**: `callback_tenant`, `callback_entity_set`,
+  `callback_entity_id`, `callback_on_approve`, `callback_on_deny`,
+  `pending_decision_id`
+- **New action**: `RegisterCallback` (self-loop on Pending state) — allows
+  any caller to register a callback target before the decision is resolved
+- **New effect**: `DispatchCallback` on both `Approve` and `Deny` actions —
+  when the decision is resolved, the handler reads the callback fields and
+  dispatches the registered action on the target entity
+
+The callback mechanism is generic: any entity type can register as a
+callback target, not just OpenPaw Sessions.
+
+### Sub-Decision 3: PendingDecision → GovernanceDecision Link
+
+Add `governance_decision_id: Option<String>` to `PendingDecision`. Set it
+immediately after GD entity creation in `record_authz_denial()`. The
+approve/deny API endpoints use this link to dispatch the corresponding
+`GovernanceDecision.Approve` or `GovernanceDecision.Deny` entity action,
+which triggers the effect pipeline (GenerateCedarPolicy + DispatchCallback).
+
+### Sub-Decision 4: Thin Transports
+
+Remove Session lookup + ResumeAfterApproval/Fail dispatch from both Discord
+and Slack transports. Transports now only:
+1. Call the platform's `/api/tenants/{tenant}/decisions/{id}/approve` or
+   `/deny` endpoint
+2. Update the channel message to show the result
+
+Session resumption is handled entirely by the GovernanceDecision callback
+mechanism through the entity effect pipeline.
+
+### Sub-Decision 5: WASM Callback Registration
+
+The `request_approval` WASM module (triggered by `Session.PauseForApproval`)
+registers the callback after posting approval buttons:
+1. Queries GovernanceDecisions in `temper-system` by `pending_decision_id`
+2. Dispatches `RegisterCallback` with the Session entity as target
+
+## Consequences
+
+### Positive
+
+- **Single code path**: Approval resolution flows through one entity-driven
+  lane (GovernanceDecision effects) instead of being scattered across
+  transports, API handlers, and dead hooks.
+- **Transport simplification**: ~100 lines of duplicated orchestration logic
+  removed from Discord and Slack transports. Adding a new transport (e.g.,
+  Teams) requires zero approval-flow logic.
+- **hooks.rs is alive**: The `GenerateCedarPolicy` and `DispatchCallback`
+  effects now actually fire through the dispatch pipeline.
+- **Generic callback mechanism**: Other entities can register callbacks on
+  GovernanceDecision, not just OpenPaw Sessions.
+- **Graceful degradation**: If no callback is registered, approval still
+  works (policy generated) — the Session just doesn't auto-resume.
+
+### Negative
+
+- **Cross-tenant WASM call**: `request_approval` makes a cross-tenant call
+  to `temper-system` to register the callback. This is a proven pattern
+  (already used by `record_authz_denial`) but adds one extra HTTP call per
+  approval notification.
+- **Transitional redundancy**: `handle_approve_decision` still generates
+  Cedar policies inline AND dispatches `GovernanceDecision.Approve` which
+  triggers `GenerateCedarPolicy` via the effect handler. The inline
+  generation handles prospective validation and D-Record creation that the
+  hook doesn't do yet. This redundancy can be removed in a future cleanup.
+
+### DST Compliance
+
+`DispatchCallback` uses `tokio::spawn` for the cross-tenant dispatch
+(annotated `// determinism-ok: async callback dispatch for governance
+decision resolution`). This follows the same pattern as existing scheduled
+action dispatch in the codebase.
+
+## Files Modified
+
+### temper-server
+- `state/custom_effects.rs` — NEW: CustomEffectHandler trait
+- `state/mod.rs` — Register handler field on ServerState
+- `state/dispatch/effects.rs` — Call handler after integrations
+- `state/pending_decisions.rs` — Add governance_decision_id field
+- `authz/helpers.rs` — Link PD to GD after creation
+- `api/decisions.rs` — Dispatch GD.Approve/Deny from endpoints
+
+### temper-platform
+- `specs/GovernanceDecision.ioa.toml` — Callback fields, RegisterCallback, DispatchCallback
+- `specs/model.csdl.xml` — New properties and bound action
+- `hooks.rs` — PlatformEffectHandler, DispatchCallback, GenerateCedarPolicy from fields
+- `state.rs` — Register handler during construction
+
+### openpaw-codex
+- `os-apps/paw-agent/wasm/request_approval/src/lib.rs` — Register GD callback
+- `crates/paw-transport/src/discord/transport.rs` — Remove orchestration
+- `crates/paw-transport/src/slack/transport.rs` — Remove orchestration


### PR DESCRIPTION
## Summary
- replay approved and denied GovernanceDecision callbacks on late registration
- resolve callback entity-set names back to governed entity types
- repair entity-set maps on skipped reinstall and support nested inline spec bundles rooted at `model.csdl.xml`

## Verification
- cargo test -p temper-platform
- cargo test -p temper-server observe::
- cargo test -p temper-platform late_callback_registration_replays_approved_governance_decision
- cargo test -p temper-platform approved_governance_decision_dispatches_callback_registered_with_entity_set_name