### PR TITLE
[codex] Fix durable dispatch effects

### DIFF
--- a/crates/temper-server/src/idempotency.rs
+++ b/crates/temper-server/src/idempotency.rs
@@ -23,6 +23,9 @@ struct IdempotencyEntry {
     response: EntityResponse,
     /// When this entry was created (for TTL eviction).
     created_at: chrono::DateTime<chrono::Utc>,
+    /// Whether dispatcher-side post-dispatch effects have completed for this
+    /// cached response.
+    effects_applied: bool,
 }
 
 /// Per-entity-actor idempotency cache.
@@ -45,7 +48,10 @@ impl IdempotencyCache {
     /// Look up a cached response. Returns `None` if not found or expired.
     pub fn get(&self, actor_key: &str, idem_key: &str) -> Option<EntityResponse> {
         let now = sim_now();
-        let entries = self.entries.read().unwrap(); // ci-ok: infallible lock
+        let entries = match self.entries.read() {
+            Ok(entries) => entries,
+            Err(poisoned) => poisoned.into_inner(),
+        };
         let actor_entries = entries.get(actor_key)?;
         let entry = actor_entries.get(idem_key)?;
 
@@ -58,10 +64,71 @@ impl IdempotencyCache {
         Some(entry.response.clone())
     }
 
+    /// Look up a cached response only after post-dispatch effects have run.
+    ///
+    /// HTTP/OData callers use this stricter lookup so a retry after a dropped
+    /// actor reply re-enters dispatch and fires effects instead of short-
+    /// circuiting at the protocol boundary.
+    pub fn get_after_effects_applied(
+        &self,
+        actor_key: &str,
+        idem_key: &str,
+    ) -> Option<EntityResponse> {
+        let now = sim_now();
+        let entries = self.entries.read().unwrap(); // ci-ok: infallible lock
+        let actor_entries = entries.get(actor_key)?;
+        let entry = actor_entries.get(idem_key)?;
+
+        let age = now.signed_duration_since(entry.created_at);
+        if age.num_seconds() > IDEMPOTENCY_TTL_SECS || !entry.effects_applied {
+            return None;
+        }
+
+        Some(entry.response.clone())
+    }
+
     /// Cache a response for a given actor and idempotency key.
     ///
     /// If the per-actor budget is exceeded, the oldest entry is evicted.
     pub fn put(&self, actor_key: &str, idem_key: &str, response: EntityResponse) {
+        self.put_with_effects_applied(actor_key, idem_key, response, false);
+    }
+
+    /// Cache a response whose post-dispatch effects are known to be complete.
+    pub fn put_effects_applied(&self, actor_key: &str, idem_key: &str, response: EntityResponse) {
+        self.put_with_effects_applied(actor_key, idem_key, response, true);
+    }
+
+    /// Mark a cached response as having completed post-dispatch effects.
+    pub fn mark_effects_applied(&self, actor_key: &str, idem_key: &str) -> bool {
+        let now = sim_now();
+        let mut entries = match self.entries.write() {
+            Ok(entries) => entries,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let Some(actor_entries) = entries.get_mut(actor_key) else {
+            return false;
+        };
+        let Some(entry) = actor_entries.get_mut(idem_key) else {
+            return false;
+        };
+
+        let age = now.signed_duration_since(entry.created_at);
+        if age.num_seconds() > IDEMPOTENCY_TTL_SECS {
+            return false;
+        }
+
+        entry.effects_applied = true;
+        true
+    }
+
+    fn put_with_effects_applied(
+        &self,
+        actor_key: &str,
+        idem_key: &str,
+        response: EntityResponse,
+        effects_applied: bool,
+    ) {
         let now = sim_now();
         let mut entries = self.entries.write().unwrap(); // ci-ok: infallible lock
         let actor_entries = entries.entry(actor_key.to_string()).or_default();
@@ -90,6 +157,7 @@ impl IdempotencyCache {
             IdempotencyEntry {
                 response,
                 created_at: now,
+                effects_applied,
             },
         );
     }
@@ -138,6 +206,35 @@ mod tests {
         cache.put("Order:o1", "key-1", resp.clone());
         let cached = cache.get("Order:o1", "key-1");
         assert!(cached.is_some());
+        assert_eq!(cached.unwrap().state.status, "Active");
+    }
+
+    #[test]
+    fn pending_effects_do_not_satisfy_protocol_cache_hit() {
+        let cache = IdempotencyCache::new();
+        cache.put("Order:o1", "key-1", make_response("Active"));
+
+        assert!(cache.get("Order:o1", "key-1").is_some());
+        assert!(
+            cache
+                .get_after_effects_applied("Order:o1", "key-1")
+                .is_none()
+        );
+
+        assert!(cache.mark_effects_applied("Order:o1", "key-1"));
+        assert!(
+            cache
+                .get_after_effects_applied("Order:o1", "key-1")
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn put_effects_applied_satisfies_protocol_cache_hit() {
+        let cache = IdempotencyCache::new();
+        cache.put_effects_applied("Order:o1", "key-1", make_response("Active"));
+
+        let cached = cache.get_after_effects_applied("Order:o1", "key-1");
         assert_eq!(cached.unwrap().state.status, "Active");
     }
 

--- a/crates/temper-server/src/odata/bindings.rs
+++ b/crates/temper-server/src/odata/bindings.rs
@@ -19,6 +19,10 @@ use crate::request_context::AgentContext;
 use crate::response::{ODataResponse, odata_error};
 use crate::state::{DispatchError, DispatchExtOptions, ServerState};
 
+fn idempotency_actor_key(tenant: &TenantId, entity_type: &str, entity_id: &str) -> String {
+    format!("{tenant}:{entity_type}:{entity_id}")
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn dispatch_bound_action(
     state: &ServerState,
@@ -258,9 +262,11 @@ pub(super) async fn dispatch_bound_action(
     }
 
     // Idempotency cache check
-    let actor_key = format!("{entity_type}:{key_str}");
+    let actor_key = idempotency_actor_key(tenant, entity_type, key_str);
     if let Some(ref idem_key) = idempotency_key
-        && let Some(cached) = state.idempotency_cache.get(&actor_key, idem_key)
+        && let Some(cached) = state
+            .idempotency_cache
+            .get_after_effects_applied(&actor_key, idem_key)
     {
         let body = annotate_entity(
             serde_json::to_value(&cached.state).unwrap_or_default(),
@@ -299,9 +305,11 @@ pub(super) async fn dispatch_bound_action(
             if response.success {
                 // Cache for idempotency
                 if let Some(ref idem_key) = idempotency_key {
-                    state
-                        .idempotency_cache
-                        .put(&actor_key, idem_key, response.clone());
+                    state.idempotency_cache.put_effects_applied(
+                        &actor_key,
+                        idem_key,
+                        response.clone(),
+                    );
                 }
 
                 http_span.set_status(Status::Ok);
@@ -380,4 +388,19 @@ pub(super) async fn dispatch_bound_action(
 
     http_span.end_with_timestamp(http_end);
     response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn idempotency_actor_key_matches_actor_persistence_id_shape() {
+        let tenant = TenantId::new("acme");
+
+        assert_eq!(
+            idempotency_actor_key(&tenant, "WorkCycle", "wc-1"),
+            "acme:WorkCycle:wc-1"
+        );
+    }
 }

--- a/crates/temper-server/src/state/dispatch/actions.rs
+++ b/crates/temper-server/src/state/dispatch/actions.rs
@@ -3,7 +3,7 @@ use tracing::instrument;
 use crate::entity_actor::{EntityMsg, EntityResponse};
 use crate::request_context::AgentContext;
 use crate::state::trajectory::{TrajectoryEntry, TrajectorySource};
-use temper_runtime::scheduler::sim_now;
+use temper_runtime::scheduler::{sim_now, sim_uuid};
 use temper_runtime::tenant::TenantId;
 
 use super::effects::PostDispatchContext;
@@ -328,7 +328,12 @@ impl crate::state::ServerState {
         let action_name = action.to_string();
         let params_for_retry = params;
         let cross_for_retry = cross_entity_booleans;
-        let idempotency_key = agent_ctx.idempotency_key.clone();
+        let idempotency_key = Some(agent_ctx.idempotency_key.clone().unwrap_or_else(|| {
+            format!(
+                "dispatch:{tenant}:{entity_type}:{entity_id}:{action}:{}",
+                sim_uuid()
+            )
+        }));
         // W2 phase: ask_reply — round-trip through the retry layer to the
         // actor and back. Aggregates with other phase spans by prefix.
         let ask_span = tracing::info_span!(
@@ -492,6 +497,13 @@ impl crate::state::ServerState {
             await_integration,
         };
         let response = self.run_post_dispatch_effects(&ctx, response).await;
+        if response.success
+            && let Some(ref idem_key) = idempotency_key
+        {
+            let actor_key = format!("{tenant}:{entity_type}:{entity_id}");
+            self.idempotency_cache
+                .mark_effects_applied(&actor_key, idem_key);
+        }
 
         tracing::Span::current().record("success", response.success);
         if let Some(ref err) = response.error {

--- a/crates/temper-server/src/state/dispatch/mod.rs
+++ b/crates/temper-server/src/state/dispatch/mod.rs
@@ -176,6 +176,7 @@ impl crate::state::ServerState {
             per_attempt_timeout: self.action_dispatch_timeout,
             ..retry::RetryPolicy::default()
         }
+        .with_attempt_budget_floor()
     }
 }
 

--- a/crates/temper-server/src/state/dispatch/retry.rs
+++ b/crates/temper-server/src/state/dispatch/retry.rs
@@ -82,6 +82,24 @@ impl RetryPolicy {
     pub(crate) fn remaining(&self, elapsed: Duration) -> Duration {
         self.total_deadline.saturating_sub(elapsed)
     }
+
+    /// Return a copy whose total deadline can accommodate every configured
+    /// attempt at `per_attempt_timeout` plus the configured backoff bases.
+    pub(crate) fn with_attempt_budget_floor(mut self) -> Self {
+        let attempts = self.max_attempts.max(1);
+        let attempts_budget = self
+            .per_attempt_timeout
+            .checked_mul(attempts)
+            .unwrap_or(Duration::MAX);
+        let backoff_budget = (1..attempts).fold(Duration::ZERO, |acc, attempt| {
+            acc.saturating_add(Duration::from_millis(self.base_delay_ms_for(attempt)))
+        });
+        let minimum_total = attempts_budget.saturating_add(backoff_budget);
+        if self.total_deadline < minimum_total {
+            self.total_deadline = minimum_total;
+        }
+        self
+    }
 }
 
 /// Outcome of `ask_with_backoff`.
@@ -309,5 +327,18 @@ mod tests {
         // layer depends on.
         let effective = p.max_attempts.max(1);
         assert_eq!(effective, 1);
+    }
+
+    #[test]
+    fn attempt_budget_floor_prevents_per_attempt_timeout_from_disabling_retry() {
+        let p = RetryPolicy {
+            total_deadline: Duration::from_secs(30),
+            per_attempt_timeout: Duration::from_secs(30),
+            max_attempts: 3,
+            base_delays_ms: vec![0, 50, 200],
+        }
+        .with_attempt_budget_floor();
+
+        assert_eq!(p.total_deadline, Duration::from_millis(90_250));
     }
 }

--- a/crates/temper-server/tests/dispatch_retry_idempotency.rs
+++ b/crates/temper-server/tests/dispatch_retry_idempotency.rs
@@ -1,0 +1,106 @@
+//! Regression tests for dispatch retry idempotency around post-dispatch effects.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use temper_runtime::ActorSystem;
+use temper_runtime::scheduler::install_deterministic_context;
+use temper_runtime::tenant::TenantId;
+use temper_server::registry::SpecRegistry;
+use temper_server::request_context::AgentContext;
+use temper_server::{ServerEventStore, ServerState};
+use temper_spec::csdl::parse_csdl;
+use temper_store_sim::SimEventStore;
+
+const CSDL_XML: &str = include_str!("../../../test-fixtures/specs/model.csdl.xml");
+
+const TASK_WITH_TIMEOUT_IOA: &str = r#"
+[automaton]
+name = "TimedTask"
+states = ["Idle", "Running", "TimedOut"]
+initial = "Idle"
+allow_indefinite_states = ["Idle", "TimedOut"]
+
+[[action]]
+name = "Start"
+kind = "input"
+from = ["Idle"]
+to = "Running"
+
+[[action]]
+name = "TimeoutFail"
+kind = "internal"
+from = ["Running"]
+to = "TimedOut"
+
+[[state_timeout]]
+state = "Running"
+after_seconds = 60
+on_timeout = "TimeoutFail"
+"#;
+
+fn build_state_with_sim_store(seed: u64) -> (ServerState, SimEventStore) {
+    let sim_store = SimEventStore::no_faults(seed);
+    let store = ServerEventStore::Sim(sim_store.clone(), None);
+
+    let mut registry = SpecRegistry::new();
+    let csdl = parse_csdl(CSDL_XML).expect("CSDL parse");
+    registry.register_tenant(
+        "default",
+        csdl,
+        CSDL_XML.to_string(),
+        &[("TimedTask", TASK_WITH_TIMEOUT_IOA)],
+    );
+
+    let system = ActorSystem::new("dispatch-retry-idempotency");
+    let mut state = ServerState::from_registry(system, registry);
+    state.event_store = Some(Arc::new(store));
+    state.action_dispatch_timeout = Duration::from_millis(5);
+    (state, sim_store)
+}
+
+#[tokio::test]
+async fn retry_after_dropped_reply_replays_success_response_and_runs_effects_without_header() {
+    let (_guard, _clock, _ids) = install_deterministic_context(48);
+    let (state, sim_store) = build_state_with_sim_store(48);
+    let tenant = TenantId::default();
+    let entity_id = "timed-task-1";
+    let persistence_id = format!("default:TimedTask:{entity_id}");
+
+    state
+        .get_or_create_tenant_entity(
+            &tenant,
+            "TimedTask",
+            entity_id,
+            serde_json::json!({"Id": entity_id}),
+        )
+        .await
+        .expect("entity creation succeeds");
+
+    sim_store.inject_append_delay(&persistence_id, Duration::from_millis(25));
+
+    let response = state
+        .dispatch_tenant_action(
+            &tenant,
+            "TimedTask",
+            entity_id,
+            "Start",
+            serde_json::json!({}),
+            &AgentContext::default(),
+        )
+        .await
+        .expect("dispatch should recover the timed-out first reply");
+
+    assert!(
+        response.success,
+        "retry should return the cached successful Start response, got {:?}",
+        response.error
+    );
+    assert_eq!(response.state.status, "Running");
+
+    assert_eq!(
+        state.state_timeout_tracker.pending_snapshot(),
+        vec![("TimedTask".to_string(), 1)],
+        "post-dispatch effects from the successful Start transition must arm the state_timeout"
+    );
+}

--- a/crates/temper-store-sim/Cargo.toml
+++ b/crates/temper-store-sim/Cargo.toml
@@ -12,6 +12,4 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
-
-[dev-dependencies]
 tokio = { workspace = true, features = ["full"] }

--- a/crates/temper-store-sim/src/lib.rs
+++ b/crates/temper-store-sim/src/lib.rs
@@ -8,8 +8,9 @@
 //! The same `ServerEventStore` dispatch enum adds a `Sim` variant that routes
 //! to this implementation. Production code runs unchanged.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use temper_runtime::persistence::{EventStore, PersistenceEnvelope, PersistenceError};
 use temper_runtime::tenant::parse_persistence_id_parts;
@@ -128,6 +129,12 @@ struct SimEventStoreInner {
     /// retry-path tests where probabilistic injection would be flaky. See
     /// `inject_concurrency_violations`.
     pending_concurrency_violations: BTreeMap<String, u64>,
+    /// One-shot append delays per `persistence_id`.
+    ///
+    /// Used by dispatch retry tests to deterministically model "the actor
+    /// persisted the transition, but the caller's ask timeout expired before
+    /// the reply arrived".
+    pending_append_delays: BTreeMap<String, VecDeque<Duration>>,
 }
 
 impl SimEventStore {
@@ -140,6 +147,7 @@ impl SimEventStore {
                 rng: DeterministicRng::new(seed),
                 faults,
                 pending_concurrency_violations: BTreeMap::new(),
+                pending_append_delays: BTreeMap::new(),
             })),
         }
     }
@@ -173,6 +181,22 @@ impl SimEventStore {
             .get(persistence_id)
             .copied()
             .unwrap_or(0)
+    }
+
+    /// Delay the next append for `persistence_id` by `delay`.
+    ///
+    /// The delay is consumed once. Multiple calls queue multiple delays in
+    /// FIFO order.
+    pub fn inject_append_delay(&self, persistence_id: &str, delay: Duration) {
+        let mut inner = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        inner
+            .pending_append_delays
+            .entry(persistence_id.to_string())
+            .or_default()
+            .push_back(delay);
     }
 
     /// Create a SimEventStore with no fault injection.
@@ -245,6 +269,30 @@ impl EventStore for SimEventStore {
         expected_sequence: u64,
         events: &[PersistenceEnvelope],
     ) -> Result<u64, PersistenceError> {
+        let append_delay = {
+            let mut inner = self
+                .inner
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let delay = inner
+                .pending_append_delays
+                .get_mut(persistence_id)
+                .and_then(VecDeque::pop_front);
+            if inner
+                .pending_append_delays
+                .get(persistence_id)
+                .is_some_and(VecDeque::is_empty)
+            {
+                inner.pending_append_delays.remove(persistence_id);
+            }
+            delay
+        };
+        if let Some(delay) = append_delay
+            && !delay.is_zero()
+        {
+            tokio::time::sleep(delay).await;
+        }
+
         let mut inner = self.inner.lock().expect("SimEventStore lock poisoned"); // ci-ok: infallible lock
 
         // Deterministic one-shot injection (see `inject_concurrency_violations`).


### PR DESCRIPTION
## Summary

Fixes the dispatch retry race where an actor can persist a state transition, the caller can time out before receiving the reply, and a retry can observe the advanced state without running dispatcher-side effects.

Changes:
- add effect-aware idempotency cache state so protocol/OData cache hits only return after post-dispatch effects are marked applied
- generate a stable internal idempotency key per dispatch call when the caller did not provide one, so retries replay the actor successful response
- align OData idempotency actor keys with tenant-qualified actor persistence ids
- add a retry budget floor so longer per-attempt timeouts do not accidentally consume the whole retry deadline
- add deterministic sim-store append delays and a regression test for the dropped-reply/side-effect race

## Why

The previous timeout bump only made the race rarer. The durable state change and dispatcher-side effects needed to become idempotent as one semantic operation.

## Validation

- `cargo test -p temper-server --test dispatch_retry_idempotency -- --nocapture`
- `cargo test -p temper-server effects -- --nocapture`
- `cargo test -p temper-server attempt_budget_floor_prevents_per_attempt_timeout_from_disabling_retry -- --nocapture`
- `cargo test -p temper-server idempotency_actor_key_matches_actor_persistence_id_shape -- --nocapture`
- Pre-push gates passed through rustfmt, clippy, readability ratchet, and a large chunk of `cargo test --workspace`; the remaining long full-suite gate was interrupted at user request and pushed with `--no-verify`.
