### PR TITLE
otel: supersede ADR-0053 — one service per deployment

### DIFF
--- a/crates/temper-observe/src/otel.rs
+++ b/crates/temper-observe/src/otel.rs
@@ -276,14 +276,14 @@ where
 /// Guard returned by [`init_tracing`].  Holds provider handles so the
 /// caller can [`shutdown`](OtelGuard::shutdown) cleanly before exit.
 ///
-/// ADR-0053: two tracer providers live inside one process. The `temper`
-/// provider is the global default; the `openpaw` provider is exposed via
-/// [`openpaw_tracer()`] and used by trigger/HTTP/installer code paths so
-/// spans emitted from that tier surface under `service:openpaw` in
-/// Datadog while platform dispatch spans stay on `service:temper`.
+/// One process → one service identity. ADR-0053 tried to emit two
+/// services from one process (platform vs embodiment); that model
+/// conflicts with OpenTelemetry's resource-per-provider design. Superseded
+/// 2026-04-20 in favor of one `service.name` per deployment — when Temper
+/// ships inside another embodiment (Tamago, future services), that
+/// binary sets its own `DD_SERVICE`.
 pub struct OtelGuard {
     tracer_provider: SdkTracerProvider,
-    openpaw_tracer_provider: Option<SdkTracerProvider>,
     meter_provider: SdkMeterProvider,
     logger_provider: SdkLoggerProvider,
 }
@@ -294,11 +294,6 @@ impl OtelGuard {
         if let Err(e) = self.tracer_provider.shutdown() {
             eprintln!("tracer provider shutdown error: {e}");
         }
-        if let Some(p) = self.openpaw_tracer_provider
-            && let Err(e) = p.shutdown()
-        {
-            eprintln!("openpaw tracer provider shutdown error: {e}");
-        }
         if let Err(e) = self.meter_provider.shutdown() {
             eprintln!("meter provider shutdown error: {e}");
         }
@@ -306,48 +301,6 @@ impl OtelGuard {
             eprintln!("logger provider shutdown error: {e}");
         }
     }
-}
-
-/// ADR-0053: handle to the `openpaw` tracer provider. Populated by
-/// [`init_tracing`] after it successfully builds the second provider.
-/// Accessed via [`openpaw_tracer()`].
-static OPENPAW_TRACER: std::sync::OnceLock<opentelemetry::global::BoxedTracer> =
-    std::sync::OnceLock::new();
-
-/// Return a tracer that emits `service:openpaw` spans. Use this for
-/// trigger / HTTP / installer / CLI code paths; platform dispatch code
-/// should use the default global tracer (which emits `service:temper`).
-///
-/// If `init_tracing` was not called (or OTEL export is disabled) this
-/// falls back to the global tracer — callers observe the same tracing
-/// behavior as before, just without the service split.
-pub fn openpaw_tracer() -> opentelemetry::global::BoxedTracer {
-    use opentelemetry::global;
-    // BoxedTracer isn't Clone, so we call the factory every time.
-    // The returned tracer is a thin Arc-backed handle and cheap to
-    // construct. When `install_openpaw_tracer` has been called the
-    // "openpaw" scope resolves to the openpaw provider; otherwise it
-    // falls back to the global `service:temper` provider.
-    let _primed = OPENPAW_TRACER.get().is_some();
-    global::tracer("openpaw")
-}
-
-/// Register the `openpaw` tracer as a scoped tracer so subsequent calls
-/// to `global::tracer("openpaw")` return a handle that emits through the
-/// openpaw provider's pipeline.
-///
-/// OpenTelemetry's global tracer registry is the single `GlobalTracerProvider`;
-/// to route a named tracer to a separate provider we wrap the openpaw
-/// provider in a small adapter and call `global::set_tracer_provider`
-/// for the openpaw scope.
-fn install_openpaw_tracer(provider: &SdkTracerProvider) {
-    let tracer = provider.tracer("openpaw");
-    // Store a BoxedTracer-compatible representation so callers of
-    // openpaw_tracer() get the openpaw-service handle when available.
-    // In practice tracing_opentelemetry bridges the global provider; the
-    // explicit handle here is for direct use (e.g. manual spans in
-    // trigger code).
-    let _ = OPENPAW_TRACER.set(opentelemetry::global::BoxedTracer::new(Box::new(tracer)));
 }
 
 /// Initialise observability for the process.
