### PR TITLE
fix(dispatch): remove monty_repl concurrency semaphore

### DIFF
--- a/crates/temper-server/src/runtime_metrics.rs
+++ b/crates/temper-server/src/runtime_metrics.rs
@@ -21,9 +21,6 @@ struct RuntimeMetrics {
     event_replay_duration: Histogram<f64>,
     blob_io_wait_duration_ms: Histogram<f64>,
     blob_local_fast_path_requests_total: Counter<u64>,
-    monty_repl_acquisitions_total: Counter<u64>,
-    monty_repl_observed_active_invocations: Histogram<f64>,
-    monty_repl_wait_duration_ms: Histogram<f64>,
     wasm_integration_default_timeout_used_total: Counter<u64>,
     entity_concurrency_retry_total: Counter<u64>,
     entity_concurrency_retry_attempts: Histogram<u64>,
@@ -112,21 +109,6 @@ fn metrics() -> &'static RuntimeMetrics {
                 .with_description(
                     "Requests served by the in-process local blob fast path without loopback HTTP.",
                 )
-                .build(),
-            monty_repl_acquisitions_total: meter
-                .u64_counter("temper_monty_repl_acquisitions_total")
-                .with_description("Total number of monty_repl execution gate acquisitions.")
-                .build(),
-            monty_repl_observed_active_invocations: meter
-                .f64_histogram("temper_monty_repl_observed_active_invocations")
-                .with_description(
-                    "Observed number of concurrent monty_repl WASM executions at acquire/release points.",
-                )
-                .build(),
-            monty_repl_wait_duration_ms: meter
-                .f64_histogram("temper_monty_repl_wait_duration_ms")
-                .with_unit("ms")
-                .with_description("Time spent waiting to acquire the monty_repl execution gate.")
                 .build(),
             wasm_integration_default_timeout_used_total: meter
                 .u64_counter("temper_wasm_integration_default_timeout_used_total")
@@ -431,39 +413,6 @@ pub fn record_blob_local_fast_path_request(method: &str) {
 /// Record process resident memory usage.
 pub fn record_process_resident_memory_bytes(bytes: u64) {
     metrics().process_resident_memory_bytes.record(bytes, &[]);
-}
-
-/// Record the number of concurrent monty_repl executions.
-pub fn record_monty_repl_active_invocations(count: u64, max_concurrency: usize) {
-    metrics().monty_repl_observed_active_invocations.record(
-        count as f64,
-        &[KeyValue::new(
-            "max_concurrency",
-            i64::try_from(max_concurrency).unwrap_or(i64::MAX),
-        )],
-    );
-}
-
-/// Record a successful monty_repl gate acquisition.
-pub fn record_monty_repl_acquisition(max_concurrency: usize) {
-    metrics().monty_repl_acquisitions_total.add(
-        1,
-        &[KeyValue::new(
-            "max_concurrency",
-            i64::try_from(max_concurrency).unwrap_or(i64::MAX),
-        )],
-    );
-}
-
-/// Record time spent waiting for the monty_repl execution gate.
-pub fn record_monty_repl_wait_duration(duration: Duration, max_concurrency: usize) {
-    metrics().monty_repl_wait_duration_ms.record(
-        duration.as_secs_f64() * 1000.0,
-        &[KeyValue::new(
-            "max_concurrency",
-            i64::try_from(max_concurrency).unwrap_or(i64::MAX),
-        )],
-    );
 }
 
 /// Record a WASM integration dispatch that fell back to the default timeout

--- a/crates/temper-server/src/state/dispatch/wasm.rs
+++ b/crates/temper-server/src/state/dispatch/wasm.rs
@@ -1,10 +1,7 @@
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, OnceLock};
-use std::time::Instant;
+use std::sync::Arc;
 
 use opentelemetry::{Context as OtelContext, trace::TraceContextExt};
 use serde_json::{Value, json};
-use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tracing::{Instrument, Span, instrument};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
@@ -42,74 +39,6 @@ struct WasmDispatchCtx<'a> {
 const HTTP_CALL_AUTHZ_DENIED_PREFIX: &str = "authorization denied for http_call";
 const MONTY_REPL_MODULE: &str = "monty_repl";
 const OPENPAW_SERVICE_NAME: &str = "openpaw";
-
-fn monty_repl_max_concurrency() -> usize {
-    static MAX_CONCURRENCY: OnceLock<usize> = OnceLock::new();
-    *MAX_CONCURRENCY.get_or_init(|| {
-        std::env::var("TEMPER_MONTY_REPL_MAX_CONCURRENCY") // determinism-ok: read once at startup
-            .ok()
-            .and_then(|value| value.trim().parse::<usize>().ok())
-            .filter(|value| *value > 0)
-            .unwrap_or(2)
-    })
-}
-
-fn monty_repl_semaphore() -> &'static Arc<Semaphore> {
-    static SEMAPHORE: OnceLock<Arc<Semaphore>> = OnceLock::new();
-    SEMAPHORE.get_or_init(|| Arc::new(Semaphore::new(monty_repl_max_concurrency())))
-}
-
-fn monty_repl_active_counter() -> &'static AtomicU64 {
-    static ACTIVE: AtomicU64 = AtomicU64::new(0);
-    &ACTIVE
-}
-
-struct MontyReplExecutionPermit {
-    _permit: OwnedSemaphorePermit,
-    max_concurrency: usize,
-}
-
-impl MontyReplExecutionPermit {
-    async fn acquire() -> Self {
-        let max_concurrency = monty_repl_max_concurrency();
-        let wait_started = Instant::now();
-        let permit = monty_repl_semaphore()
-            .clone()
-            .acquire_owned()
-            .await
-            .expect("monty_repl semaphore should not be closed");
-        let wait_duration = wait_started.elapsed();
-        crate::runtime_metrics::record_monty_repl_acquisition(max_concurrency);
-        crate::runtime_metrics::record_monty_repl_wait_duration(wait_duration, max_concurrency);
-        let active = monty_repl_active_counter().fetch_add(1, Ordering::SeqCst) + 1;
-        crate::runtime_metrics::record_monty_repl_active_invocations(active, max_concurrency);
-        tracing::info!(
-            module = MONTY_REPL_MODULE,
-            wait_ms = wait_duration.as_millis() as u64,
-            active_invocations = active,
-            max_concurrency,
-            "acquired monty_repl execution permit"
-        );
-        Self {
-            _permit: permit,
-            max_concurrency,
-        }
-    }
-}
-
-impl Drop for MontyReplExecutionPermit {
-    fn drop(&mut self) {
-        let previous = monty_repl_active_counter().fetch_sub(1, Ordering::SeqCst);
-        let active = previous.saturating_sub(1);
-        crate::runtime_metrics::record_monty_repl_active_invocations(active, self.max_concurrency);
-        tracing::info!(
-            module = MONTY_REPL_MODULE,
-            active_invocations = active,
-            max_concurrency = self.max_concurrency,
-            "released monty_repl execution permit"
-        );
-    }
-}
 
 fn http_call_authz_denied_error(reason: &str) -> String {
     format!("{HTTP_CALL_AUTHZ_DENIED_PREFIX}: {reason}")
@@ -658,11 +587,6 @@ impl crate::state::ServerState {
     ) -> Result<Option<EntityResponse>, String> {
         // Existing action-triggered invocations don't use streams — pass empty registry.
         let streams = Arc::new(std::sync::RwLock::new(StreamRegistry::default()));
-        let _monty_repl_permit = if module_name == MONTY_REPL_MODULE {
-            Some(MontyReplExecutionPermit::acquire().await)
-        } else {
-            None
-        };
         match self
             .wasm_engine
             .invoke_with_blobs(hash, &inv_ctx, host, limits, streams, blob_cache)


### PR DESCRIPTION
## Summary
- Deletes the global `monty_repl_max_concurrency` semaphore (default 2) that was gating every Session turn in Temper — the root cause of the 2026-04-19 pileup that froze 27 sessions for 37+ hours.
- Keeps the `MONTY_REPL_MODULE` const because it's still used at `wasm.rs:694` for LLM observability tool-span tagging.
- Drops three now-dead OTel metrics (`temper_monty_repl_acquisitions_total`, `temper_monty_repl_observed_active_invocations`, `temper_monty_repl_wait_duration_ms`) and their emitters.

## Why a full rip, not raise the default
Leaving the infrastructure in invites someone to set `TEMPER_MONTY_REPL_MAX_CONCURRENCY=2` again. Cost control belongs at the contended resource (per-tenant admission on `call_provider`, provider-side rate limiter) — not a global fixed number. See the paired openpaw ADR-0038.

## Paired PR
- openpaw: PR coming after this merges. openpaw's `Cargo.toml` pulls temper at `branch = "main"`, so the monty rip must reach `nerdsane/temper@main` before the openpaw build can pick it up.

## Test plan
- [ ] `cargo check -p temper-server` locally: clean (verified on branch)
- [ ] CI green
- [ ] After merge: confirm next openpaw Docker build at `ghcr.io/nerdsane/temperpaw:edge` resolves temper to this commit SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)