### PR TITLE
feat: compound boolean asserts in invariants (#101)

### DIFF
--- a/crates/temper-runtime/src/scheduler/sim_actor_system.rs
+++ b/crates/temper-runtime/src/scheduler/sim_actor_system.rs
@@ -600,57 +600,15 @@ impl SimActorSystem {
                     continue;
                 }
 
-                let violated = match &inv.assert {
-                    super::sim_handler::SpecAssert::CounterPositive { var } => {
-                        // Currently only "items" counter is tracked.
-                        if var == "items" {
-                            item_count == 0
-                        } else {
-                            false
-                        }
-                    }
-                    super::sim_handler::SpecAssert::NoFurtherTransitions => {
-                        // This is called after a successful transition. If
-                        // status_before was the terminal state (one of the
-                        // `when` states), a transition should not have fired.
-                        inv.when.iter().any(|s| s == status_before)
-                    }
-                    super::sim_handler::SpecAssert::OrderingConstraint { before, after } => {
-                        // If the entity is now in the "after" state, check
-                        // that "before" was visited in event history.
-                        if status_after == after.as_str() {
-                            let events = handler.events_json();
-                            if let Some(arr) = events.as_array() {
-                                let visited_before = arr.iter().any(|e| {
-                                    e.get("to_status").and_then(|s| s.as_str())
-                                        == Some(before.as_str())
-                                });
-                                !visited_before // violated if "before" was never visited
-                            } else {
-                                false
-                            }
-                        } else {
-                            false // Not in the "after" state, invariant doesn't apply
-                        }
-                    }
-                    super::sim_handler::SpecAssert::NeverState { state } => {
-                        // Violated if the entity is currently in the forbidden state.
-                        status_after == state.as_str()
-                    }
-                    super::sim_handler::SpecAssert::CounterCompare { var, op, value } => {
-                        // Only the "items" counter is passed to check_invariants.
-                        // Other counters require expanding the SimActorHandler trait.
-                        let counter_val = if var == "items" { item_count } else { 0 };
-                        let passed = match op {
-                            super::sim_handler::CompareOp::Gt => counter_val > *value,
-                            super::sim_handler::CompareOp::Gte => counter_val >= *value,
-                            super::sim_handler::CompareOp::Lt => counter_val < *value,
-                            super::sim_handler::CompareOp::Lte => counter_val <= *value,
-                            super::sim_handler::CompareOp::Eq => counter_val == *value,
-                        };
-                        !passed // violated if comparison fails
-                    }
-                };
+                let passed = evaluate_spec_assert(
+                    &inv.assert,
+                    handler.as_ref(),
+                    &inv.when,
+                    status_before,
+                    status_after,
+                    item_count,
+                );
+                let violated = !passed;
 
                 self.recorded_invariants
                     .push((actor_id.to_string(), inv.name.clone(), !violated));
@@ -681,6 +639,67 @@ impl SimActorSystem {
                 tick,
             });
         }
+    }
+}
+
+/// Evaluate a [`SpecAssert`] against handler state. Returns `true` if the
+/// assertion holds, `false` if violated. Recurses through `And`/`Or`.
+fn evaluate_spec_assert(
+    assert: &super::sim_handler::SpecAssert,
+    handler: &dyn super::sim_handler::SimActorHandler,
+    when: &[String],
+    status_before: &str,
+    status_after: &str,
+    item_count: usize,
+) -> bool {
+    use super::sim_handler::{CompareOp, SpecAssert};
+
+    match assert {
+        SpecAssert::CounterPositive { var } => {
+            if var == "items" {
+                item_count > 0
+            } else {
+                true // Unknown counter: not in scope for invariant checking here.
+            }
+        }
+        SpecAssert::NoFurtherTransitions => {
+            // Holds unless status_before was a terminal state in `when`.
+            !when.iter().any(|s| s == status_before)
+        }
+        SpecAssert::OrderingConstraint { before, after } => {
+            if status_after == after.as_str() {
+                let events = handler.events_json();
+                if let Some(arr) = events.as_array() {
+                    arr.iter().any(|e| {
+                        e.get("to_status").and_then(|s| s.as_str()) == Some(before.as_str())
+                    })
+                } else {
+                    true
+                }
+            } else {
+                true
+            }
+        }
+        SpecAssert::NeverState { state } => status_after != state.as_str(),
+        SpecAssert::CounterCompare { var, op, value } => {
+            let counter_val = if var == "items" { item_count } else { 0 };
+            match op {
+                CompareOp::Gt => counter_val > *value,
+                CompareOp::Gte => counter_val >= *value,
+                CompareOp::Lt => counter_val < *value,
+                CompareOp::Lte => counter_val <= *value,
+                CompareOp::Eq => counter_val == *value,
+            }
+        }
+        SpecAssert::BoolRequired { var, expect } => {
+            handler.bool_field(var).unwrap_or(false) == *expect
+        }
+        SpecAssert::And(parts) => parts.iter().all(|p| {
+            evaluate_spec_assert(p, handler, when, status_before, status_after, item_count)
+        }),
+        SpecAssert::Or(parts) => parts.iter().any(|p| {
+            evaluate_spec_assert(p, handler, when, status_before, status_after, item_count)
+        }),
     }
 }
 

