### PR TITLE
otel: remove embodiment tag — use env + host instead

### DIFF
--- a/crates/temper-observe/src/otel.rs
+++ b/crates/temper-observe/src/otel.rs
@@ -469,17 +469,6 @@ pub fn init_tracing(
         "runtime-id",
         uuid::Uuid::new_v4().to_string(),
     ));
-    // ADR-0053: embodiment tag identifies which Temper host this process
-    // is. When Tamago (macOS menu bar) ships, its process emits
-    // embodiment:tamago; the openpaw-server process here emits
-    // embodiment:openpaw (or whatever EMBODIMENT is set to). Lets the
-    // Service Catalog surface one `service:temper` across many hosts.
-    if let Some(embodiment) = read_non_empty_env("EMBODIMENT") {
-        resource_attrs.push(KeyValue::new("embodiment", embodiment));
-    } else if let Some(embodiment) = read_non_empty_env("TEMPER_EMBODIMENT") {
-        resource_attrs.push(KeyValue::new("embodiment", embodiment));
-    }
-
     let resource = Resource::builder_empty()
         .with_attributes(resource_attrs)
         .build();
@@ -527,11 +516,6 @@ pub fn init_tracing(
         }
         if let Some(version) = resolve_service_version() {
             attrs.push(KeyValue::new("service.version", version));
-        }
-        if let Some(embodiment) =
-            read_non_empty_env("EMBODIMENT").or_else(|| read_non_empty_env("TEMPER_EMBODIMENT"))
-        {
-            attrs.push(KeyValue::new("embodiment", embodiment));
         }
         // Share runtime-id with the temper provider so traces that
         // span both services have the same runtime-id for profile

--- a/crates/temper-server/src/profiling.rs
+++ b/crates/temper-server/src/profiling.rs
@@ -115,15 +115,11 @@ async fn upload_to_agent(pprof_bytes: Vec<u8>, profile_type: &str) {
     let version = std::env::var("BUILD_VERSION")
         .or_else(|_| std::env::var("DD_VERSION"))
         .unwrap_or_else(|_| "dev".to_string());
-    let embodiment = std::env::var("EMBODIMENT")
-        .or_else(|_| std::env::var("TEMPER_EMBODIMENT"))
-        .unwrap_or_else(|_| "openpaw".to_string());
 
     let form = reqwest::multipart::Form::new()
         .text("tags[]", format!("service:{service}"))
         .text("tags[]", format!("env:{env}"))
         .text("tags[]", format!("version:{version}"))
-        .text("tags[]", format!("embodiment:{embodiment}"))
         .text("tags[]", format!("profile.component:{profile_type}"))
         .part(
             "data[profile.pprof]",

--- a/docs/adrs/0053-datadog-service-decoupling.md
+++ b/docs/adrs/0053-datadog-service-decoupling.md
@@ -54,27 +54,26 @@ Platform code paths (dispatch, actor, WASM host, state-timeouts, admission, Ceda
 
 Implementation: a per-meter resource override, same pattern as tracers. Two `Meter` handles, one per service.
 
-### Sub-Decision 3: `embodiment` tag on all emissions
+### Sub-Decision 3: Disambiguate instances via `env` + `host`, not a custom tag
 
-Every span, metric, and log emits `embodiment:<name>` as a resource attribute. Values:
+The earlier draft of this ADR introduced a custom `embodiment` resource attribute to distinguish Railway from local-Mac Temper instances. That was wrong: Datadog already ships `env` as a first-class resource attribute and auto-tags every span/metric/log with `host`. Together these disambiguate instances without any new concept:
 
-- `embodiment:openpaw` — the Railway-deployed OpenPaw server.
-- `embodiment:tamago` — the macOS menu bar app (when Temper is running embedded in it).
-- `embodiment:dev` — local developer runs.
-- Future values declared per deployment.
+- `env:prod` → the Railway Temper.
+- `env:dev` (auto-set by OTel or explicitly set locally) → any Mac instance.
+- Multiple local instances in parallel → `env:dev host:<hostname>` disambiguates them. If you need finer control, pass `DD_ENV=dev-<suffix>`.
 
-**Why**: this is what makes the Service Catalog useful. `service:temper embodiment:tamago` shows Temper's SLOs in the Tamago context; `service:temper embodiment:openpaw` shows them on Railway. One service, many homes.
+No `embodiment` tag. No parallel concept to explain. No dashboard filters that mix the two vocabularies. Correction issued 2026-04-20 before any dashboard or monitor shipped using the custom tag.
 
 ### Sub-Decision 4: Cross-service trace continuity
 
 A single user-initiated flow traverses both services:
 
 ```
-Slack webhook receive         (service:openpaw, embodiment:openpaw)
-  └─ trigger.dispatch         (service:openpaw, embodiment:openpaw)
-       └─ Session.Configure   (service:temper,  embodiment:openpaw)
-            └─ wasm.invoke    (service:temper,  embodiment:openpaw)
-                 └─ provider  (service:temper,  embodiment:openpaw)
+Slack webhook receive         (service:openpaw, env:prod)
+  └─ trigger.dispatch         (service:openpaw, env:prod)
+       └─ Session.Configure   (service:temper,  env:prod)
+            └─ wasm.invoke    (service:temper,  env:prod)
+                 └─ provider  (service:temper,  env:prod)
 ```
 
 Trace ID is preserved across service boundaries because both tracers share the same propagation context. Datadog's APM UI renders cross-service traces natively — no special configuration needed on the ingestion side.


### PR DESCRIPTION
Correction to ADR-0053. The custom `embodiment` tag duplicated `env` — ripping it out before any dashboard or traffic relies on it.

- Code: drop `EMBODIMENT`/`TEMPER_EMBODIMENT` plumbing from both tracer providers and the profiler uploader.
- ADR-0053 Sub-Decision 3 rewritten: use `env:prod` for Railway, `env:dev` for local Macs (disambiguated by the auto-set `host` tag when running multiple).

🤖 Generated with [Claude Code](https://claude.com/claude-code)