### PR TITLE
[codex] Bound OS app warm restart reconcile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6127,6 +6127,7 @@ dependencies = [
  "temper-store-turso",
  "temper-verify",
  "temper-wasm",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-test",

--- a/crates/temper-platform/Cargo.toml
+++ b/crates/temper-platform/Cargo.toml
@@ -38,3 +38,4 @@ tokio-test = { workspace = true }
 tower = { workspace = true }
 hyper = { workspace = true }
 wiremock = { workspace = true }
+tempfile = "3.27.0"

--- a/crates/temper-platform/src/os_apps/mod.rs
+++ b/crates/temper-platform/src/os_apps/mod.rs
@@ -16,6 +16,8 @@ use std::sync::{OnceLock, RwLock};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use temper_runtime::tenant::TenantId;
+use temper_server::platform_store::InstalledAppRecord;
+use temper_server::registry::VerificationStatus;
 use temper_spec::automaton;
 use temper_spec::csdl::{emit_csdl_xml, merge_csdl, parse_csdl};
 
@@ -1188,6 +1190,292 @@ fn collect_install_order(
     Ok(())
 }
 
+/// Resolve a deduplicated dependency-first install order for a set of apps.
+pub fn resolve_os_app_install_order(app_names: &[String]) -> Result<Vec<String>, String> {
+    let mut visiting = HashSet::new();
+    let mut visited = HashSet::new();
+    let mut order = Vec::new();
+    for app_name in app_names {
+        collect_install_order(app_name, &mut visiting, &mut visited, &mut order)?;
+    }
+    Ok(order)
+}
+
+fn app_entry(app_name: &str) -> Option<AppEntry> {
+    let cat = catalog().read().unwrap(); // ci-ok: infallible lock
+    cat.entries
+        .iter()
+        .find(|entry| entry.name == app_name)
+        .cloned()
+}
+
+fn digest_bytes(parts: &[(&str, Vec<u8>)]) -> String {
+    let mut hasher = Sha256::new();
+    for (name, bytes) in parts {
+        hasher.update(name.as_bytes());
+        hasher.update([0]);
+        hasher.update(bytes);
+        hasher.update([0xff]);
+    }
+    format!("sha256:{:x}", hasher.finalize())
+}
+
+fn digest_app_bundle(app_name: &str, bundle: &AppBundle) -> OsAppBundleDigest {
+    let entry = app_entry(app_name);
+    let app_version = entry
+        .as_ref()
+        .map(|entry| entry.version.clone())
+        .unwrap_or_else(|| "0.1.0".to_string());
+
+    let mut spec_parts = Vec::new();
+    for (entity_type, ioa_source) in &bundle.specs {
+        spec_parts.push((
+            format!("spec:{entity_type}"),
+            ioa_source.as_bytes().to_vec(),
+        ));
+    }
+    if let Some(csdl) = &bundle.csdl {
+        spec_parts.push(("csdl".to_string(), csdl.as_bytes().to_vec()));
+    }
+    if let Some(cross_invariants) = &bundle.cross_invariants_toml {
+        spec_parts.push((
+            "cross-invariants".to_string(),
+            cross_invariants.as_bytes().to_vec(),
+        ));
+    }
+    spec_parts.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut policy_parts: Vec<(String, Vec<u8>)> = bundle
+        .cedar_policies
+        .iter()
+        .enumerate()
+        .map(|(idx, policy)| (format!("policy:{idx}"), policy.as_bytes().to_vec()))
+        .collect();
+    policy_parts.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut wasm_parts = Vec::new();
+    for (module_name, wasm_bytes) in &bundle.wasm_modules {
+        wasm_parts.push((format!("wasm:{module_name}"), wasm_bytes.clone()));
+    }
+    for (module_name, config) in &bundle.wasm_module_configs {
+        let config_bytes = serde_json::to_vec(config).unwrap_or_default();
+        wasm_parts.push((format!("wasm-config:{module_name}"), config_bytes));
+    }
+    wasm_parts.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut content_parts = Vec::new();
+    if let Some(app_guide) = entry.as_ref().and_then(|entry| entry.app_guide.as_ref()) {
+        content_parts.push(("APP.md".to_string(), app_guide.as_bytes().to_vec()));
+    }
+    for agent in &bundle.agents {
+        content_parts.push((
+            format!("agent:{}:content", agent.name),
+            agent.content.as_bytes().to_vec(),
+        ));
+    }
+    for skill in &bundle.skills {
+        content_parts.push((
+            format!(
+                "skill:{}:{}",
+                skill.agent_name.as_deref().unwrap_or("_system"),
+                skill.name
+            ),
+            skill.content.as_bytes().to_vec(),
+        ));
+        for companion in &skill.companion_files {
+            content_parts.push((
+                format!(
+                    "skill-companion:{}:{}:{}",
+                    skill.agent_name.as_deref().unwrap_or("_system"),
+                    skill.name,
+                    companion.name
+                ),
+                companion.content.clone(),
+            ));
+        }
+    }
+    for file in &bundle.system_files {
+        content_parts.push((
+            format!("system:{}", file.relative_path),
+            file.content.clone(),
+        ));
+    }
+    for adr in &bundle.adrs {
+        content_parts.push((
+            format!("adr:{}", adr.file_name),
+            adr.content.as_bytes().to_vec(),
+        ));
+    }
+    content_parts.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut seed_parts = Vec::new();
+    for seed in &bundle.seed_instances {
+        seed_parts.push((
+            format!(
+                "seed:{}:{}",
+                seed.entity_type,
+                seed.id.as_deref().unwrap_or("_generated")
+            ),
+            serde_json::to_vec(seed).unwrap_or_default(),
+        ));
+    }
+    seed_parts.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let spec_digest = digest_bytes(
+        &spec_parts
+            .iter()
+            .map(|(name, bytes)| (name.as_str(), bytes.clone()))
+            .collect::<Vec<_>>(),
+    );
+    let policy_digest = digest_bytes(
+        &policy_parts
+            .iter()
+            .map(|(name, bytes)| (name.as_str(), bytes.clone()))
+            .collect::<Vec<_>>(),
+    );
+    let wasm_digest = digest_bytes(
+        &wasm_parts
+            .iter()
+            .map(|(name, bytes)| (name.as_str(), bytes.clone()))
+            .collect::<Vec<_>>(),
+    );
+    let content_digest = digest_bytes(
+        &content_parts
+            .iter()
+            .map(|(name, bytes)| (name.as_str(), bytes.clone()))
+            .collect::<Vec<_>>(),
+    );
+    let seed_digest = digest_bytes(
+        &seed_parts
+            .iter()
+            .map(|(name, bytes)| (name.as_str(), bytes.clone()))
+            .collect::<Vec<_>>(),
+    );
+    let bundle_digest = digest_bytes(&[
+        ("app_name", app_name.as_bytes().to_vec()),
+        ("app_version", app_version.as_bytes().to_vec()),
+        ("spec", spec_digest.as_bytes().to_vec()),
+        ("policy", policy_digest.as_bytes().to_vec()),
+        ("wasm", wasm_digest.as_bytes().to_vec()),
+        ("content", content_digest.as_bytes().to_vec()),
+        ("seed", seed_digest.as_bytes().to_vec()),
+    ]);
+
+    OsAppBundleDigest {
+        app_name: app_name.to_string(),
+        app_version,
+        bundle_digest,
+        spec_digest,
+        policy_digest,
+        wasm_digest,
+        content_digest,
+        seed_digest,
+    }
+}
+
+/// Compute the current bundle digest for an app in the catalog.
+pub fn os_app_bundle_digest(app_name: &str) -> Option<OsAppBundleDigest> {
+    get_os_app(app_name).map(|bundle| digest_app_bundle(app_name, &bundle))
+}
+
+fn tenant_has_ready_app_specs_for_bundle(
+    state: &PlatformState,
+    tenant: &str,
+    bundle: &AppBundle,
+) -> bool {
+    let tenant_id = TenantId::new(tenant);
+    let registry = state.registry.read().unwrap(); // ci-ok: infallible lock
+    bundle.specs.iter().all(|(entity_type, _)| {
+        let has_table = registry.get_table(&tenant_id, entity_type).is_some();
+        let is_ready = matches!(
+            registry.get_verification_status(&tenant_id, entity_type),
+            Some(VerificationStatus::Completed(_) | VerificationStatus::Restored(_))
+        );
+        has_table && is_ready
+    })
+}
+
+async fn record_app_install_metadata(
+    state: &PlatformState,
+    tenant: &str,
+    digest: &OsAppBundleDigest,
+    status: &str,
+) {
+    let Some(ps) = state
+        .server
+        .event_store
+        .as_ref()
+        .and_then(|store| store.platform_store())
+    else {
+        return;
+    };
+
+    let record = InstalledAppRecord {
+        tenant: tenant.to_string(),
+        app_name: digest.app_name.clone(),
+        app_version: digest.app_version.clone(),
+        bundle_digest: digest.bundle_digest.clone(),
+        spec_digest: digest.spec_digest.clone(),
+        policy_digest: digest.policy_digest.clone(),
+        wasm_digest: digest.wasm_digest.clone(),
+        content_digest: digest.content_digest.clone(),
+        seed_digest: digest.seed_digest.clone(),
+        installed_at: None,
+        last_reconciled_at: None,
+        status: status.to_string(),
+    };
+
+    if let Err(error) = ps.record_installed_app_metadata(&record).await {
+        tracing::warn!(
+            tenant,
+            app = %digest.app_name,
+            error = %error,
+            "Failed to persist OS app digest metadata"
+        );
+    }
+}
+
+/// Reconcile one app without recursively processing dependencies.
+///
+/// Callers that need dependencies should first call
+/// [`resolve_os_app_install_order`] and reconcile each returned app once.
+pub async fn reconcile_os_app(
+    state: &PlatformState,
+    tenant: &str,
+    app_name: &str,
+) -> Result<OsAppReconcileResult, String> {
+    let bundle = get_os_app(app_name).ok_or_else(|| format!("OS app '{app_name}' not found"))?;
+    let digest = digest_app_bundle(app_name, &bundle);
+
+    if let Some(ps) = state
+        .server
+        .event_store
+        .as_ref()
+        .and_then(|store| store.platform_store())
+        && let Ok(Some(record)) = ps.get_installed_app(tenant, app_name).await
+        && record.bundle_digest == digest.bundle_digest
+        && tenant_has_ready_app_specs_for_bundle(state, tenant, &bundle)
+    {
+        tracing::info!(
+            tenant,
+            app = %app_name,
+            bundle_digest = %digest.bundle_digest,
+            "OS app unchanged; skipping hot reconcile"
+        );
+        return Ok(OsAppReconcileResult::Skipped {
+            app_name: app_name.to_string(),
+            bundle_digest: digest.bundle_digest,
+        });
+    }
+
+    let install = install_os_app_without_dependencies(state, tenant, app_name).await?;
+    Ok(OsAppReconcileResult::Installed {
+        app_name: app_name.to_string(),
+        bundle_digest: digest.bundle_digest,
+        install,
+    })
+}
+
 /// Install an OS app into a tenant (workspace).
 ///
 /// Reads app files from disk, runs the verification cascade, registers
@@ -1579,6 +1867,9 @@ async fn install_os_app_without_dependencies(
 
     // ── Step 9: Create seed instances. ───────────────────────────────
     let seed_created = bootstrap_seed_data(state, &tenant_id, tenant, &bundle.seed_instances).await;
+
+    let bundle_digest = digest_app_bundle(app_name, &bundle);
+    record_app_install_metadata(state, tenant, &bundle_digest, "installed").await;
 
     Ok(InstallResult {
         added,

--- a/crates/temper-platform/src/os_apps/mod.rs
+++ b/crates/temper-platform/src/os_apps/mod.rs
@@ -9,15 +9,13 @@
 //!
 //! Install reuses [`crate::bootstrap::bootstrap_tenant_specs`] so every app goes through the same verification cascade as system specs.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::{OnceLock, RwLock};
 
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use temper_runtime::tenant::TenantId;
-use temper_server::platform_store::InstalledAppRecord;
-use temper_server::registry::VerificationStatus;
 use temper_spec::automaton;
 use temper_spec::csdl::{emit_csdl_xml, merge_csdl, parse_csdl};
 
@@ -26,8 +24,10 @@ use crate::state::PlatformState;
 
 mod agent_bootstrap;
 pub mod git_sources;
+mod reconcile;
 mod system_files;
 mod types;
+pub use reconcile::{os_app_bundle_digest, reconcile_os_app, resolve_os_app_install_order};
 pub use types::*;
 
 fn read_app_manifest(app_dir: &Path) -> Option<AppManifest> {
@@ -1169,313 +1169,6 @@ fn os_app_dependencies(name: &str) -> Vec<String> {
     }
 }
 
-fn collect_install_order(
-    app_name: &str,
-    visiting: &mut HashSet<String>,
-    visited: &mut HashSet<String>,
-    order: &mut Vec<String>,
-) -> Result<(), String> {
-    if visited.contains(app_name) {
-        return Ok(());
-    }
-    if !visiting.insert(app_name.to_string()) {
-        return Err(format!("Cyclic OS app dependency detected at '{app_name}'"));
-    }
-    for dependency in os_app_dependencies(app_name) {
-        collect_install_order(&dependency, visiting, visited, order)?;
-    }
-    visiting.remove(app_name);
-    visited.insert(app_name.to_string());
-    order.push(app_name.to_string());
-    Ok(())
-}
-
-/// Resolve a deduplicated dependency-first install order for a set of apps.
-pub fn resolve_os_app_install_order(app_names: &[String]) -> Result<Vec<String>, String> {
-    let mut visiting = HashSet::new();
-    let mut visited = HashSet::new();
-    let mut order = Vec::new();
-    for app_name in app_names {
-        collect_install_order(app_name, &mut visiting, &mut visited, &mut order)?;
-    }
-    Ok(order)
-}
-
-fn app_entry(app_name: &str) -> Option<AppEntry> {
-    let cat = catalog().read().unwrap(); // ci-ok: infallible lock
-    cat.entries
-        .iter()
-        .find(|entry| entry.name == app_name)
-        .cloned()
-}
-
-fn digest_bytes(parts: &[(&str, Vec<u8>)]) -> String {
-    let mut hasher = Sha256::new();
-    for (name, bytes) in parts {
-        hasher.update(name.as_bytes());
-        hasher.update([0]);
-        hasher.update(bytes);
-        hasher.update([0xff]);
-    }
-    format!("sha256:{:x}", hasher.finalize())
-}
-
-fn digest_app_bundle(app_name: &str, bundle: &AppBundle) -> OsAppBundleDigest {
-    let entry = app_entry(app_name);
-    let app_version = entry
-        .as_ref()
-        .map(|entry| entry.version.clone())
-        .unwrap_or_else(|| "0.1.0".to_string());
-
-    let mut spec_parts = Vec::new();
-    for (entity_type, ioa_source) in &bundle.specs {
-        spec_parts.push((
-            format!("spec:{entity_type}"),
-            ioa_source.as_bytes().to_vec(),
-        ));
-    }
-    if let Some(csdl) = &bundle.csdl {
-        spec_parts.push(("csdl".to_string(), csdl.as_bytes().to_vec()));
-    }
-    if let Some(cross_invariants) = &bundle.cross_invariants_toml {
-        spec_parts.push((
-            "cross-invariants".to_string(),
-            cross_invariants.as_bytes().to_vec(),
-        ));
-    }
-    spec_parts.sort_by(|a, b| a.0.cmp(&b.0));
-
-    let mut policy_parts: Vec<(String, Vec<u8>)> = bundle
-        .cedar_policies
-        .iter()
-        .enumerate()
-        .map(|(idx, policy)| (format!("policy:{idx}"), policy.as_bytes().to_vec()))
-        .collect();
-    policy_parts.sort_by(|a, b| a.0.cmp(&b.0));
-
-    let mut wasm_parts = Vec::new();
-    for (module_name, wasm_bytes) in &bundle.wasm_modules {
-        wasm_parts.push((format!("wasm:{module_name}"), wasm_bytes.clone()));
-    }
-    for (module_name, config) in &bundle.wasm_module_configs {
-        let config_bytes = serde_json::to_vec(config).unwrap_or_default();
-        wasm_parts.push((format!("wasm-config:{module_name}"), config_bytes));
-    }
-    wasm_parts.sort_by(|a, b| a.0.cmp(&b.0));
-
-    let mut content_parts = Vec::new();
-    if let Some(app_guide) = entry.as_ref().and_then(|entry| entry.app_guide.as_ref()) {
-        content_parts.push(("APP.md".to_string(), app_guide.as_bytes().to_vec()));
-    }
-    for agent in &bundle.agents {
-        content_parts.push((
-            format!("agent:{}:content", agent.name),
-            agent.content.as_bytes().to_vec(),
-        ));
-    }
-    for skill in &bundle.skills {
-        content_parts.push((
-            format!(
-                "skill:{}:{}",
-                skill.agent_name.as_deref().unwrap_or("_system"),
-                skill.name
-            ),
-            skill.content.as_bytes().to_vec(),
-        ));
-        for companion in &skill.companion_files {
-            content_parts.push((
-                format!(
-                    "skill-companion:{}:{}:{}",
-                    skill.agent_name.as_deref().unwrap_or("_system"),
-                    skill.name,
-                    companion.name
-                ),
-                companion.content.clone(),
-            ));
-        }
-    }
-    for file in &bundle.system_files {
-        content_parts.push((
-            format!("system:{}", file.relative_path),
-            file.content.clone(),
-        ));
-    }
-    for adr in &bundle.adrs {
-        content_parts.push((
-            format!("adr:{}", adr.file_name),
-            adr.content.as_bytes().to_vec(),
-        ));
-    }
-    content_parts.sort_by(|a, b| a.0.cmp(&b.0));
-
-    let mut seed_parts = Vec::new();
-    for seed in &bundle.seed_instances {
-        seed_parts.push((
-            format!(
-                "seed:{}:{}",
-                seed.entity_type,
-                seed.id.as_deref().unwrap_or("_generated")
-            ),
-            serde_json::to_vec(seed).unwrap_or_default(),
-        ));
-    }
-    seed_parts.sort_by(|a, b| a.0.cmp(&b.0));
-
-    let spec_digest = digest_bytes(
-        &spec_parts
-            .iter()
-            .map(|(name, bytes)| (name.as_str(), bytes.clone()))
-            .collect::<Vec<_>>(),
-    );
-    let policy_digest = digest_bytes(
-        &policy_parts
-            .iter()
-            .map(|(name, bytes)| (name.as_str(), bytes.clone()))
-            .collect::<Vec<_>>(),
-    );
-    let wasm_digest = digest_bytes(
-        &wasm_parts
-            .iter()
-            .map(|(name, bytes)| (name.as_str(), bytes.clone()))
-            .collect::<Vec<_>>(),
-    );
-    let content_digest = digest_bytes(
-        &content_parts
-            .iter()
-            .map(|(name, bytes)| (name.as_str(), bytes.clone()))
-            .collect::<Vec<_>>(),
-    );
-    let seed_digest = digest_bytes(
-        &seed_parts
-            .iter()
-            .map(|(name, bytes)| (name.as_str(), bytes.clone()))
-            .collect::<Vec<_>>(),
-    );
-    let bundle_digest = digest_bytes(&[
-        ("app_name", app_name.as_bytes().to_vec()),
-        ("app_version", app_version.as_bytes().to_vec()),
-        ("spec", spec_digest.as_bytes().to_vec()),
-        ("policy", policy_digest.as_bytes().to_vec()),
-        ("wasm", wasm_digest.as_bytes().to_vec()),
-        ("content", content_digest.as_bytes().to_vec()),
-        ("seed", seed_digest.as_bytes().to_vec()),
-    ]);
-
-    OsAppBundleDigest {
-        app_name: app_name.to_string(),
-        app_version,
-        bundle_digest,
-        spec_digest,
-        policy_digest,
-        wasm_digest,
-        content_digest,
-        seed_digest,
-    }
-}
-
-/// Compute the current bundle digest for an app in the catalog.
-pub fn os_app_bundle_digest(app_name: &str) -> Option<OsAppBundleDigest> {
-    get_os_app(app_name).map(|bundle| digest_app_bundle(app_name, &bundle))
-}
-
-fn tenant_has_ready_app_specs_for_bundle(
-    state: &PlatformState,
-    tenant: &str,
-    bundle: &AppBundle,
-) -> bool {
-    let tenant_id = TenantId::new(tenant);
-    let registry = state.registry.read().unwrap(); // ci-ok: infallible lock
-    bundle.specs.iter().all(|(entity_type, _)| {
-        let has_table = registry.get_table(&tenant_id, entity_type).is_some();
-        let is_ready = matches!(
-            registry.get_verification_status(&tenant_id, entity_type),
-            Some(VerificationStatus::Completed(_) | VerificationStatus::Restored(_))
-        );
-        has_table && is_ready
-    })
-}
-
-async fn record_app_install_metadata(
-    state: &PlatformState,
-    tenant: &str,
-    digest: &OsAppBundleDigest,
-    status: &str,
-) {
-    let Some(ps) = state
-        .server
-        .event_store
-        .as_ref()
-        .and_then(|store| store.platform_store())
-    else {
-        return;
-    };
-
-    let record = InstalledAppRecord {
-        tenant: tenant.to_string(),
-        app_name: digest.app_name.clone(),
-        app_version: digest.app_version.clone(),
-        bundle_digest: digest.bundle_digest.clone(),
-        spec_digest: digest.spec_digest.clone(),
-        policy_digest: digest.policy_digest.clone(),
-        wasm_digest: digest.wasm_digest.clone(),
-        content_digest: digest.content_digest.clone(),
-        seed_digest: digest.seed_digest.clone(),
-        installed_at: None,
-        last_reconciled_at: None,
-        status: status.to_string(),
-    };
-
-    if let Err(error) = ps.record_installed_app_metadata(&record).await {
-        tracing::warn!(
-            tenant,
-            app = %digest.app_name,
-            error = %error,
-            "Failed to persist OS app digest metadata"
-        );
-    }
-}
-
-/// Reconcile one app without recursively processing dependencies.
-///
-/// Callers that need dependencies should first call
-/// [`resolve_os_app_install_order`] and reconcile each returned app once.
-pub async fn reconcile_os_app(
-    state: &PlatformState,
-    tenant: &str,
-    app_name: &str,
-) -> Result<OsAppReconcileResult, String> {
-    let bundle = get_os_app(app_name).ok_or_else(|| format!("OS app '{app_name}' not found"))?;
-    let digest = digest_app_bundle(app_name, &bundle);
-
-    if let Some(ps) = state
-        .server
-        .event_store
-        .as_ref()
-        .and_then(|store| store.platform_store())
-        && let Ok(Some(record)) = ps.get_installed_app(tenant, app_name).await
-        && record.bundle_digest == digest.bundle_digest
-        && tenant_has_ready_app_specs_for_bundle(state, tenant, &bundle)
-    {
-        tracing::info!(
-            tenant,
-            app = %app_name,
-            bundle_digest = %digest.bundle_digest,
-            "OS app unchanged; skipping hot reconcile"
-        );
-        return Ok(OsAppReconcileResult::Skipped {
-            app_name: app_name.to_string(),
-            bundle_digest: digest.bundle_digest,
-        });
-    }
-
-    let install = install_os_app_without_dependencies(state, tenant, app_name).await?;
-    Ok(OsAppReconcileResult::Installed {
-        app_name: app_name.to_string(),
-        bundle_digest: digest.bundle_digest,
-        install,
-    })
-}
-
 /// Install an OS app into a tenant (workspace).
 ///
 /// Reads app files from disk, runs the verification cascade, registers
@@ -1490,10 +1183,7 @@ pub async fn install_os_app(
     tenant: &str,
     app_name: &str,
 ) -> Result<InstallResult, String> {
-    let mut visiting = HashSet::new();
-    let mut visited = HashSet::new();
-    let mut order = Vec::new();
-    collect_install_order(app_name, &mut visiting, &mut visited, &mut order)?;
+    let order = resolve_os_app_install_order(&[app_name.to_string()])?;
 
     let mut final_result = None;
     for app in order {
@@ -1868,8 +1558,7 @@ async fn install_os_app_without_dependencies(
     // ── Step 9: Create seed instances. ───────────────────────────────
     let seed_created = bootstrap_seed_data(state, &tenant_id, tenant, &bundle.seed_instances).await;
 
-    let bundle_digest = digest_app_bundle(app_name, &bundle);
-    record_app_install_metadata(state, tenant, &bundle_digest, "installed").await;
+    reconcile::record_app_install_metadata_for_bundle(state, tenant, app_name, &bundle).await;
 
     Ok(InstallResult {
         added,

--- a/crates/temper-platform/src/os_apps/mod_test.rs
+++ b/crates/temper-platform/src/os_apps/mod_test.rs
@@ -4,6 +4,7 @@ use super::agent_bootstrap::{
 use super::*;
 use std::collections::HashMap;
 use std::fs;
+use std::path::PathBuf;
 use std::time::Duration;
 
 use temper_authz::SecurityContext;
@@ -155,6 +156,70 @@ fn test_list_skills_returns_catalog() {
         evo.app_guide.is_some(),
         "evolution should have an app guide"
     );
+}
+
+#[test]
+fn test_resolve_os_app_install_order_dedupes_shared_dependencies() {
+    let temp = tempfile::tempdir().unwrap();
+
+    for (name, deps) in [
+        ("base", Vec::<&str>::new()),
+        ("left", vec!["base"]),
+        ("right", vec!["base"]),
+        ("top", vec!["left", "right"]),
+    ] {
+        let app_dir = temp.path().join(name);
+        fs::create_dir_all(&app_dir).unwrap();
+        fs::write(
+            app_dir.join("app.toml"),
+            format!(
+                "name = \"{name}\"\ndescription = \"{name}\"\nversion = \"0.1.0\"\ndependencies = [{}]\n",
+                deps.into_iter()
+                    .map(|dep| format!("\"{dep}\""))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        )
+        .unwrap();
+        fs::write(app_dir.join("APP.md"), format!("# {name}\n")).unwrap();
+    }
+
+    set_os_apps_dir(temp.path().to_path_buf());
+    let order = resolve_os_app_install_order(&["top".to_string(), "right".to_string()]).unwrap();
+
+    assert_eq!(order, vec!["base", "left", "right", "top"]);
+    set_os_apps_dir(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../os-apps"));
+}
+
+#[tokio::test]
+async fn test_reconcile_os_app_skips_unchanged_bundle_digest() {
+    let db_path = format!("/tmp/temper-test-digest-{}.db", uuid::Uuid::new_v4());
+    let db_url = format!("file:{db_path}");
+
+    let turso = temper_store_turso::TursoEventStore::new(&db_url, None)
+        .await
+        .unwrap();
+    let mut state = PlatformState::new(None);
+    state.server.event_store = Some(std::sync::Arc::new(
+        temper_server::event_store::ServerEventStore::Turso(turso),
+    ));
+
+    install_skill(&state, "test-digest", "project-management")
+        .await
+        .expect("initial install should succeed");
+
+    let result = reconcile_os_app(&state, "test-digest", "project-management")
+        .await
+        .expect("unchanged reconcile should succeed");
+
+    assert!(
+        matches!(result, OsAppReconcileResult::Skipped { .. }),
+        "unchanged app should skip hot reinstall, got {result:?}"
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(format!("{db_path}-wal"));
+    let _ = std::fs::remove_file(format!("{db_path}-shm"));
 }
 
 #[test]

--- a/crates/temper-platform/src/os_apps/reconcile.rs
+++ b/crates/temper-platform/src/os_apps/reconcile.rs
@@ -307,6 +307,6 @@ pub async fn reconcile_os_app(
     Ok(OsAppReconcileResult::Installed {
         app_name: app_name.to_string(),
         bundle_digest: digest.bundle_digest,
-        install,
+        install: Box::new(install),
     })
 }

--- a/crates/temper-platform/src/os_apps/reconcile.rs
+++ b/crates/temper-platform/src/os_apps/reconcile.rs
@@ -1,0 +1,312 @@
+use std::collections::HashSet;
+
+use sha2::{Digest, Sha256};
+use temper_runtime::tenant::TenantId;
+use temper_server::platform_store::InstalledAppRecord;
+use temper_server::registry::VerificationStatus;
+
+use super::{
+    AppBundle, AppEntry, OsAppBundleDigest, OsAppReconcileResult, catalog, get_os_app,
+    install_os_app_without_dependencies, os_app_dependencies,
+};
+use crate::state::PlatformState;
+
+pub(super) fn collect_install_order(
+    app_name: &str,
+    visiting: &mut HashSet<String>,
+    visited: &mut HashSet<String>,
+    order: &mut Vec<String>,
+) -> Result<(), String> {
+    if visited.contains(app_name) {
+        return Ok(());
+    }
+    if !visiting.insert(app_name.to_string()) {
+        return Err(format!("Cyclic OS app dependency detected at '{app_name}'"));
+    }
+    for dependency in os_app_dependencies(app_name) {
+        collect_install_order(&dependency, visiting, visited, order)?;
+    }
+    visiting.remove(app_name);
+    visited.insert(app_name.to_string());
+    order.push(app_name.to_string());
+    Ok(())
+}
+
+/// Resolve a deduplicated dependency-first install order for a set of apps.
+pub fn resolve_os_app_install_order(app_names: &[String]) -> Result<Vec<String>, String> {
+    let mut visiting = HashSet::new();
+    let mut visited = HashSet::new();
+    let mut order = Vec::new();
+    for app_name in app_names {
+        collect_install_order(app_name, &mut visiting, &mut visited, &mut order)?;
+    }
+    Ok(order)
+}
+
+fn app_entry(app_name: &str) -> Option<AppEntry> {
+    let cat = catalog().read().expect("OS app catalog lock poisoned");
+    cat.entries
+        .iter()
+        .find(|entry| entry.name == app_name)
+        .cloned()
+}
+
+fn digest_bytes(parts: &[(&str, Vec<u8>)]) -> String {
+    let mut hasher = Sha256::new();
+    for (name, bytes) in parts {
+        hasher.update(name.as_bytes());
+        hasher.update([0]);
+        hasher.update(bytes);
+        hasher.update([0xff]);
+    }
+    format!("sha256:{:x}", hasher.finalize())
+}
+
+fn digest_named_parts(parts: &[(String, Vec<u8>)]) -> String {
+    let parts = parts
+        .iter()
+        .map(|(name, bytes)| (name.as_str(), bytes.clone()))
+        .collect::<Vec<_>>();
+    digest_bytes(&parts)
+}
+
+fn digest_app_bundle(app_name: &str, bundle: &AppBundle) -> OsAppBundleDigest {
+    let entry = app_entry(app_name);
+    let app_version = entry
+        .as_ref()
+        .map(|entry| entry.version.clone())
+        .unwrap_or_else(|| "0.1.0".to_string());
+
+    let mut spec_parts = Vec::new();
+    for (entity_type, ioa_source) in &bundle.specs {
+        spec_parts.push((
+            format!("spec:{entity_type}"),
+            ioa_source.as_bytes().to_vec(),
+        ));
+    }
+    if let Some(csdl) = &bundle.csdl {
+        spec_parts.push(("csdl".to_string(), csdl.as_bytes().to_vec()));
+    }
+    if let Some(cross_invariants) = &bundle.cross_invariants_toml {
+        spec_parts.push((
+            "cross-invariants".to_string(),
+            cross_invariants.as_bytes().to_vec(),
+        ));
+    }
+    spec_parts.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut policy_parts: Vec<(String, Vec<u8>)> = bundle
+        .cedar_policies
+        .iter()
+        .enumerate()
+        .map(|(idx, policy)| (format!("policy:{idx}"), policy.as_bytes().to_vec()))
+        .collect();
+    policy_parts.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut wasm_parts = Vec::new();
+    for (module_name, wasm_bytes) in &bundle.wasm_modules {
+        wasm_parts.push((format!("wasm:{module_name}"), wasm_bytes.clone()));
+    }
+    for (module_name, config) in &bundle.wasm_module_configs {
+        let config_bytes = serde_json::to_vec(config).unwrap_or_default();
+        wasm_parts.push((format!("wasm-config:{module_name}"), config_bytes));
+    }
+    wasm_parts.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut content_parts = Vec::new();
+    if let Some(app_guide) = entry.as_ref().and_then(|entry| entry.app_guide.as_ref()) {
+        content_parts.push(("APP.md".to_string(), app_guide.as_bytes().to_vec()));
+    }
+    for agent in &bundle.agents {
+        content_parts.push((
+            format!("agent:{}:content", agent.name),
+            agent.content.as_bytes().to_vec(),
+        ));
+    }
+    for skill in &bundle.skills {
+        content_parts.push((
+            format!(
+                "skill:{}:{}",
+                skill.agent_name.as_deref().unwrap_or("_system"),
+                skill.name
+            ),
+            skill.content.as_bytes().to_vec(),
+        ));
+        for companion in &skill.companion_files {
+            content_parts.push((
+                format!(
+                    "skill-companion:{}:{}:{}",
+                    skill.agent_name.as_deref().unwrap_or("_system"),
+                    skill.name,
+                    companion.name
+                ),
+                companion.content.clone(),
+            ));
+        }
+    }
+    for file in &bundle.system_files {
+        content_parts.push((
+            format!("system:{}", file.relative_path),
+            file.content.clone(),
+        ));
+    }
+    for adr in &bundle.adrs {
+        content_parts.push((
+            format!("adr:{}", adr.file_name),
+            adr.content.as_bytes().to_vec(),
+        ));
+    }
+    content_parts.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut seed_parts = Vec::new();
+    for seed in &bundle.seed_instances {
+        seed_parts.push((
+            format!(
+                "seed:{}:{}",
+                seed.entity_type,
+                seed.id.as_deref().unwrap_or("_generated")
+            ),
+            serde_json::to_vec(seed).unwrap_or_default(),
+        ));
+    }
+    seed_parts.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let spec_digest = digest_named_parts(&spec_parts);
+    let policy_digest = digest_named_parts(&policy_parts);
+    let wasm_digest = digest_named_parts(&wasm_parts);
+    let content_digest = digest_named_parts(&content_parts);
+    let seed_digest = digest_named_parts(&seed_parts);
+    let bundle_digest = digest_bytes(&[
+        ("app_name", app_name.as_bytes().to_vec()),
+        ("app_version", app_version.as_bytes().to_vec()),
+        ("spec", spec_digest.as_bytes().to_vec()),
+        ("policy", policy_digest.as_bytes().to_vec()),
+        ("wasm", wasm_digest.as_bytes().to_vec()),
+        ("content", content_digest.as_bytes().to_vec()),
+        ("seed", seed_digest.as_bytes().to_vec()),
+    ]);
+
+    OsAppBundleDigest {
+        app_name: app_name.to_string(),
+        app_version,
+        bundle_digest,
+        spec_digest,
+        policy_digest,
+        wasm_digest,
+        content_digest,
+        seed_digest,
+    }
+}
+
+/// Compute the current bundle digest for an app in the catalog.
+pub fn os_app_bundle_digest(app_name: &str) -> Option<OsAppBundleDigest> {
+    get_os_app(app_name).map(|bundle| digest_app_bundle(app_name, &bundle))
+}
+
+fn tenant_has_ready_app_specs_for_bundle(
+    state: &PlatformState,
+    tenant: &str,
+    bundle: &AppBundle,
+) -> bool {
+    let tenant_id = TenantId::new(tenant);
+    let registry = state.registry.read().expect("Spec registry lock poisoned");
+    bundle.specs.iter().all(|(entity_type, _)| {
+        let has_table = registry.get_table(&tenant_id, entity_type).is_some();
+        let is_ready = matches!(
+            registry.get_verification_status(&tenant_id, entity_type),
+            Some(VerificationStatus::Completed(_) | VerificationStatus::Restored(_))
+        );
+        has_table && is_ready
+    })
+}
+
+async fn record_app_install_metadata(
+    state: &PlatformState,
+    tenant: &str,
+    digest: &OsAppBundleDigest,
+    status: &str,
+) {
+    let Some(ps) = state
+        .server
+        .event_store
+        .as_ref()
+        .and_then(|store| store.platform_store())
+    else {
+        return;
+    };
+
+    let record = InstalledAppRecord {
+        tenant: tenant.to_string(),
+        app_name: digest.app_name.clone(),
+        app_version: digest.app_version.clone(),
+        bundle_digest: digest.bundle_digest.clone(),
+        spec_digest: digest.spec_digest.clone(),
+        policy_digest: digest.policy_digest.clone(),
+        wasm_digest: digest.wasm_digest.clone(),
+        content_digest: digest.content_digest.clone(),
+        seed_digest: digest.seed_digest.clone(),
+        installed_at: None,
+        last_reconciled_at: None,
+        status: status.to_string(),
+    };
+
+    if let Err(error) = ps.record_installed_app_metadata(&record).await {
+        tracing::warn!(
+            tenant,
+            app = %digest.app_name,
+            error = %error,
+            "Failed to persist OS app digest metadata"
+        );
+    }
+}
+
+pub(super) async fn record_app_install_metadata_for_bundle(
+    state: &PlatformState,
+    tenant: &str,
+    app_name: &str,
+    bundle: &AppBundle,
+) {
+    let bundle_digest = digest_app_bundle(app_name, bundle);
+    record_app_install_metadata(state, tenant, &bundle_digest, "installed").await;
+}
+
+/// Reconcile one app without recursively processing dependencies.
+///
+/// Callers that need dependencies should first call
+/// [`resolve_os_app_install_order`] and reconcile each returned app once.
+pub async fn reconcile_os_app(
+    state: &PlatformState,
+    tenant: &str,
+    app_name: &str,
+) -> Result<OsAppReconcileResult, String> {
+    let bundle = get_os_app(app_name).ok_or_else(|| format!("OS app '{app_name}' not found"))?;
+    let digest = digest_app_bundle(app_name, &bundle);
+
+    if let Some(ps) = state
+        .server
+        .event_store
+        .as_ref()
+        .and_then(|store| store.platform_store())
+        && let Ok(Some(record)) = ps.get_installed_app(tenant, app_name).await
+        && record.bundle_digest == digest.bundle_digest
+        && tenant_has_ready_app_specs_for_bundle(state, tenant, &bundle)
+    {
+        tracing::info!(
+            tenant,
+            app = %app_name,
+            bundle_digest = %digest.bundle_digest,
+            "OS app unchanged; skipping hot reconcile"
+        );
+        return Ok(OsAppReconcileResult::Skipped {
+            app_name: app_name.to_string(),
+            bundle_digest: digest.bundle_digest,
+        });
+    }
+
+    let install = install_os_app_without_dependencies(state, tenant, app_name).await?;
+    Ok(OsAppReconcileResult::Installed {
+        app_name: app_name.to_string(),
+        bundle_digest: digest.bundle_digest,
+        install,
+    })
+}

--- a/crates/temper-platform/src/os_apps/types.rs
+++ b/crates/temper-platform/src/os_apps/types.rs
@@ -37,6 +37,34 @@ pub struct InstallResult {
     pub seed_instances: Vec<String>,
 }
 
+/// Stable digest breakdown for an OS app bundle.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct OsAppBundleDigest {
+    pub app_name: String,
+    pub app_version: String,
+    pub bundle_digest: String,
+    pub spec_digest: String,
+    pub policy_digest: String,
+    pub wasm_digest: String,
+    pub content_digest: String,
+    pub seed_digest: String,
+}
+
+/// Outcome of digest-aware app reconcile.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(tag = "result", rename_all = "snake_case")]
+pub enum OsAppReconcileResult {
+    Skipped {
+        app_name: String,
+        bundle_digest: String,
+    },
+    Installed {
+        app_name: String,
+        bundle_digest: String,
+        install: InstallResult,
+    },
+}
+
 /// Parsed app.toml manifest.
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct AppManifest {

--- a/crates/temper-platform/src/os_apps/types.rs
+++ b/crates/temper-platform/src/os_apps/types.rs
@@ -61,7 +61,7 @@ pub enum OsAppReconcileResult {
     Installed {
         app_name: String,
         bundle_digest: String,
-        install: InstallResult,
+        install: Box<InstallResult>,
     },
 }
 

--- a/crates/temper-server/src/platform_store.rs
+++ b/crates/temper-server/src/platform_store.rs
@@ -57,6 +57,23 @@ pub struct WasmModuleRow {
     pub sha256_hash: String,
 }
 
+/// Durable metadata for an installed OS app bundle.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct InstalledAppRecord {
+    pub tenant: String,
+    pub app_name: String,
+    pub app_version: String,
+    pub bundle_digest: String,
+    pub spec_digest: String,
+    pub policy_digest: String,
+    pub wasm_digest: String,
+    pub content_digest: String,
+    pub seed_digest: String,
+    pub installed_at: Option<String>,
+    pub last_reconciled_at: Option<String>,
+    pub status: String,
+}
+
 // ---------------------------------------------------------------------------
 // Trait
 // ---------------------------------------------------------------------------
@@ -130,6 +147,19 @@ pub trait PlatformStore: Send + Sync {
 
     /// Record that an OS app was installed in a tenant.
     async fn record_installed_app(&self, tenant: &str, app_name: &str) -> Result<(), String>;
+
+    /// Record digest metadata for an installed OS app bundle.
+    async fn record_installed_app_metadata(
+        &self,
+        record: &InstalledAppRecord,
+    ) -> Result<(), String>;
+
+    /// Load digest metadata for an installed OS app bundle.
+    async fn get_installed_app(
+        &self,
+        tenant: &str,
+        app_name: &str,
+    ) -> Result<Option<InstalledAppRecord>, String>;
 
     /// List all installed apps across all tenants (for boot + UI).
     async fn list_all_installed_apps(&self) -> Result<Vec<(String, String)>, String>;
@@ -273,6 +303,52 @@ impl PlatformStore for TursoEventStore {
     async fn record_installed_app(&self, tenant: &str, app_name: &str) -> Result<(), String> {
         self.record_installed_app(tenant, app_name)
             .await
+            .map_err(|e| e.to_string())
+    }
+
+    async fn record_installed_app_metadata(
+        &self,
+        record: &InstalledAppRecord,
+    ) -> Result<(), String> {
+        self.record_installed_app_metadata(
+            &record.tenant,
+            &record.app_name,
+            &record.app_version,
+            &record.bundle_digest,
+            &record.spec_digest,
+            &record.policy_digest,
+            &record.wasm_digest,
+            &record.content_digest,
+            &record.seed_digest,
+            &record.status,
+        )
+        .await
+        .map_err(|e| e.to_string())
+    }
+
+    async fn get_installed_app(
+        &self,
+        tenant: &str,
+        app_name: &str,
+    ) -> Result<Option<InstalledAppRecord>, String> {
+        self.get_installed_app(tenant, app_name)
+            .await
+            .map(|row| {
+                row.map(|row| InstalledAppRecord {
+                    tenant: row.tenant_id,
+                    app_name: row.app_name,
+                    app_version: row.app_version,
+                    bundle_digest: row.bundle_digest,
+                    spec_digest: row.spec_digest,
+                    policy_digest: row.policy_digest,
+                    wasm_digest: row.wasm_digest,
+                    content_digest: row.content_digest,
+                    seed_digest: row.seed_digest,
+                    installed_at: Some(row.installed_at),
+                    last_reconciled_at: row.last_reconciled_at,
+                    status: row.status,
+                })
+            })
             .map_err(|e| e.to_string())
     }
 
@@ -454,6 +530,8 @@ mod sim_platform_store {
         constraints: BTreeMap<String, String>,
         /// Installed apps: (tenant, app_name).
         installed_apps: BTreeSet<(String, String)>,
+        /// Installed app digest metadata keyed by (tenant, app_name).
+        installed_app_records: BTreeMap<(String, String), InstalledAppRecord>,
         /// Pending decisions: id -> JSON data.
         pending_decisions: BTreeMap<String, (String, String, String)>,
         /// WASM modules keyed by (tenant, module_name).
@@ -472,6 +550,7 @@ mod sim_platform_store {
                     policies: BTreeMap::new(),
                     constraints: BTreeMap::new(),
                     installed_apps: BTreeSet::new(),
+                    installed_app_records: BTreeMap::new(),
                     pending_decisions: BTreeMap::new(),
                     wasm_modules: BTreeMap::new(),
                 })),
@@ -706,6 +785,41 @@ mod sim_platform_store {
                 .installed_apps
                 .insert((tenant.to_string(), app_name.to_string()));
             Ok(())
+        }
+
+        async fn record_installed_app_metadata(
+            &self,
+            record: &InstalledAppRecord,
+        ) -> Result<(), String> {
+            let mut inner = self.inner.lock().expect("SimPlatformStore lock poisoned"); // ci-ok: infallible lock
+
+            let prob = inner.faults.app_record_failure_prob;
+            if inner.rng.chance(prob) {
+                return Err("SimPlatformStore: injected app metadata record failure".into());
+            }
+
+            let key = (record.tenant.clone(), record.app_name.clone());
+            inner.installed_apps.insert(key.clone());
+            inner.installed_app_records.insert(key, record.clone());
+            Ok(())
+        }
+
+        async fn get_installed_app(
+            &self,
+            tenant: &str,
+            app_name: &str,
+        ) -> Result<Option<InstalledAppRecord>, String> {
+            let mut inner = self.inner.lock().expect("SimPlatformStore lock poisoned"); // ci-ok: infallible lock
+
+            let prob = inner.faults.app_list_failure_prob;
+            if inner.rng.chance(prob) {
+                return Err("SimPlatformStore: injected app metadata read failure".into());
+            }
+
+            Ok(inner
+                .installed_app_records
+                .get(&(tenant.to_string(), app_name.to_string()))
+                .cloned())
         }
 
         async fn list_all_installed_apps(&self) -> Result<Vec<(String, String)>, String> {

--- a/crates/temper-server/src/platform_store.rs
+++ b/crates/temper-server/src/platform_store.rs
@@ -200,7 +200,7 @@ pub trait PlatformStore: Send + Sync {
 // TursoEventStore implementation
 // ---------------------------------------------------------------------------
 
-use temper_store_turso::{TursoEventStore, TursoSpecVerificationUpdate};
+use temper_store_turso::{TursoEventStore, TursoInstalledAppRow, TursoSpecVerificationUpdate};
 
 #[async_trait::async_trait]
 impl PlatformStore for TursoEventStore {
@@ -310,20 +310,23 @@ impl PlatformStore for TursoEventStore {
         &self,
         record: &InstalledAppRecord,
     ) -> Result<(), String> {
-        self.record_installed_app_metadata(
-            &record.tenant,
-            &record.app_name,
-            &record.app_version,
-            &record.bundle_digest,
-            &record.spec_digest,
-            &record.policy_digest,
-            &record.wasm_digest,
-            &record.content_digest,
-            &record.seed_digest,
-            &record.status,
-        )
-        .await
-        .map_err(|e| e.to_string())
+        let row = TursoInstalledAppRow {
+            tenant_id: record.tenant.clone(),
+            app_name: record.app_name.clone(),
+            app_version: record.app_version.clone(),
+            bundle_digest: record.bundle_digest.clone(),
+            spec_digest: record.spec_digest.clone(),
+            policy_digest: record.policy_digest.clone(),
+            wasm_digest: record.wasm_digest.clone(),
+            content_digest: record.content_digest.clone(),
+            seed_digest: record.seed_digest.clone(),
+            installed_at: record.installed_at.clone().unwrap_or_default(),
+            last_reconciled_at: record.last_reconciled_at.clone(),
+            status: record.status.clone(),
+        };
+        self.record_installed_app_metadata(&row)
+            .await
+            .map_err(|e| e.to_string())
     }
 
     async fn get_installed_app(

--- a/crates/temper-server/src/trigger/resolver.rs
+++ b/crates/temper-server/src/trigger/resolver.rs
@@ -24,12 +24,14 @@ pub(crate) fn resolve_target_id(
         TargetResolver::Field { field } => fields
             .get(field)
             .and_then(|v| v.as_str())
+            .filter(|value| !value.is_empty())
             .map(|s| s.to_string()),
         TargetResolver::SameId => Some(source_entity_id.to_string()),
         TargetResolver::Static { entity_id } => Some(entity_id.clone()),
         TargetResolver::CreateIfMissing { id_field } => fields
             .get(id_field)
             .and_then(|v| v.as_str())
+            .filter(|value| !value.is_empty())
             .map(|s| s.to_string())
             .or_else(|| Some(format!("{source_entity_id}-derived"))),
         // Fresh UUID on every dispatch. `sim_uuid()` is DST-safe: in
@@ -63,6 +65,17 @@ mod tests {
             field: "missing".to_string(),
         };
         assert_eq!(resolve_target_id(&resolver, "src-1", &json!({})), None);
+    }
+
+    #[test]
+    fn field_resolver_returns_none_when_field_is_empty() {
+        let resolver = TargetResolver::Field {
+            field: "workspace_id".to_string(),
+        };
+        assert_eq!(
+            resolve_target_id(&resolver, "src-1", &json!({"workspace_id": ""})),
+            None
+        );
     }
 
     #[test]

--- a/crates/temper-store-turso/src/lib.rs
+++ b/crates/temper-store-turso/src/lib.rs
@@ -72,8 +72,8 @@ pub use metrics::init_metrics;
 pub use router::{TenantRegistryRow, TenantStoreRouter, TenantUserRow};
 pub use store::{
     ActionStats, AgentSummary, DesignTimeEventRow, EvolutionRecordRow, FeatureRequestRow,
-    PolicyDenialPatternRow, PolicyRow, TursoEventStore, TursoSpecRow, TursoTenantConstraintRow,
-    TursoTrajectoryRow, TursoWasmInvocationRow, TursoWasmModuleMetadataRow, TursoWasmModuleRow,
-    UnmetIntentAggRow,
+    PolicyDenialPatternRow, PolicyRow, TursoEventStore, TursoInstalledAppRow, TursoSpecRow,
+    TursoTenantConstraintRow, TursoTrajectoryRow, TursoWasmInvocationRow,
+    TursoWasmModuleMetadataRow, TursoWasmModuleRow, UnmetIntentAggRow,
     ots::{OtsTrajectoryParams, OtsTrajectoryRow},
 };

--- a/crates/temper-store-turso/src/schema.rs
+++ b/crates/temper-store-turso/src/schema.rs
@@ -209,46 +209,8 @@ pub const CREATE_POLICY_DENIAL_PATTERNS_TENANT_INDEX: &str = "\
 CREATE INDEX IF NOT EXISTS idx_policy_denial_patterns_tenant
     ON policy_denial_patterns(tenant, last_seen DESC);";
 
-/// Tracks which OS apps are installed per tenant (workspace).
-///
-/// On boot, `restore_registry_from_turso()` reads the `specs` table to reload
-/// entity types. This table provides metadata for the UI ("Installed" badge)
-/// and future re-install logic.
-pub const CREATE_TENANT_INSTALLED_APPS_TABLE: &str = "\
-CREATE TABLE IF NOT EXISTS tenant_installed_apps (
-    tenant_id TEXT NOT NULL,
-    app_name TEXT NOT NULL,
-    app_version TEXT NOT NULL DEFAULT '',
-    bundle_digest TEXT NOT NULL DEFAULT '',
-    spec_digest TEXT NOT NULL DEFAULT '',
-    policy_digest TEXT NOT NULL DEFAULT '',
-    wasm_digest TEXT NOT NULL DEFAULT '',
-    content_digest TEXT NOT NULL DEFAULT '',
-    seed_digest TEXT NOT NULL DEFAULT '',
-    installed_at TEXT NOT NULL DEFAULT (datetime('now')),
-    last_reconciled_at TEXT,
-    status TEXT NOT NULL DEFAULT 'installed',
-    PRIMARY KEY (tenant_id, app_name)
-);";
-
-pub const ALTER_INSTALLED_APPS_ADD_APP_VERSION: &str =
-    "ALTER TABLE tenant_installed_apps ADD COLUMN app_version TEXT NOT NULL DEFAULT ''";
-pub const ALTER_INSTALLED_APPS_ADD_BUNDLE_DIGEST: &str =
-    "ALTER TABLE tenant_installed_apps ADD COLUMN bundle_digest TEXT NOT NULL DEFAULT ''";
-pub const ALTER_INSTALLED_APPS_ADD_SPEC_DIGEST: &str =
-    "ALTER TABLE tenant_installed_apps ADD COLUMN spec_digest TEXT NOT NULL DEFAULT ''";
-pub const ALTER_INSTALLED_APPS_ADD_POLICY_DIGEST: &str =
-    "ALTER TABLE tenant_installed_apps ADD COLUMN policy_digest TEXT NOT NULL DEFAULT ''";
-pub const ALTER_INSTALLED_APPS_ADD_WASM_DIGEST: &str =
-    "ALTER TABLE tenant_installed_apps ADD COLUMN wasm_digest TEXT NOT NULL DEFAULT ''";
-pub const ALTER_INSTALLED_APPS_ADD_CONTENT_DIGEST: &str =
-    "ALTER TABLE tenant_installed_apps ADD COLUMN content_digest TEXT NOT NULL DEFAULT ''";
-pub const ALTER_INSTALLED_APPS_ADD_SEED_DIGEST: &str =
-    "ALTER TABLE tenant_installed_apps ADD COLUMN seed_digest TEXT NOT NULL DEFAULT ''";
-pub const ALTER_INSTALLED_APPS_ADD_LAST_RECONCILED_AT: &str =
-    "ALTER TABLE tenant_installed_apps ADD COLUMN last_reconciled_at TEXT";
-pub const ALTER_INSTALLED_APPS_ADD_STATUS: &str =
-    "ALTER TABLE tenant_installed_apps ADD COLUMN status TEXT NOT NULL DEFAULT 'installed'";
+mod installed_apps;
+pub use installed_apps::*;
 
 // ---------------------------------------------------------------------------
 // Phase 0: Turso as single source of truth — new tables + trajectory extensions

--- a/crates/temper-store-turso/src/schema.rs
+++ b/crates/temper-store-turso/src/schema.rs
@@ -218,9 +218,37 @@ pub const CREATE_TENANT_INSTALLED_APPS_TABLE: &str = "\
 CREATE TABLE IF NOT EXISTS tenant_installed_apps (
     tenant_id TEXT NOT NULL,
     app_name TEXT NOT NULL,
+    app_version TEXT NOT NULL DEFAULT '',
+    bundle_digest TEXT NOT NULL DEFAULT '',
+    spec_digest TEXT NOT NULL DEFAULT '',
+    policy_digest TEXT NOT NULL DEFAULT '',
+    wasm_digest TEXT NOT NULL DEFAULT '',
+    content_digest TEXT NOT NULL DEFAULT '',
+    seed_digest TEXT NOT NULL DEFAULT '',
     installed_at TEXT NOT NULL DEFAULT (datetime('now')),
+    last_reconciled_at TEXT,
+    status TEXT NOT NULL DEFAULT 'installed',
     PRIMARY KEY (tenant_id, app_name)
 );";
+
+pub const ALTER_INSTALLED_APPS_ADD_APP_VERSION: &str =
+    "ALTER TABLE tenant_installed_apps ADD COLUMN app_version TEXT NOT NULL DEFAULT ''";
+pub const ALTER_INSTALLED_APPS_ADD_BUNDLE_DIGEST: &str =
+    "ALTER TABLE tenant_installed_apps ADD COLUMN bundle_digest TEXT NOT NULL DEFAULT ''";
+pub const ALTER_INSTALLED_APPS_ADD_SPEC_DIGEST: &str =
+    "ALTER TABLE tenant_installed_apps ADD COLUMN spec_digest TEXT NOT NULL DEFAULT ''";
+pub const ALTER_INSTALLED_APPS_ADD_POLICY_DIGEST: &str =
+    "ALTER TABLE tenant_installed_apps ADD COLUMN policy_digest TEXT NOT NULL DEFAULT ''";
+pub const ALTER_INSTALLED_APPS_ADD_WASM_DIGEST: &str =
+    "ALTER TABLE tenant_installed_apps ADD COLUMN wasm_digest TEXT NOT NULL DEFAULT ''";
+pub const ALTER_INSTALLED_APPS_ADD_CONTENT_DIGEST: &str =
+    "ALTER TABLE tenant_installed_apps ADD COLUMN content_digest TEXT NOT NULL DEFAULT ''";
+pub const ALTER_INSTALLED_APPS_ADD_SEED_DIGEST: &str =
+    "ALTER TABLE tenant_installed_apps ADD COLUMN seed_digest TEXT NOT NULL DEFAULT ''";
+pub const ALTER_INSTALLED_APPS_ADD_LAST_RECONCILED_AT: &str =
+    "ALTER TABLE tenant_installed_apps ADD COLUMN last_reconciled_at TEXT";
+pub const ALTER_INSTALLED_APPS_ADD_STATUS: &str =
+    "ALTER TABLE tenant_installed_apps ADD COLUMN status TEXT NOT NULL DEFAULT 'installed'";
 
 // ---------------------------------------------------------------------------
 // Phase 0: Turso as single source of truth — new tables + trajectory extensions

--- a/crates/temper-store-turso/src/schema/installed_apps.rs
+++ b/crates/temper-store-turso/src/schema/installed_apps.rs
@@ -1,0 +1,33 @@
+/// Tracks which OS apps are installed per tenant (workspace).
+///
+/// On boot, `restore_registry_from_turso()` reads the `specs` table to reload
+/// entity types. This table provides durable metadata for bounded reconcile.
+pub const CREATE_TENANT_INSTALLED_APPS_TABLE: &str = "\
+CREATE TABLE IF NOT EXISTS tenant_installed_apps (
+    tenant_id TEXT NOT NULL, app_name TEXT NOT NULL, app_version TEXT NOT NULL DEFAULT '',
+    bundle_digest TEXT NOT NULL DEFAULT '', spec_digest TEXT NOT NULL DEFAULT '',
+    policy_digest TEXT NOT NULL DEFAULT '', wasm_digest TEXT NOT NULL DEFAULT '',
+    content_digest TEXT NOT NULL DEFAULT '', seed_digest TEXT NOT NULL DEFAULT '',
+    installed_at TEXT NOT NULL DEFAULT (datetime('now')),
+    last_reconciled_at TEXT, status TEXT NOT NULL DEFAULT 'installed',
+    PRIMARY KEY (tenant_id, app_name)
+);";
+
+pub const ALTER_INSTALLED_APPS_ADD_APP_VERSION: &str =
+    "ALTER TABLE tenant_installed_apps ADD COLUMN app_version TEXT NOT NULL DEFAULT ''";
+pub const ALTER_INSTALLED_APPS_ADD_BUNDLE_DIGEST: &str =
+    "ALTER TABLE tenant_installed_apps ADD COLUMN bundle_digest TEXT NOT NULL DEFAULT ''";
+pub const ALTER_INSTALLED_APPS_ADD_SPEC_DIGEST: &str =
+    "ALTER TABLE tenant_installed_apps ADD COLUMN spec_digest TEXT NOT NULL DEFAULT ''";
+pub const ALTER_INSTALLED_APPS_ADD_POLICY_DIGEST: &str =
+    "ALTER TABLE tenant_installed_apps ADD COLUMN policy_digest TEXT NOT NULL DEFAULT ''";
+pub const ALTER_INSTALLED_APPS_ADD_WASM_DIGEST: &str =
+    "ALTER TABLE tenant_installed_apps ADD COLUMN wasm_digest TEXT NOT NULL DEFAULT ''";
+pub const ALTER_INSTALLED_APPS_ADD_CONTENT_DIGEST: &str =
+    "ALTER TABLE tenant_installed_apps ADD COLUMN content_digest TEXT NOT NULL DEFAULT ''";
+pub const ALTER_INSTALLED_APPS_ADD_SEED_DIGEST: &str =
+    "ALTER TABLE tenant_installed_apps ADD COLUMN seed_digest TEXT NOT NULL DEFAULT ''";
+pub const ALTER_INSTALLED_APPS_ADD_LAST_RECONCILED_AT: &str =
+    "ALTER TABLE tenant_installed_apps ADD COLUMN last_reconciled_at TEXT";
+pub const ALTER_INSTALLED_APPS_ADD_STATUS: &str =
+    "ALTER TABLE tenant_installed_apps ADD COLUMN status TEXT NOT NULL DEFAULT 'installed'";

--- a/crates/temper-store-turso/src/store/mod.rs
+++ b/crates/temper-store-turso/src/store/mod.rs
@@ -177,6 +177,19 @@ impl TursoEventStore {
         conn.execute(schema::CREATE_TENANT_INSTALLED_APPS_TABLE, ())
             .await
             .map_err(storage_error)?;
+        for stmt in &[
+            schema::ALTER_INSTALLED_APPS_ADD_APP_VERSION,
+            schema::ALTER_INSTALLED_APPS_ADD_BUNDLE_DIGEST,
+            schema::ALTER_INSTALLED_APPS_ADD_SPEC_DIGEST,
+            schema::ALTER_INSTALLED_APPS_ADD_POLICY_DIGEST,
+            schema::ALTER_INSTALLED_APPS_ADD_WASM_DIGEST,
+            schema::ALTER_INSTALLED_APPS_ADD_CONTENT_DIGEST,
+            schema::ALTER_INSTALLED_APPS_ADD_SEED_DIGEST,
+            schema::ALTER_INSTALLED_APPS_ADD_LAST_RECONCILED_AT,
+            schema::ALTER_INSTALLED_APPS_ADD_STATUS,
+        ] {
+            let _ = conn.execute(*stmt, ()).await;
+        }
 
         // Phase 0: New tables for Turso-as-single-source-of-truth.
         conn.execute(schema::CREATE_FEATURE_REQUESTS_TABLE, ())
@@ -360,6 +373,23 @@ pub struct TursoSpecRow {
     pub updated_at: String,
     /// Whether this spec has been committed (WAL-style commit flag).
     pub committed: bool,
+}
+
+/// Row returned by installed OS app metadata queries.
+#[derive(Debug, Clone)]
+pub struct TursoInstalledAppRow {
+    pub tenant_id: String,
+    pub app_name: String,
+    pub app_version: String,
+    pub bundle_digest: String,
+    pub spec_digest: String,
+    pub policy_digest: String,
+    pub wasm_digest: String,
+    pub content_digest: String,
+    pub seed_digest: String,
+    pub installed_at: String,
+    pub last_reconciled_at: Option<String>,
+    pub status: String,
 }
 
 /// Row returned by trajectory queries.

--- a/crates/temper-store-turso/src/store/mod.rs
+++ b/crates/temper-store-turso/src/store/mod.rs
@@ -177,7 +177,7 @@ impl TursoEventStore {
         conn.execute(schema::CREATE_TENANT_INSTALLED_APPS_TABLE, ())
             .await
             .map_err(storage_error)?;
-        for stmt in &[
+        for stmt in [
             schema::ALTER_INSTALLED_APPS_ADD_APP_VERSION,
             schema::ALTER_INSTALLED_APPS_ADD_BUNDLE_DIGEST,
             schema::ALTER_INSTALLED_APPS_ADD_SPEC_DIGEST,
@@ -188,7 +188,7 @@ impl TursoEventStore {
             schema::ALTER_INSTALLED_APPS_ADD_LAST_RECONCILED_AT,
             schema::ALTER_INSTALLED_APPS_ADD_STATUS,
         ] {
-            let _ = conn.execute(*stmt, ()).await;
+            let _ = conn.execute(stmt, ()).await;
         }
 
         // Phase 0: New tables for Turso-as-single-source-of-truth.

--- a/crates/temper-store-turso/src/store/specs.rs
+++ b/crates/temper-store-turso/src/store/specs.rs
@@ -4,7 +4,7 @@ use libsql::{TransactionBehavior, params};
 use temper_runtime::persistence::{PersistenceError, storage_error};
 use tracing::instrument;
 
-use super::{TursoEventStore, TursoSpecRow};
+use super::{TursoEventStore, TursoInstalledAppRow, TursoSpecRow};
 use crate::TursoSpecVerificationUpdate;
 use crate::metrics::TursoQueryTimer;
 
@@ -240,6 +240,101 @@ impl TursoEventStore {
         .await
         .map_err(storage_error)?;
         Ok(())
+    }
+
+    /// Record or update digest metadata for an installed OS app.
+    #[allow(clippy::too_many_arguments)]
+    #[instrument(skip_all, fields(tenant_id, app_name, otel.name = "turso.record_installed_app_metadata"))]
+    pub async fn record_installed_app_metadata(
+        &self,
+        tenant_id: &str,
+        app_name: &str,
+        app_version: &str,
+        bundle_digest: &str,
+        spec_digest: &str,
+        policy_digest: &str,
+        wasm_digest: &str,
+        content_digest: &str,
+        seed_digest: &str,
+        status: &str,
+    ) -> Result<(), PersistenceError> {
+        let _query_timer = TursoQueryTimer::start("turso.record_installed_app_metadata");
+        let conn = self.configured_connection().await?;
+        conn.execute(
+            "INSERT INTO tenant_installed_apps (
+                 tenant_id, app_name, app_version, bundle_digest, spec_digest,
+                 policy_digest, wasm_digest, content_digest, seed_digest,
+                 installed_at, last_reconciled_at, status
+             )
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, datetime('now'), datetime('now'), ?10)
+             ON CONFLICT(tenant_id, app_name) DO UPDATE SET
+                 app_version = excluded.app_version,
+                 bundle_digest = excluded.bundle_digest,
+                 spec_digest = excluded.spec_digest,
+                 policy_digest = excluded.policy_digest,
+                 wasm_digest = excluded.wasm_digest,
+                 content_digest = excluded.content_digest,
+                 seed_digest = excluded.seed_digest,
+                 last_reconciled_at = datetime('now'),
+                 status = excluded.status",
+            params![
+                tenant_id,
+                app_name,
+                app_version,
+                bundle_digest,
+                spec_digest,
+                policy_digest,
+                wasm_digest,
+                content_digest,
+                seed_digest,
+                status
+            ],
+        )
+        .await
+        .map_err(storage_error)?;
+        Ok(())
+    }
+
+    /// Load digest metadata for an installed OS app.
+    #[instrument(skip_all, fields(tenant_id, app_name, otel.name = "turso.get_installed_app"))]
+    pub async fn get_installed_app(
+        &self,
+        tenant_id: &str,
+        app_name: &str,
+    ) -> Result<Option<TursoInstalledAppRow>, PersistenceError> {
+        let _query_timer = TursoQueryTimer::start("turso.get_installed_app");
+        let conn = self.configured_connection().await?;
+        let mut rows = conn
+            .query(
+                "SELECT tenant_id, app_name, app_version, bundle_digest, spec_digest,
+                        policy_digest, wasm_digest, content_digest, seed_digest,
+                        installed_at, last_reconciled_at, status
+                 FROM tenant_installed_apps
+                 WHERE tenant_id = ?1 AND app_name = ?2
+                 LIMIT 1",
+                params![tenant_id, app_name],
+            )
+            .await
+            .map_err(storage_error)?;
+
+        let Some(row) = rows.next().await.map_err(storage_error)? else {
+            return Ok(None);
+        };
+
+        Ok(Some(TursoInstalledAppRow {
+            tenant_id: row.get(0).map_err(storage_error)?,
+            app_name: row.get(1).map_err(storage_error)?,
+            app_version: row.get(2).map_err(storage_error)?,
+            bundle_digest: row.get(3).map_err(storage_error)?,
+            spec_digest: row.get(4).map_err(storage_error)?,
+            policy_digest: row.get(5).map_err(storage_error)?,
+            wasm_digest: row.get(6).map_err(storage_error)?,
+            content_digest: row.get(7).map_err(storage_error)?,
+            seed_digest: row.get(8).map_err(storage_error)?,
+            installed_at: row.get(9).map_err(storage_error)?,
+            last_reconciled_at: row.get(10).map_err(storage_error)?,
+            status: row.get(11).map_err(storage_error)?,
+        }))
     }
 
     /// List all installed apps across all tenants (for boot + UI).

--- a/crates/temper-store-turso/src/store/specs.rs
+++ b/crates/temper-store-turso/src/store/specs.rs
@@ -243,20 +243,10 @@ impl TursoEventStore {
     }
 
     /// Record or update digest metadata for an installed OS app.
-    #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all, fields(tenant_id, app_name, otel.name = "turso.record_installed_app_metadata"))]
+    #[instrument(skip_all, fields(tenant_id = %record.tenant_id, app_name = %record.app_name, otel.name = "turso.record_installed_app_metadata"))]
     pub async fn record_installed_app_metadata(
         &self,
-        tenant_id: &str,
-        app_name: &str,
-        app_version: &str,
-        bundle_digest: &str,
-        spec_digest: &str,
-        policy_digest: &str,
-        wasm_digest: &str,
-        content_digest: &str,
-        seed_digest: &str,
-        status: &str,
+        record: &TursoInstalledAppRow,
     ) -> Result<(), PersistenceError> {
         let _query_timer = TursoQueryTimer::start("turso.record_installed_app_metadata");
         let conn = self.configured_connection().await?;
@@ -278,16 +268,16 @@ impl TursoEventStore {
                  last_reconciled_at = datetime('now'),
                  status = excluded.status",
             params![
-                tenant_id,
-                app_name,
-                app_version,
-                bundle_digest,
-                spec_digest,
-                policy_digest,
-                wasm_digest,
-                content_digest,
-                seed_digest,
-                status
+                record.tenant_id.as_str(),
+                record.app_name.as_str(),
+                record.app_version.as_str(),
+                record.bundle_digest.as_str(),
+                record.spec_digest.as_str(),
+                record.policy_digest.as_str(),
+                record.wasm_digest.as_str(),
+                record.content_digest.as_str(),
+                record.seed_digest.as_str(),
+                record.status.as_str()
             ],
         )
         .await

--- a/docs/adrs/0059-bounded-warm-restart-and-digest-aware-app-reconcile.md
+++ b/docs/adrs/0059-bounded-warm-restart-and-digest-aware-app-reconcile.md
@@ -1,0 +1,142 @@
+# ADR-0059: Bounded Warm Restart and Digest-Aware App Reconcile
+
+- Status: Accepted
+- Date: 2026-04-24
+- Deciders: Temper core maintainers
+- Related:
+  - ADR-0027: OS App Catalog
+  - ADR-0032: Platform Store Trait and Sim Platform DST
+  - ADR-0048: Dispatch Retry and Error Taxonomy
+  - ADR-0057: Native Immutable File Read Plane for TemperFS
+  - `crates/temper-platform/src/os_apps/mod.rs`
+  - `crates/temper-server/src/platform_store.rs`
+  - `crates/temper-store-turso/src/store/specs.rs`
+
+## Context
+
+TemperPaw production restarts exposed a structural startup problem in Temper: the server could become externally alive before all configured platform surfaces were actually usable, and warm restarts repeated expensive cold-bootstrap work.
+
+The most visible symptoms were:
+
+- startup OS-app dependencies were processed more than once when multiple startup apps shared the same dependency
+- warm restarts reinstalled app specs, policies, WASM modules, seeded files, agents, skills, ADRs, and seed entities even when disk content had not changed
+- helper paths sometimes relied on in-memory runtime indexes before restart recovery had repopulated them
+- missing or malformed trigger target fields could generate invalid persistence ids such as `default:Workspace:`
+- startup observability reported broad phase completion, but did not expose enough per-app skip/reconcile information to prove that warm restart was bounded
+
+The architecture goal is not to hide startup cost behind an early liveness signal. It is to make cold bootstrap, warm restart, and durable reconcile separate paths with explicit readiness semantics.
+
+## Decision
+
+### 1. Cold bootstrap and warm restart are separate platform operations
+
+Cold bootstrap remains the path that creates first-time durable platform state for a tenant.
+
+Warm restart is a bounded reconcile path:
+
+- recover durable platform state first
+- compute the current app bundle digest from disk/source content
+- compare it with durable installed-app metadata
+- skip unchanged apps when registry specs are already ready
+- reconcile only apps whose durable digest or recovered runtime state is stale
+
+This keeps entity-first semantics while avoiding repeated full OS-app installation on every process restart.
+
+### 2. Installed app metadata includes content digests
+
+The platform store records one durable metadata row per tenant/app containing:
+
+- app version
+- bundle digest
+- spec digest
+- policy digest
+- WASM digest
+- content digest
+- seed digest
+- install and reconcile timestamps
+- status
+
+The bundle digest covers app manifest data, specs, CSDL, cross invariants, Cedar policies, WASM module bytes/config, `APP.md`, agents/souls, skills and companion files, system files, ADR files, and seed entities.
+
+This metadata is intentionally stored below the process-local runtime registry. Runtime indexes can be rebuilt, but skip decisions must be anchored in durable state plus readiness of recovered specs.
+
+### 3. Startup app dependency order is deduplicated
+
+Startup DAG resolution uses one visited set across the entire requested startup app list.
+
+Each app is processed once, even if it appears as a dependency of multiple startup apps. This preserves dependency ordering while preventing duplicate install/reconcile work.
+
+### 4. Digest-aware reconcile is the public startup API
+
+Temper exposes a reconcile operation for startup callers. The result is explicit:
+
+- `Skipped` when durable digest matches and recovered specs are ready
+- `Installed` when the app had to be installed or reconciled
+
+Callers should emit per-app timing, skip/reconcile counts, and startup phase durations around this API instead of inferring health from process liveness.
+
+### 5. Empty trigger target fields are not valid entity ids
+
+Trigger target resolution treats empty string fields as missing values.
+
+This prevents invalid persistence ids with empty id segments and forces create-if-missing or missing-target paths to behave consistently.
+
+## Rollout Plan
+
+1. **Phase 0** — Add durable installed-app digest metadata, deduped startup app ordering, digest-aware reconcile, and empty trigger-target guards.
+2. **Phase 1** — Move TemperPaw startup to the reconcile API and emit per-phase/per-app startup telemetry.
+3. **Phase 2** — Gate production readiness on the configured required surfaces for each deployment while keeping `/healthz` as process liveness.
+4. **Phase 3** — Move bulky content reconcile off the hot path where app semantics allow asynchronous post-ready repair.
+
+## Readiness Gates
+
+- A warm restart must recover durable app metadata before app helpers rely on process-local indexes.
+- A configured startup app must be either skipped with matching digest and ready specs or reconciled successfully.
+- Deployment readiness must not be satisfied by process liveness alone.
+- Required transports and external user-facing surfaces must report connected/usable status before the deployment marks itself ready.
+
+## Consequences
+
+### Positive
+
+- Warm restart cost becomes proportional to changed or unrecovered app state instead of total startup content size.
+- App source changes are detected by content digest rather than coarse installed/not-installed checks.
+- Shared startup dependencies are processed once.
+- Operators get a clean skip vs reconcile signal for startup observability.
+- Invalid empty target ids are rejected at the resolver boundary.
+
+### Negative
+
+- App install now maintains durable metadata in addition to registry state.
+- Digest computation must track every content class that should participate in reconcile.
+- Callers need to choose which bulky reconcile work is required before readiness and which can run after ready.
+
+### Risks
+
+- A content class omitted from the digest could leave stale seeded state after restart. The implementation mitigates this by hashing manifest, specs, policies, WASM, seeded content, agents, skills, system files, ADRs, and seed data.
+- Runtime registry corruption with a matching durable digest could be skipped incorrectly. The reconcile API mitigates this by requiring recovered specs to be ready before skipping.
+- New metadata columns must migrate existing tenant stores. The Turso migration adds nullable columns so existing rows continue to load.
+
+### DST Compliance
+
+- Determinism is preserved because app install/reconcile still writes through explicit platform store operations and entity/bootstrap registration.
+- Digest calculation is deterministic over sorted bundle inputs.
+- The new reconcile skip path is a read-only decision over durable metadata and recovered registry state.
+
+## Non-Goals
+
+- Replacing entity/action semantics with an external orchestrator
+- Solving every session/context materialization cost in this ADR
+- Making Discord or any single transport special in the Temper core
+- Removing liveness checks; `/healthz` remains appropriate for process supervision
+
+## Alternatives Considered
+
+1. **Always reinstall startup apps on restart** — rejected because it repeats cold-bootstrap work and keeps warm restart latency tied to total app content size.
+2. **Trust only in-memory runtime indexes** — rejected because indexes are process-local and may not be recovered when helper paths run.
+3. **Use file mtimes for reconcile** — rejected because mtimes are not stable across build/deploy/copy flows and do not represent source-of-truth content.
+4. **Move all reconcile off the hot path immediately** — rejected because readiness must still prove required specs and runtime surfaces are usable before accepting traffic.
+
+## Rollback Policy
+
+The reconcile API is additive. If digest-aware skip misbehaves, callers can temporarily fall back to the existing install path while keeping the metadata columns in place. The empty-target resolver guard is safe to keep because empty ids were never valid persistence ids.

--- a/docs/adrs/0060-bounded-warm-restart-and-digest-aware-app-reconcile.md
+++ b/docs/adrs/0060-bounded-warm-restart-and-digest-aware-app-reconcile.md
@@ -1,4 +1,4 @@
-# ADR-0059: Bounded Warm Restart and Digest-Aware App Reconcile
+# ADR-0060: Bounded Warm Restart and Digest-Aware App Reconcile
 
 - Status: Accepted
 - Date: 2026-04-24


### PR DESCRIPTION
## Summary

Adds digest-aware OS-app reconcile so warm restarts can skip unchanged startup apps after durable metadata and recovered specs prove the app is ready. Also deduplicates startup dependency order, stores installed-app digest metadata in Turso/PlatformStore, guards empty trigger target fields, and documents the bounded warm-restart architecture in ADR-0059.

## Validation

- cargo test -p temper-platform
- cargo test -p temper-store-turso
- cargo test -p temper-platform test_resolve_os_app_install_order_dedupes_shared_dependencies
- cargo test -p temper-platform test_reconcile_os_app_skips_unchanged_bundle_digest
- cargo test -p temper-server field_resolver_returns_none_when_field_is_empty
- cargo test -p temper-server was started and remained green through completed suites; the long debug DST random workload was stopped per the approved skip-local-push-gate path.

## Notes

TemperPaw will consume this via its branch-main git dependencies once this lands on main.