### PR TITLE
untangle default tenant secrets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,8 +3,8 @@
 ## MANDATORY FIRST ACTION: Check Assigned Issues
 
 **On EVERY session start, your FIRST action — before responding to the user — MUST be:**
-1. Call `mcp__temper__execute` with: `await temper.list("rita-agents", "Issues", "$filter=AssigneeId eq 'claude-code'")`
-2. If the call fails (403/404), install the PM app first: `await temper.install_app("rita-agents", "project-management")`, then retry
+1. Call `mcp__temper__execute` with the tenant configured for the current project, for example: `await temper.list("{tenant}", "Issues", "$filter=AssigneeId eq 'claude-code'")`
+2. If the call fails (403/404), install the PM app first for your configured tenant: `await temper.install_app("{tenant}", "project-management")`, then retry
 3. Summarize assigned issues, then mention other open issues
 4. **Do NOT skip this. Do NOT wait for the user to ask.**
 
@@ -13,7 +13,7 @@
 **You are an agent running on Temper. This is your operating layer — not an optional tool.** When a Temper server is running (`mcp__temper__execute` is available), ALL your stateful work — planning, task tracking, progress, knowledge — MUST flow through Temper entities, not markdown files.
 
 **Specifically:**
-- **Planning and task tracking** → Use the PM OS app (`await temper.install_app("pm")` if not installed, tenant `rita-agents`). Create Issues, use `BeginPlanning` → `WritePlan` → `ApprovePlan` → `StartWork` flow. Do NOT use `.progress/` files when Temper is available.
+- **Planning and task tracking** → Use the PM OS app (`await temper.install_app("{tenant}", "project-management")` if not installed). Create Issues, use `BeginPlanning` → `WritePlan` → `ApprovePlan` → `StartWork` flow. Do NOT use `.progress/` files when Temper is available.
 - **Building apps for users** → Use the Temper App Builder skill (`.claude/skills/temper-developer.md`). Workflow: interview → generate IOA specs + CSDL → verify → deploy. Use `/temper-developer`.
 - **Any MCP tool call** → ALWAYS read `.claude/skills/temper-agent.md` first. It has the exact Python API, spec format, and governance flow.
 
@@ -102,7 +102,7 @@ Cedar policies reference this attribute to distinguish verified agents from unve
 - SpecRegistry maps (TenantId, EntityType) → specs + TransitionTable
 - Postgres/Redis are tenant-scoped
 - Single-tenant uses TenantId::default() = "default"
-- **Active agent tenant: `rita-agents`** — all agent MCP calls should use tenant `"rita-agents"`
+- **Active agent tenant:** use the tenant configured for the current project or server. Pass it explicitly to agent MCP calls instead of assuming a hardcoded repository tenant.
 
 ### Deterministic Simulation (FoundationDB/TigerBeetle Standards)
 In simulation-visible crates (temper-runtime, temper-jit, temper-server):

--- a/crates/temper-cli/src/serve/mod.rs
+++ b/crates/temper-cli/src/serve/mod.rs
@@ -153,10 +153,7 @@ pub async fn run(
         // ANTHROPIC_API_KEY — makes {secret:anthropic_api_key} resolve in LLM integrations.
         if let Ok(key) = std::env::var("ANTHROPIC_API_KEY") {
             // determinism-ok: env var read at startup for configuration
-            let _ = vault.cache_secret("default", "anthropic_api_key", key.clone());
-            if tenant != "default" {
-                let _ = vault.cache_secret(&tenant, "anthropic_api_key", key);
-            }
+            let _ = vault.cache_platform_secret("anthropic_api_key", key);
         }
 
         // blob_endpoint — points blob_adapter at the server's internal blob storage
@@ -164,19 +161,13 @@ pub async fn run(
         // determinism-ok: env var read at startup for configuration
         if std::env::var("BLOB_ENDPOINT").is_err() {
             let blob_url = format!("http://127.0.0.1:{port}/_internal/blobs");
-            let _ = vault.cache_secret("default", "blob_endpoint", blob_url.clone());
-            if tenant != "default" {
-                let _ = vault.cache_secret(&tenant, "blob_endpoint", blob_url);
-            }
+            let _ = vault.cache_platform_secret("blob_endpoint", blob_url);
         }
 
         // temper_api_url — points WASM modules at this server for TemperFS calls.
         {
             let api_url = format!("http://127.0.0.1:{port}");
-            let _ = vault.cache_secret("default", "temper_api_url", api_url.clone());
-            if tenant != "default" {
-                let _ = vault.cache_secret(&tenant, "temper_api_url", api_url);
-            }
+            let _ = vault.cache_platform_secret("temper_api_url", api_url);
         }
 
         // sandbox_url — local sandbox for tool execution.
@@ -229,11 +220,7 @@ pub async fn run(
 
                 sandbox_url
             };
-
-            let _ = vault.cache_secret("default", "sandbox_url", sandbox_url.clone());
-            if tenant != "default" {
-                let _ = vault.cache_secret(&tenant, "sandbox_url", sandbox_url);
-            }
+            let _ = vault.cache_platform_secret("sandbox_url", sandbox_url);
         }
     }
 