--- a/crates/temper-runtime/src/scheduler/sim_handler.rs
+++ b/crates/temper-runtime/src/scheduler/sim_handler.rs
@@ -23,8 +23,9 @@ pub struct SpecInvariant {
 /// A checkable assertion from the spec.
 ///
 /// These map to the small set of invariant patterns that the framework can
-/// check automatically. Domain-specific invariants that don't fit these
-/// patterns still need a manual `set_invariant_checker()`.
+/// check automatically. Compound variants (`And`/`Or`) compose them, so
+/// `migrations_ok && typecheck_ok` becomes
+/// `And(vec![BoolRequired{"migrations_ok", true}, BoolRequired{"typecheck_ok", true}])`.
 #[derive(Debug, Clone)]
 pub enum SpecAssert {
     /// A counter variable must be positive (e.g., `items > 0`).
@@ -43,6 +44,14 @@ pub enum SpecAssert {
         op: CompareOp,
         value: usize,
     },
+    /// A boolean state variable must match an expected value.
+    ///
+    /// `expect = true` for `flag`; `expect = false` for `!flag`.
+    BoolRequired { var: String, expect: bool },
+    /// All subexpressions must hold.
+    And(Vec<SpecAssert>),
+    /// At least one subexpression must hold.
+    Or(Vec<SpecAssert>),
 }
 
 /// Comparison operators for counter invariants.
@@ -93,6 +102,15 @@ pub trait SimActorHandler: Send {
     /// successful transition. Returns empty by default.
     fn spec_invariants(&self) -> &[SpecInvariant] {
         &[]
+    }
+
+    /// Read a boolean state variable by name for invariant evaluation.
+    ///
+    /// Returns `None` when the variable is absent (treated as `false` by
+    /// `BoolRequired` evaluators). Override this to expose booleans
+    /// from the underlying entity state. Default: no boolean state.
+    fn bool_field(&self, _var: &str) -> Option<bool> {
+        None
     }
 
     /// Custom effects (integration triggers) emitted by the last action.

--- a/crates/temper-server/src/entity_actor/sim_handler.rs
+++ b/crates/temper-server/src/entity_actor/sim_handler.rs
@@ -98,9 +98,13 @@ impl EntityActorHandler {
 /// then maps the result to the runtime type. Returns `None` for expressions
 /// that the framework cannot check automatically.
 fn parse_assert_expr(expr: &str) -> Option<SpecAssert> {
-    use temper_spec::automaton::{AssertCompareOp, ParsedAssert, parse_assert_expr as parse};
+    use temper_spec::automaton::parse_assert_expr as parse;
+    translate_parsed(parse(expr)?)
+}
 
-    let parsed = parse(expr)?;
+fn translate_parsed(parsed: temper_spec::automaton::ParsedAssert) -> Option<SpecAssert> {
+    use temper_spec::automaton::{AssertCompareOp, ParsedAssert};
+
     match parsed {
         ParsedAssert::CounterPositive { var } => Some(SpecAssert::CounterPositive { var }),
         ParsedAssert::NoFurtherTransitions => Some(SpecAssert::NoFurtherTransitions),
@@ -121,6 +125,17 @@ fn parse_assert_expr(expr: &str) -> Option<SpecAssert> {
                 op: runtime_op,
                 value,
             })
+        }
+        ParsedAssert::BoolRequired { var, expect } => {
+            Some(SpecAssert::BoolRequired { var, expect })
+        }
+        ParsedAssert::And(parts) => {
+            let mapped: Option<Vec<_>> = parts.into_iter().map(translate_parsed).collect();
+            mapped.map(SpecAssert::And)
+        }
+        ParsedAssert::Or(parts) => {
+            let mapped: Option<Vec<_>> = parts.into_iter().map(translate_parsed).collect();
+            mapped.map(SpecAssert::Or)
         }
     }
 }
@@ -203,6 +218,10 @@ impl SimActorHandler for EntityActorHandler {
 
     fn spec_invariants(&self) -> &[SpecInvariant] {
         &self.invariants
+    }
+
+    fn bool_field(&self, var: &str) -> Option<bool> {
+        self.state.booleans.get(var).copied()
     }
 
     fn pending_callbacks(&self) -> Vec<String> {

--- a/crates/temper-spec/src/automaton/assert_parser.rs
+++ b/crates/temper-spec/src/automaton/assert_parser.rs
@@ -38,85 +38,291 @@ pub enum ParsedAssert {
         op: AssertCompareOp,
         value: usize,
     },
+    /// A bare boolean variable must be true (e.g., `payment_captured`).
+    ///
+    /// `expect = true` matches `name`; `expect = false` matches `!name`.
+    BoolRequired { var: String, expect: bool },
+    /// All subexpressions must hold (short-circuit).
+    And(Vec<ParsedAssert>),
+    /// At least one subexpression must hold (short-circuit).
+    Or(Vec<ParsedAssert>),
 }
 
 /// Parse an assertion expression from an IOA spec into a [`ParsedAssert`].
 ///
 /// Returns `None` for expressions that cannot be structurally parsed.
 ///
-/// # Recognized patterns
+/// # Grammar
 ///
-/// - `"items > 0"` → `CounterPositive { var: "items" }`
+/// ```text
+/// expr    = or_expr
+/// or_expr = and_expr ( "||" and_expr )*
+/// and_expr = atom ( "&&" atom )*
+/// atom    = "(" expr ")" | "!" atom | terminal
+/// terminal = counter_cmp | ordering(...) | never(...)
+///          | no_further_transitions | bare_bool
+/// ```
+///
+/// # Recognized terminals
+///
+/// - `"items > 0"` → `CounterPositive`
 /// - `"no_further_transitions"` → `NoFurtherTransitions`
-/// - `"ordering(StateA, StateB)"` → `OrderingConstraint { before, after }`
-/// - `"never(StateName)"` → `NeverState { state }`
+/// - `"ordering(StateA, StateB)"` → `OrderingConstraint`
+/// - `"never(StateName)"` → `NeverState`
 /// - `"var >= N"`, `"var <= N"`, `"var == N"`, `"var > N"`, `"var < N"` → `CounterCompare`
+/// - `"flag"` / `"!flag"` → `BoolRequired`
+///
+/// # Compound expressions
+///
+/// - `"a && b && c"` → `And(vec![a, b, c])`
+/// - `"a || b"` → `Or(vec![a, b])`
+/// - `"a && (b || c)"` → `And(vec![a, Or(vec![b, c])])`
 pub fn parse_assert_expr(expr: &str) -> Option<ParsedAssert> {
-    let trimmed = expr.trim();
+    let tokens = tokenize(expr)?;
+    let mut cursor = 0;
+    let result = parse_or(&tokens, &mut cursor)?;
+    // Reject trailing garbage.
+    if cursor != tokens.len() {
+        return None;
+    }
+    Some(result)
+}
 
-    // Pattern: "items > 0" or "var > 0" — shorthand for CounterPositive.
-    if trimmed.contains("> 0") && !trimmed.contains(">=") {
-        let var = trimmed.split('>').next()?.trim().to_string();
-        if !var.is_empty() {
-            return Some(ParsedAssert::CounterPositive { var });
+// ---------------------------------------------------------------------------
+// Tokenizer
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Tok {
+    LParen,
+    RParen,
+    And,
+    Or,
+    Not,
+    Comma,
+    Ident(String),
+    Number(String),
+    CmpOp(AssertCompareOp),
+}
+
+fn tokenize(input: &str) -> Option<Vec<Tok>> {
+    let bytes = input.as_bytes();
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c.is_ascii_whitespace() {
+            i += 1;
+            continue;
         }
-    }
-
-    // Pattern: "no_further_transitions"
-    if trimmed == "no_further_transitions" {
-        return Some(ParsedAssert::NoFurtherTransitions);
-    }
-
-    // Pattern: "ordering(StateA, StateB)" — StateA must precede StateB.
-    if trimmed.starts_with("ordering(") && trimmed.ends_with(')') {
-        let inner = &trimmed[9..trimmed.len() - 1];
-        let parts: Vec<&str> = inner.split(',').map(|s| s.trim()).collect();
-        if parts.len() == 2 && !parts[0].is_empty() && !parts[1].is_empty() {
-            return Some(ParsedAssert::OrderingConstraint {
-                before: parts[0].to_string(),
-                after: parts[1].to_string(),
-            });
-        }
-    }
-
-    // Pattern: "never(StateName)" — entity should never be in this state.
-    if trimmed.starts_with("never(") && trimmed.ends_with(')') {
-        let state = trimmed[6..trimmed.len() - 1].trim().to_string();
-        if !state.is_empty() {
-            return Some(ParsedAssert::NeverState { state });
-        }
-    }
-
-    // Generalized counter comparison: "var >= N", "var <= N", "var == N",
-    // "var > N", "var < N". Order matters: check two-char ops before one-char.
-    let ops: &[(&str, AssertCompareOp)] = &[
-        (">=", AssertCompareOp::Gte),
-        ("<=", AssertCompareOp::Lte),
-        ("==", AssertCompareOp::Eq),
-        (">", AssertCompareOp::Gt),
-        ("<", AssertCompareOp::Lt),
-    ];
-    for (op_str, op) in ops {
-        if let Some(pos) = trimmed.find(op_str) {
-            let var = trimmed[..pos].trim().to_string();
-            let val_str = trimmed[pos + op_str.len()..].trim();
-            if let Ok(value) = val_str.parse::<usize>() {
-                // "var > 0" is already handled by CounterPositive above.
-                if *op_str == ">" && value == 0 {
-                    continue;
+        match c {
+            b'(' => {
+                out.push(Tok::LParen);
+                i += 1;
+            }
+            b')' => {
+                out.push(Tok::RParen);
+                i += 1;
+            }
+            b',' => {
+                out.push(Tok::Comma);
+                i += 1;
+            }
+            b'&' if i + 1 < bytes.len() && bytes[i + 1] == b'&' => {
+                out.push(Tok::And);
+                i += 2;
+            }
+            b'|' if i + 1 < bytes.len() && bytes[i + 1] == b'|' => {
+                out.push(Tok::Or);
+                i += 2;
+            }
+            b'!' if i + 1 < bytes.len() && bytes[i + 1] == b'=' => {
+                // "!=" is not supported — reject.
+                return None;
+            }
+            b'!' => {
+                out.push(Tok::Not);
+                i += 1;
+            }
+            b'>' if i + 1 < bytes.len() && bytes[i + 1] == b'=' => {
+                out.push(Tok::CmpOp(AssertCompareOp::Gte));
+                i += 2;
+            }
+            b'<' if i + 1 < bytes.len() && bytes[i + 1] == b'=' => {
+                out.push(Tok::CmpOp(AssertCompareOp::Lte));
+                i += 2;
+            }
+            b'=' if i + 1 < bytes.len() && bytes[i + 1] == b'=' => {
+                out.push(Tok::CmpOp(AssertCompareOp::Eq));
+                i += 2;
+            }
+            b'>' => {
+                out.push(Tok::CmpOp(AssertCompareOp::Gt));
+                i += 1;
+            }
+            b'<' => {
+                out.push(Tok::CmpOp(AssertCompareOp::Lt));
+                i += 1;
+            }
+            b if b.is_ascii_alphabetic() || b == b'_' => {
+                let start = i;
+                while i < bytes.len()
+                    && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_')
+                {
+                    i += 1;
                 }
-                if !var.is_empty() {
-                    return Some(ParsedAssert::CounterCompare {
-                        var,
-                        op: op.clone(),
-                        value,
-                    });
+                out.push(Tok::Ident(input[start..i].to_string()));
+            }
+            b if b.is_ascii_digit() => {
+                let start = i;
+                while i < bytes.len() && bytes[i].is_ascii_digit() {
+                    i += 1;
                 }
+                out.push(Tok::Number(input[start..i].to_string()));
+            }
+            _ => return None,
+        }
+    }
+    Some(out)
+}
+
+// ---------------------------------------------------------------------------
+// Recursive-descent parser
+// ---------------------------------------------------------------------------
+
+fn parse_or(tokens: &[Tok], cursor: &mut usize) -> Option<ParsedAssert> {
+    let first = parse_and(tokens, cursor)?;
+    let mut parts = vec![first];
+    while matches!(tokens.get(*cursor), Some(Tok::Or)) {
+        *cursor += 1;
+        parts.push(parse_and(tokens, cursor)?);
+    }
+    Some(if parts.len() == 1 {
+        parts.into_iter().next().unwrap()
+    } else {
+        ParsedAssert::Or(parts)
+    })
+}
+
+fn parse_and(tokens: &[Tok], cursor: &mut usize) -> Option<ParsedAssert> {
+    let first = parse_atom(tokens, cursor)?;
+    let mut parts = vec![first];
+    while matches!(tokens.get(*cursor), Some(Tok::And)) {
+        *cursor += 1;
+        parts.push(parse_atom(tokens, cursor)?);
+    }
+    Some(if parts.len() == 1 {
+        parts.into_iter().next().unwrap()
+    } else {
+        ParsedAssert::And(parts)
+    })
+}
+
+fn parse_atom(tokens: &[Tok], cursor: &mut usize) -> Option<ParsedAssert> {
+    match tokens.get(*cursor) {
+        Some(Tok::LParen) => {
+            *cursor += 1;
+            let inner = parse_or(tokens, cursor)?;
+            if !matches!(tokens.get(*cursor), Some(Tok::RParen)) {
+                return None;
+            }
+            *cursor += 1;
+            Some(inner)
+        }
+        Some(Tok::Not) => {
+            *cursor += 1;
+            let inner = parse_atom(tokens, cursor)?;
+            // Only `!bool_var` supported; negating compounds or comparisons needs
+            // explicit De Morgan expansion by the spec author.
+            if let ParsedAssert::BoolRequired { var, expect } = inner {
+                Some(ParsedAssert::BoolRequired {
+                    var,
+                    expect: !expect,
+                })
+            } else {
+                None
             }
         }
+        _ => parse_terminal(tokens, cursor),
+    }
+}
+
+fn parse_terminal(tokens: &[Tok], cursor: &mut usize) -> Option<ParsedAssert> {
+    let start = *cursor;
+    let first = tokens.get(*cursor)?.clone();
+
+    // no_further_transitions (bare identifier).
+    if let Tok::Ident(name) = &first {
+        // ordering(A, B)
+        if name == "ordering" && matches!(tokens.get(*cursor + 1), Some(Tok::LParen)) {
+            *cursor += 2;
+            let before = match tokens.get(*cursor) {
+                Some(Tok::Ident(s)) => s.clone(),
+                _ => return None,
+            };
+            *cursor += 1;
+            if !matches!(tokens.get(*cursor), Some(Tok::Comma)) {
+                return None;
+            }
+            *cursor += 1;
+            let after = match tokens.get(*cursor) {
+                Some(Tok::Ident(s)) => s.clone(),
+                _ => return None,
+            };
+            *cursor += 1;
+            if !matches!(tokens.get(*cursor), Some(Tok::RParen)) {
+                return None;
+            }
+            *cursor += 1;
+            return Some(ParsedAssert::OrderingConstraint { before, after });
+        }
+
+        // never(StateName)
+        if name == "never" && matches!(tokens.get(*cursor + 1), Some(Tok::LParen)) {
+            *cursor += 2;
+            let state = match tokens.get(*cursor) {
+                Some(Tok::Ident(s)) => s.clone(),
+                _ => return None,
+            };
+            *cursor += 1;
+            if !matches!(tokens.get(*cursor), Some(Tok::RParen)) {
+                return None;
+            }
+            *cursor += 1;
+            return Some(ParsedAssert::NeverState { state });
+        }
+
+        // Counter comparison: "var OP N"
+        if let (Some(Tok::CmpOp(op)), Some(Tok::Number(n))) =
+            (tokens.get(*cursor + 1), tokens.get(*cursor + 2))
+        {
+            let var = name.clone();
+            let op = op.clone();
+            let value: usize = n.parse().ok()?;
+            *cursor += 3;
+            // "var > 0" is CounterPositive.
+            if matches!(op, AssertCompareOp::Gt) && value == 0 {
+                return Some(ParsedAssert::CounterPositive { var });
+            }
+            return Some(ParsedAssert::CounterCompare { var, op, value });
+        }
+
+        // no_further_transitions (exactly).
+        if name == "no_further_transitions" {
+            *cursor += 1;
+            return Some(ParsedAssert::NoFurtherTransitions);
+        }
+
+        // Bare boolean identifier.
+        *cursor += 1;
+        return Some(ParsedAssert::BoolRequired {
+            var: name.clone(),
+            expect: true,
+        });
     }
 
-    // Unrecognized expression.
+    // Reset cursor on failed match so the caller can try another path.
+    *cursor = start;
     None
 }
 
@@ -230,22 +436,47 @@ mod tests {
     }
 
     #[test]
-    fn test_unrecognized_returns_none() {
-        assert_eq!(parse_assert_expr("payment_captured"), None);
-        assert_eq!(parse_assert_expr("some random text"), None);
+    fn test_bare_bool_is_bool_required() {
+        assert_eq!(
+            parse_assert_expr("payment_captured"),
+            Some(ParsedAssert::BoolRequired {
+                var: "payment_captured".to_string(),
+                expect: true,
+            })
+        );
+    }
+
+    #[test]
+    fn test_negated_bool() {
+        assert_eq!(
+            parse_assert_expr("!payment_captured"),
+            Some(ParsedAssert::BoolRequired {
+                var: "payment_captured".to_string(),
+                expect: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_empty_returns_none() {
         assert_eq!(parse_assert_expr(""), None);
+        assert_eq!(parse_assert_expr("   "), None);
+    }
+
+    #[test]
+    fn test_unknown_symbols_return_none() {
+        assert_eq!(parse_assert_expr("@@"), None);
+        assert_eq!(parse_assert_expr("a != b"), None);
     }
 
     #[test]
     fn test_gt_zero_is_counter_positive_not_compare() {
-        // "var > 0" should be CounterPositive, not CounterCompare
         let result = parse_assert_expr("items > 0");
         assert!(matches!(result, Some(ParsedAssert::CounterPositive { .. })));
     }
 
     #[test]
     fn test_gte_zero_is_counter_compare() {
-        // "var >= 0" is NOT counter positive, it's a (trivial) compare
         assert_eq!(
             parse_assert_expr("items >= 0"),
             Some(ParsedAssert::CounterCompare {
@@ -254,5 +485,125 @@ mod tests {
                 value: 0,
             })
         );
+    }
+
+    // --- Compound expressions ---
+
+    #[test]
+    fn test_and_two_bools() {
+        assert_eq!(
+            parse_assert_expr("a && b"),
+            Some(ParsedAssert::And(vec![
+                ParsedAssert::BoolRequired { var: "a".into(), expect: true },
+                ParsedAssert::BoolRequired { var: "b".into(), expect: true },
+            ]))
+        );
+    }
+
+    #[test]
+    fn test_and_three_bools() {
+        assert_eq!(
+            parse_assert_expr("migrations_ok && typecheck_ok && unit_tests_ok"),
+            Some(ParsedAssert::And(vec![
+                ParsedAssert::BoolRequired { var: "migrations_ok".into(), expect: true },
+                ParsedAssert::BoolRequired { var: "typecheck_ok".into(), expect: true },
+                ParsedAssert::BoolRequired { var: "unit_tests_ok".into(), expect: true },
+            ]))
+        );
+    }
+
+    #[test]
+    fn test_or_two_bools() {
+        assert_eq!(
+            parse_assert_expr("reviewed_by_code || reviewed_by_dst"),
+            Some(ParsedAssert::Or(vec![
+                ParsedAssert::BoolRequired { var: "reviewed_by_code".into(), expect: true },
+                ParsedAssert::BoolRequired { var: "reviewed_by_dst".into(), expect: true },
+            ]))
+        );
+    }
+
+    #[test]
+    fn test_paren_precedence() {
+        // Without parens, && binds tighter than ||.
+        // "a && (b || c)" = And(a, Or(b, c))
+        assert_eq!(
+            parse_assert_expr("a && (b || c)"),
+            Some(ParsedAssert::And(vec![
+                ParsedAssert::BoolRequired { var: "a".into(), expect: true },
+                ParsedAssert::Or(vec![
+                    ParsedAssert::BoolRequired { var: "b".into(), expect: true },
+                    ParsedAssert::BoolRequired { var: "c".into(), expect: true },
+                ]),
+            ]))
+        );
+    }
+
+    #[test]
+    fn test_precedence_without_parens() {
+        // "a || b && c" = Or(a, And(b, c)) — && binds tighter.
+        assert_eq!(
+            parse_assert_expr("a || b && c"),
+            Some(ParsedAssert::Or(vec![
+                ParsedAssert::BoolRequired { var: "a".into(), expect: true },
+                ParsedAssert::And(vec![
+                    ParsedAssert::BoolRequired { var: "b".into(), expect: true },
+                    ParsedAssert::BoolRequired { var: "c".into(), expect: true },
+                ]),
+            ]))
+        );
+    }
+
+    #[test]
+    fn test_nested_parens() {
+        assert_eq!(
+            parse_assert_expr("((a))"),
+            Some(ParsedAssert::BoolRequired { var: "a".into(), expect: true })
+        );
+    }
+
+    #[test]
+    fn test_mixed_compound_with_compare() {
+        assert_eq!(
+            parse_assert_expr("items > 0 && payment_captured"),
+            Some(ParsedAssert::And(vec![
+                ParsedAssert::CounterPositive { var: "items".into() },
+                ParsedAssert::BoolRequired { var: "payment_captured".into(), expect: true },
+            ]))
+        );
+    }
+
+    #[test]
+    fn test_unbalanced_paren_returns_none() {
+        assert_eq!(parse_assert_expr("(a && b"), None);
+        assert_eq!(parse_assert_expr("a && b)"), None);
+    }
+
+    #[test]
+    fn test_whitespace_insensitive_compound() {
+        assert_eq!(
+            parse_assert_expr("  a   &&   b  "),
+            Some(ParsedAssert::And(vec![
+                ParsedAssert::BoolRequired { var: "a".into(), expect: true },
+                ParsedAssert::BoolRequired { var: "b".into(), expect: true },
+            ]))
+        );
+    }
+
+    #[test]
+    fn test_negated_in_compound() {
+        assert_eq!(
+            parse_assert_expr("a && !b"),
+            Some(ParsedAssert::And(vec![
+                ParsedAssert::BoolRequired { var: "a".into(), expect: true },
+                ParsedAssert::BoolRequired { var: "b".into(), expect: false },
+            ]))
+        );
+    }
+
+    #[test]
+    fn test_trailing_operator_returns_none() {
+        assert_eq!(parse_assert_expr("a &&"), None);
+        assert_eq!(parse_assert_expr("&& a"), None);
     }
 }

--- a/crates/temper-verify/src/model/builder.rs
+++ b/crates/temper-verify/src/model/builder.rs
@@ -173,57 +173,78 @@ fn resolve_invariants(automaton: &Automaton) -> Vec<ResolvedInvariant> {
     for inv in &automaton.invariants {
         let expr = inv.assert.trim();
 
-        // Primary: use the shared assertion parser
-        if let Some(parsed) = parse_assert_expr(expr) {
-            let kind = match parsed {
-                ParsedAssert::CounterPositive { var } => InvariantKind::CounterPositive { var },
-                ParsedAssert::NoFurtherTransitions => InvariantKind::NoFurtherTransitions,
-                ParsedAssert::NeverState { state } => InvariantKind::NeverState { state },
-                ParsedAssert::CounterCompare { var, op, value } => {
-                    InvariantKind::CounterCompare { var, op, value }
-                }
-                ParsedAssert::OrderingConstraint { .. } => {
-                    // Not encodable at model level (requires path history tracking).
-                    // The runtime sim_handler handles this directly.
-                    InvariantKind::Unverifiable {
-                        expression: expr.to_string(),
-                    }
-                }
-            };
-            result.push(ResolvedInvariant {
-                name: inv.name.clone(),
-                trigger_states: inv.when.clone(),
-                required_states: vec![],
-                kind,
-            });
-            continue;
-        }
-
-        // Fallback: bare identifier → BoolRequired (if it's a known boolean)
-        if !expr.contains(' ') && bool_names.contains(&expr) {
-            result.push(ResolvedInvariant {
-                name: inv.name.clone(),
-                trigger_states: inv.when.clone(),
-                required_states: vec![],
-                kind: InvariantKind::BoolRequired {
-                    var: expr.to_string(),
-                },
-            });
-            continue;
-        }
-
-        // Unrecognized: explicit Unverifiable instead of silent Implication
+        let kind = match parse_assert_expr(expr) {
+            Some(parsed) => translate_parsed_assert(parsed, expr, &bool_names),
+            None => InvariantKind::Unverifiable {
+                expression: expr.to_string(),
+            },
+        };
         result.push(ResolvedInvariant {
             name: inv.name.clone(),
             trigger_states: inv.when.clone(),
             required_states: vec![],
-            kind: InvariantKind::Unverifiable {
-                expression: expr.to_string(),
-            },
+            kind,
         });
     }
 
     result
+}
+
+/// Translate a [`ParsedAssert`] into an [`InvariantKind`].
+///
+/// Bare boolean references are only accepted when the variable is declared
+/// as a `bool` in the automaton state; otherwise the whole expression falls
+/// through to `Unverifiable`. This preserves the pre-compound behavior of
+/// rejecting unknown identifiers rather than silently asserting on them.
+fn translate_parsed_assert(
+    parsed: ParsedAssert,
+    raw: &str,
+    bool_names: &[&str],
+) -> InvariantKind {
+    match try_translate(&parsed, bool_names) {
+        Some(kind) => kind,
+        None => InvariantKind::Unverifiable {
+            expression: raw.to_string(),
+        },
+    }
+}
+
+fn try_translate(parsed: &ParsedAssert, bool_names: &[&str]) -> Option<InvariantKind> {
+    match parsed {
+        ParsedAssert::CounterPositive { var } => Some(InvariantKind::CounterPositive {
+            var: var.clone(),
+        }),
+        ParsedAssert::NoFurtherTransitions => Some(InvariantKind::NoFurtherTransitions),
+        ParsedAssert::NeverState { state } => Some(InvariantKind::NeverState {
+            state: state.clone(),
+        }),
+        ParsedAssert::CounterCompare { var, op, value } => Some(InvariantKind::CounterCompare {
+            var: var.clone(),
+            op: op.clone(),
+            value: *value,
+        }),
+        ParsedAssert::BoolRequired { var, expect } => {
+            if bool_names.contains(&var.as_str()) {
+                Some(InvariantKind::BoolRequired {
+                    var: var.clone(),
+                    expect: *expect,
+                })
+            } else {
+                None
+            }
+        }
+        ParsedAssert::OrderingConstraint { .. } => None,
+        ParsedAssert::And(parts) => {
+            let mapped: Option<Vec<_>> =
+                parts.iter().map(|p| try_translate(p, bool_names)).collect();
+            mapped.map(InvariantKind::And)
+        }
+        ParsedAssert::Or(parts) => {
+            let mapped: Option<Vec<_>> =
+                parts.iter().map(|p| try_translate(p, bool_names)).collect();
+            mapped.map(InvariantKind::Or)
+        }
+    }
 }
 
 /// Translate IOA liveness properties into resolved liveness.
@@ -421,5 +442,126 @@ mod tests {
                 t.name, t.from_states, t.to_state, t.guard, t.effects
             );
         }
+    }
+
+    // --- Compound invariant tests ---------------------------------------
+
+    const COMPOUND_IOA: &str = r#"
+[automaton]
+name = "Release"
+states = ["Planning", "Testing", "Shipped"]
+initial = "Planning"
+
+[[state]]
+name = "migrations_ok"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "typecheck_ok"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "unit_tests_ok"
+type = "bool"
+initial = "false"
+
+[[action]]
+name = "EnterTesting"
+kind = "input"
+from = ["Planning"]
+to = "Testing"
+
+[[action]]
+name = "Ship"
+kind = "internal"
+from = ["Testing"]
+to = "Shipped"
+
+[[invariant]]
+name = "TestingRequiresAllGates"
+when = ["Testing", "Shipped"]
+assert = "migrations_ok && typecheck_ok && unit_tests_ok"
+
+[[invariant]]
+name = "EitherReviewer"
+when = ["Shipped"]
+assert = "migrations_ok || typecheck_ok"
+"#;
+
+    #[test]
+    fn test_compound_and_invariant_resolves_to_and() {
+        let model = build_model_from_ioa(COMPOUND_IOA, 2).unwrap();
+        let inv = model
+            .invariants
+            .iter()
+            .find(|i| i.name == "TestingRequiresAllGates")
+            .expect("TestingRequiresAllGates invariant must be present");
+        match &inv.kind {
+            InvariantKind::And(parts) => {
+                assert_eq!(parts.len(), 3);
+                for p in parts {
+                    assert!(
+                        matches!(p, InvariantKind::BoolRequired { expect: true, .. }),
+                        "part should be BoolRequired{{expect:true}}, got {p:?}"
+                    );
+                }
+            }
+            other => panic!("expected And, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_compound_or_invariant_resolves_to_or() {
+        let model = build_model_from_ioa(COMPOUND_IOA, 2).unwrap();
+        let inv = model
+            .invariants
+            .iter()
+            .find(|i| i.name == "EitherReviewer")
+            .expect("EitherReviewer invariant must be present");
+        match &inv.kind {
+            InvariantKind::Or(parts) => {
+                assert_eq!(parts.len(), 2);
+            }
+            other => panic!("expected Or, got {other:?}"),
+        }
+    }
+
+    const COMPOUND_UNDECLARED_IOA: &str = r#"
+[automaton]
+name = "Release"
+states = ["Planning", "Shipped"]
+initial = "Planning"
+
+[[state]]
+name = "migrations_ok"
+type = "bool"
+initial = "false"
+
+[[action]]
+name = "Ship"
+kind = "internal"
+from = ["Planning"]
+to = "Shipped"
+
+[[invariant]]
+name = "MixedDeclaredUndeclared"
+when = ["Shipped"]
+assert = "migrations_ok && undeclared_flag"
+"#;
+
+    #[test]
+    fn test_compound_with_undeclared_bool_becomes_unverifiable() {
+        let model = build_model_from_ioa(COMPOUND_UNDECLARED_IOA, 2).unwrap();
+        let inv = model
+            .invariants
+            .iter()
+            .find(|i| i.name == "MixedDeclaredUndeclared")
+            .unwrap();
+        assert!(
+            matches!(inv.kind, InvariantKind::Unverifiable { .. }),
+            "compound expression referencing an undeclared bool must fall back to Unverifiable"
+        );
     }
 }

--- a/crates/temper-verify/src/model/stateright_impl.rs
+++ b/crates/temper-verify/src/model/stateright_impl.rs
@@ -37,18 +37,86 @@ fn check_counter_positive(model: &TemperModel, state: &TemperModelState) -> bool
     true
 }
 
-/// Check all BoolRequired invariants: when status is in triggers, bool must be true.
+/// Check all BoolRequired invariants: when status is in triggers, bool matches `expect`.
 fn check_bool_required(model: &TemperModel, state: &TemperModelState) -> bool {
     for inv in &model.invariants {
-        if let InvariantKind::BoolRequired { ref var } = inv.kind {
+        if let InvariantKind::BoolRequired { ref var, expect } = inv.kind {
             let triggered =
                 inv.trigger_states.is_empty() || inv.trigger_states.contains(&state.status);
             if triggered {
                 let val = state.booleans.get(var).copied().unwrap_or(false);
-                if !val {
+                if val != expect {
                     return false;
                 }
             }
+        }
+    }
+    true
+}
+
+/// Evaluate a single [`InvariantKind`] against state. Returns `true` if holds.
+///
+/// Shared by `check_compound_invariants` for `And`/`Or` recursion.
+fn kind_holds(
+    kind: &InvariantKind,
+    required_states: &[String],
+    model: &TemperModel,
+    state: &TemperModelState,
+) -> bool {
+    match kind {
+        InvariantKind::StatusInSet => model.states.contains(&state.status),
+        InvariantKind::CounterPositive { var } => {
+            state.counters.get(var).copied().unwrap_or(0) > 0
+        }
+        InvariantKind::BoolRequired { var, expect } => {
+            state.booleans.get(var).copied().unwrap_or(false) == *expect
+        }
+        InvariantKind::NoFurtherTransitions => {
+            // Holds iff no transitions are enabled from current state.
+            !model.transitions.iter().any(|t| {
+                let status_ok = t.from_states.is_empty()
+                    || t.from_states.iter().any(|s| s == &state.status);
+                status_ok && evaluate_guard(&t.guard, state)
+            })
+        }
+        InvariantKind::Implication => {
+            let valid: Vec<&String> = required_states
+                .iter()
+                .filter(|s| model.states.contains(s))
+                .collect();
+            valid.is_empty() || valid.contains(&&state.status)
+        }
+        InvariantKind::CounterCompare { var, op, value } => {
+            let val = state.counters.get(var).copied().unwrap_or(0);
+            match op {
+                AssertCompareOp::Gt => val > *value,
+                AssertCompareOp::Gte => val >= *value,
+                AssertCompareOp::Lt => val < *value,
+                AssertCompareOp::Lte => val <= *value,
+                AssertCompareOp::Eq => val == *value,
+            }
+        }
+        InvariantKind::NeverState { state: forbidden } => state.status != *forbidden,
+        InvariantKind::And(parts) => parts
+            .iter()
+            .all(|k| kind_holds(k, required_states, model, state)),
+        InvariantKind::Or(parts) => parts
+            .iter()
+            .any(|k| kind_holds(k, required_states, model, state)),
+        InvariantKind::Unverifiable { .. } => true,
+    }
+}
+
+/// Check all compound (And/Or) invariants via recursive `kind_holds`.
+fn check_compound_invariants(model: &TemperModel, state: &TemperModelState) -> bool {
+    for inv in &model.invariants {
+        if !matches!(inv.kind, InvariantKind::And(_) | InvariantKind::Or(_)) {
+            continue;
+        }
+        let triggered =
+            inv.trigger_states.is_empty() || inv.trigger_states.contains(&state.status);
+        if triggered && !kind_holds(&inv.kind, &inv.required_states, model, state) {
+            return false;
         }
     }
     true
@@ -352,6 +420,18 @@ impl Model for TemperModel {
             .any(|i| matches!(i.kind, InvariantKind::NeverState { .. }));
         if has_never_state {
             props.push(Property::always("NeverStateInvariants", check_never_state));
+        }
+
+        // Safety: Compound (And/Or) invariants
+        let has_compound = self
+            .invariants
+            .iter()
+            .any(|i| matches!(i.kind, InvariantKind::And(_) | InvariantKind::Or(_)));
+        if has_compound {
+            props.push(Property::always(
+                "CompoundInvariants",
+                check_compound_invariants,
+            ));
         }
 
         // Note: Unverifiable invariants generate no properties (skipped).

--- a/crates/temper-verify/src/model/types.rs
+++ b/crates/temper-verify/src/model/types.rs
@@ -142,8 +142,10 @@ pub enum InvariantKind {
     StatusInSet,
     /// When status is in trigger_states, a counter must be > 0.
     CounterPositive { var: String },
-    /// When status is in trigger_states, a boolean must be true.
-    BoolRequired { var: String },
+    /// When status is in trigger_states, a boolean must match `expect`.
+    ///
+    /// `expect = true` encodes `flag`; `expect = false` encodes `!flag`.
+    BoolRequired { var: String, expect: bool },
     /// When status is in trigger_states, no transitions should be enabled.
     NoFurtherTransitions,
     /// When status is in trigger_states, status must also be in required_states.
@@ -156,6 +158,10 @@ pub enum InvariantKind {
     },
     /// The entity should never be in this state.
     NeverState { state: String },
+    /// Compound: all subexpressions must hold.
+    And(Vec<InvariantKind>),
+    /// Compound: at least one subexpression must hold.
+    Or(Vec<InvariantKind>),
     /// Assertion expression that cannot be verified at model level.
     /// Surfaces as a warning in the cascade result.
     Unverifiable { expression: String },

--- a/crates/temper-verify/src/proptest_gen.rs
+++ b/crates/temper-verify/src/proptest_gen.rs
@@ -58,51 +58,66 @@ fn check_invariants(model: &TemperModel, state: &TemperModelState) -> Result<(),
             continue;
         }
 
-        let violated = match &inv.kind {
-            InvariantKind::StatusInSet => !model.states.contains(&state.status),
-            InvariantKind::CounterPositive { var } => {
-                state.counters.get(var).copied().unwrap_or(0) == 0
-            }
-            InvariantKind::BoolRequired { var } => {
-                !state.booleans.get(var).copied().unwrap_or(false)
-            }
-            InvariantKind::NoFurtherTransitions => {
-                let mut actions = Vec::new();
-                model.actions(state, &mut actions);
-                !actions.is_empty()
-            }
-            InvariantKind::Implication => {
-                let valid_required: Vec<&String> = inv
-                    .required_states
-                    .iter()
-                    .filter(|s| model.states.contains(s))
-                    .collect();
-                if valid_required.is_empty() {
-                    false // constrains non-status variables
-                } else {
-                    !valid_required.contains(&&state.status)
-                }
-            }
-            InvariantKind::CounterCompare { var, op, value } => {
-                let val = state.counters.get(var).copied().unwrap_or(0);
-                let holds = match op {
-                    AssertCompareOp::Gt => val > *value,
-                    AssertCompareOp::Gte => val >= *value,
-                    AssertCompareOp::Lt => val < *value,
-                    AssertCompareOp::Lte => val <= *value,
-                    AssertCompareOp::Eq => val == *value,
-                };
-                !holds
-            }
-            InvariantKind::NeverState { state: forbidden } => state.status == *forbidden,
-            InvariantKind::Unverifiable { .. } => false, // not checkable, never violated
-        };
-
-        if violated {
+        if kind_violated(&inv.kind, &inv.required_states, model, state) {
             return Err(inv.name.clone());
         }
     }
     Ok(())
+}
+
+/// Evaluate whether an [`InvariantKind`] is violated given model+state.
+///
+/// Pure recursion over compound variants; does not consult `trigger_states`.
+fn kind_violated(
+    kind: &InvariantKind,
+    required_states: &[String],
+    model: &TemperModel,
+    state: &TemperModelState,
+) -> bool {
+    match kind {
+        InvariantKind::StatusInSet => !model.states.contains(&state.status),
+        InvariantKind::CounterPositive { var } => {
+            state.counters.get(var).copied().unwrap_or(0) == 0
+        }
+        InvariantKind::BoolRequired { var, expect } => {
+            state.booleans.get(var).copied().unwrap_or(false) != *expect
+        }
+        InvariantKind::NoFurtherTransitions => {
+            let mut actions = Vec::new();
+            model.actions(state, &mut actions);
+            !actions.is_empty()
+        }
+        InvariantKind::Implication => {
+            let valid_required: Vec<&String> = required_states
+                .iter()
+                .filter(|s| model.states.contains(s))
+                .collect();
+            if valid_required.is_empty() {
+                false
+            } else {
+                !valid_required.contains(&&state.status)
+            }
+        }
+        InvariantKind::CounterCompare { var, op, value } => {
+            let val = state.counters.get(var).copied().unwrap_or(0);
+            let holds = match op {
+                AssertCompareOp::Gt => val > *value,
+                AssertCompareOp::Gte => val >= *value,
+                AssertCompareOp::Lt => val < *value,
+                AssertCompareOp::Lte => val <= *value,
+                AssertCompareOp::Eq => val == *value,
+            };
+            !holds
+        }
+        InvariantKind::NeverState { state: forbidden } => state.status == *forbidden,
+        InvariantKind::And(parts) => parts
+            .iter()
+            .any(|k| kind_violated(k, required_states, model, state)),
+        InvariantKind::Or(parts) => parts
+            .iter()
+            .all(|k| kind_violated(k, required_states, model, state)),
+        InvariantKind::Unverifiable { .. } => false,
+    }
 }
 
 /// Collect enabled actions for a state.

--- a/crates/temper-verify/src/simulation.rs
+++ b/crates/temper-verify/src/simulation.rs
@@ -346,42 +346,7 @@ fn check_invariants_on_state(
             continue;
         }
 
-        let violated = match &inv.kind {
-            InvariantKind::StatusInSet => !model.states.contains(&state_after.status),
-            InvariantKind::CounterPositive { var } => {
-                state_after.counters.get(var).copied().unwrap_or(0) == 0
-            }
-            InvariantKind::BoolRequired { var } => {
-                !state_after.booleans.get(var).copied().unwrap_or(false)
-            }
-            InvariantKind::NoFurtherTransitions => {
-                // Check that no transitions are enabled from this state
-                let mut actions = Vec::new();
-                model.actions(state_after, &mut actions);
-                !actions.is_empty()
-            }
-            InvariantKind::Implication => {
-                let valid: Vec<&String> = inv
-                    .required_states
-                    .iter()
-                    .filter(|s| model.states.contains(s))
-                    .collect();
-                !valid.is_empty() && !valid.contains(&&state_after.status)
-            }
-            InvariantKind::CounterCompare { var, op, value } => {
-                let val = state_after.counters.get(var).copied().unwrap_or(0);
-                let holds = match op {
-                    AssertCompareOp::Gt => val > *value,
-                    AssertCompareOp::Gte => val >= *value,
-                    AssertCompareOp::Lt => val < *value,
-                    AssertCompareOp::Lte => val <= *value,
-                    AssertCompareOp::Eq => val == *value,
-                };
-                !holds
-            }
-            InvariantKind::NeverState { state } => state_after.status == *state,
-            InvariantKind::Unverifiable { .. } => false, // not checkable, never violated
-        };
+        let violated = sim_kind_violated(&inv.kind, &inv.required_states, model, state_after);
 
         if violated {
             violations.push(InvariantViolation {
@@ -393,6 +358,57 @@ fn check_invariants_on_state(
                 tick,
             });
         }
+    }
+}
+
+/// Evaluate whether an [`InvariantKind`] is violated given model+state.
+///
+/// Pure recursion over compound variants; does not consult `trigger_states`.
+fn sim_kind_violated(
+    kind: &InvariantKind,
+    required_states: &[String],
+    model: &TemperModel,
+    state_after: &TemperModelState,
+) -> bool {
+    match kind {
+        InvariantKind::StatusInSet => !model.states.contains(&state_after.status),
+        InvariantKind::CounterPositive { var } => {
+            state_after.counters.get(var).copied().unwrap_or(0) == 0
+        }
+        InvariantKind::BoolRequired { var, expect } => {
+            state_after.booleans.get(var).copied().unwrap_or(false) != *expect
+        }
+        InvariantKind::NoFurtherTransitions => {
+            let mut actions = Vec::new();
+            model.actions(state_after, &mut actions);
+            !actions.is_empty()
+        }
+        InvariantKind::Implication => {
+            let valid: Vec<&String> = required_states
+                .iter()
+                .filter(|s| model.states.contains(s))
+                .collect();
+            !valid.is_empty() && !valid.contains(&&state_after.status)
+        }
+        InvariantKind::CounterCompare { var, op, value } => {
+            let val = state_after.counters.get(var).copied().unwrap_or(0);
+            let holds = match op {
+                AssertCompareOp::Gt => val > *value,
+                AssertCompareOp::Gte => val >= *value,
+                AssertCompareOp::Lt => val < *value,
+                AssertCompareOp::Lte => val <= *value,
+                AssertCompareOp::Eq => val == *value,
+            };
+            !holds
+        }
+        InvariantKind::NeverState { state } => state_after.status == *state,
+        InvariantKind::And(parts) => parts
+            .iter()
+            .any(|k| sim_kind_violated(k, required_states, model, state_after)),
+        InvariantKind::Or(parts) => parts
+            .iter()
+            .all(|k| sim_kind_violated(k, required_states, model, state_after)),
+        InvariantKind::Unverifiable { .. } => false,
     }
 }
 

--- a/crates/temper-verify/src/smt.rs
+++ b/crates/temper-verify/src/smt.rs
@@ -162,8 +162,15 @@ fn check_invariant_induction(model: &TemperModel, max_counter: usize) -> Vec<(St
                     var,
                     max_counter,
                 ),
-                InvariantKind::BoolRequired { var } => {
-                    check_bool_required_induction_z3(model, &inv.trigger_states, var)
+                InvariantKind::BoolRequired { var, expect } => {
+                    // Induction checker assumes `expect = true`. For `!flag`,
+                    // fall back to runtime simulation (model checking still
+                    // exercises it via proptest_gen and simulation).
+                    if *expect {
+                        check_bool_required_induction_z3(model, &inv.trigger_states, var)
+                    } else {
+                        true
+                    }
                 }
                 InvariantKind::NoFurtherTransitions => {
                     // For each trigger state: no transitions should have it
@@ -214,6 +221,18 @@ fn check_invariant_induction(model: &TemperModel, max_counter: usize) -> Vec<(St
                         .iter()
                         .any(|t| t.to_state.as_ref().is_some_and(|to| to == state))
                 }
+                InvariantKind::And(parts) => {
+                    // Sound over-approximation: `a && b` is inductive iff each
+                    // part is inductive under the same trigger_states.
+                    parts.iter().all(|p| {
+                        kind_inductive_smt(model, &inv.trigger_states, p, max_counter)
+                    })
+                }
+                InvariantKind::Or(_) => {
+                    // Disjunctive induction requires joint encoding; runtime
+                    // simulation (proptest_gen/simulation) catches violations.
+                    true
+                }
                 InvariantKind::Unverifiable { .. } => {
                     // Not checkable at model level — trivially inductive.
                     true
@@ -223,6 +242,60 @@ fn check_invariant_induction(model: &TemperModel, max_counter: usize) -> Vec<(St
             (inv.name.clone(), inductive)
         })
         .collect()
+}
+
+/// Recursive induction check for a single [`InvariantKind`] — used by `And`.
+///
+/// Mirrors the per-variant logic in [`check_invariant_induction`]; compound
+/// recursion is sound at the And layer (all parts must hold). For Or, returns
+/// `true` (see note above — runtime catches disjunctive violations).
+fn kind_inductive_smt(
+    model: &TemperModel,
+    trigger_states: &[String],
+    kind: &InvariantKind,
+    max_counter: usize,
+) -> bool {
+    match kind {
+        InvariantKind::StatusInSet => model.transitions.iter().all(|t| {
+            t.to_state
+                .as_ref()
+                .map(|s| model.states.contains(s))
+                .unwrap_or(true)
+        }),
+        InvariantKind::CounterPositive { var } => {
+            check_counter_positive_induction_z3(model, trigger_states, var, max_counter)
+        }
+        InvariantKind::BoolRequired { var, expect } => {
+            if *expect {
+                check_bool_required_induction_z3(model, trigger_states, var)
+            } else {
+                true
+            }
+        }
+        InvariantKind::NoFurtherTransitions => trigger_states.iter().all(|trigger| {
+            !model
+                .transitions
+                .iter()
+                .any(|t| t.from_states.contains(trigger) || t.from_states.is_empty())
+        }),
+        InvariantKind::Implication => true,
+        InvariantKind::CounterCompare { var, op, value } => check_counter_compare_induction_z3(
+            model,
+            trigger_states,
+            var,
+            op,
+            *value,
+            max_counter,
+        ),
+        InvariantKind::NeverState { state } => !model
+            .transitions
+            .iter()
+            .any(|t| t.to_state.as_ref().is_some_and(|to| to == state)),
+        InvariantKind::And(parts) => parts
+            .iter()
+            .all(|p| kind_inductive_smt(model, trigger_states, p, max_counter)),
+        InvariantKind::Or(_) | InvariantKind::Unverifiable { .. } => true,
+    }
 }
 
 /// Z3 induction check for CounterPositive invariants.


### PR DESCRIPTION
Resolves #101.

## Summary
- Extend IOA invariant asserts with `&&`, `||`, parens, and `!` negation
- `migrations_ok && typecheck_ok && unit_tests_ok` now works as a single-expression invariant, so safety properties spanning N gates no longer have to be replicated as per-transition guards

## Details
- **Parser** (`crates/temper-spec/src/automaton/assert_parser.rs`) rewritten as recursive-descent tokenizer + parser; adds `ParsedAssert::BoolRequired{var,expect}`, `And(Vec)`, `Or(Vec)`
- **Runtime** (`temper-runtime/scheduler/{sim_handler,sim_actor_system}`) adds matching `SpecAssert` variants and a recursive `evaluate_spec_assert` helper; new `SimActorHandler::bool_field(var)` trait accessor
- **Server** (`temper-server/entity_actor/sim_handler`) translates new `ParsedAssert` variants and exposes booleans
- **Verify** (`temper-verify`) adds `InvariantKind::And/Or`, updates `BoolRequired` to carry `expect`, recursively evaluates across `proptest_gen`, `simulation`, `stateright_impl`, and `smt`
- Compound expressions referencing undeclared bools fall back to `Unverifiable` so model checking stays safe
- SMT induction: `And` sound via per-part check; `Or` defers to runtime (joint encoding out of scope)

## Test plan
- [x] `cargo test -p temper-spec` — 194 pass (26 parser tests including compound coverage)
- [x] `cargo test -p temper-runtime --lib` — 92 pass
- [x] `cargo test -p temper-server --lib` — 226 pass
- [x] `cargo test -p temper-verify --lib` — 76 pass + 3 new compound tests
- [x] Workspace `cargo build` clean
- [x] Code review (see `code-reviewer` agent findings — all green with low-severity follow-ups)

🤖 Generated with [Claude Code](https://claude.com/claude-code)