### PR TITLE
feat(reaction): promote cross-entity reactions to first-class app primitive (#128)

### DIFF
--- a/crates/temper-server/src/reaction/dispatcher.rs
+++ b/crates/temper-server/src/reaction/dispatcher.rs
@@ -72,6 +72,33 @@ impl ReactionDispatcher {
         let mut results = Vec::new();
 
         for rule in rules {
+            // Guard evaluation: skip rules whose guard evaluates to false.
+            // Guard-skipped rules do not produce a `ReactionResult` — they
+            // never fired.
+            if let Some(guard) = &rule.when.guard {
+                let mut queries = Vec::new();
+                super::guard::collect_cross_entity_queries(guard, fields, &mut queries);
+                let mut resolved = super::guard::CrossStatusMap::new();
+                for q in &queries {
+                    let status = state
+                        .resolve_entity_status(tenant, &q.entity_type, &q.target_entity_id)
+                        .await;
+                    let matched = status.as_deref().map(|s| q.matches(s)).unwrap_or(false);
+                    resolved.insert(q.key(), matched);
+                }
+                let passed = super::guard::evaluate_with_resolved(
+                    guard, fields, to_state, &resolved, &rule.name,
+                );
+                if !passed {
+                    tracing::debug!(
+                        rule = rule.name,
+                        cross_entity_queries = queries.len(),
+                        "reaction guard failed; skipping rule"
+                    );
+                    continue;
+                }
+            }
+
             let target_entity_id =
                 match super::resolver::resolve_target_id(&rule.resolve_target, entity_id, fields) {
                     Some(id) => id,

--- a/crates/temper-server/src/reaction/dispatcher.rs
+++ b/crates/temper-server/src/reaction/dispatcher.rs
@@ -102,6 +102,9 @@ impl ReactionDispatcher {
                 "Dispatching reaction"
             );
 
+            let effective_params =
+                super::params::build_effective_params(&rule.then, fields, &rule.name);
+
             // Fire the target action via the core dispatch (no reaction cascade
             // to avoid infinite async recursion — we handle cascading ourselves).
             let dispatch_result = state
@@ -110,7 +113,7 @@ impl ReactionDispatcher {
                     &rule.then.entity_type,
                     &target_entity_id,
                     &rule.then.action,
-                    rule.then.params.clone(),
+                    effective_params,
                     &AgentContext::system(),
                     false,
                 )

--- a/crates/temper-server/src/reaction/guard.rs
+++ b/crates/temper-server/src/reaction/guard.rs
@@ -1,0 +1,480 @@
+//! Reaction guard evaluation.
+//!
+//! Guards are evaluated in two passes so production (async) and simulation
+//! (sync) share the same traversal:
+//!
+//! 1. [`collect_cross_entity_queries`] walks the guard tree and emits every
+//!    [`super::types::ReactionGuard::CrossEntityStateIn`] query. Leaf
+//!    variants that only touch the source entity are *not* emitted — those
+//!    are decided later from `source_fields` alone.
+//! 2. The caller resolves the queries into a [`CrossStatusMap`] using the
+//!    appropriate lookup primitive (async `resolve_entity_status` for
+//!    production, synchronous actor-status read for the sim).
+//! 3. [`evaluate_with_resolved`] re-walks the same tree using the resolved
+//!    map plus `source_fields` to produce the final boolean.
+//!
+//! This split is the same pattern used at `state/dispatch/cross_entity.rs`
+//! for IOA guards (ADR-0015). Reusing it keeps the two worlds consistent
+//! and avoids dragging the IOA `Guard` enum's transition-table context into
+//! the reaction path.
+
+use std::collections::BTreeMap;
+
+use super::types::ReactionGuard;
+
+/// Unresolved cross-entity query raised by [`collect_cross_entity_queries`].
+///
+/// The `target_entity_id` is read out of the source entity's fields at
+/// collection time so both the production and simulation lookup primitives
+/// receive identical inputs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CrossEntityQuery {
+    pub(crate) entity_type: String,
+    pub(crate) target_entity_id: String,
+    pub(crate) required_status: Vec<String>,
+}
+
+impl CrossEntityQuery {
+    /// Stable map key used by [`CrossStatusMap`]. Must be a deterministic
+    /// function of the query fields so the two passes agree.
+    pub(crate) fn key(&self) -> String {
+        format!("{}:{}", self.entity_type, self.target_entity_id)
+    }
+
+    /// Helper: check a resolved status against `required_status`.
+    pub(crate) fn matches(&self, status: &str) -> bool {
+        self.required_status.iter().any(|s| s == status)
+    }
+}
+
+/// Results of cross-entity status lookups, keyed by
+/// `"{entity_type}:{target_entity_id}"`. `true` = guard condition satisfied.
+/// Missing entries count as `false` during evaluation.
+pub(crate) type CrossStatusMap = BTreeMap<String, bool>;
+
+/// First pass — walk the guard tree and collect unresolved cross-entity
+/// queries. Queries whose `entity_id_source` field is absent or not a
+/// non-empty string are NOT emitted; those branches evaluate to `false`
+/// during the second pass (stricter than IOA's vacuous-truth handling — for
+/// reactions, an empty target ID is almost always a misconfiguration the
+/// author should notice).
+pub(crate) fn collect_cross_entity_queries(
+    guard: &ReactionGuard,
+    source_fields: &serde_json::Value,
+    out: &mut Vec<CrossEntityQuery>,
+) {
+    match guard {
+        ReactionGuard::FieldEquals { .. }
+        | ReactionGuard::FieldIn { .. }
+        | ReactionGuard::BoolTrue { .. }
+        | ReactionGuard::BoolFalse { .. }
+        | ReactionGuard::StateIn { .. } => {}
+        ReactionGuard::CrossEntityStateIn {
+            entity_type,
+            entity_id_source,
+            required_status,
+        } => {
+            if let Some(target_id) = source_fields
+                .get(entity_id_source)
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+            {
+                out.push(CrossEntityQuery {
+                    entity_type: entity_type.clone(),
+                    target_entity_id: target_id.to_string(),
+                    required_status: required_status.clone(),
+                });
+            }
+        }
+        ReactionGuard::AllOf { guards } | ReactionGuard::AnyOf { guards } => {
+            for g in guards {
+                collect_cross_entity_queries(g, source_fields, out);
+            }
+        }
+        ReactionGuard::Not { guard } => {
+            collect_cross_entity_queries(guard, source_fields, out);
+        }
+    }
+}
+
+/// Second pass — evaluate the guard using the source fields, the source
+/// entity's post-action status, and the resolved cross-entity map.
+///
+/// Unknown source field → `false`. Unresolved cross-entity query (missing
+/// target id, lookup failure) → `false`.
+pub(crate) fn evaluate_with_resolved(
+    guard: &ReactionGuard,
+    source_fields: &serde_json::Value,
+    source_status: &str,
+    resolved: &CrossStatusMap,
+    rule_name: &str,
+) -> bool {
+    match guard {
+        ReactionGuard::FieldEquals { field, value } => match source_fields.get(field) {
+            Some(found) => found == value,
+            None => {
+                tracing::debug!(
+                    rule = rule_name,
+                    field = field,
+                    "reaction guard `field_equals` source field missing — false"
+                );
+                false
+            }
+        },
+        ReactionGuard::FieldIn { field, values } => match source_fields.get(field) {
+            Some(found) => values.iter().any(|v| v == found),
+            None => {
+                tracing::debug!(
+                    rule = rule_name,
+                    field = field,
+                    "reaction guard `field_in` source field missing — false"
+                );
+                false
+            }
+        },
+        ReactionGuard::BoolTrue { field } => source_fields
+            .get(field)
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        ReactionGuard::BoolFalse { field } => {
+            match source_fields.get(field).and_then(|v| v.as_bool()) {
+                Some(b) => !b,
+                None => false,
+            }
+        }
+        ReactionGuard::StateIn { values } => values.iter().any(|v| v == source_status),
+        ReactionGuard::CrossEntityStateIn {
+            entity_type,
+            entity_id_source,
+            ..
+        } => {
+            let Some(target_id) = source_fields
+                .get(entity_id_source)
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+            else {
+                tracing::warn!(
+                    rule = rule_name,
+                    entity_type = entity_type,
+                    entity_id_source = entity_id_source,
+                    "reaction guard `cross_entity_state_in` target id missing on source — false"
+                );
+                return false;
+            };
+            let key = format!("{entity_type}:{target_id}");
+            resolved.get(&key).copied().unwrap_or(false)
+        }
+        ReactionGuard::AllOf { guards } => guards
+            .iter()
+            .all(|g| evaluate_with_resolved(g, source_fields, source_status, resolved, rule_name)),
+        ReactionGuard::AnyOf { guards } => guards
+            .iter()
+            .any(|g| evaluate_with_resolved(g, source_fields, source_status, resolved, rule_name)),
+        ReactionGuard::Not { guard } => {
+            !evaluate_with_resolved(guard, source_fields, source_status, resolved, rule_name)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reaction::types::ReactionGuard;
+    use serde_json::json;
+
+    fn empty_map() -> CrossStatusMap {
+        CrossStatusMap::new()
+    }
+
+    // ---------- source-only leaf evaluation ---------------------------------
+
+    #[test]
+    fn field_equals_true_on_match() {
+        let g = ReactionGuard::FieldEquals {
+            field: "job_type".to_string(),
+            value: json!("source_search"),
+        };
+        let fields = json!({"job_type": "source_search"});
+        assert!(evaluate_with_resolved(
+            &g,
+            &fields,
+            "Done",
+            &empty_map(),
+            "r"
+        ));
+    }
+
+    #[test]
+    fn field_equals_false_on_miss() {
+        let g = ReactionGuard::FieldEquals {
+            field: "job_type".to_string(),
+            value: json!("source_search"),
+        };
+        assert!(!evaluate_with_resolved(
+            &g,
+            &json!({}),
+            "Done",
+            &empty_map(),
+            "r"
+        ));
+        assert!(!evaluate_with_resolved(
+            &g,
+            &json!({"job_type": "other"}),
+            "Done",
+            &empty_map(),
+            "r"
+        ));
+    }
+
+    #[test]
+    fn field_in_matches_any_of_values() {
+        let g = ReactionGuard::FieldIn {
+            field: "stage".to_string(),
+            values: vec![json!("a"), json!("b")],
+        };
+        assert!(evaluate_with_resolved(
+            &g,
+            &json!({"stage": "b"}),
+            "Done",
+            &empty_map(),
+            "r"
+        ));
+        assert!(!evaluate_with_resolved(
+            &g,
+            &json!({"stage": "c"}),
+            "Done",
+            &empty_map(),
+            "r"
+        ));
+    }
+
+    #[test]
+    fn bool_true_and_false_variants() {
+        let t = ReactionGuard::BoolTrue {
+            field: "ready".to_string(),
+        };
+        let f = ReactionGuard::BoolFalse {
+            field: "ready".to_string(),
+        };
+        assert!(evaluate_with_resolved(
+            &t,
+            &json!({"ready": true}),
+            "X",
+            &empty_map(),
+            "r"
+        ));
+        assert!(!evaluate_with_resolved(
+            &t,
+            &json!({"ready": false}),
+            "X",
+            &empty_map(),
+            "r"
+        ));
+        assert!(evaluate_with_resolved(
+            &f,
+            &json!({"ready": false}),
+            "X",
+            &empty_map(),
+            "r"
+        ));
+        // Missing field → false for both.
+        assert!(!evaluate_with_resolved(
+            &t,
+            &json!({}),
+            "X",
+            &empty_map(),
+            "r"
+        ));
+        assert!(!evaluate_with_resolved(
+            &f,
+            &json!({}),
+            "X",
+            &empty_map(),
+            "r"
+        ));
+    }
+
+    #[test]
+    fn state_in_matches_post_status() {
+        let g = ReactionGuard::StateIn {
+            values: vec!["Complete".to_string(), "Partial".to_string()],
+        };
+        assert!(evaluate_with_resolved(
+            &g,
+            &json!({}),
+            "Complete",
+            &empty_map(),
+            "r"
+        ));
+        assert!(!evaluate_with_resolved(
+            &g,
+            &json!({}),
+            "Failed",
+            &empty_map(),
+            "r"
+        ));
+    }
+
+    // ---------- cross-entity collection + resolution ------------------------
+
+    #[test]
+    fn cross_entity_collects_and_evaluates() {
+        let g = ReactionGuard::CrossEntityStateIn {
+            entity_type: "Workspace".to_string(),
+            entity_id_source: "workspace_id".to_string(),
+            required_status: vec!["Active".to_string()],
+        };
+        let fields = json!({"workspace_id": "ws-42"});
+
+        let mut queries = Vec::new();
+        collect_cross_entity_queries(&g, &fields, &mut queries);
+        assert_eq!(queries.len(), 1);
+        assert_eq!(queries[0].entity_type, "Workspace");
+        assert_eq!(queries[0].target_entity_id, "ws-42");
+        assert!(queries[0].matches("Active"));
+        assert!(!queries[0].matches("Archived"));
+        assert_eq!(queries[0].key(), "Workspace:ws-42");
+
+        // Resolved: Active — guard passes.
+        let mut resolved = CrossStatusMap::new();
+        resolved.insert("Workspace:ws-42".to_string(), true);
+        assert!(evaluate_with_resolved(&g, &fields, "X", &resolved, "r"));
+
+        // Resolved: not Active — guard fails.
+        let mut resolved = CrossStatusMap::new();
+        resolved.insert("Workspace:ws-42".to_string(), false);
+        assert!(!evaluate_with_resolved(&g, &fields, "X", &resolved, "r"));
+
+        // Unresolved (entity fetch failed) — guard fails.
+        assert!(!evaluate_with_resolved(&g, &fields, "X", &empty_map(), "r"));
+    }
+
+    #[test]
+    fn cross_entity_missing_target_id_is_false_and_not_collected() {
+        let g = ReactionGuard::CrossEntityStateIn {
+            entity_type: "Workspace".to_string(),
+            entity_id_source: "workspace_id".to_string(),
+            required_status: vec!["Active".to_string()],
+        };
+        // No workspace_id on source.
+        let fields = json!({});
+        let mut queries = Vec::new();
+        collect_cross_entity_queries(&g, &fields, &mut queries);
+        assert!(queries.is_empty(), "no queries collected when id missing");
+        assert!(!evaluate_with_resolved(&g, &fields, "X", &empty_map(), "r"));
+
+        // Empty string — also not collected.
+        let fields = json!({"workspace_id": ""});
+        let mut queries = Vec::new();
+        collect_cross_entity_queries(&g, &fields, &mut queries);
+        assert!(queries.is_empty());
+        assert!(!evaluate_with_resolved(&g, &fields, "X", &empty_map(), "r"));
+    }
+
+    // ---------- composite ---------------------------------------------------
+
+    #[test]
+    fn all_of_requires_every_child() {
+        let g = ReactionGuard::AllOf {
+            guards: vec![
+                ReactionGuard::BoolTrue {
+                    field: "a".to_string(),
+                },
+                ReactionGuard::BoolTrue {
+                    field: "b".to_string(),
+                },
+            ],
+        };
+        assert!(evaluate_with_resolved(
+            &g,
+            &json!({"a": true, "b": true}),
+            "X",
+            &empty_map(),
+            "r"
+        ));
+        assert!(!evaluate_with_resolved(
+            &g,
+            &json!({"a": true, "b": false}),
+            "X",
+            &empty_map(),
+            "r"
+        ));
+    }
+
+    #[test]
+    fn any_of_requires_one_child() {
+        let g = ReactionGuard::AnyOf {
+            guards: vec![
+                ReactionGuard::BoolTrue {
+                    field: "a".to_string(),
+                },
+                ReactionGuard::BoolTrue {
+                    field: "b".to_string(),
+                },
+            ],
+        };
+        assert!(evaluate_with_resolved(
+            &g,
+            &json!({"a": false, "b": true}),
+            "X",
+            &empty_map(),
+            "r"
+        ));
+        assert!(!evaluate_with_resolved(
+            &g,
+            &json!({"a": false, "b": false}),
+            "X",
+            &empty_map(),
+            "r"
+        ));
+    }
+
+    #[test]
+    fn not_inverts() {
+        let g = ReactionGuard::Not {
+            guard: Box::new(ReactionGuard::BoolTrue {
+                field: "a".to_string(),
+            }),
+        };
+        assert!(evaluate_with_resolved(
+            &g,
+            &json!({"a": false}),
+            "X",
+            &empty_map(),
+            "r"
+        ));
+        assert!(!evaluate_with_resolved(
+            &g,
+            &json!({"a": true}),
+            "X",
+            &empty_map(),
+            "r"
+        ));
+    }
+
+    #[test]
+    fn composite_collects_cross_entity_from_all_branches() {
+        let g = ReactionGuard::AllOf {
+            guards: vec![
+                ReactionGuard::CrossEntityStateIn {
+                    entity_type: "A".to_string(),
+                    entity_id_source: "a_id".to_string(),
+                    required_status: vec!["Ok".to_string()],
+                },
+                ReactionGuard::Not {
+                    guard: Box::new(ReactionGuard::CrossEntityStateIn {
+                        entity_type: "B".to_string(),
+                        entity_id_source: "b_id".to_string(),
+                        required_status: vec!["Bad".to_string()],
+                    }),
+                },
+            ],
+        };
+        let fields = json!({"a_id": "a-1", "b_id": "b-1"});
+        let mut queries = Vec::new();
+        collect_cross_entity_queries(&g, &fields, &mut queries);
+        assert_eq!(queries.len(), 2);
+        assert!(queries.iter().any(|q| q.entity_type == "A"));
+        assert!(queries.iter().any(|q| q.entity_type == "B"));
+    }
+}

--- a/crates/temper-server/src/reaction/mod.rs
+++ b/crates/temper-server/src/reaction/mod.rs
@@ -9,6 +9,7 @@
 //! fulfilment cascades.
 
 pub mod dispatcher;
+pub(crate) mod guard;
 pub(crate) mod params;
 pub mod registry;
 pub(crate) mod resolver;
@@ -19,6 +20,6 @@ pub use dispatcher::ReactionDispatcher;
 pub use registry::ReactionRegistry;
 pub use sim_dispatcher::SimReactionSystem;
 pub use types::{
-    MAX_REACTION_DEPTH, MAX_REACTIONS_PER_TENANT, ReactionResult, ReactionRule, ReactionTarget,
-    ReactionTrigger, TargetResolver,
+    MAX_GUARD_DEPTH, MAX_REACTION_DEPTH, MAX_REACTIONS_PER_TENANT, ReactionGuard, ReactionResult,
+    ReactionRule, ReactionTarget, ReactionTrigger, TargetResolver,
 };

--- a/crates/temper-server/src/reaction/mod.rs
+++ b/crates/temper-server/src/reaction/mod.rs
@@ -9,6 +9,7 @@
 //! fulfilment cascades.
 
 pub mod dispatcher;
+pub(crate) mod params;
 pub mod registry;
 pub(crate) mod resolver;
 pub mod sim_dispatcher;

--- a/crates/temper-server/src/reaction/params.rs
+++ b/crates/temper-server/src/reaction/params.rs
@@ -1,0 +1,158 @@
+//! Shared helper for merging static and dynamic reaction params.
+//!
+//! Used by both the async [`super::dispatcher::ReactionDispatcher`] and the
+//! deterministic [`super::sim_dispatcher::SimReactionSystem`] so production
+//! and simulation apply identical merge semantics.
+
+use super::types::ReactionTarget;
+
+/// Build the effective params for a reaction dispatch.
+///
+/// Starts from the static `target.params` and overlays values read out of the
+/// source entity's `source_fields` according to `target.params_from`.
+///
+/// Semantics:
+/// * Static `params` is expected to be a JSON object (or null/absent, treated
+///   as an empty object). Non-object values are returned unchanged; dynamic
+///   merging is skipped and a warning is logged, since the reaction author
+///   declared params as something other than a map.
+/// * For each `(target_key, source_field)` in `params_from`, the source value
+///   is inserted at `target_key`. A `None` source field logs a warning and
+///   skips that key — the reaction still fires with a partial param map.
+/// * `params` and `params_from` keys must not collide; that is enforced at
+///   parse time in `registry::parse_reactions`, so a collision at runtime
+///   would indicate a bug. If one is observed here, `params_from` wins and we
+///   log an error.
+pub(crate) fn build_effective_params(
+    target: &ReactionTarget,
+    source_fields: &serde_json::Value,
+    rule_name: &str,
+) -> serde_json::Value {
+    if target.params_from.is_empty() {
+        return target.params.clone();
+    }
+
+    let mut merged = match target.params.clone() {
+        serde_json::Value::Object(map) => map,
+        serde_json::Value::Null => serde_json::Map::new(),
+        other => {
+            tracing::warn!(
+                rule = rule_name,
+                "reaction `params` is not a JSON object; skipping params_from merge"
+            );
+            return other;
+        }
+    };
+
+    for (target_key, source_field) in &target.params_from {
+        if merged.contains_key(target_key) {
+            tracing::error!(
+                rule = rule_name,
+                key = target_key,
+                "reaction params/params_from collision at dispatch time \
+                 (should be caught at parse time); params_from wins"
+            );
+        }
+
+        match source_fields.get(source_field) {
+            Some(value) => {
+                merged.insert(target_key.clone(), value.clone());
+            }
+            None => {
+                tracing::warn!(
+                    rule = rule_name,
+                    target_key = target_key,
+                    source_field = source_field,
+                    "params_from source field missing on source entity; \
+                     skipping key (reaction still fires with partial params)"
+                );
+            }
+        }
+    }
+
+    serde_json::Value::Object(merged)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reaction::types::ReactionTarget;
+    use serde_json::json;
+    use std::collections::BTreeMap;
+
+    fn target_with(params: serde_json::Value, params_from: Vec<(&str, &str)>) -> ReactionTarget {
+        let mut pf = BTreeMap::new();
+        for (k, v) in params_from {
+            pf.insert(k.to_string(), v.to_string());
+        }
+        ReactionTarget {
+            entity_type: "Target".to_string(),
+            action: "Do".to_string(),
+            params,
+            params_from: pf,
+        }
+    }
+
+    #[test]
+    fn static_only_returns_params_unchanged() {
+        let t = target_with(json!({"a": 1}), vec![]);
+        let out = build_effective_params(&t, &json!({}), "rule");
+        assert_eq!(out, json!({"a": 1}));
+    }
+
+    #[test]
+    fn dynamic_only_reads_from_source_fields() {
+        let t = target_with(json!({}), vec![("input", "output")]);
+        let fields = json!({"output": "stage-2-payload"});
+        let out = build_effective_params(&t, &fields, "rule");
+        assert_eq!(out, json!({"input": "stage-2-payload"}));
+    }
+
+    #[test]
+    fn static_and_dynamic_merge_both() {
+        let t = target_with(
+            json!({"requested_by": "system"}),
+            vec![("job_type", "next_stage"), ("input", "output")],
+        );
+        let fields = json!({"next_stage": "source_search", "output": "payload"});
+        let out = build_effective_params(&t, &fields, "rule");
+        assert_eq!(
+            out,
+            json!({
+                "requested_by": "system",
+                "job_type": "source_search",
+                "input": "payload",
+            })
+        );
+    }
+
+    #[test]
+    fn missing_source_field_skips_key_and_fires_with_partial_params() {
+        let t = target_with(json!({"requested_by": "system"}), vec![("input", "output")]);
+        let out = build_effective_params(&t, &json!({}), "rule");
+        assert_eq!(out, json!({"requested_by": "system"}));
+    }
+
+    #[test]
+    fn null_static_params_treated_as_empty_object() {
+        let t = target_with(json!(null), vec![("k", "v")]);
+        let fields = json!({"v": "val"});
+        let out = build_effective_params(&t, &fields, "rule");
+        assert_eq!(out, json!({"k": "val"}));
+    }
+
+    #[test]
+    fn non_object_static_params_bypass_merge() {
+        let t = target_with(json!("literal-string"), vec![("k", "v")]);
+        let out = build_effective_params(&t, &json!({"v": "val"}), "rule");
+        assert_eq!(out, json!("literal-string"));
+    }
+
+    #[test]
+    fn collision_params_from_wins() {
+        let t = target_with(json!({"shared": "static"}), vec![("shared", "src")]);
+        let fields = json!({"src": "dynamic"});
+        let out = build_effective_params(&t, &fields, "rule");
+        assert_eq!(out, json!({"shared": "dynamic"}));
+    }
+}

--- a/crates/temper-server/src/reaction/registry.rs
+++ b/crates/temper-server/src/reaction/registry.rs
@@ -7,7 +7,8 @@ use std::collections::BTreeMap;
 use temper_runtime::tenant::TenantId;
 
 use super::types::{
-    MAX_REACTIONS_PER_TENANT, ReactionRule, ReactionTarget, ReactionTrigger, TargetResolver,
+    MAX_GUARD_DEPTH, MAX_REACTIONS_PER_TENANT, ReactionGuard, ReactionRule, ReactionTarget,
+    ReactionTrigger, TargetResolver,
 };
 
 /// Registry of reaction rules, indexed per-tenant for fast lookup.
@@ -128,6 +129,8 @@ struct TriggerToml {
     entity_type: String,
     action: Option<String>,
     to_state: Option<String>,
+    #[serde(default)]
+    guard: Option<ReactionGuard>,
 }
 
 #[derive(serde::Deserialize)]
@@ -230,12 +233,25 @@ pub fn parse_reactions(toml_str: &str) -> Result<Vec<ReactionRule>, String> {
             }
         }
 
+        // Guard depth budget — enforced at parse time so drift is caught
+        // before any reaction fires (TigerStyle).
+        if let Some(ref g) = r.when.guard {
+            let d = g.depth();
+            if d > MAX_GUARD_DEPTH {
+                return Err(format!(
+                    "Reaction '{}': guard nesting depth {d} exceeds budget of {MAX_GUARD_DEPTH}",
+                    r.name
+                ));
+            }
+        }
+
         rules.push(ReactionRule {
             name: r.name,
             when: ReactionTrigger {
                 entity_type: r.when.entity_type,
                 action: r.when.action,
                 to_state: r.when.to_state,
+                guard: r.when.guard,
             },
             then: ReactionTarget {
                 entity_type: r.then.entity_type,
@@ -268,6 +284,7 @@ mod tests {
                 entity_type: entity_type.to_string(),
                 action: action.map(|s| s.to_string()),
                 to_state: to_state.map(|s| s.to_string()),
+                guard: None,
             },
             then: ReactionTarget {
                 entity_type: target_type.to_string(),
@@ -606,6 +623,119 @@ type = "same_id"
         let err = parse_reactions(toml).unwrap_err();
         assert!(
             err.contains("key 'shared' appears in both `params` and `params_from`"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_reactions_accepts_source_field_guard() {
+        let toml = r#"
+[[reaction]]
+name = "guarded"
+[reaction.when]
+entity_type = "CurationJob"
+action = "Complete"
+[reaction.when.guard]
+type = "field_equals"
+field = "job_type"
+value = "source_search"
+[reaction.then]
+entity_type = "CurationJob"
+action = "Submit"
+[reaction.resolve_target]
+type = "create"
+"#;
+        let rules = parse_reactions(toml).expect("parse");
+        assert_eq!(rules.len(), 1);
+        assert!(matches!(
+            rules[0].when.guard,
+            Some(ReactionGuard::FieldEquals { ref field, .. }) if field == "job_type"
+        ));
+    }
+
+    #[test]
+    fn parse_reactions_accepts_cross_entity_guard() {
+        let toml = r#"
+[[reaction]]
+name = "parent_active_only"
+[reaction.when]
+entity_type = "Session"
+action = "Complete"
+[reaction.when.guard]
+type = "cross_entity_state_in"
+entity_type = "Workspace"
+entity_id_source = "workspace_id"
+required_status = ["Active"]
+[reaction.then]
+entity_type = "Workspace"
+action = "Ack"
+[reaction.resolve_target]
+type = "field"
+field = "workspace_id"
+"#;
+        let rules = parse_reactions(toml).expect("parse");
+        assert_eq!(rules.len(), 1);
+        assert!(matches!(
+            rules[0].when.guard,
+            Some(ReactionGuard::CrossEntityStateIn { ref entity_type, .. })
+                if entity_type == "Workspace"
+        ));
+    }
+
+    #[test]
+    fn parse_reactions_accepts_composite_guard() {
+        let toml = r#"
+[[reaction]]
+name = "composite"
+[reaction.when]
+entity_type = "A"
+[reaction.when.guard]
+type = "all_of"
+guards = [
+  { type = "bool_true", field = "ready" },
+  { type = "state_in", values = ["Complete"] },
+]
+[reaction.then]
+entity_type = "B"
+action = "Do"
+[reaction.resolve_target]
+type = "same_id"
+"#;
+        let rules = parse_reactions(toml).expect("parse");
+        assert!(matches!(
+            rules[0].when.guard,
+            Some(ReactionGuard::AllOf { .. })
+        ));
+    }
+
+    #[test]
+    fn parse_reactions_rejects_deeply_nested_guard() {
+        // depth 5 > MAX_GUARD_DEPTH = 4 — should be rejected at parse.
+        let toml = r#"
+[[reaction]]
+name = "too_deep"
+[reaction.when]
+entity_type = "A"
+[reaction.when.guard]
+type = "not"
+[reaction.when.guard.guard]
+type = "not"
+[reaction.when.guard.guard.guard]
+type = "not"
+[reaction.when.guard.guard.guard.guard]
+type = "not"
+[reaction.when.guard.guard.guard.guard.guard]
+type = "bool_true"
+field = "x"
+[reaction.then]
+entity_type = "B"
+action = "Do"
+[reaction.resolve_target]
+type = "same_id"
+"#;
+        let err = parse_reactions(toml).unwrap_err();
+        assert!(
+            err.contains("guard nesting depth 5 exceeds budget of 4"),
             "unexpected error: {err}"
         );
     }

--- a/crates/temper-server/src/reaction/registry.rs
+++ b/crates/temper-server/src/reaction/registry.rs
@@ -201,6 +201,7 @@ pub fn parse_reactions(toml_str: &str) -> Result<Vec<ReactionRule>, String> {
                 })?;
                 TargetResolver::CreateIfMissing { id_field }
             }
+            "create" => TargetResolver::Create,
             other => {
                 return Err(format!(
                     "Reaction '{}': unknown resolver type '{other}'",
@@ -521,7 +522,7 @@ type = "static"
 entity_id = "singleton-1"
 
 [[reaction]]
-name = "create_resolver"
+name = "create_if_missing_resolver"
 [reaction.when]
 entity_type = "A"
 [reaction.then]
@@ -530,9 +531,19 @@ action = "Do"
 [reaction.resolve_target]
 type = "create_if_missing"
 id_field = "b_id"
+
+[[reaction]]
+name = "create_resolver"
+[reaction.when]
+entity_type = "A"
+[reaction.then]
+entity_type = "B"
+action = "Do"
+[reaction.resolve_target]
+type = "create"
 "#;
         let rules = parse_reactions(toml).unwrap();
-        assert_eq!(rules.len(), 4);
+        assert_eq!(rules.len(), 5);
         assert!(
             matches!(rules[0].resolve_target, TargetResolver::Field { ref field } if field == "b_id")
         );
@@ -543,6 +554,7 @@ id_field = "b_id"
         assert!(
             matches!(rules[3].resolve_target, TargetResolver::CreateIfMissing { ref id_field } if id_field == "b_id")
         );
+        assert!(matches!(rules[4].resolve_target, TargetResolver::Create));
     }
 
     #[test]

--- a/crates/temper-server/src/reaction/registry.rs
+++ b/crates/temper-server/src/reaction/registry.rs
@@ -136,6 +136,8 @@ struct TargetToml {
     action: String,
     #[serde(default)]
     params: Option<serde_json::Value>,
+    #[serde(default)]
+    params_from: Option<BTreeMap<String, String>>,
 }
 
 #[derive(serde::Deserialize)]
@@ -207,6 +209,26 @@ pub fn parse_reactions(toml_str: &str) -> Result<Vec<ReactionRule>, String> {
             }
         };
 
+        let static_params = r.then.params.unwrap_or(serde_json::json!({}));
+        let params_from = r.then.params_from.unwrap_or_default();
+
+        // Collision check: static `params` and dynamic `params_from` must not
+        // name the same target key. We only enforce this when `params` is an
+        // object (the only shape that could collide). Non-object `params`
+        // (null, scalar, array) are tolerated — `build_effective_params` will
+        // skip the dynamic merge and log a warning at dispatch time.
+        if let serde_json::Value::Object(ref map) = static_params {
+            for key in params_from.keys() {
+                if map.contains_key(key) {
+                    return Err(format!(
+                        "Reaction '{}': key '{}' appears in both `params` and `params_from`; \
+                         pick one source",
+                        r.name, key
+                    ));
+                }
+            }
+        }
+
         rules.push(ReactionRule {
             name: r.name,
             when: ReactionTrigger {
@@ -217,7 +239,8 @@ pub fn parse_reactions(toml_str: &str) -> Result<Vec<ReactionRule>, String> {
             then: ReactionTarget {
                 entity_type: r.then.entity_type,
                 action: r.then.action,
-                params: r.then.params.unwrap_or(serde_json::json!({})),
+                params: static_params,
+                params_from,
             },
             resolve_target,
         });
@@ -249,6 +272,7 @@ mod tests {
                 entity_type: target_type.to_string(),
                 action: target_action.to_string(),
                 params: serde_json::json!({}),
+                params_from: BTreeMap::new(),
             },
             resolve_target: TargetResolver::SameId,
         }
@@ -519,6 +543,77 @@ id_field = "b_id"
         assert!(
             matches!(rules[3].resolve_target, TargetResolver::CreateIfMissing { ref id_field } if id_field == "b_id")
         );
+    }
+
+    #[test]
+    fn parse_reactions_accepts_params_from() {
+        let toml = r#"
+[[reaction]]
+name = "pipeline_chain"
+[reaction.when]
+entity_type = "CurationJob"
+action = "Complete"
+[reaction.then]
+entity_type = "CurationJob"
+action = "Submit"
+params = { requested_by = "system" }
+params_from = { job_type = "next_stage", input = "output" }
+[reaction.resolve_target]
+type = "create_if_missing"
+id_field = "next_job_id"
+"#;
+        let rules = parse_reactions(toml).unwrap();
+        assert_eq!(rules.len(), 1);
+        let target = &rules[0].then;
+        assert_eq!(
+            target.params_from.get("job_type").map(String::as_str),
+            Some("next_stage")
+        );
+        assert_eq!(
+            target.params_from.get("input").map(String::as_str),
+            Some("output")
+        );
+        assert_eq!(target.params, serde_json::json!({"requested_by": "system"}));
+    }
+
+    #[test]
+    fn parse_reactions_rejects_params_collision() {
+        let toml = r#"
+[[reaction]]
+name = "collide"
+[reaction.when]
+entity_type = "A"
+[reaction.then]
+entity_type = "B"
+action = "Do"
+params = { shared = "static" }
+params_from = { shared = "src" }
+[reaction.resolve_target]
+type = "same_id"
+"#;
+        let err = parse_reactions(toml).unwrap_err();
+        assert!(
+            err.contains("key 'shared' appears in both `params` and `params_from`"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_reactions_missing_params_from_defaults_empty() {
+        let toml = r#"
+[[reaction]]
+name = "static_only"
+[reaction.when]
+entity_type = "A"
+[reaction.then]
+entity_type = "B"
+action = "Do"
+params = { a = 1 }
+[reaction.resolve_target]
+type = "same_id"
+"#;
+        let rules = parse_reactions(toml).unwrap();
+        assert!(rules[0].then.params_from.is_empty());
     }
 
     #[test]

--- a/crates/temper-server/src/reaction/resolver.rs
+++ b/crates/temper-server/src/reaction/resolver.rs
@@ -4,6 +4,8 @@
 //! simulation [`SimReactionSystem`] to determine which entity instance
 //! a reaction rule targets.
 
+use temper_runtime::scheduler::sim_uuid;
+
 use super::types::TargetResolver;
 
 /// Resolve the target entity ID for a reaction rule.
@@ -30,6 +32,11 @@ pub(crate) fn resolve_target_id(
             .and_then(|v| v.as_str())
             .map(|s| s.to_string())
             .or_else(|| Some(format!("{source_entity_id}-derived"))),
+        // Fresh UUID on every dispatch. `sim_uuid()` is DST-safe: in
+        // simulation it comes from the seeded `DeterministicIdGen`, in
+        // production it's `Uuid::now_v7()`. Reaction cascades under
+        // `SimReactionSystem` stay reproducible across seeded runs.
+        TargetResolver::Create => Some(sim_uuid().to_string()),
     }
 }
 
@@ -97,6 +104,55 @@ mod tests {
         assert_eq!(
             resolve_target_id(&resolver, "src-1", &json!({})),
             Some("src-1-derived".to_string())
+        );
+    }
+
+    #[test]
+    fn create_resolver_returns_fresh_id_each_call() {
+        use temper_runtime::scheduler::install_deterministic_context;
+        // Same seed — under the sim context, ids are deterministic but each
+        // call advances the seeded generator, so two consecutive calls yield
+        // distinct ids.
+        let (_guard, _clock, _id_gen) = install_deterministic_context(1234);
+
+        let resolver = TargetResolver::Create;
+        let id1 = resolve_target_id(&resolver, "src-1", &json!({})).unwrap();
+        let id2 = resolve_target_id(&resolver, "src-1", &json!({})).unwrap();
+        assert_ne!(
+            id1, id2,
+            "Create resolver must produce a fresh id each call"
+        );
+        assert!(!id1.is_empty());
+        assert!(!id2.is_empty());
+    }
+
+    #[test]
+    fn create_resolver_is_deterministic_across_seeded_runs() {
+        use temper_runtime::scheduler::install_deterministic_context;
+
+        let ids_run1 = {
+            let (_guard, _clock, _id_gen) = install_deterministic_context(42);
+            let resolver = TargetResolver::Create;
+            vec![
+                resolve_target_id(&resolver, "s", &json!({})).unwrap(),
+                resolve_target_id(&resolver, "s", &json!({})).unwrap(),
+                resolve_target_id(&resolver, "s", &json!({})).unwrap(),
+            ]
+        };
+
+        let ids_run2 = {
+            let (_guard, _clock, _id_gen) = install_deterministic_context(42);
+            let resolver = TargetResolver::Create;
+            vec![
+                resolve_target_id(&resolver, "s", &json!({})).unwrap(),
+                resolve_target_id(&resolver, "s", &json!({})).unwrap(),
+                resolve_target_id(&resolver, "s", &json!({})).unwrap(),
+            ]
+        };
+
+        assert_eq!(
+            ids_run1, ids_run2,
+            "Create resolver must produce the same id sequence under the same seed"
         );
     }
 }

--- a/crates/temper-server/src/reaction/sim_dispatcher.rs
+++ b/crates/temper-server/src/reaction/sim_dispatcher.rs
@@ -178,7 +178,9 @@ impl SimReactionSystem {
             };
 
             // Execute the target action
-            let params_str = match serde_json::to_string(&rule.then.params) {
+            let effective_params =
+                super::params::build_effective_params(&rule.then, fields, &rule.name);
+            let params_str = match serde_json::to_string(&effective_params) {
                 Ok(s) => s,
                 Err(e) => {
                     tracing::warn!(

--- a/crates/temper-server/src/reaction/sim_dispatcher.rs
+++ b/crates/temper-server/src/reaction/sim_dispatcher.rs
@@ -146,6 +146,30 @@ impl SimReactionSystem {
             .collect();
 
         for rule in rules {
+            // Guard evaluation: skip rules whose guard fails. Guard-skipped
+            // rules do not emit a `ReactionResult` — they never fired.
+            if let Some(guard) = &rule.when.guard {
+                let mut queries = Vec::new();
+                super::guard::collect_cross_entity_queries(guard, fields, &mut queries);
+                let mut resolved = super::guard::CrossStatusMap::new();
+                for q in &queries {
+                    let key = format!("{}:{}", q.entity_type, q.target_entity_id);
+                    let matched = self
+                        .entity_to_actor
+                        .get(&key)
+                        .map(|actor_id| self.inner.status(actor_id))
+                        .map(|status| q.matches(&status))
+                        .unwrap_or(false);
+                    resolved.insert(q.key(), matched);
+                }
+                let passed = super::guard::evaluate_with_resolved(
+                    guard, fields, to_state, &resolved, &rule.name,
+                );
+                if !passed {
+                    continue;
+                }
+            }
+
             let target_entity_id =
                 match super::resolver::resolve_target_id(&rule.resolve_target, entity_id, fields) {
                     Some(id) => id,

--- a/crates/temper-server/src/reaction/types.rs
+++ b/crates/temper-server/src/reaction/types.rs
@@ -2,6 +2,8 @@
 //!
 //! All types use `BTreeMap` for deterministic iteration order (DST compliance).
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 /// Maximum reaction rules per tenant (TigerStyle budget).
@@ -41,9 +43,20 @@ pub struct ReactionTarget {
     pub entity_type: String,
     /// The action to dispatch (e.g., "AuthorizePayment").
     pub action: String,
-    /// Additional parameters to pass to the target action.
+    /// Static parameters to pass to the target action.
     #[serde(default)]
     pub params: serde_json::Value,
+    /// Dynamic params: target-param-name → source-entity-field-name.
+    ///
+    /// At dispatch time, each key is read from the source entity's fields and
+    /// merged into the effective params object. Collides with `params` keys
+    /// are rejected at registry parse time. A missing source field logs a
+    /// warning and skips the key — the reaction still fires with a partial
+    /// param map (consistent with `resolver::Field`'s `None`-on-missing posture).
+    ///
+    /// `BTreeMap` for deterministic iteration order (DST compliance).
+    #[serde(default)]
+    pub params_from: BTreeMap<String, String>,
 }
 
 /// How to resolve the target entity ID for a reaction.
@@ -101,6 +114,7 @@ mod tests {
                 entity_type: "Payment".to_string(),
                 action: "AuthorizePayment".to_string(),
                 params: serde_json::json!({}),
+                params_from: BTreeMap::new(),
             },
             resolve_target: TargetResolver::Field {
                 field: "payment_id".to_string(),
@@ -112,6 +126,34 @@ mod tests {
         assert_eq!(deserialized.name, rule.name);
         assert_eq!(deserialized.when.entity_type, "Order");
         assert_eq!(deserialized.then.action, "AuthorizePayment");
+    }
+
+    #[test]
+    fn reaction_target_serialises_params_from() {
+        let mut pf = BTreeMap::new();
+        pf.insert("job_type".to_string(), "next_stage".to_string());
+        let target = ReactionTarget {
+            entity_type: "CurationJob".to_string(),
+            action: "Submit".to_string(),
+            params: serde_json::json!({}),
+            params_from: pf,
+        };
+        let json = serde_json::to_string(&target).unwrap();
+        assert!(json.contains("\"params_from\""));
+        assert!(json.contains("\"job_type\":\"next_stage\""));
+
+        let back: ReactionTarget = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            back.params_from.get("job_type").map(String::as_str),
+            Some("next_stage")
+        );
+    }
+
+    #[test]
+    fn reaction_target_defaults_params_from_empty() {
+        let json = r#"{"entity_type":"B","action":"Do"}"#;
+        let target: ReactionTarget = serde_json::from_str(json).unwrap();
+        assert!(target.params_from.is_empty());
     }
 
     #[test]

--- a/crates/temper-server/src/reaction/types.rs
+++ b/crates/temper-server/src/reaction/types.rs
@@ -80,6 +80,20 @@ pub enum TargetResolver {
         /// Field name containing the target entity ID (or derive from source).
         id_field: String,
     },
+    /// Create a genuinely new target entity with a fresh UUID on every
+    /// reaction dispatch.
+    ///
+    /// Unlike [`TargetResolver::CreateIfMissing`] — which keys off a field
+    /// on the source entity and is intended for per-source-entity singletons
+    /// (one FileVersion per File, etc.) — `Create` returns a new
+    /// [`temper_runtime::scheduler::sim_uuid`] every time. This is the
+    /// correct resolver for pipeline chaining: each source action spawns a
+    /// brand new target entity instance.
+    ///
+    /// `sim_uuid()` (not `uuid::Uuid::new_v4`) is required for DST
+    /// compliance — reaction cascades under `SimReactionSystem` must be
+    /// deterministic across seeded runs.
+    Create,
 }
 
 /// The result of dispatching a single reaction.
@@ -179,5 +193,9 @@ mod tests {
         };
         let json = serde_json::to_string(&create).unwrap();
         assert!(json.contains("\"type\":\"CreateIfMissing\""));
+
+        let fresh = TargetResolver::Create;
+        let json = serde_json::to_string(&fresh).unwrap();
+        assert!(json.contains("\"type\":\"Create\""));
     }
 }

--- a/crates/temper-server/src/reaction/types.rs
+++ b/crates/temper-server/src/reaction/types.rs
@@ -12,6 +12,13 @@ pub const MAX_REACTIONS_PER_TENANT: usize = 256;
 /// Maximum cascade depth for recursive reaction dispatch (TigerStyle budget).
 pub const MAX_REACTION_DEPTH: u32 = 8;
 
+/// Maximum nesting depth for composite reaction guards
+/// (`AllOf` / `AnyOf` / `Not`). TigerStyle: bound budgets rather than hope.
+///
+/// Enforced at parse time in [`super::registry::parse_reactions`] so drift is
+/// caught before any reaction fires.
+pub const MAX_GUARD_DEPTH: u32 = 4;
+
 /// A reaction rule: when a trigger fires, dispatch an action on a target entity.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReactionRule {
@@ -34,6 +41,107 @@ pub struct ReactionTrigger {
     pub action: Option<String>,
     /// The target state after the action. `None` = any resulting state.
     pub to_state: Option<String>,
+    /// Optional guard evaluated against the source entity's post-action state
+    /// (and optionally another entity's current state via
+    /// [`ReactionGuard::CrossEntityStateIn`]). When `Some`, the reaction only
+    /// fires if the guard evaluates `true`. Guard-skipped rules do NOT emit
+    /// a [`ReactionResult`] — they never fired.
+    #[serde(default)]
+    pub guard: Option<ReactionGuard>,
+}
+
+/// Conditional firing predicate for a reaction rule.
+///
+/// Evaluated *after* the source action commits, against the source entity's
+/// post-action fields (sync variants) or another entity's current state
+/// (`CrossEntityStateIn`).
+///
+/// Mirrors the IOA guard variant names (see ADR-0015) so developers transfer
+/// knowledge between the two evaluation paths without coupling them.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ReactionGuard {
+    /// Source field equals the given JSON value.
+    FieldEquals {
+        /// Field name on the source entity.
+        field: String,
+        /// Expected value (string, number, bool, null).
+        value: serde_json::Value,
+    },
+    /// Source field is one of the given JSON values.
+    FieldIn {
+        /// Field name on the source entity.
+        field: String,
+        /// Allowed values.
+        values: Vec<serde_json::Value>,
+    },
+    /// Source field is a JSON boolean `true`.
+    BoolTrue {
+        /// Field name on the source entity.
+        field: String,
+    },
+    /// Source field is a JSON boolean `false`.
+    BoolFalse {
+        /// Field name on the source entity.
+        field: String,
+    },
+    /// Source entity's post-action status is one of the given values.
+    /// Complements [`ReactionTrigger::to_state`] when you need multiple
+    /// allowed states expressed as a single rule.
+    StateIn {
+        /// Allowed states.
+        values: Vec<String>,
+    },
+    /// Another entity's current status must be one of the given values.
+    /// The target entity is identified by reading `entity_id_source` from
+    /// the source entity's fields. Empty / missing target IDs count as
+    /// failure (not vacuous truth) — the reaction author must be explicit
+    /// about expected wiring.
+    CrossEntityStateIn {
+        /// Target entity type.
+        entity_type: String,
+        /// Source-entity field name holding the target entity id.
+        entity_id_source: String,
+        /// Target entity statuses that satisfy the guard.
+        required_status: Vec<String>,
+    },
+    /// All child guards must pass. Bounded by [`MAX_GUARD_DEPTH`].
+    AllOf {
+        /// Child guards.
+        guards: Vec<ReactionGuard>,
+    },
+    /// At least one child guard must pass. Bounded by [`MAX_GUARD_DEPTH`].
+    AnyOf {
+        /// Child guards.
+        guards: Vec<ReactionGuard>,
+    },
+    /// Inverted child guard. Bounded by [`MAX_GUARD_DEPTH`].
+    Not {
+        /// Inner guard.
+        guard: Box<ReactionGuard>,
+    },
+}
+
+impl ReactionGuard {
+    /// Compute the maximum composite nesting depth of this guard.
+    ///
+    /// Leaf variants are depth 1. `AllOf` / `AnyOf` / `Not` add one level.
+    /// Used by [`super::registry::parse_reactions`] to reject guards deeper
+    /// than [`MAX_GUARD_DEPTH`] at parse time.
+    pub fn depth(&self) -> u32 {
+        match self {
+            ReactionGuard::FieldEquals { .. }
+            | ReactionGuard::FieldIn { .. }
+            | ReactionGuard::BoolTrue { .. }
+            | ReactionGuard::BoolFalse { .. }
+            | ReactionGuard::StateIn { .. }
+            | ReactionGuard::CrossEntityStateIn { .. } => 1,
+            ReactionGuard::AllOf { guards } | ReactionGuard::AnyOf { guards } => {
+                1 + guards.iter().map(Self::depth).max().unwrap_or(0)
+            }
+            ReactionGuard::Not { guard } => 1 + guard.depth(),
+        }
+    }
 }
 
 /// The target action to dispatch when a reaction fires.
@@ -123,6 +231,7 @@ mod tests {
                 entity_type: "Order".to_string(),
                 action: Some("ConfirmOrder".to_string()),
                 to_state: Some("Confirmed".to_string()),
+                guard: None,
             },
             then: ReactionTarget {
                 entity_type: "Payment".to_string(),
@@ -197,5 +306,64 @@ mod tests {
         let fresh = TargetResolver::Create;
         let json = serde_json::to_string(&fresh).unwrap();
         assert!(json.contains("\"type\":\"Create\""));
+    }
+
+    #[test]
+    fn reaction_guard_serde_variants() {
+        let g = ReactionGuard::FieldEquals {
+            field: "job_type".to_string(),
+            value: serde_json::json!("source_search"),
+        };
+        let j = serde_json::to_string(&g).unwrap();
+        assert!(j.contains("\"type\":\"field_equals\""));
+        let back: ReactionGuard = serde_json::from_str(&j).unwrap();
+        assert!(matches!(back, ReactionGuard::FieldEquals { .. }));
+
+        let g = ReactionGuard::CrossEntityStateIn {
+            entity_type: "Workspace".to_string(),
+            entity_id_source: "workspace_id".to_string(),
+            required_status: vec!["Active".to_string()],
+        };
+        let j = serde_json::to_string(&g).unwrap();
+        assert!(j.contains("\"type\":\"cross_entity_state_in\""));
+
+        let g = ReactionGuard::AllOf {
+            guards: vec![
+                ReactionGuard::BoolTrue {
+                    field: "a".to_string(),
+                },
+                ReactionGuard::Not {
+                    guard: Box::new(ReactionGuard::BoolFalse {
+                        field: "b".to_string(),
+                    }),
+                },
+            ],
+        };
+        let j = serde_json::to_string(&g).unwrap();
+        assert!(j.contains("\"type\":\"all_of\""));
+        assert!(j.contains("\"type\":\"not\""));
+    }
+
+    #[test]
+    fn reaction_guard_depth() {
+        let leaf = ReactionGuard::BoolTrue {
+            field: "x".to_string(),
+        };
+        assert_eq!(leaf.depth(), 1);
+
+        let pair = ReactionGuard::AllOf {
+            guards: vec![leaf.clone(), leaf.clone()],
+        };
+        assert_eq!(pair.depth(), 2);
+
+        let nested = ReactionGuard::Not {
+            guard: Box::new(pair.clone()),
+        };
+        assert_eq!(nested.depth(), 3);
+
+        let deep = ReactionGuard::AnyOf {
+            guards: vec![nested],
+        };
+        assert_eq!(deep.depth(), 4);
     }
 }

--- a/crates/temper-server/src/registry/relations.rs
+++ b/crates/temper-server/src/registry/relations.rs
@@ -115,6 +115,7 @@ pub(super) fn synthesize_agent_trigger_reactions(
                 entity_type: entity_type.to_string(),
                 action: Some(trigger.on_action.clone()),
                 to_state: trigger.to_state.clone(),
+                guard: None,
             },
             then: ReactionTarget {
                 entity_type: "Agent".to_string(),
@@ -133,6 +134,7 @@ pub(super) fn synthesize_agent_trigger_reactions(
                 entity_type: "Agent".to_string(),
                 action: Some("Assign".to_string()),
                 to_state: Some("Assigned".to_string()),
+                guard: None,
             },
             then: ReactionTarget {
                 entity_type: "Agent".to_string(),

--- a/crates/temper-server/src/registry/relations.rs
+++ b/crates/temper-server/src/registry/relations.rs
@@ -120,6 +120,7 @@ pub(super) fn synthesize_agent_trigger_reactions(
                 entity_type: "Agent".to_string(),
                 action: "Assign".to_string(),
                 params,
+                params_from: std::collections::BTreeMap::new(),
             },
             resolve_target: TargetResolver::CreateIfMissing {
                 id_field: "id".to_string(),
@@ -137,6 +138,7 @@ pub(super) fn synthesize_agent_trigger_reactions(
                 entity_type: "Agent".to_string(),
                 action: "Start".to_string(),
                 params: serde_json::json!({}),
+                params_from: std::collections::BTreeMap::new(),
             },
             resolve_target: TargetResolver::SameId,
         },

--- a/crates/temper-server/tests/reaction_cascade.rs
+++ b/crates/temper-server/tests/reaction_cascade.rs
@@ -397,6 +397,23 @@ fn cascade_with_params_from_fires_even_when_source_fields_missing() {
 }
 
 #[test]
+fn paw_fs_reactions_toml_loads_through_parser() {
+    // Regression guard: the real os-apps/temper-fs/reactions/reactions.toml
+    // must load through parse_reactions. Prior to the Phase 3 audit this
+    // file was effectively dead data (PascalCase resolver types silently
+    // rejected by the snake_case parser). Ensures future edits keep the
+    // file valid against the parser.
+    let source = include_str!("../../../os-apps/temper-fs/reactions/reactions.toml");
+    let rules = parse_reactions(source).expect("paw-fs reactions.toml must parse");
+    assert_eq!(rules.len(), 3, "expected 3 rules in paw-fs reactions.toml");
+
+    let names: Vec<&str> = rules.iter().map(|r| r.name.as_str()).collect();
+    assert!(names.contains(&"file_stream_updated_creates_version"));
+    assert!(names.contains(&"file_stream_updated_supersedes_old_version"));
+    assert!(names.contains(&"file_stream_updated_increments_workspace_usage"));
+}
+
+#[test]
 fn parse_reactions_toml_with_params_from_loads_through_registry() {
     let toml = r#"
 [[reaction]]

--- a/crates/temper-server/tests/reaction_cascade.rs
+++ b/crates/temper-server/tests/reaction_cascade.rs
@@ -65,6 +65,7 @@ fn ecommerce_registry() -> ReactionRegistry {
                 entity_type: "Payment".to_string(),
                 action: "AuthorizePayment".to_string(),
                 params: serde_json::json!({}),
+                params_from: std::collections::BTreeMap::new(),
             },
             resolve_target: TargetResolver::SameId,
         }],
@@ -196,6 +197,7 @@ fn field_based_target_resolution() {
                 entity_type: "Payment".to_string(),
                 action: "AuthorizePayment".to_string(),
                 params: serde_json::json!({}),
+                params_from: std::collections::BTreeMap::new(),
             },
             resolve_target: TargetResolver::Field {
                 field: "payment_id".to_string(),
@@ -287,6 +289,7 @@ fn multi_step_cascade_with_chained_reactions() {
                     entity_type: "Payment".to_string(),
                     action: "AuthorizePayment".to_string(),
                     params: serde_json::json!({}),
+                    params_from: std::collections::BTreeMap::new(),
                 },
                 resolve_target: TargetResolver::SameId,
             },
@@ -301,6 +304,7 @@ fn multi_step_cascade_with_chained_reactions() {
                     entity_type: "Payment".to_string(),
                     action: "CapturePayment".to_string(),
                     params: serde_json::json!({}),
+                    params_from: std::collections::BTreeMap::new(),
                 },
                 resolve_target: TargetResolver::SameId,
             },
@@ -329,6 +333,91 @@ fn multi_step_cascade_with_chained_reactions() {
     assert_eq!(results[0].depth, 0);
     assert_eq!(results[1].rule_name, "authorize_triggers_capture");
     assert_eq!(results[1].depth, 1);
+}
+
+// =========================================================================
+// Phase 1: params_from — cascade fires with dynamic params declared,
+// missing source fields don't break the cascade (warn + skip policy).
+// =========================================================================
+
+#[test]
+fn cascade_with_params_from_fires_even_when_source_fields_missing() {
+    let (_guard, clock, _id_gen) = install_deterministic_context(42);
+
+    let mut reg = ReactionRegistry::new();
+    let mut params_from = std::collections::BTreeMap::new();
+    // Reference a field that ConfirmOrder doesn't produce — the dispatcher
+    // should log a warning and skip the key, not fail the reaction.
+    params_from.insert("dynamic_key".to_string(), "missing_field".to_string());
+    reg.register_tenant_rules(
+        "shop-pf",
+        vec![ReactionRule {
+            name: "order_confirmed_with_params_from".to_string(),
+            when: ReactionTrigger {
+                entity_type: "Order".to_string(),
+                action: Some("ConfirmOrder".to_string()),
+                to_state: Some("Confirmed".to_string()),
+            },
+            then: ReactionTarget {
+                entity_type: "Payment".to_string(),
+                action: "AuthorizePayment".to_string(),
+                params: serde_json::json!({"static_key": "static_value"}),
+                params_from,
+            },
+            resolve_target: TargetResolver::SameId,
+        }],
+    );
+
+    let mut sys = SimReactionSystem::new(sim_config(), reg, "shop-pf");
+    sys.register_entity("order-pf1", "Order", "pf1", order_table());
+    sys.register_entity("payment-pf1", "Payment", "pf1", payment_table());
+
+    clock.advance();
+    sys.step("order-pf1", "AddItem", "{}").unwrap();
+    clock.advance();
+    sys.step("order-pf1", "SubmitOrder", "{}").unwrap();
+    clock.advance();
+    sys.step("order-pf1", "ConfirmOrder", "{}").unwrap();
+
+    sys.assert_status("order-pf1", "Confirmed");
+    sys.assert_status("payment-pf1", "Authorized");
+
+    let results = sys.last_results();
+    assert_eq!(results.len(), 1);
+    assert!(
+        results[0].success,
+        "reaction should fire with partial params"
+    );
+    assert_eq!(results[0].rule_name, "order_confirmed_with_params_from");
+}
+
+#[test]
+fn parse_reactions_toml_with_params_from_loads_through_registry() {
+    let toml = r#"
+[[reaction]]
+name = "order_confirmed_pipes_payment"
+[reaction.when]
+entity_type = "Order"
+action = "ConfirmOrder"
+[reaction.then]
+entity_type = "Payment"
+action = "AuthorizePayment"
+params = { source = "reaction" }
+params_from = { origin_order = "order_id" }
+[reaction.resolve_target]
+type = "same_id"
+"#;
+    let rules = parse_reactions(toml).expect("parse");
+    assert_eq!(rules.len(), 1);
+    assert_eq!(rules[0].then.params_from.len(), 1);
+    assert_eq!(
+        rules[0]
+            .then
+            .params_from
+            .get("origin_order")
+            .map(String::as_str),
+        Some("order_id")
+    );
 }
 
 // =========================================================================

--- a/crates/temper-server/tests/reaction_cascade.rs
+++ b/crates/temper-server/tests/reaction_cascade.rs
@@ -11,7 +11,7 @@ use temper_runtime::scheduler::{FaultConfig, SimActorSystemConfig, install_deter
 use temper_server::reaction::registry::{ReactionRegistry, parse_reactions};
 use temper_server::reaction::sim_dispatcher::SimReactionSystem;
 use temper_server::reaction::types::{
-    ReactionRule, ReactionTarget, ReactionTrigger, TargetResolver,
+    ReactionGuard, ReactionRule, ReactionTarget, ReactionTrigger, TargetResolver,
 };
 
 const ORDER_IOA: &str = include_str!("../../../test-fixtures/specs/order.ioa.toml");
@@ -60,6 +60,7 @@ fn ecommerce_registry() -> ReactionRegistry {
                 entity_type: "Order".to_string(),
                 action: Some("ConfirmOrder".to_string()),
                 to_state: Some("Confirmed".to_string()),
+                guard: None,
             },
             then: ReactionTarget {
                 entity_type: "Payment".to_string(),
@@ -192,6 +193,7 @@ fn field_based_target_resolution() {
                 entity_type: "Order".to_string(),
                 action: Some("ConfirmOrder".to_string()),
                 to_state: Some("Confirmed".to_string()),
+                guard: None,
             },
             then: ReactionTarget {
                 entity_type: "Payment".to_string(),
@@ -284,6 +286,7 @@ fn multi_step_cascade_with_chained_reactions() {
                     entity_type: "Order".to_string(),
                     action: Some("ConfirmOrder".to_string()),
                     to_state: Some("Confirmed".to_string()),
+                    guard: None,
                 },
                 then: ReactionTarget {
                     entity_type: "Payment".to_string(),
@@ -299,6 +302,7 @@ fn multi_step_cascade_with_chained_reactions() {
                     entity_type: "Payment".to_string(),
                     action: Some("AuthorizePayment".to_string()),
                     to_state: Some("Authorized".to_string()),
+                    guard: None,
                 },
                 then: ReactionTarget {
                     entity_type: "Payment".to_string(),
@@ -357,6 +361,7 @@ fn cascade_with_params_from_fires_even_when_source_fields_missing() {
                 entity_type: "Order".to_string(),
                 action: Some("ConfirmOrder".to_string()),
                 to_state: Some("Confirmed".to_string()),
+                guard: None,
             },
             then: ReactionTarget {
                 entity_type: "Payment".to_string(),
@@ -417,6 +422,132 @@ type = "same_id"
             .get("origin_order")
             .map(String::as_str),
         Some("order_id")
+    );
+}
+
+// =========================================================================
+// Phase 3: Guard on reaction.when — rule skips when guard fails, fires
+// when guard passes. Guard-skipped rules do NOT emit a ReactionResult.
+// =========================================================================
+
+#[test]
+fn guard_passing_rule_fires_guard_failing_rule_skipped() {
+    let (_guard, clock, _id_gen) = install_deterministic_context(42);
+
+    // Two rules on the same trigger; one guarded state_in = Confirmed,
+    // one guarded state_in = Cancelled. Only the Confirmed-guarded rule
+    // should fire.
+    let mut reg = ReactionRegistry::new();
+    reg.register_tenant_rules(
+        "shop-g",
+        vec![
+            ReactionRule {
+                name: "fires_on_confirmed".to_string(),
+                when: ReactionTrigger {
+                    entity_type: "Order".to_string(),
+                    action: Some("ConfirmOrder".to_string()),
+                    to_state: None,
+                    guard: Some(ReactionGuard::StateIn {
+                        values: vec!["Confirmed".to_string()],
+                    }),
+                },
+                then: ReactionTarget {
+                    entity_type: "Payment".to_string(),
+                    action: "AuthorizePayment".to_string(),
+                    params: serde_json::json!({}),
+                    params_from: std::collections::BTreeMap::new(),
+                },
+                resolve_target: TargetResolver::SameId,
+            },
+            ReactionRule {
+                name: "skipped_on_cancelled".to_string(),
+                when: ReactionTrigger {
+                    entity_type: "Order".to_string(),
+                    action: Some("ConfirmOrder".to_string()),
+                    to_state: None,
+                    guard: Some(ReactionGuard::StateIn {
+                        values: vec!["Cancelled".to_string()],
+                    }),
+                },
+                then: ReactionTarget {
+                    entity_type: "Payment".to_string(),
+                    action: "FailPayment".to_string(),
+                    params: serde_json::json!({}),
+                    params_from: std::collections::BTreeMap::new(),
+                },
+                resolve_target: TargetResolver::SameId,
+            },
+        ],
+    );
+
+    let mut sys = SimReactionSystem::new(sim_config(), reg, "shop-g");
+    sys.register_entity("order-g1", "Order", "g1", order_table());
+    sys.register_entity("payment-g1", "Payment", "g1", payment_table());
+
+    clock.advance();
+    sys.step("order-g1", "AddItem", "{}").unwrap();
+    clock.advance();
+    sys.step("order-g1", "SubmitOrder", "{}").unwrap();
+    clock.advance();
+    sys.step("order-g1", "ConfirmOrder", "{}").unwrap();
+
+    sys.assert_status("order-g1", "Confirmed");
+    sys.assert_status("payment-g1", "Authorized");
+
+    let results = sys.last_results();
+    // Only the passing rule emits a result; the skipped rule does not.
+    assert_eq!(results.len(), 1, "exactly one reaction should have fired");
+    assert_eq!(results[0].rule_name, "fires_on_confirmed");
+}
+
+#[test]
+fn not_guard_skips_rule_when_inner_passes() {
+    let (_guard, clock, _id_gen) = install_deterministic_context(42);
+
+    // Rule guarded with Not(StateIn[Confirmed]) — should skip because
+    // source post-state IS Confirmed.
+    let mut reg = ReactionRegistry::new();
+    reg.register_tenant_rules(
+        "shop-not",
+        vec![ReactionRule {
+            name: "skipped_when_confirmed".to_string(),
+            when: ReactionTrigger {
+                entity_type: "Order".to_string(),
+                action: Some("ConfirmOrder".to_string()),
+                to_state: None,
+                guard: Some(ReactionGuard::Not {
+                    guard: Box::new(ReactionGuard::StateIn {
+                        values: vec!["Confirmed".to_string()],
+                    }),
+                }),
+            },
+            then: ReactionTarget {
+                entity_type: "Payment".to_string(),
+                action: "AuthorizePayment".to_string(),
+                params: serde_json::json!({}),
+                params_from: std::collections::BTreeMap::new(),
+            },
+            resolve_target: TargetResolver::SameId,
+        }],
+    );
+
+    let mut sys = SimReactionSystem::new(sim_config(), reg, "shop-not");
+    sys.register_entity("order-n1", "Order", "n1", order_table());
+    sys.register_entity("payment-n1", "Payment", "n1", payment_table());
+
+    clock.advance();
+    sys.step("order-n1", "AddItem", "{}").unwrap();
+    clock.advance();
+    sys.step("order-n1", "SubmitOrder", "{}").unwrap();
+    clock.advance();
+    sys.step("order-n1", "ConfirmOrder", "{}").unwrap();
+
+    sys.assert_status("order-n1", "Confirmed");
+    // Payment should still be in its initial state — guard skipped the rule.
+    sys.assert_status("payment-n1", "Pending");
+    assert!(
+        sys.last_results().is_empty(),
+        "guard-skipped rule must not emit a ReactionResult"
     );
 }
 

--- a/crates/temper-server/tests/reaction_e2e_prod.rs
+++ b/crates/temper-server/tests/reaction_e2e_prod.rs
@@ -1,0 +1,440 @@
+//! End-to-end integration test for Phase 1–3 of nerdsane/temper#128 —
+//! exercises the **production** `ReactionDispatcher` path (async, through
+//! `ServerState.dispatch_tenant_action`) rather than the sim-only
+//! `SimReactionSystem` used in `reaction_cascade.rs`.
+//!
+//! This is the verification that closes the loop the ADR promises:
+//! a reaction declared in TOML (params_from + guard + Create resolver)
+//! actually dispatches through the live platform stack.
+
+use std::sync::Arc;
+
+use temper_runtime::ActorSystem;
+use temper_runtime::tenant::TenantId;
+use temper_server::ServerState;
+use temper_server::reaction::registry::parse_reactions;
+use temper_server::registry::SpecRegistry;
+use temper_server::request_context::AgentContext;
+use temper_spec::csdl::parse_csdl;
+
+const CSDL_XML: &str = r#"<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="Temper.ReactE2E" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="Order">
+        <Key><PropertyRef Name="Id"/></Key>
+        <Property Name="Id" Type="Edm.String" Nullable="false"/>
+        <Property Name="Status" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="Payment">
+        <Key><PropertyRef Name="Id"/></Key>
+        <Property Name="Id" Type="Edm.String" Nullable="false"/>
+        <Property Name="Status" Type="Edm.String"/>
+      </EntityType>
+      <EntityContainer Name="Container">
+        <EntitySet Name="Orders"   EntityType="Temper.ReactE2E.Order"/>
+        <EntitySet Name="Payments" EntityType="Temper.ReactE2E.Payment"/>
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>"#;
+
+const ORDER_IOA: &str = r#"
+[automaton]
+name = "Order"
+states = ["Draft", "Submitted", "Confirmed", "Cancelled"]
+initial = "Draft"
+
+[[state]]
+name = "items"
+type = "counter"
+initial = "0"
+
+[[action]]
+name = "AddItem"
+kind = "input"
+from = ["Draft"]
+
+[[action]]
+name = "SubmitOrder"
+kind = "internal"
+from = ["Draft"]
+to = "Submitted"
+guard = "items > 0"
+
+[[action]]
+name = "ConfirmOrder"
+kind = "internal"
+from = ["Submitted"]
+to = "Confirmed"
+
+[[action]]
+name = "CancelOrder"
+kind = "input"
+from = ["Draft", "Submitted"]
+to = "Cancelled"
+"#;
+
+const PAYMENT_IOA: &str = r#"
+[automaton]
+name = "Payment"
+states = ["Pending", "Authorized", "Captured", "Failed"]
+initial = "Pending"
+
+[[action]]
+name = "AuthorizePayment"
+kind = "internal"
+from = ["Pending"]
+to = "Authorized"
+
+[[action]]
+name = "CapturePayment"
+kind = "internal"
+from = ["Authorized"]
+to = "Captured"
+
+[[action]]
+name = "FailPayment"
+kind = "internal"
+from = ["Pending", "Authorized"]
+to = "Failed"
+"#;
+
+/// Build a ServerState with Order + Payment registered under the given
+/// tenant plus the supplied reaction rules. Rebuilds the reaction dispatcher
+/// so reactions fire through the production code path.
+fn build_state(tenant: &str, reactions_toml: &str) -> ServerState {
+    let mut registry = SpecRegistry::new();
+    let csdl = parse_csdl(CSDL_XML).expect("CSDL should parse");
+    let reactions = parse_reactions(reactions_toml).expect("reactions TOML should parse");
+    registry
+        .try_register_tenant_with_reactions(
+            tenant,
+            csdl,
+            CSDL_XML.to_string(),
+            &[("Order", ORDER_IOA), ("Payment", PAYMENT_IOA)],
+            reactions,
+        )
+        .expect("tenant registration");
+
+    let system = ActorSystem::new("reaction-e2e-prod");
+    let state = ServerState::from_registry(system, registry);
+    state.rebuild_reaction_dispatcher();
+    state
+}
+
+async fn dispatch(
+    state: &ServerState,
+    tenant: &TenantId,
+    entity_type: &str,
+    entity_id: &str,
+    action: &str,
+    params: serde_json::Value,
+) -> temper_server::entity_actor::EntityResponse {
+    state
+        .dispatch_tenant_action(
+            tenant,
+            entity_type,
+            entity_id,
+            action,
+            params,
+            &AgentContext::default(),
+        )
+        .await
+        .unwrap_or_else(|e| panic!("dispatch {entity_type}.{action} failed: {e}"))
+}
+
+async fn status(
+    state: &ServerState,
+    tenant: &TenantId,
+    entity_type: &str,
+    entity_id: &str,
+) -> String {
+    state
+        .get_tenant_entity_state(tenant, entity_type, entity_id)
+        .await
+        .unwrap_or_else(|e| panic!("get_entity_state {entity_type}:{entity_id} failed: {e}"))
+        .state
+        .status
+}
+
+// =========================================================================
+// E2E-1: Basic reaction fires through production dispatcher.
+//
+// Proves the whole stack wires up: parse_reactions → try_register_tenant
+// → build_reaction_registry → ReactionDispatcher → dispatch_tenant_action
+// → reaction target action completes.
+// =========================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn prod_dispatcher_fires_basic_reaction() {
+    let reactions = r#"
+[[reaction]]
+name = "order_confirmed_authorizes_payment"
+[reaction.when]
+entity_type = "Order"
+action = "ConfirmOrder"
+to_state = "Confirmed"
+[reaction.then]
+entity_type = "Payment"
+action = "AuthorizePayment"
+[reaction.resolve_target]
+type = "same_id"
+"#;
+    let tenant_name = "shop-e2e-1";
+    let state = Arc::new(build_state(tenant_name, reactions));
+    let tenant = TenantId::new(tenant_name);
+
+    dispatch(
+        &state,
+        &tenant,
+        "Order",
+        "o1",
+        "AddItem",
+        serde_json::json!({}),
+    )
+    .await;
+    dispatch(
+        &state,
+        &tenant,
+        "Order",
+        "o1",
+        "SubmitOrder",
+        serde_json::json!({}),
+    )
+    .await;
+    let r = dispatch(
+        &state,
+        &tenant,
+        "Order",
+        "o1",
+        "ConfirmOrder",
+        serde_json::json!({}),
+    )
+    .await;
+    assert!(r.success, "ConfirmOrder must succeed");
+
+    // Reaction dispatch is awaited inline by `dispatch_tenant_action`
+    // (`state/dispatch/actions.rs:157`), so by the time `r` returns the
+    // target entity's transition is already committed.
+    let order_status = status(&state, &tenant, "Order", "o1").await;
+    assert_eq!(order_status, "Confirmed");
+
+    let payment_status = status(&state, &tenant, "Payment", "o1").await;
+    assert_eq!(
+        payment_status, "Authorized",
+        "reaction should have dispatched AuthorizePayment on Payment:o1"
+    );
+}
+
+// =========================================================================
+// E2E-2: Guarded reaction — source field gate.
+//
+// Two rules on the same trigger; a source-field guard picks exactly one.
+// Proves ReactionGuard evaluation works through the production path.
+// =========================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn prod_dispatcher_honours_source_field_guard() {
+    // Two rules: one guarded state_in=["Confirmed"], one guarded
+    // state_in=["Cancelled"]. Only the Confirmed one should fire on
+    // Order.ConfirmOrder.
+    let reactions = r#"
+[[reaction]]
+name = "fires_on_confirmed"
+[reaction.when]
+entity_type = "Order"
+action = "ConfirmOrder"
+[reaction.when.guard]
+type = "state_in"
+values = ["Confirmed"]
+[reaction.then]
+entity_type = "Payment"
+action = "AuthorizePayment"
+[reaction.resolve_target]
+type = "same_id"
+
+[[reaction]]
+name = "skipped_on_cancelled"
+[reaction.when]
+entity_type = "Order"
+action = "ConfirmOrder"
+[reaction.when.guard]
+type = "state_in"
+values = ["Cancelled"]
+[reaction.then]
+entity_type = "Payment"
+action = "FailPayment"
+[reaction.resolve_target]
+type = "same_id"
+"#;
+    let tenant_name = "shop-e2e-2";
+    let state = Arc::new(build_state(tenant_name, reactions));
+    let tenant = TenantId::new(tenant_name);
+
+    dispatch(
+        &state,
+        &tenant,
+        "Order",
+        "o1",
+        "AddItem",
+        serde_json::json!({}),
+    )
+    .await;
+    dispatch(
+        &state,
+        &tenant,
+        "Order",
+        "o1",
+        "SubmitOrder",
+        serde_json::json!({}),
+    )
+    .await;
+    dispatch(
+        &state,
+        &tenant,
+        "Order",
+        "o1",
+        "ConfirmOrder",
+        serde_json::json!({}),
+    )
+    .await;
+
+    // Guard gate works: Payment is Authorized (passing rule fired), not Failed
+    // (skipped rule did NOT fire).
+    let payment_status = status(&state, &tenant, "Payment", "o1").await;
+    assert_eq!(
+        payment_status, "Authorized",
+        "state_in guard should have selected the Confirmed rule"
+    );
+}
+
+// =========================================================================
+// E2E-3: NOT guard — rule skipped because inner condition passes.
+//
+// Rule guarded with Not(StateIn[Confirmed]) must NOT fire when the source
+// post-status IS Confirmed. Confirms guard-skipped rules do not side-effect.
+// =========================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn prod_dispatcher_not_guard_skips_firing() {
+    let reactions = r#"
+[[reaction]]
+name = "skipped_when_confirmed"
+[reaction.when]
+entity_type = "Order"
+action = "ConfirmOrder"
+[reaction.when.guard]
+type = "not"
+[reaction.when.guard.guard]
+type = "state_in"
+values = ["Confirmed"]
+[reaction.then]
+entity_type = "Payment"
+action = "AuthorizePayment"
+[reaction.resolve_target]
+type = "same_id"
+"#;
+    let tenant_name = "shop-e2e-3";
+    let state = Arc::new(build_state(tenant_name, reactions));
+    let tenant = TenantId::new(tenant_name);
+
+    dispatch(
+        &state,
+        &tenant,
+        "Order",
+        "o1",
+        "AddItem",
+        serde_json::json!({}),
+    )
+    .await;
+    dispatch(
+        &state,
+        &tenant,
+        "Order",
+        "o1",
+        "SubmitOrder",
+        serde_json::json!({}),
+    )
+    .await;
+    dispatch(
+        &state,
+        &tenant,
+        "Order",
+        "o1",
+        "ConfirmOrder",
+        serde_json::json!({}),
+    )
+    .await;
+
+    // Payment should stay Pending — the reaction was gated off.
+    let payment_status = status(&state, &tenant, "Payment", "o1").await;
+    assert_eq!(
+        payment_status, "Pending",
+        "Not(state_in=Confirmed) guard must have skipped the rule"
+    );
+}
+
+// =========================================================================
+// E2E-4: params_from — dynamic params pipe through production dispatch
+// without breaking the cascade when source field is missing.
+//
+// Proves build_effective_params (shared helper between prod and sim) is
+// wired correctly into ReactionDispatcher. Uses missing-source-field case
+// because the plan's "warn + skip the key" policy is the load-bearing one.
+// =========================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn prod_dispatcher_params_from_missing_field_still_fires() {
+    let reactions = r#"
+[[reaction]]
+name = "order_confirmed_with_params_from"
+[reaction.when]
+entity_type = "Order"
+action = "ConfirmOrder"
+[reaction.then]
+entity_type = "Payment"
+action = "AuthorizePayment"
+# Reference a field Order.ConfirmOrder never produces.
+params = { note = "from_reaction" }
+params_from = { passed_field = "nonexistent" }
+[reaction.resolve_target]
+type = "same_id"
+"#;
+    let tenant_name = "shop-e2e-4";
+    let state = Arc::new(build_state(tenant_name, reactions));
+    let tenant = TenantId::new(tenant_name);
+
+    dispatch(
+        &state,
+        &tenant,
+        "Order",
+        "o1",
+        "AddItem",
+        serde_json::json!({}),
+    )
+    .await;
+    dispatch(
+        &state,
+        &tenant,
+        "Order",
+        "o1",
+        "SubmitOrder",
+        serde_json::json!({}),
+    )
+    .await;
+    dispatch(
+        &state,
+        &tenant,
+        "Order",
+        "o1",
+        "ConfirmOrder",
+        serde_json::json!({}),
+    )
+    .await;
+
+    // Payment authorized — missing source field triggered warn+skip for
+    // the passed_field key but the reaction still fired.
+    let payment_status = status(&state, &tenant, "Payment", "o1").await;
+    assert_eq!(payment_status, "Authorized");
+}

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -581,6 +581,11 @@ Evolution records reference these as portable SQL. Swapping providers doesn't br
 
 ## 9. Integration Engine
 
+Two mechanisms fire work after an action commits:
+
+- **Cross-entity reactions** — in-system choreography (another entity's action). Declarative TOML, no code. Fire-and-forget, bounded cascade, deterministic under `SimReactionSystem`. Use reactions when both source and target are Temper entities. See [`docs/reactions.md`](reactions.md) for the full reference and [ADR-0045](adrs/0045-reactions-first-class-app-primitive.md) for the design.
+- **WASM integrations** — out-of-system work (external HTTP, LLM calls, third-party APIs). Described below. Use integrations when you need computation, I/O beyond the Temper cluster, or explicit retry / timeout semantics.
+
 Integrations follow the **Outbox Pattern**: the state machine stays pure and deterministically verifiable; external calls happen out-of-band. `[[integration]]` declarations in IOA TOML are metadata — they don't affect state transitions or verification.
 
 ### Spec Syntax

--- a/docs/adrs/0045-reactions-first-class-app-primitive.md
+++ b/docs/adrs/0045-reactions-first-class-app-primitive.md
@@ -1,0 +1,172 @@
+# ADR-0045: Reactions as a First-Class App Primitive
+
+- Status: Proposed
+- Date: 2026-04-16
+- Deciders: Temper core maintainers
+- Related:
+  - ADR-0015: Agent OS Cross-Entity Primitives (cross-entity guards at the action layer)
+  - [nerdsane/temper#128](https://github.com/nerdsane/temper/issues/128)
+  - `crates/temper-server/src/reaction/` (ReactionDispatcher, registry, resolver, types)
+  - `crates/temper-server/src/state/dispatch/cross_entity.rs` (cross-entity guard fetch helper to reuse)
+  - `os-apps/temper-fs/reactions/reactions.toml` (only production consumer of hand-authored reactions today)
+
+## Context
+
+Temper already ships a production-grade cross-entity reaction system. `ReactionDispatcher` fires after every successful action, with deterministic ordering, tenant isolation, fire-and-forget semantics, and a bounded cascade depth (`MAX_REACTION_DEPTH = 8`). It works, and `paw-fs` uses it correctly.
+
+Above the surface it is almost invisible. `paw-fs` is the only app with a hand-authored `reactions.toml`. Every other app that needs a cross-entity transition writes a WASM module whose sole job is to call `temper_action()` on another entity — WASM-as-plumbing. The motivating example is katagami-curation's `build_session_message` WASM, which exists solely to react to `CurationJob.Submit` by creating a Session and dispatching `Configure` on it. This is exactly what reactions already solve for paw-fs.
+
+Three concrete capabilities are missing that would let reactions replace that WASM, plus a documentation gap that stops developers from finding the primitive in the first place:
+
+1. **Dynamic param mapping** — today `ReactionTarget.params` is wired through the dispatcher (`dispatcher.rs:113`) but only accepts static TOML literals. There's no way to pipe source-entity field values into the target action's params.
+2. **Conditional guards on reactions** — today `ReactionTrigger` matches on `(entity_type, action, to_state)`. Branching pipelines ("only fire when `job_type == 'source_search'`") require either a second-entity indirection or WASM.
+3. **Fresh-ID create resolver** — `CreateIfMissing` requires a derivable ID on the source entity. Pipeline chaining ("each CurationJob.Complete creates a new CurationJob") needs a genuinely new UUID.
+4. **Documentation** — `AGENTS.md` currently tells developers "if logic runs on state change, write a WASM integration." That advice predates reactions being usable for general pipelines.
+
+Correction on the issue's framing: `ReactionTarget.params` is *fully wired today*. The gap is not threading, it is that params are static-only. `params_from` closes that specific gap.
+
+## Decision
+
+Extend the reaction system along four axes. All additions are additive with `#[serde(default)]`; existing `paw-fs` reactions and `[[agent_trigger]]`-synthesized rules parse and behave byte-identically.
+
+### Sub-Decision 1: `params_from` — dynamic params from source fields
+
+Add `params_from: BTreeMap<String, String>` to `ReactionTarget`. Keys name target-action params; values name fields on the source entity. At dispatch time, a shared helper `build_effective_params` merges the static `params` with values read out of the source entity's `fields` value. Collision between `params` and `params_from` keys is a parse-time error. Missing source field at runtime → `tracing::warn!` and skip the key; the reaction still fires with a partial param map (consistent with existing resolver `None`-on-missing posture).
+
+```toml
+[reaction.then]
+entity_type = "CurationJob"
+action      = "Submit"
+params      = { requested_by = "system" }
+params_from = { job_type = "next_stage", input = "output" }
+```
+
+**Why this shape**: the issue's TOML sketch. BTreeMap (not HashMap) for DST compliance. Static + dynamic coexist so literals can be mixed with piped values without introducing a template language. A single helper serves both `dispatcher` and `sim_dispatcher` so production and simulation stay in lockstep.
+
+### Sub-Decision 2: `Create` target resolver — fresh UUID
+
+Add a variant to `TargetResolver` that returns a genuinely new entity ID on every dispatch via `sim_uuid()`. Distinct from `CreateIfMissing` (which is keyed on an `id_field` and intended for per-source-entity singletons like "one FileVersion per File commit").
+
+```toml
+[reaction.resolve_target]
+type = "create"
+```
+
+**Why `sim_uuid`, not `Uuid::new_v4`**: `reaction` lives in `temper-server`, a simulation-visible crate. DST rules (temper CLAUDE.md § Deterministic Simulation) require seeded sources. `sim_uuid()` already exists in `temper-runtime` and is what the rest of the reaction path uses; reusing it keeps `SimReactionSystem` deterministic across seeded runs.
+
+**Compositional value with Sub-Decision 1**: `Create` + `params_from` together replace the katagami `build_session_message` WASM exactly — fresh Session ID with fields piped from the source CurationJob, declared in TOML with zero code.
+
+### Sub-Decision 3: `ReactionGuard` — conditional firing (source + cross-entity)
+
+Add `guard: Option<ReactionGuard>` to `ReactionTrigger`. `ReactionGuard` is a new enum with three families:
+
+- **Sync source-only (no I/O):** `field_equals { field, value }`, `field_in { field, values }`, `bool_true { field }`, `bool_false { field }`, `state_in { values }` — evaluate against the source entity's post-action fields already in hand.
+- **Async cross-entity:** `cross_entity_state_in { entity_type, entity_id_source, required_status }` — fetch another entity's current state and compare. Deliberately mirrors the IOA guard variant of the same name (ADR-0015) so developers transfer knowledge between the two evaluation paths. The implementation reuses the existing fetch helper inside `crates/temper-server/src/state/dispatch/cross_entity.rs`; we do not duplicate the fetch logic.
+- **Composite:** `all_of`, `any_of`, `not` — bounded at `MAX_GUARD_DEPTH = 4`, validated at parse time.
+
+Guard-skipped rules do *not* emit a `ReactionResult`. They never fired. This matters for the `last_results()` contract and for tests that count results.
+
+```toml
+[reaction.when]
+entity_type = "CurationJob"
+action      = "Complete"
+[reaction.when.guard]
+type  = "field_equals"
+field = "job_type"
+value = "source_search"
+```
+
+**Why a new enum rather than reusing `temper-jit::Guard`**: IOA guards are compiled into the transition table and evaluated *pre-action* with transition-table context. Reaction guards evaluate *post-action* against the source entity's resulting fields, which are already available for sync variants. Reusing the full IOA enum would drag in transition-table machinery we don't need. Mirroring variant *names* and TOML vocabulary keeps the developer experience consistent without coupling the two evaluation paths.
+
+**Why include cross-entity guards now, not later**: the motivating apps (katagami pipelines, session-completion callbacks on a parent Workspace) will want them soon. Adding them to the enum in a follow-up would change the shape (adding async to `evaluate`) and force a second parser/test pass. Cheaper to ship once.
+
+### Sub-Decision 4: Documentation — make reactions discoverable
+
+- New `docs/reactions.md`: what reactions are, when to use them vs. WASM, full TOML reference, three example patterns (pipeline chaining, session-completion callback, cleanup-on-failed), and the invariants that don't change (fire-and-forget, `MAX_REACTION_DEPTH = 8`, determinism).
+- Amend `AGENTS.md`: replace "if logic runs on state change, it's a WASM integration" with "if a state change needs to trigger another entity's action, use a reaction (`docs/reactions.md`). If it needs computation, external I/O, or a new WASM-authored field, use an integration."
+
+**Why this matters for architecture, not just ergonomics**: undocumented primitives accumulate WASM workarounds. Every such workaround puts cross-entity wiring inside a WASM module's return value, which is opaque to traces, opaque to Cedar, and untestable without hosting the module. Documenting reactions closes that leak.
+
+### Sub-Decision 5: Keep reactions separate from actions (architectural reaffirmation)
+
+We considered folding cross-entity transitions into the action layer itself (e.g., letting an action's TOML declare downstream entity transitions inline, eliminating the reaction primitive). Rejected. The separation is load-bearing:
+
+1. **Verification tractability.** `temper-verify` proves each action preserves *its own entity's* invariants because each entity is a closed I/O automaton. Cross-entity transitions inside actions would force joint invariants across every pair of entities that could interact — combinatorial explosion for the model checker.
+2. **Authorization scope.** Actions run under the invoking principal's Cedar context. Reactions elevate to `AgentContext::system()` at `dispatcher.rs:114` — the platform enacts downstream transitions, not the user. Fusing the layers means either users inherit cross-entity authority they shouldn't, or we reinvent reaction-style elevation inside the action path.
+3. **Transactional boundary.** Actions are all-or-nothing with respect to their entity's invariants. Reactions are fire-and-forget — a failing reaction doesn't roll back the source. Different failure semantics; fusing them forces one or the other.
+4. **Bounded cascades.** `MAX_REACTION_DEPTH = 8` lives in the reaction dispatcher. Actions-transitioning-actions has no natural cap; you'd need the same bound in a different place.
+5. **Composition vs. contract.** Actions are the entity's verified contract. Reactions are how apps *compose* entities. Mixing them forces every cross-entity wiring change to re-verify the contract surface.
+6. **Standard pattern.** Pure transition + declarative effect is the split in Elm, Redux middleware, Kafka Streams, FoundationDB observers. Temper follows that pattern; we're not inventing one.
+
+This sub-decision doesn't ship code. It's a commitment: Track 4 extends reactions; it does not fuse them into actions.
+
+## Rollout Plan
+
+One PR on `nerdsane/temper` from `feat/reactions-first-class-primitive`. Phase commits are atomic inside the branch so reviewers can walk the history: ADR → types → `params_from` → `Create` resolver → guards → docs.
+
+1. **Commit 1** — this ADR.
+2. **Commit 2** — `ReactionTarget.params_from` + `build_effective_params` helper + registry/dispatcher/sim_dispatcher wiring + unit/integration tests.
+3. **Commit 3** — `TargetResolver::Create` variant + `sim_uuid` branch in resolver + registry parse + tests (including DST determinism).
+4. **Commit 4** — `ReactionGuard` enum + `guard.rs` evaluator (sync + async-cross-entity reusing `cross_entity.rs` fetch) + registry parse with `MAX_GUARD_DEPTH` + dispatcher/sim_dispatcher integration + tests.
+5. **Commit 5** — `docs/reactions.md` + `AGENTS.md` amendment.
+
+All five land in one PR.
+
+## Readiness Gates
+
+- `cargo test --workspace` green, including `temper-platform --test platform_e2e_dst`.
+- `paw-fs` regression: existing `os-apps/temper-fs/reactions/reactions.toml` loads and dispatches byte-identically under the extended parser.
+- Agent-trigger synthesis regression: `synthesize_agent_trigger_reactions` output unchanged (no `guard`, no `params_from`, no `Create`).
+- DST replay: two seeded runs under `SimReactionSystem` produce identical reaction firing order and identical `Create`-resolver IDs.
+- DST reviewer + code-reviewer PASS markers present before commit.
+- Pre-push 4-gate pipeline green (rustfmt, clippy, readability ratchet, full test suite).
+
+## Consequences
+
+### Positive
+- Cross-entity wiring moves from WASM modules into TOML, becoming visible to traces, reviewable as code, and testable without WASM hosting.
+- Pipeline chaining (per-stage CurationJob fan-out) becomes a 6-line TOML snippet.
+- Session-completion callbacks and cleanup-on-failed flows — long-standing WASM workarounds — become declarative.
+- Reaction observability improves: each reaction has a name, rule table entry, and tracing span.
+
+### Negative
+- `reaction.rs` surface area grows (new enum, new module, additional helper). Mitigated by keeping the action layer untouched; all complexity lives inside `crates/temper-server/src/reaction/`.
+- Cross-entity guards add async fetches to the reaction path. Capped by `MAX_REACTION_DEPTH = 8`; a per-dispatch counter attaches to the tracing span so cost stays visible.
+
+### Risks
+- **Drift between sync prod path and sim path.** Sync `dispatcher` and `sim_dispatcher` both implement guard + merged-params logic. Mitigation: extract `build_effective_params` and guard evaluation into shared helpers; integration tests run both paths on the same scenarios.
+- **Over-eager developer use replacing WASM that *should* stay WASM.** Reactions are fire-and-forget and capped at depth 8; they are not a substitute for computation-heavy or I/O-bearing logic. Mitigation: `docs/reactions.md` explicitly enumerates the "still use WASM" cases (external I/O, computation, >8 cascade depth).
+- **Cross-entity guard latency in deep cascades.** Each guard costs one entity fetch. Mitigation: fetch counter in trace span + existing depth budget + readiness-gate review of cross-entity guard use in new apps.
+
+### DST Compliance
+- `TargetResolver::Create` uses `temper-runtime::sim_uuid()`, not `uuid::Uuid::new_v4`.
+- All new collections are `BTreeMap` / `BTreeSet` for deterministic iteration.
+- Guard evaluation is a pure function of `(guard, source_fields)` for sync variants; for `cross_entity_state_in`, the sim path reads from the in-memory entity store synchronously (no wall-clock waits).
+- No new `static mut`, `lazy_static!`, or `thread_local!`.
+- No new `chrono::Utc::now()` or `std::thread::sleep()`.
+
+## Non-Goals
+
+- **No change to fire-and-forget semantics.** Reactions remain non-transactional.
+- **No expression DSL.** The issue's `"job_type eq 'source_search'"` syntax is rendered as structured enum TOML. Adding a parser is a larger commitment than this track scopes.
+- **No change to `MAX_REACTION_DEPTH` (8) or `MAX_REACTIONS_PER_TENANT` (256).**
+- **No fusion with the action layer.** See Sub-Decision 5.
+- **No changes to `paw-fs` reactions or `[[agent_trigger]]` synthesis.** Both remain byte-identical.
+- **No katagami-curation rewrite in this track.** Katagami consumes the new primitives after this PR merges; that rewrite is a separate track in katagami's repo.
+
+## Alternatives Considered
+
+1. **Expression DSL for guards** (e.g., `"job_type eq 'source_search'"`). Rejected: Temper's codebase uses structured Rust enums for guards, not expressions. A DSL would need a parser, its own error-reporting story, and would diverge from IOA guard ergonomics. Structured TOML keeps the two paths consistent.
+2. **Fold cross-entity transitions into the action layer.** Rejected (Sub-Decision 5): breaks verification tractability, authorization boundary, transactional semantics, and cascade bounds.
+3. **Source-entity-only guards now; cross-entity guards as a follow-up.** Rejected: the follow-up would change `ReactionGuard::evaluate` from sync to async, forcing a second pass through the parser and every call site. Cheaper to ship once.
+4. **Strict miss-on-`params_from` (fail the whole reaction when a source field is missing).** Rejected: inconsistent with existing resolver `None` posture. Partial params + warn matches how `resolver::Field` already handles drift.
+5. **Unbounded composite guards.** Rejected: cascade depth already caps reaction fan-out; unbounded guard nesting would make evaluation cost unpredictable. `MAX_GUARD_DEPTH = 4` is TigerStyle — bound budgets rather than hope.
+
+## Rollback Policy
+
+All additions are additive with serde defaults. Reverting the PR restores the previous reaction surface exactly; `paw-fs` and agent-trigger synthesis are unaffected by design.
+
+If a specific sub-decision proves wrong after merge:
+- `params_from`: remove the field from `ReactionTarget` and the `build_effective_params` helper; existing TOML without `params_from` is unaffected.
+- `Create` resolver: remove the variant; apps using it must switch to `CreateIfMissing` with an explicit `id_field`.
+- Guards: remove the field from `ReactionTrigger`; guarded rules become unconditional (review carefully before pulling — this could fire reactions that were previously gated off).

--- a/docs/reactions.md
+++ b/docs/reactions.md
@@ -1,0 +1,247 @@
+# Cross-Entity Reactions
+
+Reactions are Temper's declarative layer for cross-entity choreography. When a source entity completes an action, a reaction rule dispatches a target action on another entity — no WASM module required.
+
+This document is the developer reference. For architectural rationale see [ADR-0045](adrs/0045-reactions-first-class-app-primitive.md).
+
+---
+
+## When to use a reaction vs. a WASM integration
+
+| | Reactions | WASM integrations |
+|---|---|---|
+| What triggers it | Another entity's action committing | Another entity's action committing |
+| Where it runs | Temper dispatcher (Rust, in-process) | Wasmtime sandbox |
+| Authorization | `AgentContext::system()` | Configured principal |
+| Failure mode | Fire-and-forget (non-transactional) | Configurable retry / timeout |
+| Cascade bound | `MAX_REACTION_DEPTH = 8` | None (bounded by wall-clock timeout) |
+| Observable as | Tracing span + `ReactionResult` | Tracing span + integration config |
+| Determinism | Yes — deterministic under `SimReactionSystem` with a seed | No — WASM modules treated as side-effect only |
+
+**Use a reaction when:**
+- The source action and target action are both on Temper entities.
+- The work is "take X from source and call action Y on entity Z."
+- You want it to appear in verified traces, reviewable as config, testable without hosting.
+
+**Use a WASM integration when:**
+- You need external I/O (HTTP, LLM calls, third-party APIs).
+- You need to compute a value the source entity doesn't have.
+- The work is deeper than 8 cascade levels.
+- You need retry / timeout / backoff semantics.
+
+---
+
+## TOML schema
+
+Reactions live in `reactions.toml` at the app's specs directory. Example structure:
+
+```toml
+[[reaction]]
+name = "order_confirmed_triggers_payment"
+
+[reaction.when]
+entity_type = "Order"
+action = "ConfirmOrder"
+to_state = "Confirmed"
+
+[reaction.then]
+entity_type = "Payment"
+action = "AuthorizePayment"
+params = { requested_by = "system" }
+
+[reaction.resolve_target]
+type = "same_id"
+```
+
+### `[reaction.when]` — trigger
+
+| Field | Type | Required | Meaning |
+|---|---|---|---|
+| `entity_type` | string | yes | Source entity type (e.g., `Order`) |
+| `action` | string | no | Action name — omit to match any action |
+| `to_state` | string | no | Required source post-state — omit to match any |
+| `guard` | table | no | Conditional predicate (see below) |
+
+### `[reaction.then]` — target action
+
+| Field | Type | Required | Meaning |
+|---|---|---|---|
+| `entity_type` | string | yes | Target entity type |
+| `action` | string | yes | Action to dispatch |
+| `params` | inline table | no | Static parameters, merged into the target action's param payload |
+| `params_from` | inline table | no | Dynamic params: `target_key = "source_field_name"` — at dispatch, read the named source field and bind it to the target param |
+
+`params` and `params_from` **must not share keys** — that is a parse-time error.
+
+If a `params_from` source field is missing on the source entity at dispatch time, the key is logged (`tracing::warn!`) and skipped; the reaction still fires with a partial param map.
+
+### `[reaction.resolve_target]` — how to pick the target entity ID
+
+| `type` | Required fields | Behavior |
+|---|---|---|
+| `field` | `field` | Read the target entity ID from a source field. Missing → reaction skipped (warn). |
+| `same_id` | — | Target ID = source entity ID. |
+| `static` | `entity_id` | Target ID is a fixed string. Useful for per-tenant singletons. |
+| `create_if_missing` | `id_field` | Read target ID from source field; if absent, derive `"{source_id}-derived"`. Good for per-source-entity singletons (e.g., one `FileVersion` per `File`). |
+| `create` | — | Fresh UUID on every dispatch via `sim_uuid()`. Correct choice for pipeline chaining where each source action spawns a brand-new target instance. |
+
+---
+
+## Guards
+
+`[reaction.when.guard]` is an optional predicate that gates firing. Guard-skipped rules do **not** emit a `ReactionResult` — they never fired.
+
+### Source-field guards (sync, cheap)
+
+```toml
+[reaction.when.guard]
+type = "field_equals"
+field = "job_type"
+value = "source_search"
+```
+
+| `type` | Fields | Behavior |
+|---|---|---|
+| `field_equals` | `field`, `value` | Source field JSON-equals `value` |
+| `field_in` | `field`, `values` (array) | Source field ∈ `values` |
+| `bool_true` | `field` | Source field is JSON `true` |
+| `bool_false` | `field` | Source field is JSON `false` |
+| `state_in` | `values` (array) | Source post-status ∈ `values` — complements `to_state` when multiple states are acceptable |
+
+Missing source fields on any of the above evaluate to `false` with a `tracing::debug!`.
+
+### Cross-entity guard (async, one fetch per guard)
+
+```toml
+[reaction.when.guard]
+type = "cross_entity_state_in"
+entity_type = "Workspace"
+entity_id_source = "workspace_id"
+required_status = ["Active"]
+```
+
+Reads `workspace_id` from the source entity, fetches `Workspace:{workspace_id}` via the existing `resolve_entity_status` helper (same path IOA guards use), compares against `required_status`. Missing target ID or fetch failure evaluates to `false` with a `tracing::warn!` — stricter than IOA's vacuous-truth handling, since an empty target ID is almost always a misconfiguration.
+
+### Composite guards
+
+```toml
+[reaction.when.guard]
+type = "all_of"
+guards = [
+  { type = "bool_true", field = "ready" },
+  { type = "cross_entity_state_in",
+    entity_type = "Workspace",
+    entity_id_source = "workspace_id",
+    required_status = ["Active"] },
+]
+```
+
+`all_of` / `any_of` / `not` compose into `MAX_GUARD_DEPTH = 4` (validated at parse time).
+
+---
+
+## Three example patterns
+
+### 1. Pipeline chaining
+
+Each `CurationJob` completion spawns the next stage as a new job:
+
+```toml
+[[reaction]]
+name = "source_search_complete_triggers_rank"
+
+[reaction.when]
+entity_type = "CurationJob"
+action = "Complete"
+[reaction.when.guard]
+type = "field_equals"
+field = "job_type"
+value = "source_search"
+
+[reaction.then]
+entity_type = "CurationJob"
+action = "Submit"
+params = { job_type = "rank" }
+params_from = { input = "output" }
+
+[reaction.resolve_target]
+type = "create"
+```
+
+Fresh UUID for the new job, `output` from the source piped into the target's `input`.
+
+### 2. Session-completion callback
+
+When a child `Session` completes, Ack the parent — but only if the parent is still Active:
+
+```toml
+[[reaction]]
+name = "session_complete_acks_parent"
+
+[reaction.when]
+entity_type = "Session"
+action = "Complete"
+[reaction.when.guard]
+type = "cross_entity_state_in"
+entity_type = "Workspace"
+entity_id_source = "workspace_id"
+required_status = ["Active"]
+
+[reaction.then]
+entity_type = "Workspace"
+action = "AckSession"
+params_from = { session_id = "id" }
+
+[reaction.resolve_target]
+type = "field"
+field = "workspace_id"
+```
+
+### 3. Cleanup-on-failed
+
+When an entity enters Failed, clean up its related resources:
+
+```toml
+[[reaction]]
+name = "order_failed_releases_inventory"
+
+[reaction.when]
+entity_type = "Order"
+action = "FailOrder"
+to_state = "Failed"
+
+[reaction.then]
+entity_type = "InventoryHold"
+action = "Release"
+params_from = { order_id = "id" }
+
+[reaction.resolve_target]
+type = "field"
+field = "hold_id"
+```
+
+---
+
+## Invariants (what does NOT change)
+
+These properties are load-bearing and unchanged by any of the four Phase additions:
+
+- **Fire-and-forget.** A failing reaction does NOT roll back the source transition. The source action is already committed by the time the dispatcher runs.
+- **Cascade bound.** `MAX_REACTION_DEPTH = 8` caps the depth of recursive reaction chains. Beyond 8, further reactions are dropped with a warning.
+- **Tenant isolation.** Reactions only fire for rules registered under the same tenant as the source action.
+- **System principal.** Target actions dispatched by reactions run under `AgentContext::system()`, not the source action's principal.
+- **Determinism under `SimReactionSystem`.** Two seeded runs with the same inputs produce the same reaction firing order and the same `create`-resolver IDs.
+- **Budget.** `MAX_REACTIONS_PER_TENANT = 256`, `MAX_GUARD_DEPTH = 4`.
+
+---
+
+## Where reactions fit in the Temper architecture
+
+Reactions are the *composition* layer. Actions are the *contract* layer.
+
+- **Actions** are the entity's verified surface — preconditions, guards, effects, invariants. Each entity is a closed I/O Automaton, which is why `temper-verify` can model-check each action in isolation.
+- **Reactions** are how apps wire entities together. They fire *after* actions commit, elevated to the system principal, non-transactional, bounded.
+
+Keeping the layers separate is what makes verification tractable (each entity stays a closed automaton), authorization coherent (the user who submitted an Order doesn't inherit authority over Payment), and cascades bounded. See [ADR-0045 Sub-Decision 5](adrs/0045-reactions-first-class-app-primitive.md#sub-decision-5-keep-reactions-separate-from-actions-architectural-reaffirmation) for the full rationale.
+
+The only production consumer of hand-authored reactions today is `os-apps/temper-fs/reactions/reactions.toml`. Apps that need cross-entity choreography should prefer reactions over WASM integrations unless they need computation, external I/O, or retries.

--- a/os-apps/temper-fs/reactions/reactions.toml
+++ b/os-apps/temper-fs/reactions/reactions.toml
@@ -17,7 +17,7 @@ entity_type = "FileVersion"
 action = "Create"
 
 [reaction.resolve_target]
-type = "CreateIfMissing"
+type = "create_if_missing"
 id_field = "last_version_id"
 
 # When a new version is created, supersede the previous FileVersion.
@@ -33,7 +33,7 @@ entity_type = "FileVersion"
 action = "Supersede"
 
 [reaction.resolve_target]
-type = "Field"
+type = "field"
 field = "last_version_id"
 
 # When a file's content is updated, increment the workspace's used bytes.
@@ -49,5 +49,5 @@ entity_type = "Workspace"
 action = "IncrementUsage"
 
 [reaction.resolve_target]
-type = "Field"
+type = "field"
 field = "workspace_id"


### PR DESCRIPTION
## Summary

Closes [#128](https://github.com/nerdsane/temper/issues/128). Extends the existing `ReactionDispatcher` along four additive axes so apps can replace hand-written "WASM-as-plumbing" modules (e.g. katagami-curation's `build_session_message`) with declarative TOML.

**What's new:**
- `ReactionTarget.params_from` — pipe source-entity field values into target action params at dispatch time. Static `params` + dynamic `params_from` merge via a shared helper; collisions are a parse-time error; missing source fields log and skip the key (reaction still fires with partial params).
- `TargetResolver::Create` — fresh UUID per dispatch via `sim_uuid()` (DST-safe). Distinct from `CreateIfMissing`; needed for pipeline chaining where each source action spawns a brand-new target instance.
- `ReactionGuard` — conditional firing with sync source-field variants (`field_equals`, `field_in`, `bool_true/false`, `state_in`), async cross-entity `cross_entity_state_in` (reuses `ServerState::resolve_entity_status`), and composite `all_of` / `any_of` / `not` bounded at `MAX_GUARD_DEPTH = 4`. Guard-skipped rules do NOT emit a `ReactionResult`.
- Developer docs: `docs/reactions.md` (full TOML reference + three example patterns) and a pointer from `AGENT_GUIDE.md` §9.

**What's not new (architectural reaffirmation, per ADR Sub-Decision 5):**
- Reactions stay separate from the action layer. Verification tractability, authorization scope, transactional boundary, and cascade bounds all depend on the separation.
- All additions are additive with `#[serde(default)]`; paw-fs reactions and `[[agent_trigger]]`-synthesized rules remain byte-identical.

Also includes:
- **fix:** `os-apps/temper-fs/reactions/reactions.toml` resolver types had been PascalCase (`"CreateIfMissing"`, `"Field"`) while the parser matched only snake_case — dead data since merge. Snake-case corrected + regression test added.

## Commits (ADR → feature → docs → e2e)

```
b3e920a docs(adrs): 0045 reactions as first-class app primitive
88ace3f feat(reaction): params_from — pipe source fields into reaction params
84c33c8 feat(reaction): Create target resolver — fresh sim_uuid per dispatch
da29ebb feat(reaction): ReactionGuard — conditional firing, source + cross-entity
25a88a3 fix(temper-fs): snake_case resolver types in reactions.toml
7fd187b docs(reaction): developer guide for cross-entity reactions
5149e05 test(reaction): end-to-end verification through production dispatcher
```

## Test plan

**Local verification (all green):**
- [x] `cargo build --workspace`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p temper-server --lib reaction::` — 51/51
- [x] `cargo test -p temper-server --test reaction_cascade` — 12/12 (sim dispatcher, plus paw-fs reactions.toml regression load through the parser, guard pass/skip, params_from cascade, Create determinism under `SimReactionSystem`)
- [x] `cargo test -p temper-server --test reaction_e2e_prod` — 4/4 **production-path** E2E (real async `ReactionDispatcher` via `ServerState::dispatch_tenant_action`; basic reaction, source-field guard selection, `Not(state_in)` skip, `params_from` missing-field tolerance)
- [x] `cargo test -p temper-platform --test platform_e2e_dst` — 6/6
- [x] DST review marker + code review marker written for every code-bearing commit

**Not run locally — deferred to CI:**
- [ ] `cargo test --workspace` — the full workspace suite includes several heavyweight platform DST tests (`dst_platform_cedar`, `dst_platform_random`, etc.) that run stateright model-checking and individually take 5–10+ minutes. None of them touch the reaction layer. Attempts to run the suite locally blew past 30 min; pushed with `--no-verify` after Rita explicitly authorized falling back to the narrower verification. CI will run the full suite.

**Verification posture:**
- `paw-fs` `reactions.toml` now load-bearing: parsed in a regression test that fails if the file drifts from the parser again.
- `[[agent_trigger]]` synthesized rules unchanged — `guard: None`, `params_from` empty, verified by the existing tests.
- Production `ReactionDispatcher` path (not just `SimReactionSystem`) covered end-to-end in `reaction_e2e_prod.rs`.

Create resolver is not yet exercised through the live production path — the `prod_dispatcher_*` tests would need target-actor-on-demand spawn infrastructure which is out of scope for this PR. Its determinism is proven under `SimReactionSystem` (`create_resolver_is_deterministic_across_seeded_runs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)