### PR TITLE
[codex] Fix WASM timeout isolation and observability

### DIFF
--- a/crates/temper-observe/src/wide_event.rs
+++ b/crates/temper-observe/src/wide_event.rs
@@ -207,6 +207,12 @@ pub fn from_wasm_invocation(input: WasmInvocationInput<'_>) -> WideEvent {
     attributes.insert("tenant".into(), serde_json::json!(input.tenant));
     if let Some(err) = input.error {
         attributes.insert("error".into(), serde_json::json!(err));
+        attributes.insert("error.message".into(), serde_json::json!(err));
+        attributes.insert(
+            "error.type".into(),
+            serde_json::json!(classify_error(EventKind::WasmInvocation, err)),
+        );
+        attributes.insert("exception.message".into(), serde_json::json!(err));
     }
 
     let mut measurements = BTreeMap::new();
@@ -406,6 +412,12 @@ pub fn from_llm_call(input: LlmCallInput<'_>) -> WideEvent {
     }
     if let Some(err) = input.error {
         attributes.insert("error".into(), serde_json::json!(err));
+        attributes.insert("error.message".into(), serde_json::json!(err));
+        attributes.insert(
+            "error.type".into(),
+            serde_json::json!(classify_error(EventKind::LlmCall, err)),
+        );
+        attributes.insert("exception.message".into(), serde_json::json!(err));
     }
 
     let mut measurements = BTreeMap::new();
@@ -496,6 +508,12 @@ pub fn from_tool_call(input: ToolCallInput<'_>) -> WideEvent {
     }
     if let Some(err) = input.error {
         attributes.insert("error".into(), serde_json::json!(err));
+        attributes.insert("error.message".into(), serde_json::json!(err));
+        attributes.insert(
+            "error.type".into(),
+            serde_json::json!(classify_error(EventKind::ToolCall, err)),
+        );
+        attributes.insert("exception.message".into(), serde_json::json!(err));
     }
 
     let mut measurements = BTreeMap::new();
@@ -524,6 +542,70 @@ pub fn from_tool_call(input: ToolCallInput<'_>) -> WideEvent {
 // View Projections → OTEL SDK
 // =========================================================================
 
+fn key_value_from_json(key: &str, value: &serde_json::Value) -> KeyValue {
+    match value {
+        serde_json::Value::String(value) => KeyValue::new(key.to_string(), value.clone()),
+        serde_json::Value::Bool(value) => KeyValue::new(key.to_string(), *value),
+        serde_json::Value::Number(value) => {
+            if let Some(value) = value.as_i64() {
+                KeyValue::new(key.to_string(), value)
+            } else if let Some(value) = value.as_u64().and_then(|value| i64::try_from(value).ok()) {
+                KeyValue::new(key.to_string(), value)
+            } else if let Some(value) = value.as_f64() {
+                KeyValue::new(key.to_string(), value)
+            } else {
+                KeyValue::new(key.to_string(), value.to_string())
+            }
+        }
+        serde_json::Value::Null | serde_json::Value::Array(_) | serde_json::Value::Object(_) => {
+            KeyValue::new(key.to_string(), value.to_string())
+        }
+    }
+}
+
+fn classify_error(kind: EventKind, error: &str) -> &'static str {
+    let normalized = error.to_ascii_lowercase();
+    if normalized.contains("timeout") {
+        "timeout"
+    } else if normalized.contains("fuel") {
+        "fuel_exhausted"
+    } else if normalized.contains("authorization denied") || normalized.contains("forbidden") {
+        "authorization_denied"
+    } else if normalized.contains("rate limit") {
+        "rate_limit"
+    } else if normalized.contains("connection") {
+        "connection_error"
+    } else {
+        match kind {
+            EventKind::WasmInvocation => "wasm_invocation_error",
+            EventKind::LlmCall => "llm_call_error",
+            EventKind::ToolCall => "tool_call_error",
+            EventKind::AuthzDecision => "authorization_error",
+            EventKind::InvariantCheck => "invariant_error",
+            EventKind::Transition => "transition_error",
+        }
+    }
+}
+
+fn event_error_message(event: &WideEvent) -> Option<String> {
+    event
+        .attributes
+        .get("error.message")
+        .or_else(|| event.attributes.get("exception.message"))
+        .or_else(|| event.attributes.get("error"))
+        .and_then(serde_json::Value::as_str)
+        .map(ToOwned::to_owned)
+}
+
+fn event_error_type(event: &WideEvent, error_message: &str) -> String {
+    event
+        .attributes
+        .get("error.type")
+        .and_then(serde_json::Value::as_str)
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| classify_error(event.event_kind, error_message).to_string())
+}
+
 /// Project to the **Contextual View** (OTEL span).
 pub fn emit_span(event: &WideEvent) {
     let tracer = opentelemetry::global::tracer("temper");
@@ -544,7 +626,7 @@ pub fn emit_span(event: &WideEvent) {
         if k.starts_with("_otel.") {
             continue;
         }
-        attrs.push(KeyValue::new(k.clone(), v.to_string()));
+        attrs.push(key_value_from_json(k, v));
     }
     for (k, v) in &event.measurements {
         attrs.push(KeyValue::new(k.clone(), *v));
@@ -567,7 +649,19 @@ pub fn emit_span(event: &WideEvent) {
     let status = if event.success {
         Status::Ok
     } else {
-        Status::error(String::new())
+        let error_message =
+            event_error_message(event).unwrap_or_else(|| "operation failed".to_string());
+        let error_type = event_error_type(event, &error_message);
+        if !event.attributes.contains_key("error.message") {
+            attrs.push(KeyValue::new("error.message", error_message.clone()));
+        }
+        if !event.attributes.contains_key("exception.message") {
+            attrs.push(KeyValue::new("exception.message", error_message.clone()));
+        }
+        if !event.attributes.contains_key("error.type") {
+            attrs.push(KeyValue::new("error.type", error_type));
+        }
+        Status::error(error_message)
     };
 
     let start_time: SystemTime = event.timestamp.into();
@@ -732,6 +826,12 @@ mod tests {
         });
         assert!(!event.success);
         assert_eq!(event.attributes["error"], "module panicked");
+        assert_eq!(event.attributes["error.message"], "module panicked");
+        assert_eq!(event.attributes["error.type"], "wasm_invocation_error");
+        assert_eq!(
+            event_error_message(&event).as_deref(),
+            Some("module panicked")
+        );
     }
 
     #[test]

--- a/crates/temper-server/src/state/dispatch/wasm.rs
+++ b/crates/temper-server/src/state/dispatch/wasm.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 
-use opentelemetry::{Context as OtelContext, trace::TraceContextExt};
+use opentelemetry::{
+    Context as OtelContext,
+    trace::{Status, TraceContextExt},
+};
 use serde_json::{Value, json};
 use tracing::{Instrument, Span, instrument};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
@@ -166,6 +169,8 @@ impl crate::state::ServerState {
         gen_ai.input.messages = tracing::field::Empty,
         gen_ai.output.messages = tracing::field::Empty,
         error.type = tracing::field::Empty,
+        error.message = tracing::field::Empty,
+        exception.message = tracing::field::Empty,
     ))]
     async fn dispatch_single_integration(
         &self,
@@ -212,6 +217,8 @@ impl crate::state::ServerState {
         };
 
         let Some(hash) = module_hash else {
+            let error_str = format!("WASM module '{}' not found", module_name);
+            record_wasm_error_on_span(active_span, &error_str);
             return self
                 .handle_module_not_found(ctx, integration, &module_name)
                 .await;
@@ -668,9 +675,7 @@ impl crate::state::ServerState {
                 );
                 if let Some(reason) = denial_tracker.take_denial() {
                     let error_str = http_call_authz_denied_error(&reason);
-                    if integration.llm {
-                        Span::current().record("error.type", llm_error_type(&error_str).as_str());
-                    }
+                    record_wasm_error_on_current_span(&error_str);
                     return self
                         .handle_wasm_failure(
                             ctx,
@@ -761,9 +766,7 @@ impl crate::state::ServerState {
                 if let Some(reason) = denial_tracker.take_denial() {
                     error_str = http_call_authz_denied_error(&reason);
                 }
-                if integration.llm {
-                    Span::current().record("error.type", llm_error_type(&error_str).as_str());
-                }
+                record_wasm_error_on_current_span(&error_str);
                 self.handle_wasm_failure(
                     ctx,
                     &integration.name,
@@ -802,9 +805,7 @@ impl crate::state::ServerState {
                 {
                     error_str = http_call_authz_denied_error(&reason);
                 }
-                if integration.llm {
-                    Span::current().record("error.type", llm_error_type(&error_str).as_str());
-                }
+                record_wasm_error_on_current_span(&error_str);
                 self.handle_wasm_failure(
                     ctx,
                     &integration.name,
@@ -1152,6 +1153,19 @@ fn current_otel_trace_id(span: &Span) -> Option<String> {
     }
 }
 
+pub(super) fn record_wasm_error_on_current_span(error: &str) {
+    let span = Span::current();
+    record_wasm_error_on_span(&span, error);
+}
+
+fn record_wasm_error_on_span(span: &Span, error: &str) {
+    let error_type = integration_error_type(error);
+    span.record("error.type", error_type.as_str());
+    span.record("error.message", error);
+    span.record("exception.message", error);
+    span.set_status(Status::error(error.to_string()));
+}
+
 fn build_llm_root_span(
     ctx: &WasmDispatchCtx<'_>,
     integration: &temper_spec::automaton::Integration,
@@ -1191,6 +1205,8 @@ fn build_llm_root_span(
         gen_ai.input.messages = tracing::field::Empty,
         gen_ai.output.messages = tracing::field::Empty,
         error.type = tracing::field::Empty,
+        error.message = tracing::field::Empty,
+        exception.message = tracing::field::Empty,
     );
     span.set_parent(OtelContext::new());
     span
@@ -1233,7 +1249,7 @@ fn strip_private_observability_params(mut params: Value) -> Value {
     params
 }
 
-fn llm_error_type(error: &str) -> String {
+fn integration_error_type(error: &str) -> String {
     let normalized = error.to_ascii_lowercase();
     if normalized.contains("rate limit") {
         "rate_limit".to_string()

--- a/crates/temper-server/src/state/dispatch/wasm/invocation_artifacts.rs
+++ b/crates/temper-server/src/state/dispatch/wasm/invocation_artifacts.rs
@@ -1,4 +1,7 @@
-use super::{WasmDispatchCtx, WasmDispatchMode, WasmEntityRef, is_http_call_authz_denial};
+use super::{
+    WasmDispatchCtx, WasmDispatchMode, WasmEntityRef, is_http_call_authz_denial,
+    record_wasm_error_on_current_span,
+};
 use crate::entity_actor::EntityResponse;
 use crate::request_context::AgentContext;
 use crate::state::pending_decisions::PendingDecision;
@@ -52,7 +55,15 @@ impl crate::state::ServerState {
         wide_event::emit_metrics(&wide);
     }
 
-    #[instrument(skip_all, fields(otel.name = "dispatch.handle_wasm_failure", trigger_action, integration_name, module_name))]
+    #[instrument(skip_all, fields(
+        otel.name = "dispatch.handle_wasm_failure",
+        trigger_action,
+        integration_name,
+        module_name,
+        error.type = tracing::field::Empty,
+        error.message = tracing::field::Empty,
+        exception.message = tracing::field::Empty,
+    ))]
     pub(super) async fn handle_wasm_failure(
         &self,
         ctx: &WasmDispatchCtx<'_>,
@@ -62,6 +73,7 @@ impl crate::state::ServerState {
         error_str: String,
         duration_ms: u64,
     ) -> Result<Option<EntityResponse>, String> {
+        record_wasm_error_on_current_span(&error_str);
         let is_authz_denied = is_http_call_authz_denial(&error_str);
         self.record_invocation(
             ctx.entity_ref,

--- a/crates/temper-wasm/src/engine/mod.rs
+++ b/crates/temper-wasm/src/engine/mod.rs
@@ -9,7 +9,10 @@ mod telemetry;
 mod tests;
 
 use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
+use std::thread;
+use std::time::Duration;
 
 use sha2::{Digest, Sha256};
 use wasmtime::{Config, Engine, Linker, Module, ResourceLimiter, Store};
@@ -21,6 +24,8 @@ use crate::stream::StreamRegistry;
 use crate::types::{
     MAX_MODULE_SIZE, WasmInvocationContext, WasmInvocationResult, WasmResourceLimits,
 };
+
+const WASM_EPOCH_TICK_INTERVAL: Duration = Duration::from_millis(10);
 
 /// Errors from the WASM engine.
 #[derive(Debug, thiserror::Error)]
@@ -104,6 +109,57 @@ struct CachedModule {
     instance_pre_wasi: Option<wasmtime::InstancePre<HostState>>,
 }
 
+/// Background ticker for Wasmtime epoch interruption.
+///
+/// Wasmtime epochs are global to an `Engine`; per-invocation timeout tasks that
+/// call `increment_epoch()` can therefore interrupt every active store sharing
+/// that engine. A single monotonic ticker keeps epoch increments global while
+/// each store's deadline remains local and relative to the epoch at store setup.
+struct EpochTicker {
+    stop: Arc<AtomicBool>,
+    handle: Option<thread::JoinHandle<()>>,
+}
+
+impl EpochTicker {
+    fn start(engine: Engine) -> Result<Self, WasmError> {
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_for_thread = Arc::clone(&stop);
+        let handle = thread::Builder::new()
+            .name("temper-wasm-epoch".to_string())
+            .spawn(move || {
+                while !stop_for_thread.load(Ordering::Acquire) {
+                    thread::sleep(WASM_EPOCH_TICK_INTERVAL);
+                    if stop_for_thread.load(Ordering::Acquire) {
+                        break;
+                    }
+                    engine.increment_epoch();
+                }
+            })
+            .map_err(|e| WasmError::Compilation(format!("failed to start epoch ticker: {e}")))?;
+
+        Ok(Self {
+            stop,
+            handle: Some(handle),
+        })
+    }
+}
+
+impl Drop for EpochTicker {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Release);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+fn epoch_deadline_ticks(max_duration: Duration) -> u64 {
+    let tick_nanos = WASM_EPOCH_TICK_INTERVAL.as_nanos().max(1);
+    let duration_nanos = max_duration.as_nanos();
+    let ticks = duration_nanos.saturating_add(tick_nanos.saturating_sub(1)) / tick_nanos;
+    u64::try_from(ticks.max(1)).unwrap_or(u64::MAX)
+}
+
 /// Host state passed into the WASM store.
 pub(crate) struct HostState {
     /// Serialized invocation context JSON.
@@ -136,6 +192,8 @@ pub(crate) struct HostState {
 pub struct WasmEngine {
     /// The underlying wasmtime engine.
     engine: Engine,
+    /// Shared epoch ticker used by per-store relative deadlines.
+    _epoch_ticker: EpochTicker,
     /// Compiled module cache: SHA-256 hash -> compiled module.
     cache: RwLock<BTreeMap<String, Arc<CachedModule>>>,
 }
@@ -149,9 +207,11 @@ impl WasmEngine {
         config.wasm_component_model(true);
 
         let engine = Engine::new(&config).map_err(|e| WasmError::Compilation(e.to_string()))?;
+        let epoch_ticker = EpochTicker::start(engine.clone())?;
 
         Ok(Self {
             engine,
+            _epoch_ticker: epoch_ticker,
             cache: RwLock::new(BTreeMap::new()),
         })
     }
@@ -264,6 +324,9 @@ impl WasmEngine {
             callback_action = tracing::field::Empty,
             duration_ms = tracing::field::Empty,
             error = tracing::field::Empty,
+            error.type = tracing::field::Empty,
+            error.message = tracing::field::Empty,
+            exception.message = tracing::field::Empty,
         )
     )]
     pub async fn invoke(
@@ -373,23 +436,7 @@ impl WasmEngine {
             .set_fuel(limits.max_fuel)
             .map_err(|e| WasmError::Invocation(format!("failed to set fuel: {e}")))?;
         store.limiter(|state| &mut state.limiter);
-        store.set_epoch_deadline(1);
-
-        let engine_for_timeout = engine.clone();
-        let max_duration = limits.max_duration;
-        let timeout_task = tokio::spawn(async move {
-            // determinism-ok: epoch timer for WASM wall-clock timeout enforcement
-            tokio::time::sleep(max_duration).await;
-            engine_for_timeout.increment_epoch();
-        });
-
-        struct AbortOnDrop(tokio::task::JoinHandle<()>);
-        impl Drop for AbortOnDrop {
-            fn drop(&mut self) {
-                self.0.abort();
-            }
-        }
-        let _timer_guard = AbortOnDrop(timeout_task);
+        store.set_epoch_deadline(epoch_deadline_ticks(limits.max_duration));
 
         let instance = if needs_wasi {
             if let Some(ref pre) = cached.instance_pre_wasi {
@@ -434,7 +481,7 @@ impl WasmEngine {
         let result_ptr = run_fn
             .call(&mut store, (ctx_ptr as i32, ctx_bytes.len() as i32))
             .map_err(|e| {
-                telemetry::map_invoke_error(e, &context, needs_wasi, max_duration, start)
+                telemetry::map_invoke_error(e, &context, needs_wasi, limits.max_duration, start)
             })?;
 
         let duration_ms = start.elapsed().as_millis() as u64;

--- a/crates/temper-wasm/src/engine/telemetry.rs
+++ b/crates/temper-wasm/src/engine/telemetry.rs
@@ -1,6 +1,8 @@
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
+use opentelemetry::trace::Status;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 use wasmtime::Store;
 
 use crate::metrics;
@@ -58,12 +60,11 @@ pub(super) fn empty_result(
     needs_wasi: bool,
     duration_ms: u64,
 ) -> WasmInvocationResult {
-    metrics::record_wasm_invoke(
-        &context.entity_type,
-        &context.trigger_action,
+    record_failure(
+        context,
         needs_wasi,
-        false,
         duration_ms as f64,
+        "module returned empty result",
     );
     WasmInvocationResult {
         callback_action: String::new(),
@@ -81,14 +82,9 @@ pub(super) fn parse_result_json(
     duration_ms: u64,
 ) -> Result<serde_json::Value, WasmError> {
     serde_json::from_str(result_json).map_err(|error| {
-        metrics::record_wasm_invoke(
-            &context.entity_type,
-            &context.trigger_action,
-            needs_wasi,
-            false,
-            duration_ms as f64,
-        );
-        WasmError::Invocation(format!("failed to parse result JSON: {error}"))
+        let message = format!("failed to parse result JSON: {error}");
+        record_failure(context, needs_wasi, duration_ms as f64, &message);
+        WasmError::Invocation(message)
     })
 }
 
@@ -124,6 +120,16 @@ pub(super) fn finalize_result(
     if let Some(ref error_message) = error {
         tracing::Span::current().record("error", error_message.as_str());
     }
+    if !success {
+        let error_message = error
+            .as_deref()
+            .unwrap_or("module returned unsuccessful result");
+        let error_type = wasm_error_type(error_message);
+        tracing::Span::current().record("error.type", error_type);
+        tracing::Span::current().record("error.message", error_message);
+        tracing::Span::current().record("exception.message", error_message);
+        tracing::Span::current().set_status(Status::error(error_message.to_string()));
+    }
     metrics::record_wasm_invoke(
         &context.entity_type,
         &context.trigger_action,
@@ -150,8 +156,13 @@ fn record_failure(
     duration_ms: f64,
     error: &str,
 ) {
+    let error_type = wasm_error_type(error);
     tracing::Span::current().record("success", false);
     tracing::Span::current().record("error", error);
+    tracing::Span::current().record("error.type", error_type);
+    tracing::Span::current().record("error.message", error);
+    tracing::Span::current().record("exception.message", error);
+    tracing::Span::current().set_status(Status::error(error.to_string()));
     metrics::record_wasm_invoke(
         &context.entity_type,
         &context.trigger_action,
@@ -159,4 +170,17 @@ fn record_failure(
         false,
         duration_ms,
     );
+}
+
+fn wasm_error_type(error: &str) -> &'static str {
+    let normalized = error.to_ascii_lowercase();
+    if normalized.contains("timeout") {
+        "timeout"
+    } else if normalized.contains("fuel") {
+        "fuel_exhausted"
+    } else if normalized.contains("memory") {
+        "memory_limit_exceeded"
+    } else {
+        "wasm_invocation_error"
+    }
 }

--- a/crates/temper-wasm/src/engine/tests.rs
+++ b/crates/temper-wasm/src/engine/tests.rs
@@ -2,10 +2,12 @@
 
 use std::sync::Arc;
 use std::sync::RwLock;
+use std::time::Duration;
 
 use super::*;
-use crate::host_trait::SimWasmHost;
+use crate::host_trait::{SimWasmHost, WasmHost};
 use crate::stream::StreamRegistry;
+use async_trait::async_trait;
 
 // Minimal WAT module: accepts (ptr, len), writes nothing, returns 0.
 const WAT_NOOP: &str = r#"
@@ -50,6 +52,67 @@ const WAT_TRAP: &str = r#"
       )
     )
 "#;
+
+// Makes one host call, then returns normally. The host call gives another
+// invocation enough time to time out while this store is still active.
+const WAT_HOST_CALL_THEN_RETURN: &str = r#"
+    (module
+      (import "env" "host_http_call" (func $host_http_call
+        (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
+      (memory (export "memory") 1)
+      (data (i32.const 2048) "GET")
+      (data (i32.const 2056) "https://slow.test/")
+      (func (export "run") (param i32 i32) (result i32)
+        i32.const 2048
+        i32.const 3
+        i32.const 2056
+        i32.const 18
+        i32.const 0
+        i32.const 0
+        i32.const 0
+        i32.const 0
+        i32.const 4096
+        i32.const 64
+        call $host_http_call
+        drop
+        i32.const 0
+      )
+    )
+"#;
+
+struct SlowHttpHost {
+    delay: Duration,
+}
+
+#[async_trait]
+impl WasmHost for SlowHttpHost {
+    async fn http_call(
+        &self,
+        _method: &str,
+        _url: &str,
+        _headers: &[(String, String)],
+        _body: &str,
+    ) -> Result<(u16, String), String> {
+        tokio::time::sleep(self.delay).await;
+        Ok((200, r#"{"ok":true}"#.to_string()))
+    }
+
+    async fn http_call_binary(
+        &self,
+        _method: &str,
+        _url: &str,
+        _headers: &[(String, String)],
+        _body: &[u8],
+    ) -> Result<(u16, Vec<u8>), String> {
+        Ok((200, Vec::new()))
+    }
+
+    fn get_secret(&self, key: &str) -> Result<String, String> {
+        Err(format!("test secret not found: {key}"))
+    }
+
+    fn log(&self, _level: &str, _message: &str) {}
+}
 
 fn make_context() -> WasmInvocationContext {
     WasmInvocationContext {
@@ -169,6 +232,60 @@ async fn timeout_enforced_by_epoch() {
     assert!(
         matches!(result, Err(WasmError::Timeout(_))),
         "expected Timeout, got: {result:?}"
+    );
+}
+
+/// Timeout isolation: one invocation timing out must not interrupt a different
+/// active store that has not exhausted its own deadline.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn timed_out_invocation_does_not_interrupt_unrelated_active_invocation() {
+    let engine = Arc::new(WasmEngine::new().unwrap());
+    let slow_hash = engine
+        .compile_and_cache(WAT_HOST_CALL_THEN_RETURN.as_bytes())
+        .unwrap();
+    let timeout_hash = engine
+        .compile_and_cache(WAT_INFINITE_LOOP.as_bytes())
+        .unwrap();
+
+    let slow_engine = Arc::clone(&engine);
+    let slow_task = tokio::spawn(async move {
+        let limits = WasmResourceLimits {
+            max_fuel: u64::MAX,
+            max_duration: Duration::from_millis(800),
+            ..WasmResourceLimits::default()
+        };
+        let host: Arc<dyn WasmHost> = Arc::new(SlowHttpHost {
+            delay: Duration::from_millis(200),
+        });
+        slow_engine
+            .invoke(&slow_hash, &make_context(), host, &limits, make_streams())
+            .await
+    });
+
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    let timeout_limits = WasmResourceLimits {
+        max_fuel: u64::MAX,
+        max_duration: Duration::from_millis(50),
+        ..WasmResourceLimits::default()
+    };
+    let timeout_result = engine
+        .invoke(
+            &timeout_hash,
+            &make_context(),
+            make_host(),
+            &timeout_limits,
+            make_streams(),
+        )
+        .await;
+    assert!(
+        matches!(timeout_result, Err(WasmError::Timeout(_))),
+        "expected the infinite loop to time out, got: {timeout_result:?}"
+    );
+
+    let slow_result = slow_task.await.expect("slow invocation task should join");
+    assert!(
+        !matches!(slow_result, Err(WasmError::Timeout(_))),
+        "timeout leaked into unrelated active invocation: {slow_result:?}"
     );
 }
 

--- a/crates/temper-wasm/src/host_trait.rs
+++ b/crates/temper-wasm/src/host_trait.rs
@@ -850,6 +850,7 @@ impl WasmHost for ProductionWasmHost {
     }
 
     fn log(&self, level: &str, message: &str) {
+        record_guest_log_span_event(level, message, self.invocation_context.as_ref(), None);
         match level {
             "error" => tracing::error!(target: "wasm_guest", "{}", message),
             "warn" => tracing::warn!(target: "wasm_guest", "{}", message),
@@ -916,6 +917,13 @@ impl WasmHost for ProductionWasmHost {
             .and_then(|ctx| ctx.session_id.as_deref())
             .unwrap_or("");
         let trace_id = self.trace_id.as_deref().unwrap_or("");
+
+        record_guest_log_span_event(
+            &payload.level,
+            &payload.message,
+            self.invocation_context.as_ref(),
+            Some(&fields_json),
+        );
 
         match payload.level.as_str() {
             "error" => tracing::error!(
@@ -1015,6 +1023,155 @@ fn infer_guest_operation(kind: EventKind, tags: &BTreeMap<String, String>) -> Op
             .cloned()
             .or_else(|| Some("chat".to_string())),
         _ => tags.get("operation").cloned(),
+    }
+}
+
+fn guest_log_span_attrs(
+    level: &str,
+    message: &str,
+    context: Option<&WasmInvocationContext>,
+    fields_json: Option<&str>,
+) -> BTreeMap<String, String> {
+    let mut attrs = BTreeMap::new();
+    attrs.insert("log.severity".to_string(), level.to_string());
+    attrs.insert("log.message".to_string(), message.to_string());
+    attrs.insert("log.target".to_string(), "wasm_guest".to_string());
+    if let Some(context) = context {
+        attrs.insert("tenant".to_string(), context.tenant.clone());
+        attrs.insert("entity_type".to_string(), context.entity_type.clone());
+        attrs.insert("entity_id".to_string(), context.entity_id.clone());
+        attrs.insert("trigger_action".to_string(), context.trigger_action.clone());
+        if let Some(agent_id) = context
+            .agent_id
+            .as_deref()
+            .filter(|value| !value.is_empty())
+        {
+            attrs.insert("agent_id".to_string(), agent_id.to_string());
+        }
+        if let Some(session_id) = context
+            .session_id
+            .as_deref()
+            .filter(|value| !value.is_empty())
+        {
+            attrs.insert("gen_ai.conversation.id".to_string(), session_id.to_string());
+        }
+        if !context.trace_id.is_empty() {
+            attrs.insert("trace_id".to_string(), context.trace_id.clone());
+        }
+    }
+    if let Some(fields_json) = fields_json.filter(|value| !value.is_empty()) {
+        attrs.insert("fields_json".to_string(), fields_json.to_string());
+    }
+    attrs
+}
+
+fn record_guest_log_span_event(
+    level: &str,
+    message: &str,
+    context: Option<&WasmInvocationContext>,
+    fields_json: Option<&str>,
+) {
+    use opentelemetry::KeyValue;
+    use opentelemetry::trace::TraceContextExt as _;
+    use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+    let attrs = guest_log_span_attrs(level, message, context, fields_json)
+        .into_iter()
+        .map(|(key, value)| KeyValue::new(key, value))
+        .collect::<Vec<_>>();
+    emit_named_guest_log_span_event(level, message, context, fields_json);
+    let span = tracing::Span::current();
+    let cx = span.context();
+    let otel_span = cx.span();
+    if otel_span.span_context().is_valid() {
+        otel_span.add_event("wasm_guest.log", attrs);
+    }
+}
+
+fn emit_named_guest_log_span_event(
+    level: &str,
+    message: &str,
+    context: Option<&WasmInvocationContext>,
+    fields_json: Option<&str>,
+) {
+    let tenant = context.map(|ctx| ctx.tenant.as_str()).unwrap_or("");
+    let entity_type = context.map(|ctx| ctx.entity_type.as_str()).unwrap_or("");
+    let entity_id = context.map(|ctx| ctx.entity_id.as_str()).unwrap_or("");
+    let trigger_action = context.map(|ctx| ctx.trigger_action.as_str()).unwrap_or("");
+    let agent_id = context
+        .and_then(|ctx| ctx.agent_id.as_deref())
+        .unwrap_or("");
+    let session_id = context
+        .and_then(|ctx| ctx.session_id.as_deref())
+        .unwrap_or("");
+    let trace_id = context.map(|ctx| ctx.trace_id.as_str()).unwrap_or("");
+    let fields_json = fields_json.unwrap_or("");
+
+    match level.to_ascii_lowercase().as_str() {
+        "error" => tracing::event!(
+            name: "wasm_guest.log",
+            target: "wasm_guest",
+            tracing::Level::ERROR,
+            guest_log.message = %message,
+            guest_log.severity = %level,
+            guest_log.target = "wasm_guest",
+            tenant = %tenant,
+            entity_type = %entity_type,
+            entity_id = %entity_id,
+            trigger_action = %trigger_action,
+            agent_id = %agent_id,
+            gen_ai.conversation.id = %session_id,
+            trace_id = %trace_id,
+            fields_json = %fields_json,
+        ),
+        "warn" => tracing::event!(
+            name: "wasm_guest.log",
+            target: "wasm_guest",
+            tracing::Level::WARN,
+            guest_log.message = %message,
+            guest_log.severity = %level,
+            guest_log.target = "wasm_guest",
+            tenant = %tenant,
+            entity_type = %entity_type,
+            entity_id = %entity_id,
+            trigger_action = %trigger_action,
+            agent_id = %agent_id,
+            gen_ai.conversation.id = %session_id,
+            trace_id = %trace_id,
+            fields_json = %fields_json,
+        ),
+        "info" => tracing::event!(
+            name: "wasm_guest.log",
+            target: "wasm_guest",
+            tracing::Level::INFO,
+            guest_log.message = %message,
+            guest_log.severity = %level,
+            guest_log.target = "wasm_guest",
+            tenant = %tenant,
+            entity_type = %entity_type,
+            entity_id = %entity_id,
+            trigger_action = %trigger_action,
+            agent_id = %agent_id,
+            gen_ai.conversation.id = %session_id,
+            trace_id = %trace_id,
+            fields_json = %fields_json,
+        ),
+        _ => tracing::event!(
+            name: "wasm_guest.log",
+            target: "wasm_guest",
+            tracing::Level::DEBUG,
+            guest_log.message = %message,
+            guest_log.severity = %level,
+            guest_log.target = "wasm_guest",
+            tenant = %tenant,
+            entity_type = %entity_type,
+            entity_id = %entity_id,
+            trigger_action = %trigger_action,
+            agent_id = %agent_id,
+            gen_ai.conversation.id = %session_id,
+            trace_id = %trace_id,
+            fields_json = %fields_json,
+        ),
     }
 }
 
@@ -1482,6 +1639,7 @@ mod tests {
     use super::*;
     use opentelemetry::trace::{TraceContextExt, TracerProvider as _};
     use opentelemetry_sdk::trace::SdkTracerProvider;
+    use std::sync::{Arc, Mutex};
     use tracing_opentelemetry::OpenTelemetrySpanExt;
     use tracing_subscriber::prelude::*;
 
@@ -1595,6 +1753,96 @@ mod tests {
             .in_scope(|| current_traceparent_header(&tracing::Span::current(), None))
             .expect("active span should produce a traceparent");
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn guest_log_span_attrs_include_message_and_invocation_context() {
+        let context = WasmInvocationContext {
+            tenant: "tenant-a".to_string(),
+            entity_type: "Session".to_string(),
+            entity_id: "ss-1".to_string(),
+            trigger_action: "ContextReady".to_string(),
+            trigger_params: serde_json::Value::Null,
+            entity_state: serde_json::Value::Null,
+            agent_id: Some("agent-1".to_string()),
+            session_id: Some("ss-1".to_string()),
+            integration_config: BTreeMap::new(),
+            trace_id: "0123456789abcdef0123456789abcdef".to_string(),
+        };
+
+        let attrs = guest_log_span_attrs(
+            "error",
+            "provider failed",
+            Some(&context),
+            Some(r#"{"status":500}"#),
+        );
+
+        assert_eq!(attrs["log.severity"], "error");
+        assert_eq!(attrs["log.message"], "provider failed");
+        assert_eq!(attrs["tenant"], "tenant-a");
+        assert_eq!(attrs["entity_type"], "Session");
+        assert_eq!(attrs["entity_id"], "ss-1");
+        assert_eq!(attrs["trigger_action"], "ContextReady");
+        assert_eq!(attrs["agent_id"], "agent-1");
+        assert_eq!(attrs["gen_ai.conversation.id"], "ss-1");
+        assert_eq!(attrs["trace_id"], "0123456789abcdef0123456789abcdef");
+        assert_eq!(attrs["fields_json"], r#"{"status":500}"#);
+    }
+
+    #[test]
+    fn guest_log_span_event_is_named_for_trace_export() {
+        #[derive(Clone)]
+        struct EventCapture {
+            names: Arc<Mutex<Vec<String>>>,
+        }
+
+        impl<S> tracing_subscriber::Layer<S> for EventCapture
+        where
+            S: tracing::Subscriber,
+        {
+            fn on_event(
+                &self,
+                event: &tracing::Event<'_>,
+                _ctx: tracing_subscriber::layer::Context<'_, S>,
+            ) {
+                self.names
+                    .lock()
+                    .expect("event capture lock poisoned")
+                    .push(event.metadata().name().to_string());
+            }
+        }
+
+        let names = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::registry().with(EventCapture {
+            names: names.clone(),
+        });
+        let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+        let context = WasmInvocationContext {
+            tenant: "tenant-a".to_string(),
+            entity_type: "Session".to_string(),
+            entity_id: "ss-1".to_string(),
+            trigger_action: "ContextReady".to_string(),
+            trigger_params: serde_json::Value::Null,
+            entity_state: serde_json::Value::Null,
+            agent_id: Some("agent-1".to_string()),
+            session_id: Some("ss-1".to_string()),
+            integration_config: BTreeMap::new(),
+            trace_id: "0123456789abcdef0123456789abcdef".to_string(),
+        };
+
+        {
+            let span = tracing::info_span!("wasm.invoke");
+            let _guard = span.enter();
+            record_guest_log_span_event(
+                "error",
+                "provider failed",
+                Some(&context),
+                Some(r#"{"status":500}"#),
+            );
+        }
+
+        let names = names.lock().expect("event capture lock poisoned");
+        assert!(names.iter().any(|name| name == "wasm_guest.log"));
     }
 
     // --- Span-hint-header extraction (ADR-0037) ---


### PR DESCRIPTION
## Summary

- Replace per-invocation Wasmtime epoch timeout tasks with a shared engine epoch ticker and per-store relative deadlines.
- Add error.type, error.message, and exception.message fields to WASM dispatch and wide-event spans.
- Attach guest WASM logs to trace spans with a stable wasm_guest.log event and guest log attributes.

## Root Cause

A timed-out WASM invocation incremented the shared Wasmtime engine epoch while every store used set_epoch_deadline(1). Because epochs are global to the engine, one timed-out store could interrupt unrelated active stores, matching the Datadog timeout cascade.

## Verification

- cargo fmt
- cargo test -p temper-wasm
- cargo test -p temper-observe
- cargo test -p temper-server strips_private_llm_observability_params_before_callback_dispatch -- --nocapture
- Full live local OpenPaw E2E: concurrent slow WASM invocation completed while another invocation timed out, /observe/wasm/invocations showed the timeout, and OTLP contained wasm_guest.log, guest messages, error.message, timeout text, and module names.

## Notes

Per request, pushed with --no-verify after the local pre-push readability ratchet blocked on PROD_FILES_GT1000 increasing from 7 to 8. The functional checks above passed.