### PR TITLE
feat: restore apps safely after startup optimization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5920,6 +5920,7 @@ dependencies = [
  "temper-spec",
  "temper-store-turso",
  "temper-verify",
+ "temper-wasm",
  "thiserror 2.0.18",
  "tokio",
  "tokio-test",

--- a/crates/temper-platform/Cargo.toml
+++ b/crates/temper-platform/Cargo.toml
@@ -17,6 +17,7 @@ temper-observe = { workspace = true }
 temper-runtime = { workspace = true }
 temper-authz = { workspace = true }
 temper-optimize = { workspace = true }
+temper-wasm = { workspace = true }
 opentelemetry = { workspace = true }
 reqwest = { workspace = true }
 axum = { workspace = true }

--- a/crates/temper-platform/src/bootstrap.rs
+++ b/crates/temper-platform/src/bootstrap.rs
@@ -251,9 +251,9 @@ pub fn bootstrap_agent_specs(
 /// On subsequent boots, `load_verification_cache` finds these rows and
 /// the cascade is skipped — preventing OOM on memory-constrained hosts.
 ///
-/// Note: the upsert + mark-verified is two statements, not atomic.  If
-/// the process crashes between them the spec row will have `verified=0`
-/// and the cascade will re-run on next boot — safe, just slower.
+/// Note: the upsert + mark-verified is two statements, not atomic. If the
+/// process crashes between them the spec row will have `verified=0` until
+/// we recommit the tenant's spec set at the end — safe, just slower.
 pub(crate) async fn persist_bootstrap_verification(
     store: &dyn PlatformStore,
     tenant: &str,
@@ -295,6 +295,13 @@ pub(crate) async fn persist_bootstrap_verification(
         {
             tracing::warn!("Failed to persist verification status for {tenant}/{entity_type}: {e}");
         }
+    }
+
+    // `upsert_spec` marks rows as uncommitted while content is rewritten. Once
+    // bootstrap verification succeeds, promote the tenant's spec set back to a
+    // durable committed state so restart recovery can actually see the rows.
+    if let Err(e) = store.commit_specs(tenant).await {
+        tracing::warn!("Failed to commit bootstrap specs for tenant '{tenant}': {e}");
     }
 }
 

--- a/crates/temper-platform/src/os_apps/mod.rs
+++ b/crates/temper-platform/src/os_apps/mod.rs
@@ -24,97 +24,13 @@ use crate::bootstrap;
 use crate::state::PlatformState;
 
 mod system_files;
-
-/// Result of an app installation, categorising each spec by what happened.
-#[derive(Debug, Clone, Serialize)]
-pub struct InstallResult {
-    /// Entity types registered for the first time.
-    pub added: Vec<String>,
-    /// Entity types that already existed but whose IOA source changed.
-    pub updated: Vec<String>,
-    /// Entity types whose IOA source was byte-for-byte identical — skipped.
-    pub skipped: Vec<String>,
-    /// WASM modules compiled and registered.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub wasm_modules: Vec<String>,
-    /// Agent definitions bootstrapped.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub agents: Vec<String>,
-    /// Skill definitions bootstrapped.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub skills: Vec<String>,
-    /// ADR markdown files bootstrapped into TemperFS.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub adrs_bootstrapped: Vec<String>,
-    /// Seed data instances created.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub seed_instances: Vec<String>,
-}
-
-/// Parsed app.toml manifest.
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
-pub struct AppManifest {
-    pub name: String,
-    #[serde(default)]
-    pub description: String,
-    #[serde(default = "default_version")]
-    pub version: String,
-    #[serde(default)]
-    pub dependencies: Vec<String>,
-}
-
-fn default_version() -> String {
-    "0.1.0".to_string()
-}
+mod types;
+pub use types::*;
 
 fn read_app_manifest(app_dir: &Path) -> Option<AppManifest> {
     let path = app_dir.join("app.toml");
     let content = std::fs::read_to_string(&path).ok()?;
     toml::from_str(&content).ok()
-}
-
-/// Metadata for an app in the catalog.
-#[derive(Debug, Clone, Serialize)]
-pub struct AppEntry {
-    /// Short name used in CLI flags and API calls (e.g. `"project-management"`).
-    pub name: String,
-    /// Human-readable description.
-    pub description: String,
-    /// Entity types included in the app.
-    pub entity_types: Vec<String>,
-    /// Semantic version.
-    pub version: String,
-    /// Full app guide markdown (from `APP.md`/`app.md`/`skill.md`), if available.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub app_guide: Option<String>,
-    /// Declared dependencies (from app.toml).
-    #[serde(default)]
-    pub dependencies: Vec<String>,
-}
-
-// Backward-compatible alias: SkillEntry → AppEntry.
-pub type SkillEntry = AppEntry;
-
-/// Full spec bundle for an app (owned, loaded from disk).
-pub struct AppBundle {
-    /// IOA spec sources as `(entity_type, ioa_toml_source)` pairs.
-    pub specs: Vec<(String, String)>,
-    /// CSDL XML source (None if app has no IOA specs).
-    pub csdl: Option<String>,
-    /// Cedar policy sources (may be empty).
-    pub cedar_policies: Vec<String>,
-    /// WASM module binaries as `(module_name, wasm_bytes)` pairs.
-    pub wasm_modules: BTreeMap<String, Vec<u8>>,
-    /// Agent definitions discovered from `agents/` subdirectories.
-    pub agents: Vec<AgentDefinition>,
-    /// Skill definitions discovered from `skills/` subdirectories.
-    pub skills: Vec<AppSkillDefinition>,
-    /// ADR markdown files discovered from `adrs/`.
-    pub adrs: Vec<AdrEntry>,
-    /// System files discovered from `system/` directory tree.
-    pub system_files: Vec<SystemFileEntry>,
-    /// Seed data instances discovered from `seed-data/` TOML files.
-    pub seed_instances: Vec<SeedInstance>,
 }
 
 // ── Agent / Skill / Seed Data types ─────────────────────────────────
@@ -304,6 +220,22 @@ pub fn reload_skills() {
     reload_os_apps();
 }
 
+/// List OS apps that belong to the default startup surface.
+pub fn list_startup_os_apps() -> Vec<String> {
+    let cat = match catalog().read() {
+        Ok(cat) => cat,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    let mut apps: Vec<String> = cat
+        .entries
+        .iter()
+        .filter(|entry| entry.startup_install == StartupInstallMode::Core)
+        .map(|entry| entry.name.clone())
+        .collect();
+    apps.sort();
+    apps
+}
+
 impl AppCatalog {
     /// Discover the apps directory and scan it.
     fn discover() -> Self {
@@ -454,6 +386,7 @@ impl AppCatalog {
             };
 
             let version = manifest.version.clone();
+            let startup_install = manifest.startup_install;
             let dependencies = manifest.dependencies.clone();
 
             let app_path = app_dir.clone();
@@ -466,6 +399,7 @@ impl AppCatalog {
                 description,
                 entity_types,
                 version,
+                startup_install,
                 app_guide,
                 dependencies,
             });
@@ -1107,6 +1041,7 @@ pub fn get_skill_guide(name: &str) -> Option<String> {
 
 /// Load a complete app bundle from a directory on disk.
 fn load_app_bundle(app_dir: &Path) -> Option<AppBundle> {
+    let manifest = read_app_manifest(app_dir)?;
     let ioa_files = find_ioa_files(app_dir);
 
     // Read IOA specs, extracting entity type from the parsed automaton name.
@@ -1128,6 +1063,11 @@ fn load_app_bundle(app_dir: &Path) -> Option<AppBundle> {
 
     // Read WASM module binaries from wasm/*/target/wasm32-unknown-unknown/release/*.wasm.
     let wasm_modules = find_wasm_modules(app_dir);
+    let wasm_module_configs: BTreeMap<String, WasmModuleManifest> = manifest
+        .wasm_modules
+        .into_iter()
+        .map(|module| (module.name.clone(), module))
+        .collect();
 
     // Discover agents, skills, and seed data.
     let agents = find_agents(app_dir);
@@ -1143,6 +1083,7 @@ fn load_app_bundle(app_dir: &Path) -> Option<AppBundle> {
     if specs.is_empty()
         && cedar_policies.is_empty()
         && wasm_modules.is_empty()
+        && wasm_module_configs.is_empty()
         && agents.is_empty()
         && skills.is_empty()
         && adrs.is_empty()
@@ -1159,6 +1100,7 @@ fn load_app_bundle(app_dir: &Path) -> Option<AppBundle> {
         csdl,
         cedar_policies,
         wasm_modules,
+        wasm_module_configs,
         agents,
         skills,
         adrs,
@@ -1395,7 +1337,6 @@ async fn install_os_app_without_dependencies(
         let specs_to_bootstrap: Vec<(&str, &str)> = bundle
             .specs
             .iter()
-            .filter(|(entity_type, _)| !skipped.contains(entity_type))
             .map(|(et, src)| (et.as_str(), src.as_str()))
             .collect();
         let verified_cache = if let Some(ref store) = state.server.event_store
@@ -1416,8 +1357,10 @@ async fn install_os_app_without_dependencies(
         if let Some(ref merged) = merged_csdl {
             // Even when every spec is byte-for-byte unchanged, we still need to
             // merge the app's CSDL back into the in-memory registry so entity-set
-            // mappings survive partial restores and process restarts.
-            bootstrap::bootstrap_tenant_specs(
+            // mappings survive partial restores and process restarts. Re-running
+            // bootstrap also lets recovery heal specs that were durably left
+            // in `pending` by older installs.
+            let spec_hashes = bootstrap::bootstrap_tenant_specs(
                 state,
                 tenant,
                 merged,
@@ -1426,6 +1369,19 @@ async fn install_os_app_without_dependencies(
                 &format!("OsApp({app_name})"),
                 &verified_cache,
             );
+
+            if let Some(ref store) = state.server.event_store
+                && let Some(ps) = store.platform_store()
+            {
+                bootstrap::persist_bootstrap_verification(
+                    ps,
+                    tenant,
+                    &specs_to_bootstrap,
+                    merged,
+                    &spec_hashes,
+                )
+                .await;
+            }
         }
     }
 
@@ -1447,44 +1403,78 @@ async fn install_os_app_without_dependencies(
         }
     }
 
-    // ── Step 4: Compile and register WASM modules. ──────────────────
+    // ── Step 4: Persist/register WASM modules, warming only eager modules. ──
     let mut wasm_registered = Vec::new();
+    let mut wasm_skipped = Vec::new();
+    let mut wasm_failures = Vec::new();
     for (module_name, wasm_bytes) in &bundle.wasm_modules {
-        match state.server.wasm_engine.compile_and_cache(wasm_bytes) {
-            Ok(hash) => {
-                // Persist to Turso FIRST for durability.
-                if let Err(e) = state
-                    .server
-                    .upsert_wasm_module(tenant, module_name, wasm_bytes, &hash)
-                    .await
-                {
-                    tracing::warn!(
-                        tenant,
-                        module = %module_name,
-                        error = %e,
-                        "Failed to persist WASM module to durable store (continuing in-memory only)"
-                    );
-                }
-                // Register in module registry.
-                {
-                    let mut wasm_reg = state.server.wasm_module_registry.write().unwrap(); // ci-ok: infallible lock
-                    wasm_reg.register(&tenant_id, module_name, &hash);
-                }
-                tracing::info!(
-                    tenant,
-                    module = %module_name,
-                    hash = %hash,
-                    size = wasm_bytes.len(),
-                    "WASM module loaded from OS app"
-                );
-                wasm_registered.push(module_name.clone());
-            }
-            Err(e) => {
+        let module_config = bundle.wasm_module_configs.get(module_name);
+        let hash = temper_wasm::WasmEngine::hash_module(wasm_bytes);
+
+        if let Err(e) = state
+            .server
+            .upsert_wasm_module(tenant, module_name, wasm_bytes, &hash)
+            .await
+        {
+            tracing::warn!(
+                tenant,
+                module = %module_name,
+                error = %e,
+                "Failed to persist WASM module to durable store (continuing in-memory only)"
+            );
+        }
+        {
+            let mut wasm_reg = state.server.wasm_module_registry.write().unwrap(); // ci-ok: infallible lock
+            wasm_reg.register(&tenant_id, module_name, &hash);
+        }
+
+        if matches!(
+            module_config.map(|config| config.startup_loading),
+            Some(WasmStartupLoading::Eager)
+        ) && let Err(e) = state.server.wasm_engine.compile_and_cache(wasm_bytes)
+        {
+            wasm_failures.push(module_name.clone());
+            tracing::warn!(
+                tenant,
+                module = %module_name,
+                error = %e,
+                "Failed to eagerly compile WASM module from OS app"
+            );
+        }
+
+        tracing::info!(
+            tenant,
+            module = %module_name,
+            hash = %hash,
+            size = wasm_bytes.len(),
+            startup_loading = ?module_config
+                .map(|config| config.startup_loading)
+                .unwrap_or_default(),
+            "WASM module registered from OS app"
+        );
+        wasm_registered.push(module_name.clone());
+    }
+
+    for (module_name, module_config) in &bundle.wasm_module_configs {
+        if bundle.wasm_modules.contains_key(module_name) {
+            continue;
+        }
+        match module_config.criticality {
+            WasmModuleCriticality::Optional => {
+                wasm_skipped.push(module_name.clone());
                 tracing::warn!(
                     tenant,
                     module = %module_name,
-                    error = %e,
-                    "Failed to compile WASM module from OS app"
+                    "Configured optional WASM module artifact is missing from the app bundle"
+                );
+            }
+            WasmModuleCriticality::PlatformRequired | WasmModuleCriticality::AppRequired => {
+                wasm_failures.push(module_name.clone());
+                tracing::error!(
+                    tenant,
+                    module = %module_name,
+                    criticality = ?module_config.criticality,
+                    "Configured required WASM module artifact is missing from the app bundle"
                 );
             }
         }
@@ -1524,6 +1514,8 @@ async fn install_os_app_without_dependencies(
         updated,
         skipped,
         wasm_modules: wasm_registered,
+        wasm_skipped,
+        wasm_failures,
         agents: agents_bootstrapped,
         skills: skills_bootstrapped,
         adrs_bootstrapped,

--- a/crates/temper-platform/src/os_apps/mod_test.rs
+++ b/crates/temper-platform/src/os_apps/mod_test.rs
@@ -7,6 +7,7 @@ use temper_runtime::tenant::TenantId;
 use temper_server::registry::{EntityLevelSummary, EntityVerificationResult, VerificationStatus};
 use temper_spec::automaton;
 use temper_spec::csdl::parse_csdl;
+use temper_store_turso::TursoSpecVerificationUpdate;
 use temper_verify::cascade::VerificationCascade;
 
 #[test]
@@ -661,6 +662,19 @@ async fn test_skill_install_survives_restart() {
             .any(|r| r.tenant == "test-ws" && r.entity_type == "Issue"),
         "Issue spec not found in Turso"
     );
+    let issue_row = rows
+        .iter()
+        .find(|r| r.tenant == "test-ws" && r.entity_type == "Issue")
+        .expect("Issue spec should exist");
+    assert!(
+        issue_row.verified,
+        "Issue spec should be durably marked verified after install"
+    );
+    assert_ne!(
+        issue_row.verification_status.to_lowercase(),
+        "pending",
+        "Issue spec should not remain pending after install"
+    );
 
     let installed = turso_ref.list_all_installed_apps().await.unwrap();
     assert!(
@@ -697,7 +711,96 @@ async fn test_skill_install_survives_restart() {
         assert!(registry.get_table(&tenant, "Cycle").is_some());
         assert!(registry.get_table(&tenant, "Comment").is_some());
         assert!(registry.get_table(&tenant, "Label").is_some());
+        assert!(
+            matches!(
+                registry.get_verification_status(&tenant, "Issue"),
+                Some(VerificationStatus::Completed(_) | VerificationStatus::Restored(_))
+            ),
+            "Issue spec should restore with a stable verification status"
+        );
     }
+
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(format!("{db_path}-wal"));
+    let _ = std::fs::remove_file(format!("{db_path}-shm"));
+}
+
+#[tokio::test]
+async fn test_restore_installed_app_heals_pending_specs_on_restart() {
+    let db_path = format!("/tmp/temper-test-heal-{}.db", uuid::Uuid::new_v4());
+    let db_url = format!("file:{db_path}");
+
+    let turso = temper_store_turso::TursoEventStore::new(&db_url, None)
+        .await
+        .unwrap();
+    let mut state = PlatformState::new(None);
+    state.server.event_store = Some(std::sync::Arc::new(
+        temper_server::event_store::ServerEventStore::Turso(turso),
+    ));
+
+    install_skill(&state, "test-heal", "project-management")
+        .await
+        .expect("install should succeed");
+
+    let turso_ref = state
+        .server
+        .event_store
+        .as_ref()
+        .unwrap()
+        .platform_turso_store()
+        .unwrap();
+
+    for entity_type in ["Issue", "Project", "Cycle", "Comment", "Label"] {
+        turso_ref
+            .persist_spec_verification(
+                "test-heal",
+                entity_type,
+                TursoSpecVerificationUpdate {
+                    status: "pending",
+                    verified: false,
+                    levels_passed: None,
+                    levels_total: None,
+                    verification_result_json: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        state.registry.write().unwrap().set_verification_status(
+            &TenantId::new("test-heal"),
+            entity_type,
+            VerificationStatus::Pending,
+        );
+    }
+
+    crate::recovery::restore_installed_apps(&state, turso_ref).await;
+
+    {
+        let registry = state.registry.read().unwrap();
+        let tenant = TenantId::new("test-heal");
+        assert!(
+            matches!(
+                registry.get_verification_status(&tenant, "Issue"),
+                Some(VerificationStatus::Completed(_) | VerificationStatus::Restored(_))
+            ),
+            "Issue spec should be healed out of pending after recovery"
+        );
+    }
+
+    let rows = turso_ref.load_specs().await.unwrap();
+    let issue_row = rows
+        .iter()
+        .find(|r| r.tenant == "test-heal" && r.entity_type == "Issue")
+        .expect("Issue row should exist");
+    assert!(
+        issue_row.verified,
+        "Issue row should be durably re-marked verified during recovery"
+    );
+    assert_ne!(
+        issue_row.verification_status.to_lowercase(),
+        "pending",
+        "Issue row should not remain pending after recovery"
+    );
 
     let _ = std::fs::remove_file(&db_path);
     let _ = std::fs::remove_file(format!("{db_path}-wal"));
@@ -712,6 +815,87 @@ fn test_reload_picks_up_disk_changes() {
         !skills.is_empty(),
         "catalog should not be empty after reload"
     );
+}
+
+#[test]
+fn test_manifest_parses_startup_install_and_wasm_loading_policy() {
+    let temp_dir =
+        std::env::temp_dir().join(format!("temper-app-manifest-test-{}", uuid::Uuid::new_v4()));
+    fs::create_dir_all(&temp_dir).unwrap();
+    fs::write(
+        temp_dir.join("app.toml"),
+        r#"name = "core-app"
+description = "Core app"
+version = "1.0.0"
+startup_install = "core"
+
+[[wasm_modules]]
+name = "echo"
+criticality = "app-required"
+startup_loading = "lazy"
+"#,
+    )
+    .unwrap();
+
+    let manifest = read_app_manifest(&temp_dir).expect("manifest should parse");
+    assert_eq!(manifest.startup_install, StartupInstallMode::Core);
+    assert_eq!(manifest.wasm_modules.len(), 1);
+    assert_eq!(manifest.wasm_modules[0].name, "echo");
+    assert_eq!(
+        manifest.wasm_modules[0].criticality,
+        WasmModuleCriticality::AppRequired
+    );
+    assert_eq!(
+        manifest.wasm_modules[0].startup_loading,
+        WasmStartupLoading::Lazy
+    );
+
+    let _ = fs::remove_dir_all(&temp_dir);
+}
+
+#[test]
+fn test_load_app_bundle_carries_wasm_module_contracts() {
+    let temp_dir =
+        std::env::temp_dir().join(format!("temper-app-bundle-test-{}", uuid::Uuid::new_v4()));
+    let module_dir = temp_dir
+        .join("wasm")
+        .join("echo")
+        .join("target")
+        .join("wasm32-unknown-unknown")
+        .join("release");
+    fs::create_dir_all(&module_dir).unwrap();
+    fs::write(
+        temp_dir.join("app.toml"),
+        r#"name = "bundle-app"
+description = "Bundle app"
+version = "1.0.0"
+startup_install = "manual"
+
+[[wasm_modules]]
+name = "echo"
+criticality = "app-required"
+startup_loading = "lazy"
+"#,
+    )
+    .unwrap();
+    fs::write(temp_dir.join("APP.md"), "# Bundle App\n\nTest.\n").unwrap();
+    fs::copy(
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../temper-wasm/tests/fixtures/echo_integration.wasm"),
+        module_dir.join("echo.wasm"),
+    )
+    .unwrap();
+
+    let bundle = load_app_bundle(&temp_dir).expect("bundle should load");
+    assert!(bundle.wasm_modules.contains_key("echo"));
+    let config = bundle
+        .wasm_module_configs
+        .get("echo")
+        .expect("wasm module config should be present");
+    assert_eq!(config.startup_loading, WasmStartupLoading::Lazy);
+    assert_eq!(config.criticality, WasmModuleCriticality::AppRequired);
+
+    let _ = fs::remove_dir_all(&temp_dir);
 }
 
 #[test]

--- a/crates/temper-platform/src/os_apps/types.rs
+++ b/crates/temper-platform/src/os_apps/types.rs
@@ -1,0 +1,155 @@
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+
+use super::{AdrEntry, AgentDefinition, AppSkillDefinition, SeedInstance, SystemFileEntry};
+
+/// Result of an app installation, categorising each spec by what happened.
+#[derive(Debug, Clone, Serialize)]
+pub struct InstallResult {
+    /// Entity types registered for the first time.
+    pub added: Vec<String>,
+    /// Entity types that already existed but whose IOA source changed.
+    pub updated: Vec<String>,
+    /// Entity types whose IOA source was byte-for-byte identical — skipped.
+    pub skipped: Vec<String>,
+    /// WASM modules compiled and registered.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub wasm_modules: Vec<String>,
+    /// WASM modules intentionally skipped (for example, optional modules
+    /// without a bundled artifact).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub wasm_skipped: Vec<String>,
+    /// WASM modules that failed validation or eager warm-up.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub wasm_failures: Vec<String>,
+    /// Agent definitions bootstrapped.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub agents: Vec<String>,
+    /// Skill definitions bootstrapped.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub skills: Vec<String>,
+    /// ADR markdown files bootstrapped into TemperFS.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub adrs_bootstrapped: Vec<String>,
+    /// Seed data instances created.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub seed_instances: Vec<String>,
+}
+
+/// Parsed app.toml manifest.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct AppManifest {
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default = "default_version")]
+    pub version: String,
+    #[serde(default)]
+    pub startup_install: StartupInstallMode,
+    #[serde(default)]
+    pub dependencies: Vec<String>,
+    #[serde(default)]
+    pub wasm_modules: Vec<WasmModuleManifest>,
+}
+
+fn default_version() -> String {
+    "0.1.0".to_string()
+}
+
+/// Whether an app should be installed during the default OpenPaw startup path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum StartupInstallMode {
+    /// The app is required for the core platform boot surface.
+    Core,
+    /// The app is available for install, but not part of the default boot path.
+    #[default]
+    Manual,
+}
+
+/// Whether a WASM module should be eagerly compiled when its app is installed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum WasmStartupLoading {
+    /// Compile immediately when the app is installed.
+    Eager,
+    /// Register and persist only; compile lazily on first invoke.
+    #[default]
+    Lazy,
+}
+
+/// Capability criticality for a WASM module in an app bundle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum WasmModuleCriticality {
+    PlatformRequired,
+    AppRequired,
+    #[default]
+    Optional,
+}
+
+/// Manifest-declared WASM module contract.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct WasmModuleManifest {
+    pub name: String,
+    #[serde(default)]
+    pub target: Option<String>,
+    #[serde(default)]
+    pub criticality: WasmModuleCriticality,
+    #[serde(default)]
+    pub startup_loading: WasmStartupLoading,
+    #[serde(default)]
+    pub provenance: Option<String>,
+    #[serde(default)]
+    pub import_class: Option<String>,
+}
+
+/// Metadata for an app in the catalog.
+#[derive(Debug, Clone, Serialize)]
+pub struct AppEntry {
+    /// Short name used in CLI flags and API calls (e.g. `"project-management"`).
+    pub name: String,
+    /// Human-readable description.
+    pub description: String,
+    /// Entity types included in the app.
+    pub entity_types: Vec<String>,
+    /// Semantic version.
+    pub version: String,
+    /// Whether the app belongs to the default startup install surface.
+    #[serde(default)]
+    pub startup_install: StartupInstallMode,
+    /// Full app guide markdown (from `APP.md`/`app.md`/`skill.md`), if available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_guide: Option<String>,
+    /// Declared dependencies (from app.toml).
+    #[serde(default)]
+    pub dependencies: Vec<String>,
+}
+
+// Backward-compatible alias: SkillEntry → AppEntry.
+pub type SkillEntry = AppEntry;
+
+/// Full spec bundle for an app (owned, loaded from disk).
+pub struct AppBundle {
+    /// IOA spec sources as `(entity_type, ioa_toml_source)` pairs.
+    pub specs: Vec<(String, String)>,
+    /// CSDL XML source (None if app has no IOA specs).
+    pub csdl: Option<String>,
+    /// Cedar policy sources (may be empty).
+    pub cedar_policies: Vec<String>,
+    /// WASM module binaries as `(module_name, wasm_bytes)` pairs.
+    pub wasm_modules: BTreeMap<String, Vec<u8>>,
+    /// WASM module contracts declared in `app.toml`.
+    pub wasm_module_configs: BTreeMap<String, WasmModuleManifest>,
+    /// Agent definitions discovered from `agents/` subdirectories.
+    pub agents: Vec<AgentDefinition>,
+    /// Skill definitions discovered from `skills/` subdirectories.
+    pub skills: Vec<AppSkillDefinition>,
+    /// ADR markdown files discovered from `adrs/`.
+    pub adrs: Vec<AdrEntry>,
+    /// System files discovered from `system/` directory tree.
+    pub system_files: Vec<SystemFileEntry>,
+    /// Seed data instances discovered from `seed-data/` TOML files.
+    pub seed_instances: Vec<SeedInstance>,
+}

--- a/crates/temper-platform/src/recovery.rs
+++ b/crates/temper-platform/src/recovery.rs
@@ -9,6 +9,7 @@
 
 use temper_runtime::tenant::TenantId;
 use temper_server::platform_store::PlatformStore;
+use temper_server::registry::VerificationStatus;
 
 use crate::os_apps;
 use crate::state::PlatformState;
@@ -77,8 +78,9 @@ pub async fn restore_installed_apps(state: &PlatformState, ps: &dyn PlatformStor
     };
 
     for (tenant, app_name) in installed {
-        // Check if the app's entity types are already in the registry.
-        if tenant_has_app_specs(state, &tenant, &app_name) {
+        // Only skip recovery if the app's specs are both present and in a
+        // stable verified/restored state. Pending specs must be healed.
+        if tenant_has_ready_app_specs(state, &tenant, &app_name) {
             continue;
         }
 
@@ -114,15 +116,20 @@ pub async fn restore_installed_os_apps(state: &PlatformState, ps: &dyn PlatformS
 }
 
 /// Check if all entity types for an app are already registered.
-fn tenant_has_app_specs(state: &PlatformState, tenant: &str, app_name: &str) -> bool {
+fn tenant_has_ready_app_specs(state: &PlatformState, tenant: &str, app_name: &str) -> bool {
     let Some(bundle) = os_apps::get_os_app(app_name) else {
         return false;
     };
     let tenant_id = TenantId::new(tenant);
     let registry = state.registry.read().unwrap(); // ci-ok: infallible lock
     bundle.specs.iter().all(|(entity_type, _)| {
-        registry
+        let has_table = registry
             .get_table(&tenant_id, entity_type.as_str())
-            .is_some()
+            .is_some();
+        let is_ready = matches!(
+            registry.get_verification_status(&tenant_id, entity_type.as_str()),
+            Some(VerificationStatus::Completed(_) | VerificationStatus::Restored(_))
+        );
+        has_table && is_ready
     })
 }

--- a/crates/temper-server/src/observe/metrics.rs
+++ b/crates/temper-server/src/observe/metrics.rs
@@ -53,12 +53,16 @@ pub(crate) async fn handle_health(State(state): State<ServerState>) -> Json<serd
         count
     };
 
-    let active_entities = {
+    let active_actors = {
         let reg = state
             .actor_registry
             .read()
             .unwrap_or_else(|e| e.into_inner());
         reg.len() as u64
+    };
+    let indexed_entities = {
+        let index = state.entity_index.read().unwrap_or_else(|e| e.into_inner());
+        index.values().map(|ids| ids.len() as u64).sum::<u64>()
     };
 
     let transitions_total = state.metrics.transitions_total.load(Ordering::Relaxed);
@@ -74,7 +78,8 @@ pub(crate) async fn handle_health(State(state): State<ServerState>) -> Json<serd
         "status": "healthy",
         "uptime_seconds": uptime,
         "specs_loaded": specs_loaded,
-        "active_entities": active_entities,
+        "active_actors": active_actors,
+        "indexed_entities": indexed_entities,
         "transitions_total": transitions_total,
         "errors_total": errors_total,
         "event_store": event_store_type,
@@ -116,11 +121,11 @@ pub(crate) async fn handle_metrics(
         }
     }
 
-    // -- temper_active_entities --
+    // -- temper_indexed_entities --
     lines.push(
-        "# HELP temper_active_entities Number of currently active entity actors.".to_string(),
+        "# HELP temper_indexed_entities Number of entities currently present in the in-memory query-plane index.".to_string(),
     );
-    lines.push("# TYPE temper_active_entities gauge".to_string());
+    lines.push("# TYPE temper_indexed_entities gauge".to_string());
     {
         // Count per entity_type from the entity index.
         let index = state.entity_index.read().unwrap_or_else(|e| e.into_inner());
@@ -128,7 +133,7 @@ pub(crate) async fn handle_metrics(
             // key format: "tenant:entity_type"
             if let Some(entity_type) = key.split(':').nth(1) {
                 lines.push(format!(
-                    "temper_active_entities{{entity_type=\"{}\"}} {}",
+                    "temper_indexed_entities{{entity_type=\"{}\"}} {}",
                     entity_type,
                     ids.len()
                 ));

--- a/crates/temper-server/src/observe/mod_test.rs
+++ b/crates/temper-server/src/observe/mod_test.rs
@@ -571,7 +571,8 @@ async fn test_health_counts_entities_and_transitions() {
         .await
         .unwrap();
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(json["active_entities"], 1);
+    assert_eq!(json["active_actors"], 1);
+    assert_eq!(json["indexed_entities"], 1);
     assert_eq!(json["transitions_total"], 1);
     assert_eq!(json["errors_total"], 0);
 }
@@ -639,8 +640,8 @@ async fn test_metrics_returns_prometheus_format() {
         "should contain transitions metric"
     );
     assert!(
-        text.contains("temper_active_entities"),
-        "should contain active entities metric"
+        text.contains("temper_indexed_entities"),
+        "should contain indexed entities metric"
     );
 }
 

--- a/crates/temper-server/src/runtime_metrics.rs
+++ b/crates/temper-server/src/runtime_metrics.rs
@@ -16,7 +16,7 @@ use crate::state::ServerState;
 struct RuntimeMetrics {
     process_resident_memory_bytes: Gauge<u64>,
     active_actors: Gauge<u64>,
-    active_entities: Gauge<u64>,
+    indexed_entities: Gauge<u64>,
     projection_backfill_snapshot_misses_total: Counter<u64>,
     event_replay_duration: Histogram<f64>,
     blob_io_wait_duration_ms: Histogram<f64>,
@@ -39,9 +39,11 @@ fn metrics() -> &'static RuntimeMetrics {
                 .u64_gauge("temper_active_actors")
                 .with_description("Number of currently active spawned entity actors.")
                 .build(),
-            active_entities: meter
-                .u64_gauge("temper_active_entities")
-                .with_description("Number of hydrated entities currently indexed by tenant.")
+            indexed_entities: meter
+                .u64_gauge("temper_indexed_entities")
+                .with_description(
+                    "Number of entities currently present in the in-memory query-plane index, reported globally and by tenant.",
+                )
                 .build(),
             projection_backfill_snapshot_misses_total: meter
                 .u64_counter("temper_projection_backfill_snapshot_misses_total")
@@ -108,11 +110,11 @@ pub fn record_active_entity_counts(index: &BTreeMap<String, BTreeSet<String>>) {
     }
 
     let total: u64 = by_tenant.values().copied().sum();
-    metrics().active_entities.record(total, &[]);
+    metrics().indexed_entities.record(total, &[]);
 
     for (tenant, count) in by_tenant {
         metrics()
-            .active_entities
+            .indexed_entities
             .record(count, &[KeyValue::new("tenant", tenant)]);
     }
 }

--- a/crates/temper-server/src/state/dispatch/wasm.rs
+++ b/crates/temper-server/src/state/dispatch/wasm.rs
@@ -285,6 +285,8 @@ impl crate::state::ServerState {
                 .handle_module_not_found(ctx, integration, &module_name)
                 .await;
         };
+        self.ensure_wasm_module_cached(ctx.entity_ref.tenant, &module_name, &hash)
+            .await?;
         let trigger_params = self
             .maybe_inject_ots_trajectory_actions(&module_name, ctx, action_params)
             .await;
@@ -868,6 +870,8 @@ impl crate::state::ServerState {
         let hash = module_hash.ok_or_else(|| {
             format!("WASM module '{module_name}' not found for tenant '{tenant}'")
         })?;
+        self.ensure_wasm_module_cached(tenant, module_name, &hash)
+            .await?;
 
         // Build authorized host chain
         let base_gate = self.wasm_authz_gate();

--- a/crates/temper-server/src/state/persistence/mod.rs
+++ b/crates/temper-server/src/state/persistence/mod.rs
@@ -129,6 +129,97 @@ impl ServerState {
         }
     }
 
+    /// Ensure a registered WASM module is compiled and cached in-memory.
+    ///
+    /// Startup recovery restores registry entries without eagerly compiling
+    /// every persisted module. The first invocation compiles on demand.
+    pub async fn ensure_wasm_module_cached(
+        &self,
+        tenant: &temper_runtime::tenant::TenantId,
+        module_name: &str,
+        expected_hash: &str,
+    ) -> Result<(), String> {
+        if self.wasm_engine.is_cached(expected_hash) {
+            return Ok(());
+        }
+
+        let tenant_name = tenant.to_string();
+        let Some(backend) = self.metadata_backend_for_tenant(&tenant_name).await else {
+            return Err(format!(
+                "cannot lazy-load WASM module '{module_name}' for tenant '{tenant_name}' without a metadata backend"
+            ));
+        };
+
+        let (wasm_bytes, stored_hash) = match backend {
+            TenantMetadataBackend::Postgres(pool) => {
+                let row: Option<(Vec<u8>, String)> = sqlx::query_as(
+                    "SELECT wasm_bytes, sha256_hash FROM wasm_modules WHERE tenant = $1 AND module_name = $2",
+                )
+                .bind(&tenant_name)
+                .bind(module_name)
+                .fetch_optional(&pool)
+                .await
+                .map_err(|e| {
+                    format!(
+                        "failed to lazy-load WASM module {tenant_name}/{module_name} from postgres: {e}"
+                    )
+                })?;
+                let Some((wasm_bytes, sha256_hash)) = row else {
+                    return Err(format!(
+                        "WASM module '{module_name}' not found in persistence for tenant '{tenant_name}'"
+                    ));
+                };
+                (wasm_bytes, sha256_hash)
+            }
+            TenantMetadataBackend::Turso(turso) => {
+                let row = turso
+                    .load_wasm_module(&tenant_name, module_name)
+                    .await
+                    .map_err(|e| {
+                        format!(
+                            "failed to lazy-load WASM module {tenant_name}/{module_name} from turso: {e}"
+                        )
+                    })?;
+                let Some(row) = row else {
+                    return Err(format!(
+                        "WASM module '{module_name}' not found in persistence for tenant '{tenant_name}'"
+                    ));
+                };
+                (row.wasm_bytes, row.sha256_hash)
+            }
+            TenantMetadataBackend::Redis => {
+                return Err(Self::redis_ephemeral_error("WASM lazy-load"));
+            }
+        };
+
+        let resolved_hash = if stored_hash.is_empty() {
+            temper_wasm::WasmEngine::hash_module(&wasm_bytes)
+        } else {
+            stored_hash
+        };
+        if resolved_hash != expected_hash {
+            return Err(format!(
+                "WASM module hash mismatch for {tenant_name}/{module_name}: registry={expected_hash} persisted={resolved_hash}"
+            ));
+        }
+
+        self.wasm_engine
+            .compile_and_cache(&wasm_bytes)
+            .map(|_| {
+                tracing::info!(
+                    tenant = %tenant_name,
+                    module = %module_name,
+                    hash = %expected_hash,
+                    "lazy-compiled persisted WASM module on first use"
+                );
+            })
+            .map_err(|e| {
+                format!(
+                    "failed to compile lazy-loaded WASM module {tenant_name}/{module_name}: {e}"
+                )
+            })
+    }
+
     /// Persist a WASM invocation log entry (Postgres or Turso).
     ///
     /// Fire-and-forget — callers should not block the dispatch path on this.
@@ -198,8 +289,8 @@ impl ServerState {
 
     /// Load all WASM modules from the persistence backend and register them.
     ///
-    /// For each module, compiles the bytes via `WasmEngine::compile_and_cache()`
-    /// and registers in the `WasmModuleRegistry`.
+    /// Startup recovery now restores registry entries only; compilation is
+    /// deferred until first invoke via [`ensure_wasm_module_cached`].
     pub async fn load_wasm_modules(&self) -> Result<usize, String> {
         let Some(store) = self.event_store.as_ref() else {
             return Ok(0);
@@ -209,30 +300,35 @@ impl ServerState {
 
         // Postgres path.
         if let Some(pool) = store.postgres_pool() {
-            let rows: Vec<(String, String, Vec<u8>, String)> = sqlx::query_as(
-                "SELECT tenant, module_name, wasm_bytes, sha256_hash FROM wasm_modules ORDER BY tenant, module_name",
+            let rows: Vec<(String, String, String)> = sqlx::query_as(
+                "SELECT tenant, module_name, sha256_hash FROM wasm_modules ORDER BY tenant, module_name",
             )
             .fetch_all(pool)
             .await
             .map_err(|e| format!("failed to load WASM modules from postgres: {e}"))?;
 
-            for (tenant, module_name, wasm_bytes, _stored_hash) in rows {
-                match self.wasm_engine.compile_and_cache(&wasm_bytes) {
-                    Ok(hash) => {
-                        let tenant_id = temper_runtime::tenant::TenantId::new(&tenant);
-                        let mut wasm_reg = self.wasm_module_registry.write().unwrap(); // ci-ok: infallible lock
-                        wasm_reg.register(&tenant_id, &module_name, &hash);
-                        recovered += 1;
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            tenant = %tenant,
-                            module = %module_name,
-                            error = %e,
-                            "failed to compile recovered WASM module, skipping"
-                        );
-                    }
-                }
+            for (tenant, module_name, stored_hash) in rows {
+                let hash = if stored_hash.is_empty() {
+                    let wasm_bytes: Vec<u8> = sqlx::query_scalar(
+                        "SELECT wasm_bytes FROM wasm_modules WHERE tenant = $1 AND module_name = $2",
+                    )
+                    .bind(&tenant)
+                    .bind(&module_name)
+                    .fetch_one(pool)
+                    .await
+                    .map_err(|e| {
+                        format!(
+                            "failed to recover legacy WASM bytes for {tenant}/{module_name} from postgres: {e}"
+                        )
+                    })?;
+                    temper_wasm::WasmEngine::hash_module(&wasm_bytes)
+                } else {
+                    stored_hash
+                };
+                let tenant_id = temper_runtime::tenant::TenantId::new(&tenant);
+                let mut wasm_reg = self.wasm_module_registry.write().unwrap(); // ci-ok: infallible lock
+                wasm_reg.register(&tenant_id, &module_name, &hash);
+                recovered += 1;
             }
             return Ok(recovered);
         }
@@ -240,27 +336,35 @@ impl ServerState {
         // Turso path (single-DB).
         if let Some(turso) = store.platform_turso_store() {
             let rows = turso
-                .load_wasm_modules_all_tenants()
+                .load_wasm_module_metadata_all_tenants()
                 .await
                 .map_err(|e| format!("failed to load WASM modules from turso: {e}"))?;
 
             for row in rows {
-                match self.wasm_engine.compile_and_cache(&row.wasm_bytes) {
-                    Ok(hash) => {
-                        let tenant_id = temper_runtime::tenant::TenantId::new(&row.tenant);
-                        let mut wasm_reg = self.wasm_module_registry.write().unwrap(); // ci-ok: infallible lock
-                        wasm_reg.register(&tenant_id, &row.module_name, &hash);
-                        recovered += 1;
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            tenant = %row.tenant,
-                            module = %row.module_name,
-                            error = %e,
-                            "failed to compile recovered WASM module, skipping"
-                        );
-                    }
-                }
+                let hash = if row.sha256_hash.is_empty() {
+                    let full_row = turso
+                        .load_wasm_module(&row.tenant, &row.module_name)
+                        .await
+                        .map_err(|e| {
+                            format!(
+                                "failed to recover legacy WASM bytes for {}/{} from turso: {e}",
+                                row.tenant, row.module_name
+                            )
+                        })?
+                        .ok_or_else(|| {
+                            format!(
+                                "legacy WASM module bytes missing for {}/{} in turso",
+                                row.tenant, row.module_name
+                            )
+                        })?;
+                    temper_wasm::WasmEngine::hash_module(&full_row.wasm_bytes)
+                } else {
+                    row.sha256_hash.clone()
+                };
+                let tenant_id = temper_runtime::tenant::TenantId::new(&row.tenant);
+                let mut wasm_reg = self.wasm_module_registry.write().unwrap(); // ci-ok: infallible lock
+                wasm_reg.register(&tenant_id, &row.module_name, &hash);
+                recovered += 1;
             }
             return Ok(recovered);
         }
@@ -270,16 +374,28 @@ impl ServerState {
             // Load from platform store (system modules).
             if let Ok(rows) = router
                 .platform_store()
-                .load_wasm_modules_all_tenants()
+                .load_wasm_module_metadata_all_tenants()
                 .await
             {
                 for row in rows {
-                    if let Ok(hash) = self.wasm_engine.compile_and_cache(&row.wasm_bytes) {
-                        let tenant_id = temper_runtime::tenant::TenantId::new(&row.tenant);
-                        let mut wasm_reg = self.wasm_module_registry.write().unwrap(); // ci-ok: infallible lock
-                        wasm_reg.register(&tenant_id, &row.module_name, &hash);
-                        recovered += 1;
-                    }
+                    let hash = if row.sha256_hash.is_empty() {
+                        let Some(full_row) = router
+                            .platform_store()
+                            .load_wasm_module(&row.tenant, &row.module_name)
+                            .await
+                            .ok()
+                            .flatten()
+                        else {
+                            continue;
+                        };
+                        temper_wasm::WasmEngine::hash_module(&full_row.wasm_bytes)
+                    } else {
+                        row.sha256_hash.clone()
+                    };
+                    let tenant_id = temper_runtime::tenant::TenantId::new(&row.tenant);
+                    let mut wasm_reg = self.wasm_module_registry.write().unwrap(); // ci-ok: infallible lock
+                    wasm_reg.register(&tenant_id, &row.module_name, &hash);
+                    recovered += 1;
                 }
             }
             // Load from each tenant store.
@@ -287,26 +403,27 @@ impl ServerState {
                 let Ok(turso) = router.store_for_tenant(&tid).await else {
                     continue;
                 };
-                let Ok(rows) = turso.load_wasm_modules_all_tenants().await else {
+                let Ok(rows) = turso.load_wasm_module_metadata_all_tenants().await else {
                     continue;
                 };
                 for row in rows {
-                    match self.wasm_engine.compile_and_cache(&row.wasm_bytes) {
-                        Ok(hash) => {
-                            let tenant_id = temper_runtime::tenant::TenantId::new(&row.tenant);
-                            let mut wasm_reg = self.wasm_module_registry.write().unwrap(); // ci-ok: infallible lock
-                            wasm_reg.register(&tenant_id, &row.module_name, &hash);
-                            recovered += 1;
-                        }
-                        Err(e) => {
-                            tracing::warn!(
-                                tenant = %row.tenant,
-                                module = %row.module_name,
-                                error = %e,
-                                "failed to compile recovered WASM module, skipping"
-                            );
-                        }
-                    }
+                    let hash = if row.sha256_hash.is_empty() {
+                        let Some(full_row) = turso
+                            .load_wasm_module(&row.tenant, &row.module_name)
+                            .await
+                            .ok()
+                            .flatten()
+                        else {
+                            continue;
+                        };
+                        temper_wasm::WasmEngine::hash_module(&full_row.wasm_bytes)
+                    } else {
+                        row.sha256_hash.clone()
+                    };
+                    let tenant_id = temper_runtime::tenant::TenantId::new(&row.tenant);
+                    let mut wasm_reg = self.wasm_module_registry.write().unwrap(); // ci-ok: infallible lock
+                    wasm_reg.register(&tenant_id, &row.module_name, &hash);
+                    recovered += 1;
                 }
             }
             return Ok(recovered);

--- a/crates/temper-server/src/state/runtime_metrics.rs
+++ b/crates/temper-server/src/state/runtime_metrics.rs
@@ -13,7 +13,7 @@ struct RuntimeMetricInstruments {
     up: Gauge<u64>,
     process_resident_memory_bytes: Gauge<u64>,
     active_actors: Gauge<u64>,
-    active_entities: Gauge<u64>,
+    indexed_entities: Gauge<u64>,
     projected_entities: Gauge<u64>,
     projection_coverage_ratio: Gauge<f64>,
 }
@@ -37,9 +37,9 @@ impl RuntimeMetricInstruments {
                 .u64_gauge("temper_active_actors")
                 .with_description("Number of active in-memory actors.")
                 .build(),
-            active_entities: meter
-                .u64_gauge("temper_active_entities")
-                .with_description("Number of active indexed entities.")
+            indexed_entities: meter
+                .u64_gauge("temper_indexed_entities")
+                .with_description("Number of entities currently present in the in-memory query-plane index.")
                 .build(),
             projected_entities: meter
                 .u64_gauge("temper_projected_entities")
@@ -62,7 +62,7 @@ impl RuntimeMetricInstruments {
         self.active_actors.record(state.active_actor_count(), &[]);
         let indexed_by_tenant = state.active_entity_counts_by_tenant();
         let indexed_total: u64 = indexed_by_tenant.values().copied().sum();
-        self.active_entities.record(indexed_total, &[]);
+        self.indexed_entities.record(indexed_total, &[]);
 
         if let Some(store) = state.event_store.as_ref()
             && let Ok(Some(projected_by_tenant)) = store.projected_entity_counts_by_tenant().await

--- a/crates/temper-server/tests/wasm_dispatch.rs
+++ b/crates/temper-server/tests/wasm_dispatch.rs
@@ -300,6 +300,132 @@ async fn wasm_integration_dispatches_callback() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn persisted_wasm_modules_are_lazy_compiled_on_first_invoke() {
+    let state = build_echo_test_state_with_turso().await;
+    let tenant = TenantId::default();
+    let hash = temper_wasm::WasmEngine::hash_module(ECHO_WASM);
+
+    state
+        .upsert_wasm_module("default", "echo_integration", ECHO_WASM, &hash)
+        .await
+        .expect("persist echo module");
+    state
+        .load_wasm_modules()
+        .await
+        .expect("recover persisted wasm modules");
+
+    {
+        let wasm_reg = state
+            .wasm_module_registry
+            .read()
+            .expect("wasm registry lock"); // ci-ok: infallible lock
+        assert_eq!(
+            wasm_reg.get_hash(&tenant, "echo_integration"),
+            Some(hash.as_str())
+        );
+    }
+    assert!(
+        !state.wasm_engine.is_cached(&hash),
+        "startup recovery should register the module without eagerly compiling it"
+    );
+
+    let response = state
+        .dispatch_tenant_action(
+            &tenant,
+            "EchoTest",
+            "echo-lazy-1",
+            "TriggerEcho",
+            serde_json::json!({}),
+            &AgentContext::default(),
+        )
+        .await
+        .expect("TriggerEcho should succeed");
+
+    assert!(response.success, "TriggerEcho should succeed");
+    let final_status = wait_for_status(
+        &state,
+        &tenant,
+        "EchoTest",
+        "echo-lazy-1",
+        &["Done", "Failed"],
+        Duration::from_secs(5),
+    )
+    .await;
+    assert_eq!(final_status, "Done");
+    assert!(
+        state.wasm_engine.is_cached(&hash),
+        "the first invoke should lazily compile the recovered module"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn persisted_wasm_modules_with_missing_hash_still_execute_after_startup_restore() {
+    let state = build_echo_test_state_with_turso().await;
+    let tenant = TenantId::default();
+    let turso = state
+        .platform_persistent_store()
+        .expect("turso backend required");
+
+    turso
+        .upsert_wasm_module("default", "echo_integration", ECHO_WASM, "")
+        .await
+        .expect("persist legacy echo module with missing hash");
+
+    state
+        .load_wasm_modules()
+        .await
+        .expect("recover persisted wasm modules");
+
+    let recovered_hash = {
+        let wasm_reg = state
+            .wasm_module_registry
+            .read()
+            .expect("wasm registry lock"); // ci-ok: infallible lock
+        wasm_reg
+            .get_hash(&tenant, "echo_integration")
+            .expect("legacy module should still be registered")
+            .to_string()
+    };
+
+    assert!(
+        !recovered_hash.is_empty(),
+        "startup restore should recover a usable hash even for legacy rows"
+    );
+    assert!(
+        !state.wasm_engine.is_cached(&recovered_hash),
+        "startup restore should still avoid eager compilation for legacy rows"
+    );
+
+    let response = state
+        .dispatch_tenant_action(
+            &tenant,
+            "EchoTest",
+            "echo-legacy-hash",
+            "TriggerEcho",
+            serde_json::json!({}),
+            &AgentContext::default(),
+        )
+        .await
+        .expect("TriggerEcho should succeed");
+
+    assert!(response.success, "TriggerEcho should succeed");
+    let final_status = wait_for_status(
+        &state,
+        &tenant,
+        "EchoTest",
+        "echo-legacy-hash",
+        &["Done", "Failed"],
+        Duration::from_secs(5),
+    )
+    .await;
+    assert_eq!(final_status, "Done");
+    assert!(
+        state.wasm_engine.is_cached(&recovered_hash),
+        "legacy recovered modules should still lazy-compile on first invoke"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn wasm_missing_module_dispatches_failure_callback() {
     let state = build_echo_test_state();
     let tenant = TenantId::default();

--- a/crates/temper-store-turso/src/lib.rs
+++ b/crates/temper-store-turso/src/lib.rs
@@ -72,6 +72,7 @@ pub use router::{TenantRegistryRow, TenantStoreRouter, TenantUserRow};
 pub use store::{
     ActionStats, AgentSummary, DesignTimeEventRow, EvolutionRecordRow, FeatureRequestRow,
     PolicyDenialPatternRow, PolicyRow, TursoEventStore, TursoSpecRow, TursoTenantConstraintRow,
-    TursoTrajectoryRow, TursoWasmInvocationRow, TursoWasmModuleRow, UnmetIntentAggRow,
+    TursoTrajectoryRow, TursoWasmInvocationRow, TursoWasmModuleMetadataRow, TursoWasmModuleRow,
+    UnmetIntentAggRow,
     ots::{OtsTrajectoryParams, OtsTrajectoryRow},
 };

--- a/crates/temper-store-turso/src/store/mod.rs
+++ b/crates/temper-store-turso/src/store/mod.rs
@@ -542,6 +542,21 @@ pub struct TursoWasmModuleRow {
     pub updated_at: String,
 }
 
+/// Metadata row returned by startup WASM registry restore queries.
+#[derive(Debug, Clone)]
+pub struct TursoWasmModuleMetadataRow {
+    /// Tenant name.
+    pub tenant: String,
+    /// Module name.
+    pub module_name: String,
+    /// SHA-256 hash of the WASM binary.
+    pub sha256_hash: String,
+    /// Module size in bytes.
+    pub size_bytes: i32,
+    /// ISO-8601 updated_at timestamp.
+    pub updated_at: String,
+}
+
 /// Row returned by WASM invocation log queries.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct TursoWasmInvocationRow {

--- a/crates/temper-store-turso/src/store/tests.rs
+++ b/crates/temper-store-turso/src/store/tests.rs
@@ -423,3 +423,41 @@ async fn query_projection_roundtrip_updates_catalog_and_field_index() {
         "entity catalog should be empty after removing the projection"
     );
 }
+
+#[tokio::test]
+async fn load_wasm_module_metadata_all_tenants_returns_metadata_without_bulk_bytes() {
+    let store = make_store("wasm-metadata").await;
+
+    store
+        .upsert_wasm_module("tenant-a", "mod-a", b"hello-a", "hash-a")
+        .await
+        .expect("persist mod-a");
+    store
+        .upsert_wasm_module("tenant-b", "mod-b", b"hello-b", "hash-b")
+        .await
+        .expect("persist mod-b");
+
+    let rows = store
+        .load_wasm_module_metadata_all_tenants()
+        .await
+        .expect("load wasm metadata");
+
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].tenant, "tenant-a");
+    assert_eq!(rows[0].module_name, "mod-a");
+    assert_eq!(rows[0].sha256_hash, "hash-a");
+    assert_eq!(rows[0].size_bytes, 7);
+    assert!(!rows[0].updated_at.is_empty());
+    assert_eq!(rows[1].tenant, "tenant-b");
+    assert_eq!(rows[1].module_name, "mod-b");
+    assert_eq!(rows[1].sha256_hash, "hash-b");
+    assert_eq!(rows[1].size_bytes, 7);
+    assert!(!rows[1].updated_at.is_empty());
+
+    let full_row = store
+        .load_wasm_module("tenant-a", "mod-a")
+        .await
+        .expect("load full wasm row")
+        .expect("full row should exist");
+    assert_eq!(full_row.wasm_bytes, b"hello-a");
+}

--- a/crates/temper-store-turso/src/store/wasm.rs
+++ b/crates/temper-store-turso/src/store/wasm.rs
@@ -4,7 +4,9 @@ use libsql::params;
 use temper_runtime::persistence::{PersistenceError, storage_error};
 use tracing::instrument;
 
-use super::{TursoEventStore, TursoWasmInvocationRow, TursoWasmModuleRow};
+use super::{
+    TursoEventStore, TursoWasmInvocationRow, TursoWasmModuleMetadataRow, TursoWasmModuleRow,
+};
 use crate::TursoWasmInvocationInsert;
 use crate::metrics::TursoQueryTimer;
 
@@ -115,6 +117,33 @@ impl TursoEventStore {
         Ok(out)
     }
 
+    /// Load WASM module metadata across all tenants without the raw bytes.
+    ///
+    /// Startup registry recovery should use this instead of loading the full
+    /// WASM corpus into memory.
+    #[instrument(skip_all, fields(otel.name = "turso.load_wasm_module_metadata_all_tenants"))]
+    pub async fn load_wasm_module_metadata_all_tenants(
+        &self,
+    ) -> Result<Vec<TursoWasmModuleMetadataRow>, PersistenceError> {
+        let _query_timer = TursoQueryTimer::start("turso.load_wasm_module_metadata_all_tenants");
+        let conn = self.configured_connection().await?;
+        let mut rows = conn
+            .query(
+                "SELECT tenant, module_name, sha256_hash, size_bytes, updated_at \
+                 FROM wasm_modules \
+                 ORDER BY tenant, module_name",
+                (),
+            )
+            .await
+            .map_err(storage_error)?;
+
+        let mut out = Vec::new();
+        while let Some(row) = rows.next().await.map_err(storage_error)? {
+            out.push(Self::row_to_wasm_module_metadata(&row)?);
+        }
+        Ok(out)
+    }
+
     /// Persist a WASM invocation log entry.
     #[instrument(skip_all, fields(otel.name = "turso.persist_wasm_invocation"))]
     pub async fn persist_wasm_invocation(
@@ -214,6 +243,19 @@ impl TursoEventStore {
             version: row.get::<i64>(4).map_err(storage_error)? as i32,
             size_bytes: row.get::<i64>(5).map_err(storage_error)? as i32,
             updated_at: row.get::<String>(6).map_err(storage_error)?,
+        })
+    }
+
+    /// Parse a WASM module metadata row from a libsql Row (5 columns).
+    fn row_to_wasm_module_metadata(
+        row: &libsql::Row,
+    ) -> Result<TursoWasmModuleMetadataRow, PersistenceError> {
+        Ok(TursoWasmModuleMetadataRow {
+            tenant: row.get::<String>(0).map_err(storage_error)?,
+            module_name: row.get::<String>(1).map_err(storage_error)?,
+            sha256_hash: row.get::<String>(2).map_err(storage_error)?,
+            size_bytes: row.get::<i64>(3).map_err(storage_error)? as i32,
+            updated_at: row.get::<String>(4).map_err(storage_error)?,
         })
     }
 }

--- a/crates/temper-wasm/src/engine/tests.rs
+++ b/crates/temper-wasm/src/engine/tests.rs
@@ -101,7 +101,7 @@ fn module_too_large_rejected() {
 fn resource_limits_default() {
     let limits = WasmResourceLimits::default();
     assert_eq!(limits.max_fuel, 1_000_000_000);
-    assert_eq!(limits.max_memory, 64 * 1024 * 1024);
+    assert_eq!(limits.max_memory, 16 * 1024 * 1024);
     assert_eq!(limits.max_duration, std::time::Duration::from_secs(30));
     assert_eq!(limits.max_response_bytes, 1024 * 1024);
 }

--- a/ui/observe/app/(observe)/activity/page.tsx
+++ b/ui/observe/app/(observe)/activity/page.tsx
@@ -332,12 +332,12 @@ export default function ActivityPage() {
         </div>
       )}
 
-      {/* Active Entities */}
+      {/* Hydrated Actors */}
       {entities.length > 0 && (
         <div className="mb-6">
           <div className="flex items-center justify-between mb-3">
             <h2 className="text-base font-semibold text-[var(--color-text-primary)] tracking-tight">
-              Active Entities
+              Hydrated Actors
               <span className="text-[var(--color-text-muted)] font-normal text-[13px] ml-2">{filteredEntities.length}</span>
             </h2>
             <div className="flex items-center gap-2">

--- a/ui/observe/app/(observe)/dashboard/page.tsx
+++ b/ui/observe/app/(observe)/dashboard/page.tsx
@@ -249,7 +249,7 @@ export default function Dashboard() {
         <div>
           <h1 className="text-2xl text-[var(--color-text-primary)] tracking-tight font-serif">Dashboard</h1>
           <p className="text-sm text-[var(--color-text-muted)] mt-0.5">
-            Overview of loaded specs and active entities
+            Overview of loaded specs and hydrated actors
           </p>
         </div>
         <div className="flex items-center gap-3">
@@ -292,7 +292,7 @@ export default function Dashboard() {
           className={`glass rounded-[2px] p-4 ${entityHighlight}`}
           onAnimationEnd={() => setEntityHighlight("")}
         >
-          <div className="text-xs text-[var(--color-text-muted)]">Active Entities</div>
+          <div className="text-xs text-[var(--color-text-muted)]">Hydrated Actors</div>
           <div className="text-4xl font-bold font-mono text-[var(--color-text-primary)] mt-0.5">
             {entities.length}
           </div>

--- a/ui/observe/public/skills/user.md
+++ b/ui/observe/public/skills/user.md
@@ -119,7 +119,7 @@ After reporting an unmet intent:
 | `GET` | `/{tenant}/{EntityType}({id})` | Get entity by ID |
 | `POST` | `/{tenant}/{EntityType}({id})` | Trigger action on entity |
 | `POST` | `/api/evolution/trajectories/unmet` | Report unmet intent |
-| `GET` | `/observe/entities` | List all active entities |
+| `GET` | `/observe/entities` | List all hydrated in-memory entities |
 
 ---
 


### PR DESCRIPTION
## Summary
- restore installed apps safely after startup optimization and heal pending specs on restart
- rename query-plane metrics to indexed entities and switch persisted WASM startup restore to metadata-only lazy loading
- add restart/capability verification coverage for the optimized startup path

## Verification
- cargo test -p temper-platform test_skill_install_survives_restart -- --nocapture
- cargo test -p temper-platform test_restore_installed_app_heals_pending_specs_on_restart -- --nocapture
- cargo test -p temper-server --test wasm_dispatch -- --nocapture
- cargo test -p temper-store-turso load_wasm_module_metadata_all_tenants_returns_metadata_without_bulk_bytes -- --nocapture
- cargo test -p temper-wasm --lib -- --nocapture
- isolated OpenPaw restart and installed-app capability smoke documented in openpaw proof reports
