### PR TITLE
Add native immutable TemperFS read plane

### DIFF
--- a/.proof/pawfs-context-read-plane-batch-read.md
+++ b/.proof/pawfs-context-read-plane-batch-read.md
@@ -1,0 +1,45 @@
+# PawFS Context Read Plane Batch Read
+
+Date: 2026-04-23
+
+## What changed
+
+- Added `load_query_projection_fields_many(...)` in `temper-store-turso` to fetch sparse projected fields for many entities in one query.
+- Added `ServerState::read_file_texts_batch(...)` in `temper-server` to:
+  - resolve `File` metadata from the durable query plane
+  - fall back to actor state only for projection misses
+  - read blob bytes directly from the local blob store or external blob endpoint
+- Added `POST /api/files/read-text-batch` in `temper-server`.
+
+## Verification
+
+### Projection loader
+
+Command:
+
+```bash
+cargo test -p temper-store-turso load_query_projection_fields_many_returns_requested_fields_by_entity -- --nocapture
+```
+
+Result:
+
+- passed
+- proved projected `content_hash`, `mime_type`, and `has_content` load in one round trip
+
+### Batch read API
+
+Command:
+
+```bash
+cargo test -p temper-server --features observe batch_file_text_read_returns_projected_file_contents_in_request_order -- --nocapture
+```
+
+Result:
+
+- passed
+- verified `POST /api/files/read-text-batch` returns:
+  - a ready file with text content
+  - a found-but-empty file with empty text
+  - a missing file with `found=false`
+- preserved request order in the response
+

--- a/.proof/pawfs-context-read-plane-live-e2e.md
+++ b/.proof/pawfs-context-read-plane-live-e2e.md
@@ -1,0 +1,76 @@
+# PawFS Context Read Plane Live E2E
+
+Date: 2026-04-24
+Worktree: `/Users/seshendranalla/Development/temper-worktrees/pawfs-context-read-plane`
+Validated through local `temperpaw-server` using this Temper worktree via a temporary local dependency patch in the paired OpenPaw worktree.
+
+## Goal
+
+Prove the Temper-side architecture works in a real server process:
+
+- OS-app reactions load and execute after install
+- `FileVersion` lineage is explicit at runtime
+- `POST /api/files/read-version-text-batch` serves immutable historical content
+- the internal blob endpoint fast path works for local server verification
+
+## Live proof
+
+On the local server:
+
+1. Created a `File`
+2. Wrote two distinct text payloads through `PUT /tdata/Files('<id>')/$value`
+3. Queried the resulting `File` and `FileVersion` entities
+4. Called `POST /api/files/read-version-text-batch` with both the superseded and current version ids
+
+Observed runtime facts:
+
+- `File.fields.last_version_id` updated to the newest `FileVersion`
+- newest `FileVersion.status=Current`
+- previous `FileVersion.status=Superseded`
+- batch immutable read returned:
+  - `first version from live e2e`
+  - `second version from live e2e`
+
+## Runtime bugs found and fixed during live verification
+
+### 1. Reactions were not actually live after app install
+
+Symptom:
+
+- specs defined the supersede reaction
+- but the previous version stayed `Current` at runtime after later app installs
+
+Root cause:
+
+- OS-app bundles were not loading `reactions/reactions.toml`
+- bootstrap registration dropped reaction rules
+- later app installs overwrote existing tenant reactions
+
+Fix:
+
+- load reactions into `AppBundle`
+- register them during bootstrap
+- rebuild the live `ReactionDispatcher` after install
+- merge tenant reactions instead of replacing them wholesale
+
+### 2. Immutable batch reads used the wrong blob path locally
+
+Symptom:
+
+- `POST /api/files/read-version-text-batch` returned `401 Unauthorized` on the local server even though the content existed
+
+Root cause:
+
+- batch version reads followed the configured blob endpoint even when it pointed at the server's own internal `/_internal/blobs` route
+
+Fix:
+
+- detect the internal local blob endpoint
+- read directly from the local store instead of doing an external HTTP GET
+
+## What this proves
+
+- Temper now has a real native immutable read plane for TemperFS hot paths.
+- `FileVersion` lineage is not just modeled in specs; it executes correctly in the running platform.
+- app-installed reactions are active immediately after install.
+- live immutable batch reads work on the same stack OpenPaw uses for Session context assembly.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6192,6 +6192,7 @@ dependencies = [
  "criterion",
  "ed25519-dalek",
  "futures-util",
+ "hmac",
  "hyper 1.8.1",
  "libc",
  "lru",

--- a/crates/temper-jit/src/table/builder.rs
+++ b/crates/temper-jit/src/table/builder.rs
@@ -127,6 +127,9 @@ fn convert_effect(effect: ResolvedEffect) -> Effect {
         ResolvedEffect::DecrementCounter(ref var) if var == "items" => Effect::DecrementItems,
         ResolvedEffect::IncrementCounter(var) => Effect::IncrementCounter(var),
         ResolvedEffect::DecrementCounter(var) => Effect::DecrementCounter(var),
+        ResolvedEffect::SetCounterFromParam { var, param } => {
+            Effect::SetCounterFromParam { var, param }
+        }
         ResolvedEffect::SetBool { var, value } => Effect::SetBool { var, value },
         ResolvedEffect::ListAppend(var) => Effect::ListAppend(var),
         ResolvedEffect::ListRemoveAt(var) => Effect::ListRemoveAt(var),

--- a/crates/temper-jit/src/table/types.rs
+++ b/crates/temper-jit/src/table/types.rs
@@ -140,6 +140,8 @@ pub enum Effect {
     IncrementCounter(String),
     /// Decrement a named counter variable.
     DecrementCounter(String),
+    /// Set a named counter variable from an action param.
+    SetCounterFromParam { var: String, param: String },
     /// Set a named boolean variable.
     SetBool { var: String, value: bool },
     /// Emit a named event.

--- a/crates/temper-platform/src/bootstrap.rs
+++ b/crates/temper-platform/src/bootstrap.rs
@@ -9,6 +9,7 @@ use std::collections::BTreeMap;
 
 use temper_runtime::tenant::TenantId;
 use temper_server::platform_store::{PlatformStore, SpecVerificationUpdate};
+use temper_server::reaction::types::ReactionRule;
 use temper_server::registry::{EntityLevelSummary, EntityVerificationResult, VerificationStatus};
 use temper_spec::automaton;
 use temper_spec::csdl::parse_csdl;
@@ -90,6 +91,7 @@ pub(crate) struct BootstrapTenantSpecsOptions<'a> {
     pub(crate) label: &'a str,
     pub(crate) verified_cache: &'a BTreeMap<String, (String, bool)>,
     pub(crate) cross_invariants_source: Option<&'a str>,
+    pub(crate) reactions: &'a [ReactionRule],
 }
 
 pub(crate) fn bootstrap_tenant_specs(
@@ -114,6 +116,7 @@ fn bootstrap_tenant_specs_inner(
         label,
         verified_cache,
         cross_invariants_source,
+        reactions,
     } = options;
 
     tracing::info!(
@@ -172,7 +175,7 @@ fn bootstrap_tenant_specs_inner(
                 csdl,
                 csdl_source.to_string(),
                 specs,
-                Vec::new(),
+                reactions.to_vec(),
                 cross_invariants_source.map(str::to_string),
                 merge,
             )
@@ -223,6 +226,7 @@ pub fn bootstrap_system_tenant(
             label: "System",
             verified_cache,
             cross_invariants_source: None,
+            reactions: &[],
         },
     )
 }
@@ -248,6 +252,7 @@ pub fn bootstrap_agent_specs(
             label: "Agent",
             verified_cache,
             cross_invariants_source: None,
+            reactions: &[],
         },
     )
 }

--- a/crates/temper-platform/src/os_apps/mod.rs
+++ b/crates/temper-platform/src/os_apps/mod.rs
@@ -16,6 +16,7 @@ use std::sync::{OnceLock, RwLock};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use temper_runtime::tenant::TenantId;
+use temper_server::reaction::registry::parse_reactions;
 use temper_spec::automaton;
 use temper_spec::csdl::{emit_csdl_xml, merge_csdl, parse_csdl};
 
@@ -989,6 +990,19 @@ fn read_app_guide(app_dir: &Path) -> Option<String> {
     None
 }
 
+fn read_app_reactions(app_dir: &Path) -> Option<Vec<temper_server::reaction::types::ReactionRule>> {
+    for relative_path in ["reactions/reactions.toml", "specs/reactions.toml"] {
+        let path = app_dir.join(relative_path);
+        if !path.exists() {
+            continue;
+        }
+        let source = std::fs::read_to_string(&path).ok()?;
+        let reactions = parse_reactions(&source).ok()?;
+        return Some(reactions);
+    }
+    Some(Vec::new())
+}
+
 /// Extract a description from app guide markdown.
 ///
 /// Looks for the first non-header, non-empty line, or a TOML frontmatter
