### PR TITLE
[codex] Fix LLMObs model metadata

### DIFF
--- a/crates/temper-observe/src/llmobs_api.rs
+++ b/crates/temper-observe/src/llmobs_api.rs
@@ -18,6 +18,7 @@ pub struct LlmSpanInput<'a> {
     pub session_id: &'a str,
     pub trace_id: &'a str,
     pub span_id: &'a str,
+    pub span_name: &'a str,
     pub provider: &'a str,
     pub model: &'a str,
     pub system_instructions: Option<&'a str>,
@@ -52,6 +53,11 @@ pub async fn submit_llm_span(input: LlmSpanInput<'_>) -> Result<(), String> {
         return Ok(());
     };
 
+    let payload = build_llm_span_payload(&input)?;
+    post_payload(&config, payload).await
+}
+
+fn build_llm_span_payload(input: &LlmSpanInput<'_>) -> Result<Value, String> {
     let mut input_messages = input
         .input_messages_json
         .map(convert_otel_messages_to_llmobs)
@@ -77,11 +83,16 @@ pub async fn submit_llm_span(input: LlmSpanInput<'_>) -> Result<(), String> {
     let duration_ns = (input.duration_ms as f64) * 1_000_000.0;
     let trace_id = normalize_trace_id(input.trace_id);
     let span_id = normalize_span_id(input.span_id);
+    let provider = normalize_model_provider(input.provider);
+    let mut metadata = Map::from_iter([
+        ("model_name".to_string(), json!(input.model)),
+        ("model_provider".to_string(), json!(provider)),
+    ]);
 
     let mut meta = Map::from_iter([
         ("kind".to_string(), json!("llm")),
         ("model_name".to_string(), json!(input.model)),
-        ("model_provider".to_string(), json!(input.provider)),
+        ("model_provider".to_string(), json!(provider)),
     ]);
     if !input_messages.is_empty() {
         meta.insert("input".to_string(), json!({ "messages": input_messages }));
@@ -90,17 +101,14 @@ pub async fn submit_llm_span(input: LlmSpanInput<'_>) -> Result<(), String> {
         meta.insert("output".to_string(), json!({ "messages": output_messages }));
     }
     if input.finish_reason.is_some() || input.error_type.is_some() {
-        let mut metadata = Map::new();
         if let Some(finish_reason) = input.finish_reason.filter(|value| !value.is_empty()) {
             metadata.insert("finish_reason".to_string(), json!(finish_reason));
         }
         if let Some(error_type) = input.error_type.filter(|value| !value.is_empty()) {
             metadata.insert("error_type".to_string(), json!(error_type));
         }
-        if !metadata.is_empty() {
-            meta.insert("metadata".to_string(), Value::Object(metadata));
-        }
     }
+    meta.insert("metadata".to_string(), Value::Object(metadata));
     if let Some(error_type) = input.error_type.filter(|value| !value.is_empty()) {
         meta.insert(
             "error".to_string(),
@@ -126,21 +134,29 @@ pub async fn submit_llm_span(input: LlmSpanInput<'_>) -> Result<(), String> {
         metrics.insert("total_tokens".to_string(), json!(total_tokens as f64));
     }
 
-    let payload = json!({
+    let span_tags = vec![
+        format!("service:{}", input.service_name),
+        format!("session_id:{}", input.session_id),
+        format!("model_name:{}", input.model),
+        format!("model_provider:{provider}"),
+    ];
+
+    Ok(json!({
         "data": {
             "type": "span",
             "attributes": {
                 "ml_app": input.service_name,
                 "session_id": input.session_id,
-                "tags": [format!("service:{}", input.service_name)],
+                "tags": span_tags.clone(),
                 "spans": [{
                     "parent_id": "undefined",
                     "trace_id": trace_id,
                     "span_id": span_id,
-                    "name": "wasm:llm_caller",
+                    "name": input.span_name,
                     "service": input.service_name,
                     "ml_app": input.service_name,
                     "session_id": input.session_id,
+                    "tags": span_tags,
                     "status": if input.error_type.is_some() { "error" } else { "ok" },
                     "start_ns": start_ns,
                     "duration": duration_ns,
@@ -149,9 +165,7 @@ pub async fn submit_llm_span(input: LlmSpanInput<'_>) -> Result<(), String> {
                 }],
             },
         },
-    });
-
-    post_payload(&config, payload).await
+    }))
 }
 
 pub async fn submit_tool_spans(
@@ -334,6 +348,16 @@ fn normalize_span_id(span_id: &str) -> String {
     }
 }
 
+fn normalize_model_provider(provider: &str) -> String {
+    let trimmed = provider.trim();
+    match trimmed.to_ascii_lowercase().as_str() {
+        "openai_codex" => "openai".to_string(),
+        "mock" => "custom".to_string(),
+        "" => "custom".to_string(),
+        _ => trimmed.to_string(),
+    }
+}
+
 fn hash_to_decimal_id(seed: &str) -> String {
     let mut digest = Sha256::new();
     digest.update(seed.as_bytes());
@@ -432,28 +456,5 @@ pub fn parse_tool_span_inputs(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn converts_otel_messages_with_tool_calls_and_results() {
-        let messages = convert_otel_messages_to_llmobs(
-            r#"[
-              {"role":"user","parts":[{"type":"text","content":"List sessions"}]},
-              {"role":"assistant","parts":[{"type":"tool_call","id":"tool_123","name":"temper.list_sessions","arguments":{"top":3}}]},
-              {"role":"tool","parts":[{"type":"tool_call_response","id":"tool_123","result":{"sessions":["s1","s2"]}}]}
-            ]"#,
-        )
-        .unwrap();
-
-        assert_eq!(messages[0]["content"], "List sessions");
-        assert_eq!(messages[1]["tool_calls"][0]["name"], "temper.list_sessions");
-        assert_eq!(messages[2]["tool_results"][0]["tool_id"], "tool_123");
-    }
-
-    #[test]
-    fn normalizes_hex_trace_and_span_ids() {
-        assert_eq!(normalize_trace_id("0000000000000000000000000000000f"), "15");
-        assert_eq!(normalize_span_id("000000000000000a"), "10");
-    }
-}
+#[path = "llmobs_api_test.rs"]
+mod tests;

--- a/crates/temper-observe/src/llmobs_api_test.rs
+++ b/crates/temper-observe/src/llmobs_api_test.rs
@@ -1,0 +1,56 @@
+use super::*;
+
+#[test]
+fn converts_otel_messages_with_tool_calls_and_results() {
+    let messages = convert_otel_messages_to_llmobs(
+        r#"[
+          {"role":"user","parts":[{"type":"text","content":"List sessions"}]},
+          {"role":"assistant","parts":[{"type":"tool_call","id":"tool_123","name":"temper.list_sessions","arguments":{"top":3}}]},
+          {"role":"tool","parts":[{"type":"tool_call_response","id":"tool_123","result":{"sessions":["s1","s2"]}}]}
+        ]"#,
+    )
+    .unwrap();
+
+    assert_eq!(messages[0]["content"], "List sessions");
+    assert_eq!(messages[1]["tool_calls"][0]["name"], "temper.list_sessions");
+    assert_eq!(messages[2]["tool_results"][0]["tool_id"], "tool_123");
+}
+
+#[test]
+fn normalizes_hex_trace_and_span_ids() {
+    assert_eq!(normalize_trace_id("0000000000000000000000000000000f"), "15");
+    assert_eq!(normalize_span_id("000000000000000a"), "10");
+}
+
+#[test]
+fn llm_span_payload_uses_span_name_and_supported_model_metadata() {
+    let payload = build_llm_span_payload(&LlmSpanInput {
+        service_name: "openpaw",
+        session_id: "session-1",
+        trace_id: "0000000000000000000000000000000f",
+        span_id: "000000000000000a",
+        span_name: "wasm:provider_caller",
+        provider: "openai_codex",
+        model: "gpt-5.4",
+        system_instructions: None,
+        input_messages_json: None,
+        output_messages_json: None,
+        input_tokens: 10,
+        output_tokens: 20,
+        finish_reason: Some("tool_use"),
+        duration_ms: 1234,
+        error_type: None,
+    })
+    .unwrap();
+    let span = &payload["data"]["attributes"]["spans"][0];
+
+    assert_eq!(span["name"], "wasm:provider_caller");
+    assert_eq!(span["meta"]["model_name"], "gpt-5.4");
+    assert_eq!(span["meta"]["model_provider"], "openai");
+    assert_eq!(span["meta"]["metadata"]["model_name"], "gpt-5.4");
+    assert_eq!(span["meta"]["metadata"]["model_provider"], "openai");
+
+    let tags = span["tags"].as_array().unwrap();
+    assert!(tags.iter().any(|tag| tag == "model_name:gpt-5.4"));
+    assert!(tags.iter().any(|tag| tag == "model_provider:openai"));
+}

--- a/crates/temper-server/src/state/dispatch/wasm.rs
+++ b/crates/temper-server/src/state/dispatch/wasm.rs
@@ -156,6 +156,7 @@ impl crate::state::ServerState {
         wasm.module = tracing::field::Empty,
         wasm.timeout_source = tracing::field::Empty,
         gen_ai.system = tracing::field::Empty,
+        gen_ai.provider.name = tracing::field::Empty,
         gen_ai.system_instructions = tracing::field::Empty,
         gen_ai.request.model = tracing::field::Empty,
         gen_ai.operation.name = tracing::field::Empty,
@@ -599,50 +600,52 @@ impl crate::state::ServerState {
 
                 let callback_params = &result.callback_params;
 
-                // Record GenAI token usage from callback params (if present)
-                if let Some(input) = callback_params.get("input_tokens").and_then(|v| v.as_i64()) {
-                    Span::current().record("gen_ai.usage.input_tokens", input);
-                }
-                if let Some(output) = callback_params
-                    .get("output_tokens")
-                    .and_then(|v| v.as_i64())
-                {
-                    Span::current().record("gen_ai.usage.output_tokens", output);
-                }
-                // Record GenAI input/output messages for LLM Observability content.
-                // These are JSON strings of message arrays set by WASM modules.
-                if let Some(input_msgs) = callback_params
-                    .get("_gen_ai_input_messages")
-                    .and_then(|v| v.as_str())
-                {
-                    Span::current().record("gen_ai.input.messages", input_msgs);
-                }
-                if let Some(output_msgs) = callback_params
-                    .get("_gen_ai_output_messages")
-                    .and_then(|v| v.as_str())
-                {
-                    Span::current().record("gen_ai.output.messages", output_msgs);
-                }
-                if let Some(system_instructions) = callback_params
-                    .get("_gen_ai_system_instructions")
-                    .and_then(|v| v.as_str())
-                    .filter(|value| !value.is_empty())
-                {
-                    Span::current().record("gen_ai.system_instructions", system_instructions);
-                }
-                // Dynamic provider override (if WASM module reports actual provider used)
-                if let Some(provider) = callback_params
-                    .get("_gen_ai_provider")
-                    .and_then(|v| v.as_str())
-                {
-                    Span::current().record("gen_ai.system", provider);
-                }
-                if let Some(finish_reason) = callback_params
-                    .get("_gen_ai_finish_reason")
-                    .and_then(|v| v.as_str())
-                    .filter(|value| !value.is_empty())
-                {
-                    Span::current().record("gen_ai.response.finish_reasons", finish_reason);
+                if should_record_gen_ai_span_attrs(integration.llm, callback_params) {
+                    // Record GenAI token usage from callback params (if present)
+                    if let Some(input) =
+                        callback_params.get("input_tokens").and_then(|v| v.as_i64())
+                    {
+                        Span::current().record("gen_ai.usage.input_tokens", input);
+                    }
+                    if let Some(output) = callback_params
+                        .get("output_tokens")
+                        .and_then(|v| v.as_i64())
+                    {
+                        Span::current().record("gen_ai.usage.output_tokens", output);
+                    }
+                    // Record GenAI input/output messages for LLM Observability content.
+                    // These are JSON strings of message arrays set by WASM modules.
+                    if let Some(input_msgs) = callback_params
+                        .get("_gen_ai_input_messages")
+                        .and_then(|v| v.as_str())
+                    {
+                        Span::current().record("gen_ai.input.messages", input_msgs);
+                    }
+                    if let Some(output_msgs) = callback_params
+                        .get("_gen_ai_output_messages")
+                        .and_then(|v| v.as_str())
+                    {
+                        Span::current().record("gen_ai.output.messages", output_msgs);
+                    }
+                    if let Some(system_instructions) = callback_params
+                        .get("_gen_ai_system_instructions")
+                        .and_then(|v| v.as_str())
+                        .filter(|value| !value.is_empty())
+                    {
+                        Span::current().record("gen_ai.system_instructions", system_instructions);
+                    }
+                    let provider = llm_provider_for_observability(entity_state, callback_params);
+                    Span::current().record("gen_ai.system", provider.as_str());
+                    Span::current().record("gen_ai.provider.name", provider.as_str());
+                    let model = llm_model_for_observability(entity_state, callback_params);
+                    Span::current().record("gen_ai.request.model", model.as_str());
+                    if let Some(finish_reason) = callback_params
+                        .get("_gen_ai_finish_reason")
+                        .and_then(|v| v.as_str())
+                        .filter(|value| !value.is_empty())
+                    {
+                        Span::current().record("gen_ai.response.finish_reasons", finish_reason);
+                    }
                 }
 
                 let complete_seq = self.next_entity_event_sequence(
@@ -688,8 +691,14 @@ impl crate::state::ServerState {
                         llm_call_wide_event(ctx, entity_state, callback_params, result.duration_ms);
                     temper_observe::wide_event::emit_span(&event);
                     temper_observe::wide_event::emit_metrics(&event);
-                    submit_llmobs_llm_span(ctx, entity_state, callback_params, result.duration_ms)
-                        .await;
+                    submit_llmobs_llm_span(
+                        ctx,
+                        entity_state,
+                        callback_params,
+                        result.duration_ms,
+                        module_name,
+                    )
+                    .await;
                 }
                 if module_name == MONTY_REPL_MODULE {
                     submit_llmobs_tool_spans(ctx, entity_state, callback_params).await;
@@ -899,16 +908,8 @@ fn llm_call_wide_event<'a>(
     callback_params: &'a Value,
     duration_ms: u64,
 ) -> temper_observe::wide_event::WideEvent {
-    let provider = callback_params
-        .get("_gen_ai_provider")
-        .and_then(Value::as_str)
-        .or_else(|| entity_state.fields.get("provider").and_then(Value::as_str))
-        .unwrap_or("unknown");
-    let model = entity_state
-        .fields
-        .get("model")
-        .and_then(Value::as_str)
-        .unwrap_or("unknown");
+    let provider = llm_provider_for_observability(entity_state, callback_params);
+    let model = llm_model_for_observability(entity_state, callback_params);
     let session_id = ctx
         .agent_ctx
         .session_id
@@ -941,8 +942,8 @@ fn llm_call_wide_event<'a>(
         .unwrap_or_default();
 
     temper_observe::wide_event::from_llm_call(temper_observe::wide_event::LlmCallInput {
-        provider,
-        model,
+        provider: &provider,
+        model: &model,
         operation: "chat",
         entity_type: ctx.entity_ref.entity_type,
         entity_id: ctx.entity_ref.entity_id,
@@ -960,11 +961,52 @@ fn llm_call_wide_event<'a>(
     })
 }
 
+fn should_record_gen_ai_span_attrs(integration_is_llm: bool, _callback_params: &Value) -> bool {
+    integration_is_llm
+}
+
+fn llm_provider_for_observability(entity_state: &EntityState, callback_params: &Value) -> String {
+    let provider = callback_params
+        .get("_gen_ai_provider")
+        .and_then(Value::as_str)
+        .or_else(|| entity_state.fields.get("provider").and_then(Value::as_str))
+        .unwrap_or("unknown");
+    normalize_llm_provider_for_observability(provider)
+}
+
+fn normalize_llm_provider_for_observability(provider: &str) -> String {
+    let trimmed = provider.trim();
+    match trimmed.to_ascii_lowercase().as_str() {
+        "openai_codex" => "openai".to_string(),
+        "mock" => "custom".to_string(),
+        "" => "unknown".to_string(),
+        _ => trimmed.to_string(),
+    }
+}
+
+fn llm_model_for_observability(entity_state: &EntityState, callback_params: &Value) -> String {
+    callback_params
+        .get("_gen_ai_model")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            entity_state
+                .fields
+                .get("model")
+                .and_then(Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+        })
+        .unwrap_or("unknown")
+        .trim()
+        .to_string()
+}
+
 async fn submit_llmobs_llm_span(
     ctx: &WasmDispatchCtx<'_>,
     entity_state: &EntityState,
     callback_params: &Value,
     duration_ms: u64,
+    module_name: &str,
 ) {
     let current_trace_id = current_otel_trace_id(&Span::current());
     let trace_id = callback_params
@@ -978,21 +1020,14 @@ async fn submit_llmobs_llm_span(
         return;
     };
 
-    let provider = callback_params
-        .get("_gen_ai_provider")
-        .and_then(Value::as_str)
-        .or_else(|| entity_state.fields.get("provider").and_then(Value::as_str))
-        .unwrap_or("unknown");
-    let model = entity_state
-        .fields
-        .get("model")
-        .and_then(Value::as_str)
-        .unwrap_or("unknown");
+    let provider = llm_provider_for_observability(entity_state, callback_params);
+    let model = llm_model_for_observability(entity_state, callback_params);
     let session_id = ctx
         .agent_ctx
         .session_id
         .as_deref()
         .unwrap_or(ctx.entity_ref.entity_id);
+    let span_name = format!("wasm:{module_name}");
 
     let input_tokens = callback_params
         .get("input_tokens")
@@ -1009,8 +1044,9 @@ async fn submit_llmobs_llm_span(
             session_id,
             trace_id,
             span_id,
-            provider,
-            model,
+            span_name: &span_name,
+            provider: &provider,
+            model: &model,
             system_instructions: callback_params
                 .get("_gen_ai_system_instructions")
                 .and_then(Value::as_str),
@@ -1163,6 +1199,7 @@ fn build_llm_root_span(
         .get("provider")
         .and_then(|v| v.as_str())
         .unwrap_or("anthropic");
+    let provider = normalize_llm_provider_for_observability(provider);
     let model = entity_state
         .fields
         .get("model")
@@ -1181,6 +1218,7 @@ fn build_llm_root_span(
         integration = %integration.name,
         wasm.module = %module_name,
         gen_ai.system = %provider,
+        gen_ai.provider.name = %provider,
         gen_ai.system_instructions = tracing::field::Empty,
         gen_ai.request.model = %model,
         gen_ai.operation.name = "chat",
@@ -1350,6 +1388,7 @@ mod tests {
             "_gen_ai_output_messages": "[{\"role\":\"assistant\"}]",
             "_gen_ai_system_instructions": "system",
             "_gen_ai_provider": "anthropic",
+            "_gen_ai_model": "claude-sonnet-4-6",
             "_gen_ai_finish_reason": "end_turn",
             "_dd_llmobs_tool_spans": "[]",
             "gen_ai_parent_trace_id": "trace-public",
@@ -1364,7 +1403,48 @@ mod tests {
         assert!(stripped.get("_gen_ai_output_messages").is_none());
         assert!(stripped.get("_gen_ai_system_instructions").is_none());
         assert!(stripped.get("_gen_ai_provider").is_none());
+        assert!(stripped.get("_gen_ai_model").is_none());
         assert!(stripped.get("_gen_ai_finish_reason").is_none());
         assert!(stripped.get("_dd_llmobs_tool_spans").is_none());
+    }
+
+    #[test]
+    fn gen_ai_span_attrs_are_recorded_only_for_llm_integrations() {
+        let params = json!({
+            "input_tokens": 10,
+            "output_tokens": 20,
+            "_gen_ai_input_messages": "[{\"role\":\"user\"}]",
+            "_gen_ai_output_messages": "[{\"role\":\"assistant\"}]",
+            "_gen_ai_provider": "openai",
+            "_gen_ai_model": "gpt-5.4",
+        });
+
+        assert!(should_record_gen_ai_span_attrs(true, &params));
+        assert!(!should_record_gen_ai_span_attrs(false, &params));
+    }
+
+    #[test]
+    fn llm_model_for_observability_prefers_callback_model() {
+        let entity_state = EntityState {
+            entity_type: "Session".to_string(),
+            entity_id: "session-1".to_string(),
+            status: "CallingProvider".to_string(),
+            item_count: 0,
+            counters: std::collections::BTreeMap::new(),
+            booleans: std::collections::BTreeMap::new(),
+            lists: std::collections::BTreeMap::new(),
+            fields: json!({"model": "claude-sonnet-4-6"}),
+            events: std::collections::VecDeque::new(),
+            total_event_count: 0,
+            sequence_nr: 0,
+        };
+        let callback_params = json!({
+            "_gen_ai_model": "gpt-5.4",
+        });
+
+        assert_eq!(
+            llm_model_for_observability(&entity_state, &callback_params),
+            "gpt-5.4"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes the platform-side Datadog LLM Observability metadata path so LLM spans carry the actual module name, model, and normalized provider.

## Root Cause

The direct Datadog LLMObs API payload was hardcoded as `wasm:llm_caller` and did not include model/provider metadata in the places Datadog expects. Separately, non-LLM WASM integrations could still record `gen_ai.*` callback attributes, causing response-applier workflow spans to appear in LLMObs with misleading or blank content.

## Changes

- Only record `gen_ai.*` span attributes for integrations declared with `llm = true`.
- Prefer callback-reported `_gen_ai_model` and `_gen_ai_provider` over entity defaults for observability.
- Normalize `openai_codex` to Datadog's supported `openai` provider name.
- Submit direct LLMObs API spans with the actual `wasm:{module}` span name.
- Include model/provider metadata and tags in the direct Datadog LLMObs payload.
- Move LLMObs API tests to a test module to keep readability-ratchet metrics flat.

## Validation

- `cargo fmt --check`
- `cargo test -p temper-observe llmobs_api`
- `cargo test -p temper-observe`
- `cargo test -p temper-server state::dispatch::wasm::tests`
- `cargo check --workspace`
- `bash scripts/readability-ratchet.sh check .ci/readability-baseline.env`

Note: the first push hit the readability ratchet because `llmobs_api.rs` crossed 500 lines. I moved tests into `llmobs_api_test.rs`; the ratchet is green again.