@@ -289,10 +276,7 @@ pub async fn run(
     if let Some(ref token) = discord_token_resolved {
         // Seed into vault so WASM modules can also access it.
         if let Some(ref vault) = state.server.secrets_vault {
-            let _ = vault.cache_secret("default", "discord_bot_token", token.clone());
-            if tenant != "default" {
-                let _ = vault.cache_secret(&tenant, "discord_bot_token", token.clone());
-            }
+            let _ = vault.cache_platform_secret("discord_bot_token", token.clone());
         }
         spawn_channel_transport_discord(
             &state,

--- a/crates/temper-platform/src/os_apps/mod.rs
+++ b/crates/temper-platform/src/os_apps/mod.rs
@@ -7,8 +7,7 @@
 //! Backward-compatible skill aliases are preserved (`list_skills()`,
 //! `install_skill()`) to avoid breaking older callers.
 //!
-//! Install reuses [`crate::bootstrap::bootstrap_tenant_specs`] so every app
-//! goes through the same verification cascade as system specs.
+//! Install reuses [`crate::bootstrap::bootstrap_tenant_specs`] so every app goes through the same verification cascade as system specs.
 
 use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};

--- a/crates/temper-platform/src/tenant_access.rs
+++ b/crates/temper-platform/src/tenant_access.rs
@@ -39,7 +39,7 @@ fn extract_tenant(req: &Request) -> Option<String> {
 /// - `X-Temper-Principal-Kind` is `agent` (trusted backend-to-backend)
 /// - Principal doesn't start with `github:` (non-human principal)
 /// - No tenant could be extracted from the request
-/// - Tenant is `default` or `temper-system` (always accessible)
+/// - Tenant is `temper-system` (always accessible)
 /// - Not in TenantRouted mode (single-DB has no per-tenant access control)
 pub async fn tenant_access_check(
     State(state): State<PlatformState>,
@@ -77,7 +77,7 @@ pub async fn tenant_access_check(
     };
 
     // Always-accessible tenants.
-    if tenant_id == "default" || tenant_id == "temper-system" {
+    if tenant_id == "temper-system" {
         return Ok(next.run(req).await);
     }
 

--- a/crates/temper-server/src/channels/discord.rs
+++ b/crates/temper-server/src/channels/discord.rs
@@ -1553,11 +1553,11 @@ mod tests {
             entity_id: "discord-123".into(),
             action: "RecordResult".into(),
             status: "Completed".into(),
-            tenant: "rita-agents".into(),
+            tenant: "test-tenant".into(),
             agent_id: None,
             session_id: None,
         };
-        assert!(is_agent_terminal_event(&event, "rita-agents"));
+        assert!(is_agent_terminal_event(&event, "test-tenant"));
     }
 
     #[test]
@@ -1568,11 +1568,11 @@ mod tests {
             entity_id: "discord-123".into(),
             action: "Fail".into(),
             status: "Failed".into(),
-            tenant: "rita-agents".into(),
+            tenant: "test-tenant".into(),
             agent_id: None,
             session_id: None,
         };
-        assert!(is_agent_terminal_event(&event, "rita-agents"));
+        assert!(is_agent_terminal_event(&event, "test-tenant"));
     }
 
     #[test]
@@ -1583,11 +1583,11 @@ mod tests {
             entity_id: "discord-123".into(),
             action: "SandboxReady".into(),
             status: "Thinking".into(),
-            tenant: "rita-agents".into(),
+            tenant: "test-tenant".into(),
             agent_id: None,
             session_id: None,
         };
-        assert!(!is_agent_terminal_event(&event, "rita-agents"));
+        assert!(!is_agent_terminal_event(&event, "test-tenant"));
     }
 
     #[test]

--- a/crates/temper-server/src/secrets/vault.rs
+++ b/crates/temper-server/src/secrets/vault.rs
@@ -4,7 +4,7 @@
 //! (`TEMPER_VAULT_KEY` env var). Secrets are cached in memory and
 //! persisted to Postgres as `(ciphertext, nonce)` pairs.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, RwLock};
 
 use aes_gcm::aead::{Aead, OsRng}; // determinism-ok: cryptographic nonce generation, not simulation-visible
@@ -24,6 +24,8 @@ pub const MAX_SECRET_VALUE_BYTES: usize = 8192;
 pub struct SecretsVault {
     /// AES-256-GCM cipher instance.
     cipher: Arc<Aes256Gcm>,
+    /// Shared platform secrets available to every tenant.
+    platform: Arc<RwLock<BTreeMap<String, String>>>,
     /// In-memory cache: tenant → (key_name → plaintext_value).
     cache: Arc<RwLock<BTreeMap<String, BTreeMap<String, String>>>>,
 }
@@ -36,6 +38,7 @@ impl SecretsVault {
         let cipher = Aes256Gcm::new(key);
         Self {
             cipher: Arc::new(cipher),
+            platform: Arc::new(RwLock::new(BTreeMap::new())),
             cache: Arc::new(RwLock::new(BTreeMap::new())),
         }
     }
@@ -78,36 +81,66 @@ impl SecretsVault {
     pub fn cache_secret(&self, tenant: &str, key: &str, value: String) -> Result<(), String> {
         let mut cache = self.cache.write().unwrap(); // ci-ok: infallible lock
         let tenant_secrets = cache.entry(tenant.to_string()).or_default();
+        Self::insert_secret_with_budget(tenant_secrets, key, value, tenant)
+    }
 
+    /// Cache a shared platform secret in memory.
+    ///
+    /// Platform secrets act as a baseline for all tenants but are not
+    /// associated with any specific tenant ID.
+    pub fn cache_platform_secret(&self, key: &str, value: String) -> Result<(), String> {
+        let mut platform = self
+            .platform
+            .write()
+            .expect("platform secrets lock poisoned");
+        Self::insert_secret_with_budget(&mut platform, key, value, "platform")
+    }
+
+    fn insert_secret_with_budget(
+        secrets: &mut BTreeMap<String, String>,
+        key: &str,
+        value: String,
+        scope: &str,
+    ) -> Result<(), String> {
         // Budget check: only enforce on new keys, not updates.
-        if !tenant_secrets.contains_key(key) && tenant_secrets.len() >= MAX_SECRETS_PER_TENANT {
+        if !secrets.contains_key(key) && secrets.len() >= MAX_SECRETS_PER_TENANT {
             return Err(format!(
-                "tenant '{tenant}' has reached the maximum of {MAX_SECRETS_PER_TENANT} secrets"
+                "{scope} has reached the maximum of {MAX_SECRETS_PER_TENANT} secrets"
             ));
         }
 
-        tenant_secrets.insert(key.to_string(), value);
+        secrets.insert(key.to_string(), value);
         Ok(())
+    }
+
+    /// Get a platform secret value.
+    pub fn get_platform_secret(&self, key: &str) -> Option<String> {
+        let platform = self
+            .platform
+            .read()
+            .expect("platform secrets lock poisoned");
+        platform.get(key).cloned()
+    }
+
+    /// Get all platform secrets.
+    pub fn get_platform_secrets(&self) -> BTreeMap<String, String> {
+        let platform = self
+            .platform
+            .read()
+            .expect("platform secrets lock poisoned");
+        platform.clone()
     }
 
     /// Get a single secret value for a tenant.
     ///
-    /// Falls back to the `default` tenant so platform bootstrap secrets remain
-    /// available to newly created tenants until they override them.
+    /// Falls back to the platform secrets layer so shared infrastructure
+    /// configuration remains available until a tenant overrides it.
     pub fn get_secret(&self, tenant: &str, key: &str) -> Option<String> {
         let cache = self.cache.read().unwrap(); // ci-ok: infallible lock
         cache
             .get(tenant)
             .and_then(|secrets| secrets.get(key).cloned())
-            .or_else(|| {
-                if tenant == "default" {
-                    None
-                } else {
-                    cache
-                        .get("default")
-                        .and_then(|secrets| secrets.get(key).cloned())
-                }
-            })
+            .or_else(|| self.get_platform_secret(key))
     }
 
     /// Remove a secret from the in-memory cache.
@@ -120,25 +153,30 @@ impl SecretsVault {
     }
 
     /// List secret key names for a tenant (never values).
+    ///
+    /// Platform secrets are included because they are visible through the
+    /// same fallback path as tenant secrets.
     pub fn list_keys(&self, tenant: &str) -> Vec<String> {
         let cache = self.cache.read().unwrap(); // ci-ok: infallible lock
-        cache
-            .get(tenant)
-            .map(|secrets| secrets.keys().cloned().collect())
-            .unwrap_or_default()
+        let platform = self
+            .platform
+            .read()
+            .expect("platform secrets lock poisoned");
+        let mut keys = BTreeSet::new();
+        keys.extend(platform.keys().cloned());
+        if let Some(secrets) = cache.get(tenant) {
+            keys.extend(secrets.keys().cloned());
+        }
+        keys.into_iter().collect()
     }
 
     /// Get all decrypted secrets for a tenant (for WASM host injection).
     ///
-    /// `default` secrets act as a baseline and tenant-local secrets override
+    /// Platform secrets act as a baseline and tenant-local secrets override
     /// them when present.
     pub fn get_tenant_secrets(&self, tenant: &str) -> BTreeMap<String, String> {
+        let mut merged = self.get_platform_secrets();
         let cache = self.cache.read().unwrap(); // ci-ok: infallible lock
-        if tenant == "default" {
-            return cache.get("default").cloned().unwrap_or_default();
-        }
-
-        let mut merged = cache.get("default").cloned().unwrap_or_default();
         if let Some(tenant_secrets) = cache.get(tenant) {
             merged.extend(tenant_secrets.clone());
         }
@@ -186,15 +224,31 @@ mod tests {
     }
 
     #[test]
-    fn get_secret_falls_back_to_default() {
+    fn platform_secret_fallback() {
         let vault = SecretsVault::new(&test_key());
         vault
-            .cache_secret("default", "API_KEY", "sk-default".into())
+            .cache_platform_secret("API_KEY", "sk-platform".into())
             .unwrap();
 
         assert_eq!(
             vault.get_secret("tenant-b", "API_KEY"),
-            Some("sk-default".into())
+            Some("sk-platform".into())
+        );
+    }
+
+    #[test]
+    fn tenant_overrides_platform() {
+        let vault = SecretsVault::new(&test_key());
+        vault
+            .cache_platform_secret("API_KEY", "sk-platform".into())
+            .unwrap();
+        vault
+            .cache_secret("tenant-a", "API_KEY", "sk-tenant".into())
+            .unwrap();
+
+        assert_eq!(
+            vault.get_secret("tenant-a", "API_KEY"),
+            Some("sk-tenant".into())
         );
     }
 
@@ -227,17 +281,20 @@ mod tests {
     #[test]
     fn list_keys_returns_names_only() {
         let vault = SecretsVault::new(&test_key());
+        vault
+            .cache_platform_secret("GLOBAL", "platform".into())
+            .unwrap();
         vault.cache_secret("t", "B_KEY", "val-b".into()).unwrap();
         vault.cache_secret("t", "A_KEY", "val-a".into()).unwrap();
         let keys = vault.list_keys("t");
-        assert_eq!(keys, vec!["A_KEY", "B_KEY"]); // BTreeMap order
+        assert_eq!(keys, vec!["A_KEY", "B_KEY", "GLOBAL"]); // BTree order
     }
 
     #[test]
-    fn get_tenant_secrets_for_wasm() {
+    fn platform_secrets_merged() {
         let vault = SecretsVault::new(&test_key());
         vault
-            .cache_secret("default", "GLOBAL", "base".into())
+            .cache_platform_secret("GLOBAL", "base".into())
             .unwrap();
         vault.cache_secret("t", "K1", "V1".into()).unwrap();
         vault.cache_secret("t", "K2", "V2".into()).unwrap();
@@ -249,6 +306,34 @@ mod tests {
         assert_eq!(secrets["GLOBAL"], "override");
         assert_eq!(secrets["K1"], "V1");
         assert_eq!(secrets["K2"], "V2");
+    }
+
+    #[test]
+    fn no_default_special_casing() {
+        let vault = SecretsVault::new(&test_key());
+        vault
+            .cache_platform_secret("API_KEY", "sk-platform".into())
+            .unwrap();
+        vault
+            .cache_secret("default", "API_KEY", "sk-default".into())
+            .unwrap();
+        vault
+            .cache_secret("tenant-a", "OTHER", "value".into())
+            .unwrap();
+
+        assert_eq!(
+            vault.get_secret("default", "API_KEY"),
+            Some("sk-default".into())
+        );
+        assert_eq!(
+            vault.get_secret("default", "OTHER"),
+            None,
+            "default should not inherit another tenant's secrets"
+        );
+        assert_eq!(
+            vault.get_secret("tenant-b", "API_KEY"),
+            Some("sk-platform".into())
+        );
     }
 
     #[test]

--- a/crates/temper-store-turso/src/router.rs
+++ b/crates/temper-store-turso/src/router.rs
@@ -143,7 +143,7 @@ impl TenantStoreRouter {
         tenant: &str,
     ) -> Result<TursoEventStore, PersistenceError> {
         // System tenant uses the platform DB.
-        if tenant == "temper-system" || tenant == "default" {
+        if tenant == "temper-system" {
             return Ok(self.platform.clone());
         }
 

--- a/docs/adrs/0044-platform-secrets-untangle-default-tenant.md
+++ b/docs/adrs/0044-platform-secrets-untangle-default-tenant.md
@@ -1,0 +1,100 @@
+# ADR-0044: Platform secrets layer and default-tenant untangling
+
+- Status: Accepted
+- Date: 2026-04-15
+- Deciders: Temper core maintainers
+- Related:
+  - ADR-0042: Crucible reference app — Environments API with full config surface
+  - `crates/temper-server/src/secrets/vault.rs`
+  - `crates/temper-cli/src/serve/mod.rs`
+  - `crates/temper-platform/src/tenant_access.rs`
+  - `crates/temper-store-turso/src/router.rs`
+
+## Context
+
+Temper accumulated two different tenant problems over time:
+
+1. The string `"default"` drifted from being a normal fallback tenant name into a privileged control-plane escape hatch. It simultaneously acted as the baseline secrets bucket, an authorization bypass in tenant access middleware, and a routing shortcut to the shared platform database.
+2. The personal tenant name `"rita-agents"` leaked into docs, skills, and tests, which makes the repository look preconfigured for one operator instead of a reusable platform.
+
+Those behaviors are unrelated and should not be coupled to one tenant label. The platform already has a real system tenant, `"temper-system"`, for infrastructure-owned behavior. Everything else should behave like an ordinary tenant, including `"default"`.
+
+## Decision
+
+Temper will split shared infrastructure secrets from tenant-scoped secrets, remove `"default"` privilege checks, and purge `"rita-agents"` from repository-facing guidance.
+
+### Sub-Decision 1: Add a platform secrets layer
+
+`SecretsVault` gets an explicit in-memory `platform` bucket that sits alongside the per-tenant cache. Shared infrastructure values such as API keys and service URLs are cached there, and tenant secret reads fall back to that bucket.
+
+`get_secret(tenant, key)` now means:
+
+1. read the tenant override if present
+2. otherwise read the platform baseline
+
+`get_tenant_secrets(tenant)` and key listing follow the same model so the WASM host and admin APIs see the effective merged view.
+
+**Why this approach**: the old `cache["default"]` fallback was already a structural baseline, just hidden behind a tenant label. Making it explicit preserves the behavior we actually wanted while removing the accidental tenant semantics.
+
+### Sub-Decision 2: Only `temper-system` bypasses tenant access checks
+
+The tenant access middleware in `temper-platform` now treats only `"temper-system"` as always accessible. `"default"` no longer bypasses the router-backed access check.
+
+**Why this approach**: authorization bypass belongs to the system tenant, not to whichever tenant name happens to be the local default.
+
+### Sub-Decision 3: Only `temper-system` routes to the platform database
+
+`TenantStoreRouter::store_for_tenant` now shares the platform database only for `"temper-system"`. Any other tenant, including `"default"`, must have its own provisioned store or the call fails.
+
+**Why this approach**: database routing is infrastructure topology. It should be explicit and auditable rather than inferred from a human-facing default name.
+
+### Sub-Decision 4: Purge `rita-agents` from repository guidance
+
+Repository docs, skills, and tests now use placeholders such as `{tenant}`, `"my-tenant"`, or `"test-tenant"` instead of `"rita-agents"`.
+
+**Why this approach**: the repository should teach configuration, not smuggle in one operator's local tenant name.
+
+## Rollout Plan
+
+1. **Phase 0 (this PR)** — add the platform secrets layer to `SecretsVault`, move CLI seed secrets to the platform cache, remove `"default"` privilege checks, and clean up repository references to `"rita-agents"`.
+2. **Phase 1 (consumer follow-up)** — update downstream apps such as OpenPaw to seed their startup secrets into the platform cache instead of dual-writing to `"default"`.
+3. **Phase 2 (operational cleanup)** — rotate any local/global instructions that still mention `"rita-agents"` outside the repository.
+
+## Consequences
+
+### Positive
+- `"default"` is once again just a tenant name, not a backdoor.
+- Shared bootstrap configuration has a first-class home in `SecretsVault`.
+- Tenant routing and authorization now line up with the existing `"temper-system"` system boundary.
+- New users no longer encounter a leaked personal tenant name in repository instructions.
+
+### Negative
+- Any code that assumed `"default"` was always routable or always authorized must now either provision a real tenant or use `"temper-system"` intentionally.
+- The vault now has one more cache surface to reason about when debugging effective secrets.
+
+### Risks
+- Downstream applications that still dual-write into `"default"` may temporarily rely on old behavior until they adopt the new platform cache. Mitigation: the fallback shape is unchanged at read time, so the migration is mostly mechanical.
+- Operators may expect persisted `"default"` secrets to become platform secrets automatically. Mitigation: this ADR intentionally scopes the change to the in-memory vault and CLI bootstrap path; persistence migrations stay in app-specific follow-ups.
+
+### DST Compliance
+
+- `SecretsVault` lives in `temper-server`, a simulation-visible crate, but the new platform bucket is just another `RwLock<BTreeMap<...>>` alongside the existing tenant cache.
+- No new nondeterministic behavior is introduced. The vault remains behind I/O traits and is not invoked from deterministic simulation paths.
+- Existing `// determinism-ok` annotations remain sufficient because the only cryptographic behavior is unchanged AES-GCM nonce generation and encryption/decryption.
+
+## Non-Goals
+
+- Changing `TenantId::default()` away from `"default"`.
+- Changing SDK or REPL defaults that still use `"default"` as a convenient tenant name.
+- Adding a persisted platform-secrets table or cross-tenant migration layer in Temper itself.
+- Redesigning multi-tenant provisioning UX.
+
+## Alternatives Considered
+
+1. **Keep using `"default"` as the hidden platform bucket** — Rejected because it preserves the ambiguity that caused the access and routing shortcuts to accrete around that tenant.
+2. **Make all tenants privileged in single-user mode** — Rejected because authorization and routing semantics should not depend on deployment scale.
+3. **Persist platform secrets in a new backend table right away** — Rejected for this PR because the existing runtime-only bootstrap path already solves the leaking-tenant problem, and persistence migration belongs with downstream apps that currently store bootstrap secrets under tenant IDs.
+
+## Rollback Policy
+
+Revert this PR. The platform secrets fallback is structurally identical to the old `"default"` fallback, so rollback is a straight code reversal rather than a data migration.

--- a/os-apps/temper-agent/tests/fsync_e2e.sh
+++ b/os-apps/temper-agent/tests/fsync_e2e.sh
@@ -22,8 +22,8 @@ set -euo pipefail
 
 SERVER="http://localhost:3000"
 SANDBOX="http://localhost:9999"
-TENANT="rita-agents"
-HEADERS='-H "content-type: application/json" -H "x-tenant-id: rita-agents" -H "x-temper-principal-kind: admin"'
+TENANT="test-tenant"
+HEADERS='-H "content-type: application/json" -H "x-tenant-id: test-tenant" -H "x-temper-principal-kind: admin"'
 
 pass() { echo "  PASS: $1"; }
 fail() { echo "  FAIL: $1"; FAILURES=$((FAILURES + 1)); }

--- a/skills/temper-agent/SKILL.md
+++ b/skills/temper-agent/SKILL.md
@@ -105,7 +105,7 @@ You are operating inside a governed sandbox. You cannot import libraries, access
 
 ```python
 # See all loaded specs and their verification status
-specs = await temper.specs("default")
+specs = await temper.specs("my-tenant")
 return specs
 ```
 
@@ -113,7 +113,7 @@ return specs
 
 ```python
 # Full spec details: actions, guards, invariants, state vars
-detail = await temper.spec_detail("default", "WeatherQuery")
+detail = await temper.spec_detail("my-tenant", "WeatherQuery")
 return detail
 ```
 
@@ -180,7 +180,7 @@ csdl = """<?xml version="1.0" encoding="utf-8"?>
   </edmx:DataServices>
 </edmx:Edmx>"""
 
-result = await temper.submit_specs("default", {
+result = await temper.submit_specs("my-tenant", {
     "WeatherQuery.ioa.toml": ioa,
     "model.csdl.xml": csdl
 })
@@ -190,8 +190,8 @@ return result
 ### 4. Create an entity and invoke an action
 
 ```python
-created = await temper.create("default", "WeatherQueries", {"id": "q1", "city": "London"})
-result = await temper.action("default", "WeatherQueries", "q1", "FetchWeather", {"city": "London"})
+created = await temper.create("my-tenant", "WeatherQueries", {"id": "q1", "city": "London"})
+result = await temper.action("my-tenant", "WeatherQueries", "q1", "FetchWeather", {"city": "London"})
 return result
 ```
 
@@ -200,7 +200,7 @@ return result
 When Cedar denies an action, you get a structured response with `status == "authorization_denied"` and a `decision_id`. You MUST surface this to the user, then poll for approval and retry.
 
 ```python
-result = await temper.action("default", "WeatherQueries", "q1", "FetchWeather", {"city": "London"})
+result = await temper.action("my-tenant", "WeatherQueries", "q1", "FetchWeather", {"city": "London"})
 
 if isinstance(result, dict) and result.get("status") == "authorization_denied":
     decision_id = result["decision_id"]
@@ -210,11 +210,11 @@ if isinstance(result, dict) and result.get("status") == "authorization_denied":
     print(f"Approve at: the Observe UI (served by your Temper instance)")
 
     # Step 2: Poll until the human resolves the decision
-    decision = await temper.poll_decision("default", decision_id)
+    decision = await temper.poll_decision("my-tenant", decision_id)
 
     if decision["status"] == "Approved":
         # Step 3: Retry the original action — now permitted
-        result = await temper.action("default", "WeatherQueries", "q1", "FetchWeather", {"city": "London"})
+        result = await temper.action("my-tenant", "WeatherQueries", "q1", "FetchWeather", {"city": "London"})
         return result
     else:
         return f"Decision {decision_id} was denied by the human."
@@ -232,16 +232,16 @@ When you need a capability that doesn't exist yet (no matching entity type), you
 
 ```python
 # Step 1: Try to create the entity — expect 404 if type doesn't exist
-result = await temper.create("default", "EmailDrafts", {"id": "email-1"})
+result = await temper.create("my-tenant", "EmailDrafts", {"id": "email-1"})
 # If 404: entity type doesn't exist. This is an UNMET INTENT.
 # The system has recorded it as a trajectory.
 
 # Step 2: Check insights — has the evolution engine seen this pattern?
-insights = await temper.get_insights("default")
+insights = await temper.get_insights("my-tenant")
 # Look for insights recommending EmailDraft creation
 
 # Step 3: Propose specs — Cedar will gate this
-result = await temper.submit_specs("default", {
+result = await temper.submit_specs("my-tenant", {
     "EmailDraft.ioa.toml": ioa_spec,
     "model.csdl.xml": csdl
 })
@@ -251,13 +251,13 @@ if result.get("status") == "authorization_denied":
     # Tell the human, then poll
     print(f"Spec submission denied. Decision {decision_id} pending.")
     print(f"Approve at: the Observe UI (served by your Temper instance)")
-    decision = await temper.poll_decision("default", decision_id)
+    decision = await temper.poll_decision("my-tenant", decision_id)
     if decision["status"] == "Approved":
         # Retry submit_specs — now permitted
-        result = await temper.submit_specs("default", specs)
+        result = await temper.submit_specs("my-tenant", specs)
 
 # Step 4: Now create and act on the entity
-created = await temper.create("default", "EmailDrafts", {"id": "email-1"})
+created = await temper.create("my-tenant", "EmailDrafts", {"id": "email-1"})
 ```
 
 **This is how the governed creation flow works:**
@@ -476,16 +476,16 @@ Agent tries action → FAILS (404 entity not found / 409 invalid transition)
 
 ```python
 # Submit specs
-await temper.submit_specs("default", {
+await temper.submit_specs("my-tenant", {
     "WeatherQuery.ioa.toml": ioa_spec,
     "model.csdl.xml": csdl
 })
 
 # Create entity
-await temper.create("default", "WeatherQueries", {"id": "q1", "city": "London"})
+await temper.create("my-tenant", "WeatherQueries", {"id": "q1", "city": "London"})
 
 # Trigger weather fetch (may be denied by Cedar — handle it!)
-result = await temper.action("default", "WeatherQueries", "q1", "FetchWeather", {"city": "London"})
+result = await temper.action("my-tenant", "WeatherQueries", "q1", "FetchWeather", {"city": "London"})
 
 if isinstance(result, dict) and result.get("status") == "authorization_denied":
     decision_id = result["decision_id"]
@@ -493,10 +493,10 @@ if isinstance(result, dict) and result.get("status") == "authorization_denied":
     print(f"Denied by Cedar policy. Decision {decision_id} pending.")
     print(f"Approve at: the Observe UI (served by your Temper instance)")
     # Poll until human resolves the decision
-    decision = await temper.poll_decision("default", decision_id)
+    decision = await temper.poll_decision("my-tenant", decision_id)
     if decision["status"] == "Approved":
         # Retry the action — now permitted
-        result = await temper.action("default", "WeatherQueries", "q1", "FetchWeather", {"city": "London"})
+        result = await temper.action("my-tenant", "WeatherQueries", "q1", "FetchWeather", {"city": "London"})
 
 return result
 ```
@@ -504,14 +504,14 @@ return result
 ### List and inspect entities
 
 ```python
-entities = await temper.list("default", "WeatherQueries")
+entities = await temper.list("my-tenant", "WeatherQueries")
 return entities
 ```
 
 ### Filter entities with OData
 
 ```python
-entities = await temper.list("default", "WeatherQueries", "state eq 'Ready'")
+entities = await temper.list("my-tenant", "WeatherQueries", "state eq 'Ready'")
 return entities
 ```
 
@@ -519,17 +519,17 @@ return entities
 
 ```python
 # All specs for a tenant
-specs = await temper.specs("default")
+specs = await temper.specs("my-tenant")
 
 # Full detail on one entity type
-detail = await temper.spec_detail("default", "WeatherQuery")
+detail = await temper.spec_detail("my-tenant", "WeatherQuery")
 return detail
 ```
 
 ### Check a single decision status
 
 ```python
-status = await temper.get_decision_status("default", "PD-abc123")
+status = await temper.get_decision_status("my-tenant", "PD-abc123")
 return status
 ```
 


### PR DESCRIPTION
## Summary
- add a real platform-secret layer in `SecretsVault` instead of relying on the `default` tenant as an implicit platform bucket
- remove `default` special-casing from tenant auth/routing paths and clean up active `rita-agents` examples in docs/tests
- restore the `temper_platform::os_apps::git_sources` compatibility surface that OpenPaw startup still uses

## Why
OpenPaw now needs shared bootstrap secrets to come from an explicit platform cache while using the configured tenant for user/auth/setup state. This change untangles the long-standing `default` tenant coupling so downstream apps can migrate cleanly.

## Validation
- `cargo test -p temper-platform git_sources`
- local readability ratchet check against `.ci/readability-baseline.env`
- local downstream verification through the paired OpenPaw branch, including OpenPaw startup/auth/setup flows against this Temper branch