@@ -1079,6 +1093,7 @@ fn load_app_bundle(app_dir: &Path) -> Option<AppBundle> {
 
     // Read CSDL (optional — apps without specs won't have CSDL).
     let csdl = find_csdl(app_dir).and_then(|p| std::fs::read_to_string(&p).ok());
+    let reactions = read_app_reactions(app_dir)?;
     let cross_invariants_toml =
         std::fs::read_to_string(app_dir.join("specs").join("cross-invariants.toml")).ok();
 
@@ -1120,6 +1135,7 @@ fn load_app_bundle(app_dir: &Path) -> Option<AppBundle> {
         && seed_instances.is_empty()
         && app_guide.is_none()
         && csdl.is_none()
+        && reactions.is_empty()
         && cross_invariants_toml.is_none()
     {
         return None;
@@ -1128,6 +1144,7 @@ fn load_app_bundle(app_dir: &Path) -> Option<AppBundle> {
     Some(AppBundle {
         specs,
         csdl,
+        reactions,
         cross_invariants_toml,
         cedar_policies,
         wasm_modules,
@@ -1412,6 +1429,7 @@ async fn install_os_app_without_dependencies(
                     label: &format!("OsApp({app_name})"),
                     verified_cache: &verified_cache,
                     cross_invariants_source: bundle.cross_invariants_toml.as_deref(),
+                    reactions: bundle.reactions.as_slice(),
                 },
             );
 
@@ -1429,6 +1447,11 @@ async fn install_os_app_without_dependencies(
             }
         }
     }
+
+    // App installs can add or change cross-entity reactions. Refresh the live
+    // dispatcher immediately so the newly registered tenant config takes effect
+    // without requiring a process restart or a separate specs reload.
+    state.server.rebuild_reaction_dispatcher();
 
     // ── Step 3: Load Cedar policies into memory. ────────────────────
     if let Some(ref policy_text) = combined_policy {

--- a/crates/temper-platform/src/os_apps/mod_test.rs
+++ b/crates/temper-platform/src/os_apps/mod_test.rs
@@ -4,10 +4,12 @@ use super::agent_bootstrap::{
 use super::*;
 use std::collections::HashMap;
 use std::fs;
+use std::time::Duration;
 
 use temper_authz::SecurityContext;
 use temper_runtime::tenant::TenantId;
 use temper_server::registry::{EntityLevelSummary, EntityVerificationResult, VerificationStatus};
+use temper_server::request_context::AgentContext;
 use temper_spec::automaton;
 use temper_spec::csdl::parse_csdl;
 use temper_store_turso::TursoSpecVerificationUpdate;
@@ -1067,6 +1069,69 @@ fn test_state_field_str_accepts_lowercase_names() {
     assert_eq!(state_field_str(&fields, &["Name", "name"]), Some("paw"));
 }
 
+#[test]
+fn test_temper_fs_bundle_loads_reactions() {
+    let bundle = get_os_app("temper-fs").expect("temper-fs app not found");
+    let rule_names: Vec<&str> = bundle
+        .reactions
+        .iter()
+        .map(|rule| rule.name.as_str())
+        .collect();
+    assert!(
+        rule_names.contains(&"file_version_create_supersedes_previous"),
+        "temper-fs reactions missing lineage rule: {rule_names:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_install_app_registers_reactions_for_tenant() {
+    let state = PlatformState::new(None);
+
+    install_os_app(&state, "test-fs-reactions", "temper-fs")
+        .await
+        .expect("install temper-fs");
+
+    let tenant = TenantId::new("test-fs-reactions");
+    let registry = state.registry.read().unwrap(); // ci-ok: infallible lock
+    let reaction_registry = registry.build_reaction_registry();
+    let rule_names: Vec<&str> = reaction_registry
+        .lookup(&tenant, "FileVersion", "Create", "Current")
+        .into_iter()
+        .map(|rule| rule.name.as_str())
+        .collect();
+
+    assert!(
+        rule_names.contains(&"file_version_create_supersedes_previous"),
+        "tenant missing temper-fs lineage reaction after install: {rule_names:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_installing_later_apps_preserves_existing_reactions() {
+    let state = PlatformState::new(None);
+
+    install_os_app(&state, "test-fs-reaction-merge", "temper-fs")
+        .await
+        .expect("install temper-fs");
+    install_os_app(&state, "test-fs-reaction-merge", "temper-agent")
+        .await
+        .expect("install temper-agent");
+
+    let tenant = TenantId::new("test-fs-reaction-merge");
+    let registry = state.registry.read().unwrap(); // ci-ok: infallible lock
+    let reaction_registry = registry.build_reaction_registry();
+    let rule_names: Vec<&str> = reaction_registry
+        .lookup(&tenant, "FileVersion", "Create", "Current")
+        .into_iter()
+        .map(|rule| rule.name.as_str())
+        .collect();
+
+    assert!(
+        rule_names.contains(&"file_version_create_supersedes_previous"),
+        "later app install should not wipe temper-fs lineage reaction: {rule_names:?}"
+    );
+}
+
 #[tokio::test]
 async fn test_install_app_bootstraps_adrs_into_temper_fs() {
     use std::sync::Arc;
@@ -1146,6 +1211,141 @@ async fn test_install_app_bootstraps_adrs_into_temper_fs() {
     assert!(found, "expected ADR file entity to exist in TemperFS");
 
     let _ = fs::remove_dir_all(&app_root);
+    let _ = fs::remove_file(&db_path);
+    let _ = fs::remove_file(format!("{db_path}-wal"));
+    let _ = fs::remove_file(format!("{db_path}-shm"));
+}
+
+#[tokio::test]
+async fn test_local_stream_uploads_create_real_file_version_lineage() {
+    use std::sync::Arc;
+    use temper_server::event_store::ServerEventStore;
+    use temper_server::state::DispatchCommand;
+    use temper_store_turso::TursoEventStore;
+
+    let db_path = format!(
+        "/tmp/temper-file-version-lineage-{}.db",
+        uuid::Uuid::new_v4()
+    );
+    let db_url = format!("file:{db_path}");
+    let turso = TursoEventStore::new(&db_url, None).await.unwrap();
+    let mut state = PlatformState::new(None);
+    state.server.event_store = Some(Arc::new(ServerEventStore::Turso(turso)));
+
+    install_os_app(&state, "test-file-lineage", "temper-fs")
+        .await
+        .expect("install temper-fs");
+
+    let tenant = TenantId::new("test-file-lineage");
+    let agent_ctx = AgentContext::system();
+    let file_id = "file-version-lineage";
+
+    state
+        .server
+        .get_or_create_tenant_entity(&tenant, "File", file_id, serde_json::json!({}))
+        .await
+        .expect("create file actor");
+    state
+        .server
+        .dispatch(DispatchCommand {
+            tenant: &tenant,
+            entity_type: "File",
+            entity_id: file_id,
+            action: "Create",
+            params: serde_json::json!({
+                "name": "lineage.txt",
+                "path": "/lineage.txt",
+                "directory_id": "",
+                "workspace_id": "",
+                "mime_type": "text/plain",
+            }),
+            agent_ctx: &agent_ctx,
+            await_integration: false,
+        })
+        .await
+        .expect("initialize file");
+
+    state
+        .server
+        .put_file_stream_content(&tenant, file_id, b"first version", "text/plain", &agent_ctx)
+        .await
+        .expect("upload first version");
+    state
+        .server
+        .put_file_stream_content(
+            &tenant,
+            file_id,
+            b"second version",
+            "text/plain",
+            &agent_ctx,
+        )
+        .await
+        .expect("upload second version");
+
+    let file_resp = state
+        .server
+        .get_tenant_entity_state(&tenant, "File", file_id)
+        .await
+        .expect("load file state");
+    assert_eq!(file_resp.state.status, "Ready");
+    assert_eq!(file_resp.state.counters.get("version_count"), Some(&2));
+
+    let latest_version_id = file_resp
+        .state
+        .fields
+        .get("last_version_id")
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.is_empty())
+        .expect("file should point at latest version")
+        .to_string();
+
+    let latest_version = state
+        .server
+        .get_tenant_entity_state(&tenant, "FileVersion", &latest_version_id)
+        .await
+        .expect("load latest file version");
+    assert_eq!(latest_version.state.status, "Current");
+    assert_eq!(
+        latest_version.state.counters.get("version_number"),
+        Some(&2)
+    );
+
+    let previous_version_id = latest_version
+        .state
+        .fields
+        .get("previous_version_id")
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.is_empty())
+        .expect("latest version should point at previous version")
+        .to_string();
+
+    for _ in 0..20 {
+        let previous = state
+            .server
+            .get_tenant_entity_state(&tenant, "FileVersion", &previous_version_id)
+            .await
+            .expect("load previous file version");
+        if previous.state.status == "Superseded" {
+            assert_eq!(previous.state.counters.get("version_number"), Some(&1));
+            let _ = fs::remove_file(&db_path);
+            let _ = fs::remove_file(format!("{db_path}-wal"));
+            let _ = fs::remove_file(format!("{db_path}-shm"));
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+
+    let previous = state
+        .server
+        .get_tenant_entity_state(&tenant, "FileVersion", &previous_version_id)
+        .await
+        .expect("load previous file version after wait");
+    assert_eq!(
+        previous.state.status, "Superseded",
+        "previous version should be superseded after the second upload"
+    );
+    assert_eq!(previous.state.counters.get("version_number"), Some(&1));
+
     let _ = fs::remove_file(&db_path);
     let _ = fs::remove_file(format!("{db_path}-wal"));
     let _ = fs::remove_file(format!("{db_path}-shm"));

--- a/crates/temper-platform/src/os_apps/types.rs
+++ b/crates/temper-platform/src/os_apps/types.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use serde::Serialize;
+use temper_server::reaction::types::ReactionRule;
 
 use super::{AdrEntry, AgentDefinition, AppSkillDefinition, SeedInstance, SystemFileEntry};
 
@@ -136,6 +137,8 @@ pub struct AppBundle {
     pub specs: Vec<(String, String)>,
     /// CSDL XML source (None if app has no IOA specs).
     pub csdl: Option<String>,
+    /// Cross-entity reaction rules loaded from `reactions/reactions.toml`, if present.
+    pub reactions: Vec<ReactionRule>,
     /// Optional tenant-scoped cross-invariants source.
     pub cross_invariants_toml: Option<String>,
     /// Cedar policy sources (may be empty).

--- a/crates/temper-server/Cargo.toml
+++ b/crates/temper-server/Cargo.toml
@@ -51,6 +51,7 @@ ed25519-dalek = "2.1"
 futures-util = "0.3"
 lru = { workspace = true }
 sha2 = { workspace = true }
+hmac = "0.12"
 libc = { workspace = true }
 # ADR-0055: CPU profile capture. pprof-rs is used because crates.io
 # `datadog-profiling` is currently an empty placeholder (see ADR for

--- a/crates/temper-server/src/api/files.rs
+++ b/crates/temper-server/src/api/files.rs
@@ -1,0 +1,96 @@
+use axum::extract::State;
+use axum::http::HeaderMap;
+use axum::response::IntoResponse;
+use tracing::instrument;
+
+use crate::odata::extract_tenant;
+use crate::state::ServerState;
+
+#[derive(Debug, serde::Deserialize)]
+pub(crate) struct BatchTextFileReadRequest {
+    #[serde(default)]
+    file_ids: Vec<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub(crate) struct BatchTextFileVersionReadRequest {
+    #[serde(default)]
+    file_version_ids: Vec<String>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub(crate) struct BatchTextFileReadResponse {
+    files: Vec<crate::state::TextFileReadResult>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub(crate) struct BatchTextFileVersionReadResponse {
+    files: Vec<crate::state::TextFileVersionReadResult>,
+}
+
+/// POST /api/files/read-text-batch — read many text file bodies via the
+/// projection-backed immutable content path.
+#[instrument(skip_all, fields(otel.name = "POST /api/files/read-text-batch"))]
+pub(crate) async fn handle_read_text_batch(
+    State(state): State<ServerState>,
+    headers: HeaderMap,
+    axum::Json(body): axum::Json<BatchTextFileReadRequest>,
+) -> impl IntoResponse {
+    let tenant = match extract_tenant(&headers, &state) {
+        Ok(t) => t,
+        Err(e) => return e.into_response(),
+    };
+
+    match state.read_file_texts_batch(&tenant, &body.file_ids).await {
+        Ok(files) => (
+            axum::http::StatusCode::OK,
+            axum::Json(BatchTextFileReadResponse { files }),
+        )
+            .into_response(),
+        Err(error) => (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            axum::Json(serde_json::json!({
+                "error": {
+                    "code": "BatchFileReadFailed",
+                    "message": error,
+                }
+            })),
+        )
+            .into_response(),
+    }
+}
+
+/// POST /api/files/read-version-text-batch — read many immutable file version
+/// bodies via projections + direct blob fetch.
+#[instrument(skip_all, fields(otel.name = "POST /api/files/read-version-text-batch"))]
+pub(crate) async fn handle_read_version_text_batch(
+    State(state): State<ServerState>,
+    headers: HeaderMap,
+    axum::Json(body): axum::Json<BatchTextFileVersionReadRequest>,
+) -> impl IntoResponse {
+    let tenant = match extract_tenant(&headers, &state) {
+        Ok(t) => t,
+        Err(e) => return e.into_response(),
+    };
+
+    match state
+        .read_file_version_texts_batch(&tenant, &body.file_version_ids)
+        .await
+    {
+        Ok(files) => (
+            axum::http::StatusCode::OK,
+            axum::Json(BatchTextFileVersionReadResponse { files }),
+        )
+            .into_response(),
+        Err(error) => (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            axum::Json(serde_json::json!({
+                "error": {
+                    "code": "BatchFileVersionReadFailed",
+                    "message": error,
+                }
+            })),
+        )
+            .into_response(),
+    }
+}

--- a/crates/temper-server/src/api/mod.rs
+++ b/crates/temper-server/src/api/mod.rs
@@ -6,6 +6,7 @@
 
 mod authorize;
 mod decisions;
+mod files;
 mod policies;
 mod repl;
 mod secrets;
@@ -32,6 +33,8 @@ use crate::state::ServerState;
 /// - POST   /api/evolution/sentinel/check               -> trigger sentinel health check
 /// - POST   /api/evolution/analyze                      -> run IntentDiscovery loop
 /// - POST   /api/evolution/materialize                  -> persist O/P/A/I + PM issues
+/// - POST   /api/files/read-text-batch                  -> batch current-file text reads via projections + blobs
+/// - POST   /api/files/read-version-text-batch          -> batch immutable file-version text reads
 pub fn build_api_router() -> Router<ServerState> {
     Router::new()
         .route(
@@ -66,6 +69,14 @@ pub fn build_api_router() -> Router<ServerState> {
         .route(
             "/evolution/materialize",
             post(crate::observe::evolution::handle_evolution_materialize),
+        )
+        .route(
+            "/files/read-text-batch",
+            post(files::handle_read_text_batch),
+        )
+        .route(
+            "/files/read-version-text-batch",
+            post(files::handle_read_version_text_batch),
         )
         // OTS trajectory endpoints (full agent execution traces for GEPA)
         .route(

--- a/crates/temper-server/src/entity_actor/effects.rs
+++ b/crates/temper-server/src/entity_actor/effects.rs
@@ -330,6 +330,30 @@ pub fn apply_effects(
                     state.item_count = state.item_count.saturating_sub(1);
                 }
             }
+            Effect::SetCounterFromParam { var, param } => {
+                let parsed = params
+                    .get(param)
+                    .and_then(|v| {
+                        v.as_u64()
+                            .or_else(|| v.as_i64().and_then(|n| u64::try_from(n).ok()))
+                    })
+                    .and_then(|n| usize::try_from(n).ok());
+                match parsed {
+                    Some(value) => {
+                        state.counters.insert(var.clone(), value);
+                        if var == "items" {
+                            state.item_count = value;
+                        }
+                    }
+                    None => tracing::warn!(
+                        entity_type = %state.entity_type,
+                        entity_id = %state.entity_id,
+                        counter = %var,
+                        param = %param,
+                        "set_counter_from_param skipped because param was missing or not a non-negative integer"
+                    ),
+                }
+            }
             Effect::SetBool { var, value } => {
                 state.booleans.insert(var.clone(), *value);
             }
@@ -999,6 +1023,58 @@ effect = [{ type = "schedule_at", field = "next_run_at", action = "Trigger" }]
         assert!(
             result.scheduled_actions.is_empty(),
             "missing field should produce no scheduled actions"
+        );
+    }
+
+    #[test]
+    fn test_set_counter_from_param_effect_sets_counter_and_field() {
+        let spec = r#"
+[automaton]
+name = "Upload"
+states = ["Pending", "Ready"]
+initial = "Pending"
+
+[[state]]
+name = "size_bytes"
+type = "counter"
+initial = "0"
+
+[[action]]
+name = "Complete"
+from = ["Pending"]
+to = "Ready"
+params = ["payload_size"]
+effect = [{ type = "set_counter_from_param", var = "size_bytes", param = "payload_size" }]
+"#;
+
+        let table = TransitionTable::from_ioa_source(spec);
+        let mut state = EntityState {
+            entity_type: "Upload".into(),
+            entity_id: "upload-1".into(),
+            status: "Pending".into(),
+            item_count: 0,
+            counters: std::collections::BTreeMap::new(),
+            booleans: std::collections::BTreeMap::new(),
+            lists: std::collections::BTreeMap::new(),
+            fields: serde_json::json!({}),
+            events: std::collections::VecDeque::new(),
+            total_event_count: 0,
+            sequence_nr: 0,
+        };
+
+        let result = process_action(
+            &mut state,
+            &table,
+            "Complete",
+            &serde_json::json!({ "payload_size": 4096 }),
+        );
+
+        assert!(result.success, "action should succeed");
+        assert_eq!(state.status, "Ready");
+        assert_eq!(state.counters.get("size_bytes"), Some(&4096));
+        assert_eq!(
+            state.fields.get("size_bytes").and_then(|v| v.as_u64()),
+            Some(4096)
         );
     }
 

--- a/crates/temper-server/src/observe/mod_test.rs
+++ b/crates/temper-server/src/observe/mod_test.rs
@@ -13,6 +13,7 @@ use tower::ServiceExt;
 use crate::event_store::ServerEventStore;
 use crate::registry::SpecRegistry;
 use crate::request_context::AgentContext;
+use crate::secrets::vault::SecretsVault;
 use crate::state::TrajectoryEntry;
 
 const CSDL_XML: &str = include_str!("../../../../test-fixtures/specs/model.csdl.xml");
@@ -124,6 +125,215 @@ fn build_app_with_state(state: ServerState) -> Router {
         .nest("/observe", build_observe_router())
         .nest("/api", crate::api::build_api_router())
         .with_state(state)
+}
+
+#[tokio::test]
+async fn batch_file_text_read_returns_projected_file_contents_in_request_order() {
+    let state = test_state_with_turso().await;
+    let tenant = "default";
+    let turso = state
+        .persistent_store_for_tenant(tenant)
+        .await
+        .expect("tenant turso store");
+
+    turso
+        .upsert_query_projection(
+            tenant,
+            "File",
+            "file-a",
+            "Ready",
+            &serde_json::json!({
+                "content_hash": "sha256:file-a",
+                "mime_type": "application/json",
+                "has_content": true,
+            }),
+            1,
+        )
+        .await
+        .expect("upsert file-a projection");
+    turso
+        .upsert_query_projection(
+            tenant,
+            "File",
+            "file-b",
+            "Created",
+            &serde_json::json!({
+                "content_hash": "",
+                "mime_type": "text/plain",
+                "has_content": false,
+            }),
+            1,
+        )
+        .await
+        .expect("upsert file-b projection");
+    turso
+        .put_blob("temper-fs/sha256:file-a", b"{\"msg\":\"hello\"}")
+        .await
+        .expect("persist blob");
+
+    let app = build_app_with_state(state);
+    let response = app
+        .oneshot(system_post(
+            "/api/files/read-text-batch",
+            r#"{"file_ids":["file-a","file-b","missing"]}"#,
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let files = json["files"].as_array().expect("files array");
+    assert_eq!(files.len(), 3);
+
+    assert_eq!(files[0]["file_id"], "file-a");
+    assert_eq!(files[0]["found"], true);
+    assert_eq!(files[0]["content_hash"], "sha256:file-a");
+    assert_eq!(files[0]["mime_type"], "application/json");
+    assert_eq!(files[0]["text"], "{\"msg\":\"hello\"}");
+
+    assert_eq!(files[1]["file_id"], "file-b");
+    assert_eq!(files[1]["found"], true);
+    assert_eq!(files[1]["text"], "");
+
+    assert_eq!(files[2]["file_id"], "missing");
+    assert_eq!(files[2]["found"], false);
+    assert_eq!(files[2]["text"], "");
+}
+
+#[tokio::test]
+async fn batch_file_version_text_read_returns_immutable_version_contents_in_request_order() {
+    let state = test_state_with_turso().await;
+    let tenant = "default";
+    let turso = state
+        .persistent_store_for_tenant(tenant)
+        .await
+        .expect("tenant turso store");
+
+    turso
+        .upsert_query_projection(
+            tenant,
+            "FileVersion",
+            "ver-a",
+            "Current",
+            &serde_json::json!({
+                "content_hash": "sha256:ver-a",
+                "mime_type": "application/json",
+            }),
+            1,
+        )
+        .await
+        .expect("upsert ver-a projection");
+    turso
+        .upsert_query_projection(
+            tenant,
+            "FileVersion",
+            "ver-b",
+            "Superseded",
+            &serde_json::json!({
+                "content_hash": "",
+                "mime_type": "text/plain",
+            }),
+            1,
+        )
+        .await
+        .expect("upsert ver-b projection");
+    turso
+        .put_blob("temper-fs/sha256:ver-a", b"{\"msg\":\"immutable\"}")
+        .await
+        .expect("persist blob");
+
+    let app = build_app_with_state(state);
+    let response = app
+        .oneshot(system_post(
+            "/api/files/read-version-text-batch",
+            r#"{"file_version_ids":["ver-a","ver-b","missing"]}"#,
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let files = json["files"].as_array().expect("files array");
+    assert_eq!(files.len(), 3);
+
+    assert_eq!(files[0]["file_version_id"], "ver-a");
+    assert_eq!(files[0]["found"], true);
+    assert_eq!(files[0]["content_hash"], "sha256:ver-a");
+    assert_eq!(files[0]["mime_type"], "application/json");
+    assert_eq!(files[0]["text"], "{\"msg\":\"immutable\"}");
+
+    assert_eq!(files[1]["file_version_id"], "ver-b");
+    assert_eq!(files[1]["found"], true);
+    assert_eq!(files[1]["text"], "");
+
+    assert_eq!(files[2]["file_version_id"], "missing");
+    assert_eq!(files[2]["found"], false);
+    assert_eq!(files[2]["text"], "");
+}
+
+#[tokio::test]
+async fn batch_file_version_text_read_uses_local_store_for_internal_blob_endpoint() {
+    let mut state = test_state_with_turso().await;
+    let tenant = "default";
+    let turso = state
+        .persistent_store_for_tenant(tenant)
+        .await
+        .expect("tenant turso store");
+
+    turso
+        .upsert_query_projection(
+            tenant,
+            "FileVersion",
+            "ver-local",
+            "Current",
+            &serde_json::json!({
+                "content_hash": "sha256:ver-local",
+                "mime_type": "text/plain",
+            }),
+            1,
+        )
+        .await
+        .expect("upsert ver-local projection");
+    turso
+        .put_blob("temper-fs/sha256:ver-local", b"local-fast-path")
+        .await
+        .expect("persist blob");
+
+    let vault = SecretsVault::new(&[7u8; 32]);
+    vault
+        .cache_secret(
+            tenant,
+            "blob_endpoint",
+            "http://127.0.0.1:3474/_internal/blobs".to_string(),
+        )
+        .expect("cache blob endpoint");
+    state.secrets_vault = Some(Arc::new(vault));
+
+    let app = build_app_with_state(state);
+    let response = app
+        .oneshot(system_post(
+            "/api/files/read-version-text-batch",
+            r#"{"file_version_ids":["ver-local"]}"#,
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let files = json["files"].as_array().expect("files array");
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0]["file_version_id"], "ver-local");
+    assert_eq!(files[0]["found"], true);
+    assert_eq!(files[0]["text"], "local-fast-path");
 }
 
 #[tokio::test]

--- a/crates/temper-server/src/registry/mod.rs
+++ b/crates/temper-server/src/registry/mod.rs
@@ -28,6 +28,21 @@ pub use types::*;
 
 use relations::{build_relation_graph, build_webhook_routes, synthesize_agent_trigger_reactions};
 
+fn merge_reaction_rules(
+    existing: &[ReactionRule],
+    incoming: Vec<ReactionRule>,
+) -> Vec<ReactionRule> {
+    let mut merged: BTreeMap<String, ReactionRule> = existing
+        .iter()
+        .cloned()
+        .map(|rule| (rule.name.clone(), rule))
+        .collect();
+    for rule in incoming {
+        merged.insert(rule.name.clone(), rule);
+    }
+    merged.into_values().collect()
+}
+
 /// Multi-tenant specification registry.
 ///
 /// Thread-safe for concurrent reads. Registration is done at startup;
@@ -180,7 +195,11 @@ impl SpecRegistry {
                 existing_config.csdl_xml = Arc::new(csdl_xml);
                 existing_config.entity_set_map = entity_set_map;
             }
-            existing_config.reactions = reactions;
+            existing_config.reactions = if merge {
+                merge_reaction_rules(&existing_config.reactions, reactions)
+            } else {
+                reactions
+            };
             existing_config.relation_graph = relation_graph;
             // In merge mode, an incoming payload without cross-invariants must
             // not wipe the ones previously loaded for the tenant — otherwise a

--- a/crates/temper-server/src/state/file_reads.rs
+++ b/crates/temper-server/src/state/file_reads.rs
@@ -1,0 +1,588 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::{Arc, OnceLock};
+
+use futures_util::stream::{self, StreamExt};
+use hmac::{Hmac, Mac};
+use reqwest::header::{AUTHORIZATION, HOST, HeaderMap, HeaderValue};
+use sha2::{Digest, Sha256};
+use temper_runtime::tenant::TenantId;
+use temper_store_turso::store::field_index::ProjectedEntityFieldsRow;
+use tracing::instrument;
+
+use super::ServerState;
+
+const DEFAULT_BLOB_BUCKET: &str = "temper-fs";
+const FILE_BATCH_READ_CONCURRENCY: usize = 8;
+
+type HmacSha256 = Hmac<Sha256>;
+
+fn is_local_internal_blob_endpoint(endpoint: &str) -> bool {
+    let normalized = endpoint.trim_end_matches('/');
+    (normalized.starts_with("http://127.0.0.1:") || normalized.starts_with("http://localhost:"))
+        && normalized.contains("/_internal/blobs")
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct TextFileReadResult {
+    pub file_id: String,
+    pub found: bool,
+    pub content_hash: String,
+    pub mime_type: String,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct TextFileVersionReadResult {
+    pub file_version_id: String,
+    pub found: bool,
+    pub content_hash: String,
+    pub mime_type: String,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FileProjectionMeta {
+    content_hash: String,
+    mime_type: String,
+    has_content: bool,
+}
+
+impl ServerState {
+    #[instrument(skip_all, fields(
+        otel.name = "state.read_file_texts_batch",
+        tenant = %tenant,
+        file_count = file_ids.len(),
+    ))]
+    pub async fn read_file_texts_batch(
+        &self,
+        tenant: &TenantId,
+        file_ids: &[String],
+    ) -> Result<Vec<TextFileReadResult>, String> {
+        if file_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut unique_ids = Vec::new();
+        let mut seen = BTreeSet::new();
+        for file_id in file_ids {
+            if seen.insert(file_id.clone()) {
+                unique_ids.push(file_id.clone());
+            }
+        }
+
+        let meta_by_id = self
+            .load_file_projection_metadata_batch(tenant, &unique_ids)
+            .await?;
+
+        let meta_by_id = Arc::new(meta_by_id);
+        let results = stream::iter(file_ids.iter().cloned())
+            .map(|file_id| {
+                let meta_by_id = Arc::clone(&meta_by_id);
+                async move {
+                    let meta = meta_by_id.get(&file_id).cloned();
+                    self.read_single_file_text(tenant, file_id, meta).await
+                }
+            })
+            .buffered(FILE_BATCH_READ_CONCURRENCY)
+            .collect::<Vec<_>>()
+            .await;
+
+        let mut out = Vec::with_capacity(results.len());
+        for result in results {
+            out.push(result?);
+        }
+        Ok(out)
+    }
+
+    #[instrument(skip_all, fields(
+        otel.name = "state.read_file_version_texts_batch",
+        tenant = %tenant,
+        file_version_count = file_version_ids.len(),
+    ))]
+    pub async fn read_file_version_texts_batch(
+        &self,
+        tenant: &TenantId,
+        file_version_ids: &[String],
+    ) -> Result<Vec<TextFileVersionReadResult>, String> {
+        if file_version_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut unique_ids = Vec::new();
+        let mut seen = BTreeSet::new();
+        for file_version_id in file_version_ids {
+            if seen.insert(file_version_id.clone()) {
+                unique_ids.push(file_version_id.clone());
+            }
+        }
+
+        let meta_by_id = self
+            .load_file_version_projection_metadata_batch(tenant, &unique_ids)
+            .await?;
+
+        let meta_by_id = Arc::new(meta_by_id);
+        let results = stream::iter(file_version_ids.iter().cloned())
+            .map(|file_version_id| {
+                let meta_by_id = Arc::clone(&meta_by_id);
+                async move {
+                    let meta = meta_by_id.get(&file_version_id).cloned();
+                    self.read_single_file_version_text(tenant, file_version_id, meta)
+                        .await
+                }
+            })
+            .buffered(FILE_BATCH_READ_CONCURRENCY)
+            .collect::<Vec<_>>()
+            .await;
+
+        let mut out = Vec::with_capacity(results.len());
+        for result in results {
+            out.push(result?);
+        }
+        Ok(out)
+    }
+
+    async fn load_file_projection_metadata_batch(
+        &self,
+        tenant: &TenantId,
+        file_ids: &[String],
+    ) -> Result<BTreeMap<String, FileProjectionMeta>, String> {
+        let mut by_id = BTreeMap::new();
+
+        if let Some(turso) = self.persistent_store_for_tenant(tenant.as_str()).await {
+            let rows = turso
+                .load_query_projection_fields_many(
+                    tenant.as_str(),
+                    "File",
+                    file_ids,
+                    &["content_hash", "mime_type", "has_content"],
+                )
+                .await
+                .map_err(|e| format!("failed to load File projections: {e}"))?;
+            for row in rows {
+                by_id.insert(row.entity_id.clone(), file_projection_from_row(row));
+            }
+        }
+
+        let missing_ids: Vec<String> = file_ids
+            .iter()
+            .filter(|file_id| !by_id.contains_key(*file_id))
+            .cloned()
+            .collect();
+
+        for file_id in missing_ids {
+            if let Ok(resp) = self.get_tenant_entity_state(tenant, "File", &file_id).await {
+                by_id.insert(file_id, file_projection_from_state(&resp.state.fields));
+            }
+        }
+
+        Ok(by_id)
+    }
+
+    async fn load_file_version_projection_metadata_batch(
+        &self,
+        tenant: &TenantId,
+        file_version_ids: &[String],
+    ) -> Result<BTreeMap<String, FileProjectionMeta>, String> {
+        let mut by_id = BTreeMap::new();
+
+        if let Some(turso) = self.persistent_store_for_tenant(tenant.as_str()).await {
+            let rows = turso
+                .load_query_projection_fields_many(
+                    tenant.as_str(),
+                    "FileVersion",
+                    file_version_ids,
+                    &["content_hash", "mime_type"],
+                )
+                .await
+                .map_err(|e| format!("failed to load FileVersion projections: {e}"))?;
+            for row in rows {
+                by_id.insert(row.entity_id.clone(), file_version_projection_from_row(row));
+            }
+        }
+
+        let missing_ids: Vec<String> = file_version_ids
+            .iter()
+            .filter(|file_version_id| !by_id.contains_key(*file_version_id))
+            .cloned()
+            .collect();
+
+        for file_version_id in missing_ids {
+            if let Ok(resp) = self
+                .get_tenant_entity_state(tenant, "FileVersion", &file_version_id)
+                .await
+            {
+                by_id.insert(
+                    file_version_id,
+                    file_version_projection_from_state(&resp.state.fields),
+                );
+            }
+        }
+
+        Ok(by_id)
+    }
+
+    async fn read_single_file_text(
+        &self,
+        tenant: &TenantId,
+        file_id: String,
+        meta: Option<FileProjectionMeta>,
+    ) -> Result<TextFileReadResult, String> {
+        let Some(meta) = meta else {
+            return Ok(TextFileReadResult {
+                file_id,
+                found: false,
+                content_hash: String::new(),
+                mime_type: String::new(),
+                text: String::new(),
+            });
+        };
+
+        if !meta.has_content || meta.content_hash.is_empty() {
+            return Ok(TextFileReadResult {
+                file_id,
+                found: true,
+                content_hash: meta.content_hash,
+                mime_type: meta.mime_type,
+                text: String::new(),
+            });
+        }
+
+        let text = self
+            .fetch_blob_text_for_hash(tenant, &meta.content_hash)
+            .await?
+            .unwrap_or_default();
+
+        Ok(TextFileReadResult {
+            file_id,
+            found: true,
+            content_hash: meta.content_hash,
+            mime_type: meta.mime_type,
+            text,
+        })
+    }
+
+    async fn read_single_file_version_text(
+        &self,
+        tenant: &TenantId,
+        file_version_id: String,
+        meta: Option<FileProjectionMeta>,
+    ) -> Result<TextFileVersionReadResult, String> {
+        let Some(meta) = meta else {
+            return Ok(TextFileVersionReadResult {
+                file_version_id,
+                found: false,
+                content_hash: String::new(),
+                mime_type: String::new(),
+                text: String::new(),
+            });
+        };
+
+        if !meta.has_content || meta.content_hash.is_empty() {
+            return Ok(TextFileVersionReadResult {
+                file_version_id,
+                found: true,
+                content_hash: meta.content_hash,
+                mime_type: meta.mime_type,
+                text: String::new(),
+            });
+        }
+
+        let text = self
+            .fetch_blob_text_for_hash(tenant, &meta.content_hash)
+            .await?
+            .unwrap_or_default();
+
+        Ok(TextFileVersionReadResult {
+            file_version_id,
+            found: true,
+            content_hash: meta.content_hash,
+            mime_type: meta.mime_type,
+            text,
+        })
+    }
+
+    async fn fetch_blob_text_for_hash(
+        &self,
+        tenant: &TenantId,
+        content_hash: &str,
+    ) -> Result<Option<String>, String> {
+        let blob_endpoint = self
+            .secrets_vault
+            .as_ref()
+            .and_then(|vault| vault.get_secret(tenant.as_str(), "blob_endpoint"));
+
+        let blob_bytes = if let Some(endpoint) = blob_endpoint {
+            if is_local_internal_blob_endpoint(endpoint.as_str())
+                && let Some(store) = self.persistent_store_for_tenant(tenant.as_str()).await
+            {
+                crate::blobs::get_blob_bytes(
+                    &store,
+                    &format!("{DEFAULT_BLOB_BUCKET}/{content_hash}"),
+                )
+                .await
+                .map_err(|e| format!("failed to read local blob '{content_hash}': {e}"))?
+            } else {
+                let bucket = self
+                    .secrets_vault
+                    .as_ref()
+                    .and_then(|vault| vault.get_secret(tenant.as_str(), "blob_bucket"))
+                    .unwrap_or_else(|| DEFAULT_BLOB_BUCKET.to_string());
+                fetch_external_blob_bytes(
+                    self,
+                    tenant,
+                    endpoint.as_str(),
+                    content_hash,
+                    bucket.as_str(),
+                )
+                .await?
+            }
+        } else if let Some(store) = self.persistent_store_for_tenant(tenant.as_str()).await {
+            crate::blobs::get_blob_bytes(&store, &format!("{DEFAULT_BLOB_BUCKET}/{content_hash}"))
+                .await
+                .map_err(|e| format!("failed to read local blob '{content_hash}': {e}"))?
+        } else {
+            None
+        };
+
+        Ok(blob_bytes.map(|bytes| String::from_utf8_lossy(&bytes).to_string()))
+    }
+}
+
+fn file_projection_from_row(row: ProjectedEntityFieldsRow) -> FileProjectionMeta {
+    FileProjectionMeta {
+        content_hash: row
+            .fields
+            .get("content_hash")
+            .cloned()
+            .flatten()
+            .unwrap_or_default(),
+        mime_type: row
+            .fields
+            .get("mime_type")
+            .cloned()
+            .flatten()
+            .unwrap_or_default(),
+        has_content: row
+            .fields
+            .get("has_content")
+            .and_then(|value| value.as_deref())
+            .is_some_and(|value| value.eq_ignore_ascii_case("true")),
+    }
+}
+
+fn file_projection_from_state(fields: &serde_json::Value) -> FileProjectionMeta {
+    FileProjectionMeta {
+        content_hash: fields
+            .get("content_hash")
+            .and_then(|value| value.as_str())
+            .unwrap_or_default()
+            .to_string(),
+        mime_type: fields
+            .get("mime_type")
+            .and_then(|value| value.as_str())
+            .unwrap_or_default()
+            .to_string(),
+        has_content: fields
+            .get("has_content")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false),
+    }
+}
+
+fn file_version_projection_from_row(row: ProjectedEntityFieldsRow) -> FileProjectionMeta {
+    let content_hash = row
+        .fields
+        .get("content_hash")
+        .cloned()
+        .flatten()
+        .unwrap_or_default();
+    FileProjectionMeta {
+        has_content: !content_hash.is_empty(),
+        content_hash,
+        mime_type: row
+            .fields
+            .get("mime_type")
+            .cloned()
+            .flatten()
+            .unwrap_or_default(),
+    }
+}
+
+fn file_version_projection_from_state(fields: &serde_json::Value) -> FileProjectionMeta {
+    let content_hash = fields
+        .get("content_hash")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default()
+        .to_string();
+    FileProjectionMeta {
+        has_content: !content_hash.is_empty(),
+        content_hash,
+        mime_type: fields
+            .get("mime_type")
+            .and_then(|value| value.as_str())
+            .unwrap_or_default()
+            .to_string(),
+    }
+}
+
+async fn fetch_external_blob_bytes(
+    state: &ServerState,
+    tenant: &TenantId,
+    endpoint: &str,
+    content_hash: &str,
+    bucket: &str,
+) -> Result<Option<Vec<u8>>, String> {
+    let url = format!(
+        "{}/{}/{}",
+        endpoint.trim_end_matches('/'),
+        bucket.trim_matches('/'),
+        content_hash
+    );
+    let mut request = blob_http_client().get(&url);
+    let headers = build_blob_get_headers(state, tenant, &url)?;
+    for (header_name, header_value) in &headers {
+        request = request.header(header_name, header_value);
+    }
+
+    let response = request
+        .send()
+        .await
+        .map_err(|e| format!("blob GET request failed for '{content_hash}': {e}"))?;
+    if response.status() == reqwest::StatusCode::NOT_FOUND {
+        return Ok(None);
+    }
+    if !response.status().is_success() {
+        return Err(format!(
+            "blob GET failed for '{content_hash}' with HTTP {}",
+            response.status()
+        ));
+    }
+
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|e| format!("blob GET body read failed for '{content_hash}': {e}"))?;
+    Ok(Some(bytes.to_vec()))
+}
+
+fn blob_http_client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(reqwest::Client::new)
+}
+
+fn build_blob_get_headers(
+    state: &ServerState,
+    tenant: &TenantId,
+    url: &str,
+) -> Result<HeaderMap, String> {
+    let mut headers = HeaderMap::new();
+    let Some(vault) = state.secrets_vault.as_ref() else {
+        return Ok(headers);
+    };
+
+    let Some(access_key) = vault.get_secret(tenant.as_str(), "blob_access_key") else {
+        return Ok(headers);
+    };
+    let Some(secret_key) = vault.get_secret(tenant.as_str(), "blob_secret_key") else {
+        return Ok(headers);
+    };
+
+    let datetime = chrono::Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
+    let date = &datetime[..8];
+    let (host, path) = parse_url_host_path(url);
+    let canonical_uri = uri_encode_path(path);
+    let payload_hash = "UNSIGNED-PAYLOAD";
+    let region = "auto";
+    let service = "s3";
+    let scope = format!("{date}/{region}/{service}/aws4_request");
+    let canonical_headers =
+        format!("host:{host}\nx-amz-content-sha256:{payload_hash}\nx-amz-date:{datetime}\n");
+    let signed_headers = "host;x-amz-content-sha256;x-amz-date";
+    let canonical_request =
+        format!("GET\n{canonical_uri}\n\n{canonical_headers}\n{signed_headers}\n{payload_hash}");
+    let canonical_request_hash = sha256_hex(canonical_request.as_bytes());
+    let string_to_sign = format!("AWS4-HMAC-SHA256\n{datetime}\n{scope}\n{canonical_request_hash}");
+    let signing_key = derive_signing_key(&secret_key, date, region, service);
+    let signature = hex_encode(&hmac_sha256(&signing_key, string_to_sign.as_bytes()));
+    let authorization = format!(
+        "AWS4-HMAC-SHA256 Credential={access_key}/{scope},SignedHeaders={signed_headers},Signature={signature}"
+    );
+
+    headers.insert(
+        AUTHORIZATION,
+        HeaderValue::from_str(&authorization)
+            .map_err(|e| format!("invalid blob authorization header: {e}"))?,
+    );
+    headers.insert(
+        "x-amz-date",
+        HeaderValue::from_str(&datetime).map_err(|e| format!("invalid x-amz-date header: {e}"))?,
+    );
+    headers.insert(
+        "x-amz-content-sha256",
+        HeaderValue::from_static(payload_hash),
+    );
+    headers.insert(
+        HOST,
+        HeaderValue::from_str(host).map_err(|e| format!("invalid blob host header: {e}"))?,
+    );
+    Ok(headers)
+}
+
+fn sha256_hex(data: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    hex_encode(&hasher.finalize())
+}
+
+fn derive_signing_key(secret_key: &str, date: &str, region: &str, service: &str) -> Vec<u8> {
+    let k_secret = format!("AWS4{secret_key}");
+    let k_date = hmac_sha256(k_secret.as_bytes(), date.as_bytes());
+    let k_region = hmac_sha256(&k_date, region.as_bytes());
+    let k_service = hmac_sha256(&k_region, service.as_bytes());
+    hmac_sha256(&k_service, b"aws4_request")
+}
+
+fn hmac_sha256(key: &[u8], data: &[u8]) -> Vec<u8> {
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts any key length");
+    mac.update(data);
+    mac.finalize().into_bytes().to_vec()
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for &byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+fn parse_url_host_path(url: &str) -> (&str, &str) {
+    let after_scheme = if let Some(pos) = url.find("://") {
+        &url[pos + 3..]
+    } else {
+        url
+    };
+    if let Some(slash) = after_scheme.find('/') {
+        (&after_scheme[..slash], &after_scheme[slash..])
+    } else {
+        (after_scheme, "/")
+    }
+}
+
+fn uri_encode_path(path: &str) -> String {
+    let mut out = String::with_capacity(path.len() + 16);
+    for byte in path.bytes() {
+        match byte {
+            b'/' | b'-' | b'_' | b'.' | b'~' => out.push(byte as char),
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' => out.push(byte as char),
+            _ => {
+                out.push('%');
+                out.push(b"0123456789ABCDEF"[(byte >> 4) as usize] as char);
+                out.push(b"0123456789ABCDEF"[(byte & 0x0f) as usize] as char);
+            }
+        }
+    }
+    out
+}

--- a/crates/temper-server/src/state/mod.rs
+++ b/crates/temper-server/src/state/mod.rs
@@ -5,6 +5,7 @@ pub mod custom_effects;
 mod dispatch;
 mod entity_ops;
 mod evolution;
+mod file_reads;
 pub mod metrics;
 pub mod pending_decisions;
 mod persistence;
@@ -17,6 +18,7 @@ pub mod wasm_invocation_log;
 pub use admission::{AdmissionController, AdmissionOutcome, AdmissionPermit};
 pub use dispatch::{DispatchCommand, DispatchError, DispatchExtOptions, StateTimeoutTracker};
 pub use entity_ops::{FailedLevelInfo, VerificationGateError};
+pub use file_reads::{TextFileReadResult, TextFileVersionReadResult};
 pub use metrics::MetricsCollector;
 pub use pending_decisions::{
     ActionScope, DecisionStatus, DurationScope, PendingDecision, PolicyScopeMatrix, PrincipalScope,
@@ -746,8 +748,12 @@ impl ServerState {
             .and_then(|vault| vault.get_secret(&tenant.to_string(), "blob_endpoint"));
 
         if blob_endpoint.is_none()
-            && let Some(store) = self.platform_persistent_store().cloned()
+            && let Some(store) = self.persistent_store_for_tenant(tenant.as_str()).await
         {
+            let file_state = self
+                .get_tenant_entity_state(tenant, "File", file_id)
+                .await
+                .map_err(|e| format!("failed to load File('{file_id}') state: {e}"))?;
             let mut hasher = Sha256::new();
             hasher.update(body);
             let content_hash = format!("sha256:{:x}", hasher.finalize());
@@ -756,6 +762,21 @@ impl ServerState {
                 .put_blob(&blob_key, body)
                 .await
                 .map_err(|e| format!("failed to persist local blob '{blob_key}': {e}"))?;
+
+            let version_number = file_state
+                .state
+                .counters
+                .get("version_count")
+                .copied()
+                .unwrap_or(0)
+                + 1;
+            let previous_version_id = file_state
+                .state
+                .fields
+                .get("last_version_id")
+                .and_then(|value| value.as_str())
+                .unwrap_or_default();
+            let created_by = agent_ctx.agent_id.clone().unwrap_or_default();
             return self
                 .dispatch_tenant_action(
                     tenant,
@@ -766,6 +787,9 @@ impl ServerState {
                         "content_hash": content_hash,
                         "size_bytes": body.len() as i64,
                         "mime_type": mime_type,
+                        "version_number": version_number,
+                        "previous_version_id": previous_version_id,
+                        "created_by": created_by,
                     }),
                     agent_ctx,
                 )

--- a/crates/temper-spec/src/automaton/lint.rs
+++ b/crates/temper-spec/src/automaton/lint.rs
@@ -496,6 +496,7 @@ fn effect_var(effect: &Effect) -> Option<&str> {
     match effect {
         Effect::Increment { var } => Some(var.as_str()),
         Effect::Decrement { var } => Some(var.as_str()),
+        Effect::SetCounterFromParam { var, .. } => Some(var.as_str()),
         Effect::SetBool { var, .. } => Some(var.as_str()),
         Effect::Emit { .. } => None,
         Effect::ListAppend { var } => Some(var.as_str()),
@@ -533,6 +534,9 @@ fn render_effect(effect: &Effect) -> String {
     match effect {
         Effect::Increment { var } => format!("increment {var}"),
         Effect::Decrement { var } => format!("decrement {var}"),
+        Effect::SetCounterFromParam { var, param } => {
+            format!("set_counter_from_param {var} <- {param}")
+        }
         Effect::SetBool { var, value } => format!("set {var} {value}"),
         Effect::Emit { event } => format!("emit {event}"),
         Effect::ListAppend { var } => format!("list_append {var}"),

--- a/crates/temper-spec/src/automaton/parser.rs
+++ b/crates/temper-spec/src/automaton/parser.rs
@@ -271,6 +271,7 @@ fn format_effects(effects: &[Effect]) -> String {
         .map(|e| match e {
             Effect::Increment { var } => format!("{var}' = {var} + 1"),
             Effect::Decrement { var } => format!("{var}' = {var} - 1"),
+            Effect::SetCounterFromParam { var, param } => format!("{var}' = {param}"),
             Effect::SetBool { var, value } => {
                 format!("{var}' = {}", if *value { "TRUE" } else { "FALSE" })
             }

--- a/crates/temper-spec/src/automaton/parser_features_test.rs
+++ b/crates/temper-spec/src/automaton/parser_features_test.rs
@@ -146,6 +146,37 @@ effect = [{ type = "schedule", action = "Refresh", delay_seconds = 2700 }]
 }
 
 #[test]
+fn test_parse_set_counter_from_param_effect() {
+    let spec = r#"
+[automaton]
+name = "Upload"
+states = ["Pending", "Ready"]
+initial = "Pending"
+
+[[action]]
+name = "Complete"
+from = ["Pending"]
+to = "Ready"
+effect = [{ type = "set_counter_from_param", var = "size_bytes", param = "payload_size" }]
+"#;
+
+    let automaton = parse_automaton(spec).expect("should parse set_counter_from_param effect");
+    let complete = automaton
+        .actions
+        .iter()
+        .find(|action| action.name == "Complete")
+        .unwrap();
+    assert_eq!(complete.effect.len(), 1);
+    match &complete.effect[0] {
+        Effect::SetCounterFromParam { var, param } => {
+            assert_eq!(var, "size_bytes");
+            assert_eq!(param, "payload_size");
+        }
+        other => panic!("expected SetCounterFromParam, got: {other:?}"),
+    }
+}
+
+#[test]
 fn test_unknown_inline_effect_type_rejected() {
     let spec = r#"
 [automaton]

--- a/crates/temper-spec/src/automaton/toml_parser/effects.rs
+++ b/crates/temper-spec/src/automaton/toml_parser/effects.rs
@@ -76,6 +76,10 @@ fn parse_effect_fields(
             .get("var")
             .cloned()
             .map(|var| Effect::Decrement { var }),
+        "set_counter_from_param" => fields.get("var").cloned().map(|var| {
+            let param = fields.get("param").cloned().unwrap_or_else(|| var.clone());
+            Effect::SetCounterFromParam { var, param }
+        }),
         "set_bool" => fields.get("var").cloned().map(|var| Effect::SetBool {
             var,
             value: fields.get("value").is_some_and(|s| s == "true"),

--- a/crates/temper-spec/src/automaton/translate.rs
+++ b/crates/temper-spec/src/automaton/translate.rs
@@ -59,6 +59,8 @@ pub enum ResolvedEffect {
     IncrementCounter(String),
     /// Decrement a counter variable by 1.
     DecrementCounter(String),
+    /// Set a counter variable from an action param.
+    SetCounterFromParam { var: String, param: String },
     /// Set a boolean variable.
     SetBool { var: String, value: bool },
     /// Append a value to a list variable.
@@ -244,6 +246,10 @@ fn translate_single_effect(effect: &Effect) -> ResolvedEffect {
     match effect {
         Effect::Increment { var } => ResolvedEffect::IncrementCounter(var.clone()),
         Effect::Decrement { var } => ResolvedEffect::DecrementCounter(var.clone()),
+        Effect::SetCounterFromParam { var, param } => ResolvedEffect::SetCounterFromParam {
+            var: var.clone(),
+            param: param.clone(),
+        },
         Effect::SetBool { var, value } => ResolvedEffect::SetBool {
             var: var.clone(),
             value: *value,

--- a/crates/temper-spec/src/automaton/translate_test.rs
+++ b/crates/temper-spec/src/automaton/translate_test.rs
@@ -87,6 +87,30 @@ effect = [{ type = "increment", var = "count" }, { type = "set_bool", var = "don
 }
 
 #[test]
+fn translate_set_counter_from_param_effects() {
+    let spec = r#"
+[automaton]
+name = "Upload"
+states = ["Pending", "Ready"]
+initial = "Pending"
+
+[[action]]
+name = "Complete"
+from = ["Pending"]
+to = "Ready"
+effect = [{ type = "set_counter_from_param", var = "size_bytes", param = "payload_size" }]
+"#;
+    let automaton = parse_automaton(spec).unwrap();
+    let actions = translate_actions(&automaton);
+    let effects = &actions[0].effects;
+    assert_eq!(effects.len(), 1);
+    assert!(matches!(
+        &effects[0],
+        ResolvedEffect::SetCounterFromParam { var, param } if var == "size_bytes" && param == "payload_size"
+    ));
+}
+
+#[test]
 fn translate_name_heuristic_additem() {
     let spec = r#"
 [automaton]
@@ -201,6 +225,13 @@ from = ["Draft"]
 fn is_verifiable_classification() {
     assert!(ResolvedEffect::IncrementCounter("x".into()).is_verifiable());
     assert!(ResolvedEffect::DecrementCounter("x".into()).is_verifiable());
+    assert!(
+        !ResolvedEffect::SetCounterFromParam {
+            var: "x".into(),
+            param: "value".into(),
+        }
+        .is_verifiable()
+    );
     assert!(
         ResolvedEffect::SetBool {
             var: "x".into(),

--- a/crates/temper-spec/src/automaton/types.rs
+++ b/crates/temper-spec/src/automaton/types.rs
@@ -178,6 +178,9 @@ pub enum Effect {
     /// Decrement a counter variable.
     #[serde(rename = "decrement")]
     Decrement { var: String },
+    /// Set a counter variable from an action param.
+    #[serde(rename = "set_counter_from_param")]
+    SetCounterFromParam { var: String, param: String },
     /// Set a boolean variable.
     #[serde(rename = "set_bool")]
     SetBool { var: String, value: bool },

--- a/crates/temper-spec/src/automaton/types_test.rs
+++ b/crates/temper-spec/src/automaton/types_test.rs
@@ -84,6 +84,7 @@ from = ["A"]
 effect = [
     { type = "increment", var = "count" },
     { type = "decrement", var = "count" },
+    { type = "set_counter_from_param", var = "size_bytes", param = "payload_size" },
     { type = "set_bool", var = "done", value = true },
     { type = "emit", event = "order_placed" },
     { type = "list_append", var = "log" },
@@ -94,16 +95,20 @@ effect = [
 "#;
     let automaton: Automaton = toml::from_str(toml_src).unwrap();
     let effects = &automaton.actions[0].effect;
-    assert_eq!(effects.len(), 8);
+    assert_eq!(effects.len(), 9);
     assert!(matches!(&effects[0], Effect::Increment { var } if var == "count"));
     assert!(matches!(&effects[1], Effect::Decrement { var } if var == "count"));
-    assert!(matches!(&effects[2], Effect::SetBool { var, value: true } if var == "done"));
-    assert!(matches!(&effects[3], Effect::Emit { event } if event == "order_placed"));
-    assert!(matches!(&effects[4], Effect::ListAppend { var } if var == "log"));
-    assert!(matches!(&effects[5], Effect::ListRemoveAt { var } if var == "log"));
-    assert!(matches!(&effects[6], Effect::Trigger { name } if name == "run_wasm"));
+    assert!(matches!(
+        &effects[2],
+        Effect::SetCounterFromParam { var, param } if var == "size_bytes" && param == "payload_size"
+    ));
+    assert!(matches!(&effects[3], Effect::SetBool { var, value: true } if var == "done"));
+    assert!(matches!(&effects[4], Effect::Emit { event } if event == "order_placed"));
+    assert!(matches!(&effects[5], Effect::ListAppend { var } if var == "log"));
+    assert!(matches!(&effects[6], Effect::ListRemoveAt { var } if var == "log"));
+    assert!(matches!(&effects[7], Effect::Trigger { name } if name == "run_wasm"));
     assert!(
-        matches!(&effects[7], Effect::Schedule { action, delay_seconds: 30 } if action == "Retry")
+        matches!(&effects[8], Effect::Schedule { action, delay_seconds: 30 } if action == "Retry")
     );
 }
 

--- a/crates/temper-store-turso/src/store/field_index.rs
+++ b/crates/temper-store-turso/src/store/field_index.rs
@@ -6,11 +6,20 @@
 //! just to evaluate filters in memory.
 
 use libsql::{TransactionBehavior, params};
+use std::collections::{BTreeMap, BTreeSet};
 use temper_runtime::persistence::{PersistenceError, storage_error};
 use temper_runtime::scheduler::sim_now;
 use tracing::instrument;
 
 use super::TursoEventStore;
+
+/// Sparse projected field values loaded from the durable query plane.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectedEntityFieldsRow {
+    pub entity_id: String,
+    pub status: String,
+    pub fields: BTreeMap<String, Option<String>>,
+}
 
 impl TursoEventStore {
     /// Upsert the durable query-plane projection for a single entity.
@@ -202,6 +211,98 @@ impl TursoEventStore {
             }
         }
         Ok(ids)
+    }
+
+    /// Load a sparse set of projected fields for many entities in one query.
+    ///
+    /// Returns one row per projected entity that exists in the durable query
+    /// plane. Missing entity ids are omitted from the result.
+    #[instrument(skip_all, fields(
+        otel.name = "turso.load_query_projection_fields_many",
+        tenant, entity_type,
+        entity_count = entity_ids.len(),
+        field_count = field_names.len(),
+    ))]
+    pub async fn load_query_projection_fields_many(
+        &self,
+        tenant: &str,
+        entity_type: &str,
+        entity_ids: &[String],
+        field_names: &[&str],
+    ) -> Result<Vec<ProjectedEntityFieldsRow>, PersistenceError> {
+        if entity_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let conn = self.configured_connection().await?;
+        let requested_fields: BTreeSet<&str> = field_names.iter().copied().collect();
+
+        let entity_placeholders = std::iter::repeat_n("?", entity_ids.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let field_placeholders = std::iter::repeat_n("?", requested_fields.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "SELECT c.entity_id, c.status, f.field_name, f.field_value \
+             FROM entity_catalog c \
+             LEFT JOIN entity_field_index f \
+               ON c.tenant = f.tenant \
+              AND c.entity_type = f.entity_type \
+              AND c.entity_id = f.entity_id \
+              AND f.field_name IN ({field_placeholders}) \
+             WHERE c.tenant = ? \
+               AND c.entity_type = ? \
+               AND c.entity_id IN ({entity_placeholders}) \
+             ORDER BY c.entity_id, f.field_name"
+        );
+
+        let mut params: Vec<libsql::Value> =
+            Vec::with_capacity(2 + requested_fields.len() + entity_ids.len());
+        for field_name in &requested_fields {
+            params.push(libsql::Value::from((*field_name).to_string()));
+        }
+        params.push(libsql::Value::from(tenant.to_string()));
+        params.push(libsql::Value::from(entity_type.to_string()));
+        for entity_id in entity_ids {
+            params.push(libsql::Value::from(entity_id.clone()));
+        }
+
+        let mut rows = conn
+            .query(&sql, libsql::params_from_iter(params))
+            .await
+            .map_err(storage_error)?;
+
+        let mut by_entity: BTreeMap<String, ProjectedEntityFieldsRow> = BTreeMap::new();
+        while let Some(row) = rows.next().await.map_err(storage_error)? {
+            let entity_id: String = row.get(0).map_err(storage_error)?;
+            let status: String = row.get(1).map_err(storage_error)?;
+            let field_name: Option<String> = row.get(2).map_err(storage_error)?;
+            let field_value: Option<String> = row.get(3).map_err(storage_error)?;
+
+            let entry =
+                by_entity
+                    .entry(entity_id.clone())
+                    .or_insert_with(|| ProjectedEntityFieldsRow {
+                        entity_id: entity_id.clone(),
+                        status,
+                        fields: requested_fields
+                            .iter()
+                            .map(|field| ((*field).to_string(), None))
+                            .collect(),
+                    });
+
+            if let Some(field_name) = field_name
+                && requested_fields.contains(field_name.as_str())
+            {
+                entry.fields.insert(field_name, field_value);
+            }
+        }
+
+        Ok(entity_ids
+            .iter()
+            .filter_map(|entity_id| by_entity.remove(entity_id))
+            .collect())
     }
 
     /// Return projected entity counts grouped by tenant.

--- a/crates/temper-store-turso/src/store/tests.rs
+++ b/crates/temper-store-turso/src/store/tests.rs
@@ -425,6 +425,88 @@ async fn query_projection_roundtrip_updates_catalog_and_field_index() {
 }
 
 #[tokio::test]
+async fn load_query_projection_fields_many_returns_requested_fields_by_entity() {
+    let store = make_store("query-projection-fields-many").await;
+    let tenant = format!("tenant-{}", uuid::Uuid::new_v4());
+
+    store
+        .upsert_query_projection(
+            &tenant,
+            "File",
+            "file-a",
+            "Ready",
+            &serde_json::json!({
+                "content_hash": "sha256:file-a",
+                "mime_type": "application/json",
+                "has_content": true,
+                "size_bytes": 12,
+            }),
+            1,
+        )
+        .await
+        .expect("upsert file-a projection");
+    store
+        .upsert_query_projection(
+            &tenant,
+            "File",
+            "file-b",
+            "Created",
+            &serde_json::json!({
+                "content_hash": "",
+                "mime_type": "text/plain",
+                "has_content": false,
+            }),
+            1,
+        )
+        .await
+        .expect("upsert file-b projection");
+
+    let rows = store
+        .load_query_projection_fields_many(
+            &tenant,
+            "File",
+            &[
+                "file-a".to_string(),
+                "file-b".to_string(),
+                "missing".to_string(),
+            ],
+            &["content_hash", "mime_type", "has_content"],
+        )
+        .await
+        .expect("load projected fields");
+
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].entity_id, "file-a");
+    assert_eq!(rows[0].status, "Ready");
+    assert_eq!(
+        rows[0]
+            .fields
+            .get("content_hash")
+            .and_then(|v| v.as_deref()),
+        Some("sha256:file-a")
+    );
+    assert_eq!(
+        rows[0].fields.get("mime_type").and_then(|v| v.as_deref()),
+        Some("application/json")
+    );
+    assert_eq!(
+        rows[0].fields.get("has_content").and_then(|v| v.as_deref()),
+        Some("true")
+    );
+
+    assert_eq!(rows[1].entity_id, "file-b");
+    assert_eq!(rows[1].status, "Created");
+    assert_eq!(
+        rows[1].fields.get("has_content").and_then(|v| v.as_deref()),
+        Some("false")
+    );
+    assert!(
+        rows.iter().all(|row| row.entity_id != "missing"),
+        "missing entity ids should be omitted"
+    );
+}
+
+#[tokio::test]
 async fn load_wasm_module_metadata_all_tenants_returns_metadata_without_bulk_bytes() {
     let store = make_store("wasm-metadata").await;
 

--- a/crates/temper-verify/src/model/builder.rs
+++ b/crates/temper-verify/src/model/builder.rs
@@ -135,6 +135,7 @@ fn convert_effect(effect: ResolvedEffect) -> ModelEffect {
         ResolvedEffect::ListRemoveAt(var) => ModelEffect::ListRemoveAt(var),
         // Runtime-only effects should have been filtered by is_verifiable()
         ResolvedEffect::Emit(_)
+        | ResolvedEffect::SetCounterFromParam { .. }
         | ResolvedEffect::Trigger(_)
         | ResolvedEffect::Schedule { .. }
         | ResolvedEffect::ScheduleAt { .. }

--- a/docs/adrs/0057-native-immutable-file-read-plane.md
+++ b/docs/adrs/0057-native-immutable-file-read-plane.md
@@ -1,0 +1,125 @@
+# ADR-0057: Native Immutable File Read Plane for TemperFS
+
+- Status: Accepted
+- Date: 2026-04-23
+- Deciders: Temper core maintainers
+- Related:
+  - ADR-0027: OS App Catalog
+  - ADR-0029: TemperFS — A Governed File System on Temper Primitives
+  - ADR-0045: Reactions as a First-Class App Primitive
+  - ADR-0048: Dispatch Retry and Error Taxonomy
+  - `crates/temper-platform/src/os_apps/mod.rs`
+  - `crates/temper-server/src/state/file_reads.rs`
+  - `os-apps/temper-fs/specs/file.ioa.toml`
+  - `os-apps/temper-fs/specs/file_version.ioa.toml`
+
+## Context
+
+TemperFS already established the right high-level split: mutable filesystem namespace in entities, immutable bytes in blob storage.
+
+But the hot read path still behaved like a generic control-plane lookup:
+
+1. read one file at a time
+2. route through OData or generic entity lookup
+3. pay entity-state lookup and WASM/blob adapter overhead per file
+
+That shape was survivable for occasional file access, but it became the dominant latency cost for session context preparation and would become worse for any future FUSE-like filesystem surface.
+
+We also discovered a platform gap in OS-app installation: `reactions.toml` was not loaded into `AppBundle`, and app installs bootstrapped specs without rebuilding the live reaction dispatcher. As a result, the TemperFS lineage model could exist in specs without actually executing at runtime after install.
+
+## Decision
+
+### 1. File content reads are split from generic entity control reads
+
+Temper remains entity-first for writes, lifecycle, and authorization.
+
+TemperFS hot reads now use a native immutable read plane:
+
+- `File` remains the mutable namespace and head pointer entity
+- `FileVersion` is the immutable version record
+- blob bytes remain content-addressed by `content_hash`
+- hot-path read APIs load projected metadata first, then fetch blob bytes directly
+
+This preserves Temper-native ownership while avoiding per-file control-plane overhead for immutable reads.
+
+### 2. TemperFS version lineage is explicit and first-class
+
+`File.StreamUpdated` now carries version metadata:
+
+- `version_number`
+- `previous_version_id`
+- `created_by`
+
+Each content update spawns a fresh `FileVersion`, stores its id back into `File.last_version_id`, and links lineage through `previous_version_id`.
+
+The previous version is superseded by a reaction on `FileVersion.Create`, not by mutating the new version in place.
+
+### 3. Batch text reads exist for both mutable file heads and immutable versions
+
+Temper now exposes internal HTTP/API surfaces for:
+
+- batch read by current `File`
+- batch read by immutable `FileVersion`
+
+These APIs:
+
+- preserve request order
+- load projected fields in bulk where possible
+- fall back safely when projection data is missing
+- fetch blob bytes directly once the content hash is known
+
+This makes the read plane usable for session context assembly and future filesystem consumers.
+
+### 4. OS-app reactions are loaded and activated as part of install
+
+OS-app bundles now load `reactions/reactions.toml` as first-class bundle content.
+
+App installation:
+
+- carries reaction rules into bootstrap registration
+- preserves them in the tenant registry
+- rebuilds the live `ReactionDispatcher` immediately after install
+
+This makes app-installed choreography real at runtime instead of depending on a later specs reload.
+
+## Rollout Plan
+
+1. **Phase 0** — Land explicit `FileVersion` lineage, batch read APIs, and OS-app reaction activation.
+2. **Phase 1** — Move OpenPaw session context consumers onto immutable version reads where available.
+3. **Phase 2** — Reuse the same read plane for future filesystem-shaped surfaces such as `lookup`, `getattr`, and `read`.
+
+## Consequences
+
+### Positive
+
+- Immutable content reads no longer pay full per-file control-plane cost.
+- TemperFS version lineage is explicit and auditable.
+- OS-app reactions behave consistently after install and recovery.
+- The same architecture can support session context prep and future FUSE/NFS-style access.
+
+### Negative
+
+- TemperFS now depends more heavily on projection correctness for hot-path performance.
+- The platform has another explicit read surface to maintain alongside generic OData reads.
+
+### Risks
+
+- Projection drift could produce stale or missing batch-read metadata. The implementation mitigates this with safe fallback to entity-state reads for misses.
+- Future callers could overuse the batch API for non-hot-path workloads. The design expectation is that this API is for immutable content-heavy paths, not general orchestration.
+
+### DST Compliance
+
+- Determinism is preserved because write semantics still flow through entity actions and event-sourced state transitions.
+- Batch read APIs are read-only projections over committed state plus blob lookup; they do not introduce background mutation or hidden orchestration.
+
+## Non-Goals
+
+- Replacing OData as the general-purpose platform API
+- Introducing an external sidecar cache or database outside Temper ownership
+- Delivering a full FUSE implementation in this ADR
+
+## Alternatives Considered
+
+1. **Keep reading files through generic OData/entity paths** — rejected because latency scales with file count and punishes immutable content reads with control-plane overhead.
+2. **Store session/app content in an external cache outside Temper** — rejected because it breaks Temper-native ownership and complicates authorization and recovery.
+3. **Treat `File` head state as sufficient and skip explicit version lineage** — rejected because historical session references need immutable identity, not a mutable head pointer.

--- a/os-apps/temper-fs/APP.md
+++ b/os-apps/temper-fs/APP.md
@@ -40,7 +40,7 @@ Single file within TemperFS. Content stored externally; metadata tracked here.
 
 **Key actions**:
 - **Create**: Create file entry (content not yet uploaded)
-- **StreamUpdated**: Fired by $value PUT handler after upload succeeds; advances to Ready
+- **StreamUpdated**: Fired by $value PUT handler after upload succeeds; advances to Ready and spawns a fresh immutable `FileVersion`
 - **Lock / Unlock**: Prevent or re-enable content modifications
 - **Archive**: Terminal state
 
@@ -48,12 +48,12 @@ Single file within TemperFS. Content stored externally; metadata tracked here.
 
 ### FileVersion
 
-Immutable record of a specific file version. Created on each content upload.
+Immutable record of a specific file version. Created on each content upload and linked back to the previous immutable version before superseding it.
 
 **States**: Current → Superseded
 
 **Key actions**:
-- **Create**: Record version with file ID, version number, content hash, size, and creator
+- **Create**: Record version with file ID, version number, content hash, mime type, size, previous version ID, and creator
 - **Supersede**: Mark as replaced by a newer version (terminal)
 
 ## Setup

--- a/os-apps/temper-fs/reactions/reactions.toml
+++ b/os-apps/temper-fs/reactions/reactions.toml
@@ -3,30 +3,20 @@
 # Cross-entity reactions fired by the ReactionDispatcher.
 # Reactions are fire-and-forget, cascade depth bounded by MAX_REACTION_DEPTH = 8.
 
-# When a file's content is updated via $value PUT, create a new FileVersion.
+# When a new file version is created, supersede the previous FileVersion if one exists.
 [[reaction]]
-name = "file_stream_updated_creates_version"
+name = "file_version_create_supersedes_previous"
 
 [reaction.when]
-entity_type = "File"
-action = "StreamUpdated"
-to_state = "Ready"
-
-[reaction.then]
 entity_type = "FileVersion"
 action = "Create"
 
-[reaction.resolve_target]
-type = "create_if_missing"
-id_field = "last_version_id"
-
-# When a new version is created, supersede the previous FileVersion.
-[[reaction]]
-name = "file_stream_updated_supersedes_old_version"
-
-[reaction.when]
-entity_type = "File"
-action = "StreamUpdated"
+[reaction.when.guard]
+type = "not"
+[reaction.when.guard.guard]
+type = "field_equals"
+field = "previous_version_id"
+value = ""
 
 [reaction.then]
 entity_type = "FileVersion"
@@ -34,7 +24,7 @@ action = "Supersede"
 
 [reaction.resolve_target]
 type = "field"
-field = "last_version_id"
+field = "previous_version_id"
 
 # When a file's content is updated, increment the workspace's used bytes.
 [[reaction]]

--- a/os-apps/temper-fs/specs/file.ioa.toml
+++ b/os-apps/temper-fs/specs/file.ioa.toml
@@ -36,6 +36,11 @@ name = "mime_type"
 type = "string"
 initial = ""
 
+[[state]]
+name = "last_version_id"
+type = "string"
+initial = ""
+
 # --- Actions ---
 
 [[action]]
@@ -51,8 +56,13 @@ name = "StreamUpdated"
 kind = "input"
 from = ["Created", "Ready"]
 to = "Ready"
-params = ["content_hash", "size_bytes", "mime_type"]
-effect = '[{ type = "increment", var = "version_count" }, { type = "set_bool", var = "has_content", value = "true" }]'
+params = ["content_hash", "size_bytes", "mime_type", "version_number", "previous_version_id", "created_by"]
+effect = [
+  { type = "increment", var = "version_count" },
+  { type = "set_counter_from_param", var = "size_bytes", param = "size_bytes" },
+  { type = "set_bool", var = "has_content", value = "true" },
+  { type = "spawn", entity_type = "FileVersion", entity_id_source = "{uuid}", initial_action = "Create", store_id_in = "last_version_id" },
+]
 hint = "Fired by $value PUT handler after WASM upload succeeds. Updates content metadata and advances to Ready. Not callable from Locked."
 
 [[action]]

--- a/os-apps/temper-fs/specs/file_version.ioa.toml
+++ b/os-apps/temper-fs/specs/file_version.ioa.toml
@@ -26,9 +26,19 @@ type = "string"
 initial = ""
 
 [[state]]
+name = "mime_type"
+type = "string"
+initial = ""
+
+[[state]]
 name = "size_bytes"
 type = "counter"
 initial = "0"
+
+[[state]]
+name = "previous_version_id"
+type = "string"
+initial = ""
 
 [[state]]
 name = "created_by"
@@ -42,7 +52,11 @@ name = "Create"
 kind = "input"
 from = ["Current"]
 to = "Current"
-params = ["file_id", "version_number", "content_hash", "size_bytes", "created_by"]
+params = ["file_id", "version_number", "content_hash", "mime_type", "size_bytes", "previous_version_id", "created_by"]
+effect = [
+  { type = "set_counter_from_param", var = "version_number", param = "version_number" },
+  { type = "set_counter_from_param", var = "size_bytes", param = "size_bytes" },
+]
 hint = "Create a new file version record with content metadata."
 
 [[action]]

--- a/os-apps/temper-fs/specs/model.csdl.xml
+++ b/os-apps/temper-fs/specs/model.csdl.xml
@@ -106,6 +106,7 @@
         <Property Name="HasContent" Type="Edm.Boolean" DefaultValue="false"/>
         <Property Name="ContentHash" Type="Edm.String"/>
         <Property Name="MimeType" Type="Edm.String"/>
+        <Property Name="LastVersionId" Type="Edm.Guid"/>
         <Property Name="CreatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
         <Property Name="UpdatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
         <NavigationProperty Name="Directory" Type="Temper.FS.Directory">
@@ -113,6 +114,9 @@
         </NavigationProperty>
         <NavigationProperty Name="Workspace" Type="Temper.FS.Workspace">
           <ReferentialConstraint Property="WorkspaceId" ReferencedProperty="Id"/>
+        </NavigationProperty>
+        <NavigationProperty Name="LastVersion" Type="Temper.FS.FileVersion">
+          <ReferentialConstraint Property="LastVersionId" ReferencedProperty="Id"/>
         </NavigationProperty>
         <NavigationProperty Name="Versions" Type="Collection(Temper.FS.FileVersion)"/>
         <Annotation Term="Temper.Vocab.StateMachine.States">
@@ -134,11 +138,16 @@
         <Property Name="Status" Type="Temper.FS.FileVersionStatus" Nullable="false"/>
         <Property Name="VersionNumber" Type="Edm.Int32" Nullable="false"/>
         <Property Name="ContentHash" Type="Edm.String" Nullable="false"/>
+        <Property Name="MimeType" Type="Edm.String" Nullable="false"/>
         <Property Name="SizeBytes" Type="Edm.Int64" Nullable="false"/>
+        <Property Name="PreviousVersionId" Type="Edm.Guid"/>
         <Property Name="CreatedBy" Type="Edm.String"/>
         <Property Name="CreatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
         <NavigationProperty Name="File" Type="Temper.FS.File">
           <ReferentialConstraint Property="FileId" ReferencedProperty="Id"/>
+        </NavigationProperty>
+        <NavigationProperty Name="PreviousVersion" Type="Temper.FS.FileVersion">
+          <ReferentialConstraint Property="PreviousVersionId" ReferencedProperty="Id"/>
         </NavigationProperty>
         <Annotation Term="Temper.Vocab.StateMachine.States">
           <Collection><String>Current</String><String>Superseded</String></Collection>
@@ -246,6 +255,9 @@
         <Parameter Name="content_hash" Type="Edm.String" Nullable="false"/>
         <Parameter Name="size_bytes" Type="Edm.Int64" Nullable="false"/>
         <Parameter Name="mime_type" Type="Edm.String" Nullable="false"/>
+        <Parameter Name="version_number" Type="Edm.Int32" Nullable="false"/>
+        <Parameter Name="previous_version_id" Type="Edm.Guid"/>
+        <Parameter Name="created_by" Type="Edm.String"/>
         <ReturnType Type="Temper.FS.File"/>
         <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
           <Collection><String>Created</String><String>Ready</String></Collection>
@@ -307,10 +319,12 @@
         <EntitySet Name="Files" EntityType="Temper.FS.File">
           <NavigationPropertyBinding Path="Directory" Target="Directories"/>
           <NavigationPropertyBinding Path="Workspace" Target="Workspaces"/>
+          <NavigationPropertyBinding Path="LastVersion" Target="FileVersions"/>
           <NavigationPropertyBinding Path="Versions" Target="FileVersions"/>
         </EntitySet>
         <EntitySet Name="FileVersions" EntityType="Temper.FS.FileVersion">
           <NavigationPropertyBinding Path="File" Target="Files"/>
+          <NavigationPropertyBinding Path="PreviousVersion" Target="FileVersions"/>
         </EntitySet>
       </EntityContainer>
 

--- a/os-apps/temper-fs/specs/workspace.ioa.toml
+++ b/os-apps/temper-fs/specs/workspace.ioa.toml
@@ -33,6 +33,7 @@ kind = "input"
 from = ["Active"]
 to = "Active"
 params = ["name", "quota_limit"]
+effect = [{ type = "set_counter_from_param", var = "quota_limit", param = "quota_limit" }]
 hint = "Create a new workspace with a name and storage quota."
 
 [[action]]
@@ -41,6 +42,7 @@ kind = "input"
 from = ["Active"]
 to = "Active"
 params = ["quota_limit"]
+effect = [{ type = "set_counter_from_param", var = "quota_limit", param = "quota_limit" }]
 hint = "Update the workspace storage quota limit."
 
 [[action]]

--- a/os-apps/temper-fs/wasm/blob_adapter/Cargo.lock
+++ b/os-apps/temper-fs/wasm/blob_adapter/Cargo.lock
@@ -5,3 +5,101 @@ version = 4
 [[package]]
 name = "blob-adapter"
 version = "0.1.0"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/os-apps/temper-fs/wasm/blob_adapter/Cargo.toml
+++ b/os-apps/temper-fs/wasm/blob_adapter/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]
+
+[dev-dependencies]
+serde_json = "1"

--- a/os-apps/temper-fs/wasm/blob_adapter/src/lib.rs
+++ b/os-apps/temper-fs/wasm/blob_adapter/src/lib.rs
@@ -136,12 +136,7 @@ fn handle_upload(ctx_json: &str) -> i32 {
     // 2. CAS dedup — skip upload if blob already stored
     if cache_contains(&content_hash) {
         log("info", "blob_adapter: CAS cache hit, skipping upload");
-        let result = format!(
-            r#"{{"action":"StreamUpdated","params":{{"content_hash":"{}","size_bytes":{},"mime_type":"{}"}},"success":true}}"#,
-            escape_json(&content_hash),
-            size_bytes,
-            escape_json(&content_type),
-        );
+        let result = build_stream_updated_result(ctx_json, &content_hash, &size_bytes, &content_type);
         set_result(&result);
         return 0;
     }
@@ -166,12 +161,7 @@ fn handle_upload(ctx_json: &str) -> i32 {
     cache_from_stream(&content_hash, &stream_id);
 
     // 7. Return action + params for server to dispatch
-    let result = format!(
-        r#"{{"action":"StreamUpdated","params":{{"content_hash":"{}","size_bytes":{},"mime_type":"{}"}},"success":true}}"#,
-        escape_json(&content_hash),
-        size_bytes,
-        escape_json(&content_type),
-    );
+    let result = build_stream_updated_result(ctx_json, &content_hash, &size_bytes, &content_type);
     set_result(&result);
     0
 }
@@ -483,6 +473,58 @@ fn extract_nested_json_str(json: &str, outer_key: &str, inner_key: &str) -> Stri
     String::new()
 }
 
+fn build_stream_updated_result(
+    ctx_json: &str,
+    content_hash: &str,
+    size_bytes: &str,
+    mime_type: &str,
+) -> String {
+    let (version_number, previous_version_id, created_by) =
+        extract_stream_version_metadata(ctx_json);
+    format!(
+        r#"{{"action":"StreamUpdated","params":{{"content_hash":"{}","size_bytes":{},"mime_type":"{}","version_number":{},"previous_version_id":"{}","created_by":"{}"}},"success":true}}"#,
+        escape_json(content_hash),
+        size_bytes,
+        escape_json(mime_type),
+        version_number,
+        escape_json(&previous_version_id),
+        escape_json(&created_by),
+    )
+}
+
+fn extract_stream_version_metadata(ctx_json: &str) -> (u64, String, String) {
+    let entity_state = extract_json_object(ctx_json, "entity_state");
+    let fields = if entity_state.is_empty() {
+        String::new()
+    } else {
+        extract_json_object(&entity_state, "fields")
+    };
+    let version_count = extract_field_from_entity_state(&entity_state, &fields, "version_count")
+        .parse::<u64>()
+        .unwrap_or(0);
+    let previous_version_id =
+        extract_field_from_entity_state(&entity_state, &fields, "last_version_id");
+    let created_by = extract_json_str(ctx_json, "agent_id");
+    (
+        version_count.saturating_add(1),
+        previous_version_id,
+        created_by,
+    )
+}
+
+fn extract_field_from_entity_state(entity_state: &str, fields: &str, field: &str) -> String {
+    if !fields.is_empty() {
+        let value = extract_json_str(fields, field);
+        if !value.is_empty() {
+            return value;
+        }
+    }
+    if !entity_state.is_empty() {
+        return extract_json_str(entity_state, field);
+    }
+    String::new()
+}
+
 /// Minimal JSON string escaping.
 fn escape_json(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
@@ -497,4 +539,59 @@ fn escape_json(s: &str) -> String {
         }
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_stream_updated_result;
+
+    #[test]
+    fn stream_updated_result_includes_version_metadata_for_existing_file() {
+        let ctx_json = r#"{
+            "agent_id":"agent-7",
+            "entity_state":{
+                "fields":{
+                    "version_count":2,
+                    "last_version_id":"ver-2"
+                }
+            }
+        }"#;
+
+        let result = build_stream_updated_result(
+            ctx_json,
+            "sha256:new-content",
+            "42",
+            "text/plain",
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+
+        assert_eq!(parsed["action"], "StreamUpdated");
+        assert_eq!(parsed["params"]["content_hash"], "sha256:new-content");
+        assert_eq!(parsed["params"]["size_bytes"], 42);
+        assert_eq!(parsed["params"]["mime_type"], "text/plain");
+        assert_eq!(parsed["params"]["version_number"], 3);
+        assert_eq!(parsed["params"]["previous_version_id"], "ver-2");
+        assert_eq!(parsed["params"]["created_by"], "agent-7");
+    }
+
+    #[test]
+    fn stream_updated_result_defaults_first_version_metadata() {
+        let ctx_json = r#"{
+            "entity_state":{
+                "fields":{}
+            }
+        }"#;
+
+        let result = build_stream_updated_result(
+            ctx_json,
+            "sha256:first-content",
+            "7",
+            "application/json",
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+
+        assert_eq!(parsed["params"]["version_number"], 1);
+        assert_eq!(parsed["params"]["previous_version_id"], "");
+        assert_eq!(parsed["params"]["created_by"], "");
+    }
 }


### PR DESCRIPTION
## Summary
- add a native immutable TemperFS read plane with batch current-file and file-version reads
- make TemperFS file version lineage explicit and live at runtime
- load and preserve OS-app reactions during install, and rebuild the live dispatcher
- add ADR and live proof notes for the new architecture

## Testing
- cargo test -p temper-platform test_temper_fs_bundle_loads_reactions -- --nocapture
- cargo test -p temper-platform test_install_app_registers_reactions_for_tenant -- --nocapture
- cargo test -p temper-platform test_installing_later_apps_preserves_existing_reactions -- --nocapture
- cargo test -p temper-platform test_local_stream_uploads_create_real_file_version_lineage -- --nocapture
- cargo test --manifest-path os-apps/temper-fs/wasm/blob_adapter/Cargo.toml -- --nocapture
- cargo test -p temper-store-turso load_query_projection_fields_many_returns_requested_fields_by_entity -- --nocapture
- cargo test -p temper-server --features observe batch_file_text_read_returns_projected_file_contents_in_request_order -- --nocapture
- cargo test -p temper-server --features observe batch_file_version_text_read_returns_immutable_version_contents_in_request_order -- --nocapture
- cargo test -p temper-server --features observe batch_file_version_text_read_uses_local_store_for_internal_blob_endpoint -- --nocapture
- cargo test -p temper-server test_set_counter_from_param_effect_sets_counter_and_field -- --nocapture