@@ -505,59 +458,6 @@ pub fn init_tracing(
 
     opentelemetry::global::set_tracer_provider(tracer_provider.clone());
 
-    // ADR-0053: openpaw tracer provider. Identical pipeline (same
-    // exporter, same sampler) but resource carries `service.name =
-    // openpaw`. Lives in parallel with the platform provider so one
-    // process emits two Service Catalog entries.
-    let openpaw_resource = {
-        let mut attrs = vec![KeyValue::new("service.name", "openpaw")];
-        if let Some(environment) = resolve_deployment_environment() {
-            attrs.push(KeyValue::new("deployment.environment.name", environment));
-        }
-        if let Some(version) = resolve_service_version() {
-            attrs.push(KeyValue::new("service.version", version));
-        }
-        // Share runtime-id with the temper provider so traces that
-        // span both services have the same runtime-id for profile
-        // stitching.
-        attrs.push(KeyValue::new(
-            "runtime-id",
-            resource
-                .iter()
-                .find(|(k, _)| k.as_str() == "runtime-id")
-                .map(|(_, v)| v.to_string())
-                .unwrap_or_else(|| uuid::Uuid::new_v4().to_string()),
-        ));
-        Resource::builder_empty().with_attributes(attrs).build()
-    };
-
-    let openpaw_exporter = build_with_retry("openpaw trace exporter", || {
-        SpanExporter::builder()
-            .with_http()
-            .with_timeout(Duration::from_secs(10))
-            .build()
-    })
-    .ok();
-    let openpaw_provider = openpaw_exporter.map(|exporter| {
-        let proc = BatchSpanProcessor::builder(exporter)
-            .with_batch_config(
-                SpanBatchConfigBuilder::default()
-                    .with_max_queue_size(trace_queue)
-                    .with_max_export_batch_size(TRACE_BATCH_MAX_EXPORT_BATCH_SIZE)
-                    .with_scheduled_delay(Duration::from_millis(TRACE_BATCH_SCHEDULE_DELAY_MS))
-                    .build(),
-            )
-            .build();
-        SdkTracerProvider::builder()
-            .with_span_processor(proc)
-            .with_sampler(sampler)
-            .with_resource(openpaw_resource)
-            .build()
-    });
-    if let Some(ref p) = openpaw_provider {
-        install_openpaw_tracer(p);
-    }
-
     // --- Metrics ---
     let metric_exporter = build_with_retry("metric exporter", || {
         MetricExporter::builder()
@@ -662,7 +562,6 @@ pub fn init_tracing(
 
     Ok(OtelGuard {
         tracer_provider,
-        openpaw_tracer_provider: openpaw_provider,
         meter_provider,
         logger_provider,
     })

--- a/docs/adrs/0053-datadog-service-decoupling.md
+++ b/docs/adrs/0053-datadog-service-decoupling.md
@@ -1,15 +1,41 @@
 # ADR-0053: Datadog Service Decoupling — `temper` vs `openpaw`
 
-- Status: Accepted
+- Status: **Superseded 2026-04-20**
 - Date: 2026-04-18
 - Deciders: Temper core maintainers
 - Related:
   - ADR-0052: Instrumentation as policy
   - ADR-0054: Log standard
   - ADR-0055: Continuous profiling
-  - `crates/temper-server/src/otel.rs` (to be created or modified)
-  - `crates/temper-server/src/main.rs` (tracer / meter init)
-  - `/Users/seshendranalla/Development/openpaw/dd-dashboards/` (dashboard split)
+
+## Supersession note (2026-04-20)
+
+This ADR proposed emitting two services — `service:temper` for platform spans and `service:openpaw` for embodiment spans — from a single process, via a second OpenTelemetry `SdkTracerProvider`.
+
+**That design was wrong.** OpenTelemetry's resource model pins `service.name` to the provider; emitting two from one process requires either explicit tracer-handle plumbing at every call site (loses `tracing::info_span!` / `#[instrument]` ergonomics) or span-name filter routing at the subscriber layer (policy-as-string — rename a span, routing silently breaks).
+
+The correct model is **one `service.name` per process**, named after the deployment:
+
+| Deployment | `service.name` | Temper presence |
+|---|---|---|
+| Railway openpaw server (today) | `openpaw` | Library linked in |
+| Standalone Temper server (hypothetical) | `temper` | It IS the service |
+| Tamago Mac app | `tamago` | Library linked in |
+| Future embodiment | whatever | Library linked in |
+
+Cross-deployment "all Temper activity" queries use span attributes (e.g. `span.name:dispatch.*`) or the existing `temper_*` metric prefix, not a service-level filter. Datadog's Service Catalog gains entries as embodiments ship — each deployment is one catalog row, which is what the catalog was designed for.
+
+**What changed in code 2026-04-20:**
+- Removed `openpaw_tracer()` / `install_openpaw_tracer()` / `OPENPAW_TRACER` static / second `SdkTracerProvider` from `crates/temper-observe/src/otel.rs`.
+- `OtelGuard` no longer carries `openpaw_tracer_provider`.
+- `embodiment` resource tag already removed in ADR-0053 Sub-Decision 3 rewrite (nerdsane/temper#153).
+
+**What did not change:**
+- `@runtime-id` resource tag stays (ADR-0055, profile↔trace stitching).
+- `service.name = openpaw` continues to be set via the `DD_SERVICE` env or the single `SdkTracerProvider`'s service-name resource attribute — unchanged from production today.
+- When a new deployment ships (Tamago, standalone Temper), it sets `DD_SERVICE` to its own name. No framework work required.
+
+The original decision text below is preserved for the historical record. Do not treat it as current design.
 
 ## Context
 


### PR DESCRIPTION
## Summary

Rip the second SdkTracerProvider from ADR-0053. The "two services from one process" design conflicts with OTel's resource-per-provider model and couldn't be migrated cleanly.

**Replaced with**: one `service.name` per process, named after the deployment (openpaw on Railway, tamago on Mac, future temper-standalone = temper). Cross-deployment "all Temper" queries use span attributes, not service filters.

- Delete `openpaw_tracer()`, `install_openpaw_tracer()`, `OPENPAW_TRACER` static, second `SdkTracerProvider`.
- `OtelGuard` simplified.
- ADR-0053 marked Superseded with explanation.

Production behavior unchanged — `service:openpaw` was always the only identity emitting.

## Test plan

- [x] 8 otel lib tests green.
- [x] Workspace compiles.
- [x] No call sites referenced `openpaw_tracer()` yet (confirmed via grep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)