### PR TITLE
Bound warm restart runtime recovery

### DIFF
--- a/crates/temper-platform/src/os_apps/mod.rs
+++ b/crates/temper-platform/src/os_apps/mod.rs
@@ -27,6 +27,10 @@ pub mod git_sources;
 mod reconcile;
 mod system_files;
 mod types;
+pub(crate) use reconcile::{
+    mark_app_specs_restored_from_matching_digest, tenant_has_ready_app_specs_for_bundle,
+    tenant_has_registered_app_specs_for_bundle,
+};
 pub use reconcile::{os_app_bundle_digest, reconcile_os_app, resolve_os_app_install_order};
 pub use types::*;
 

--- a/crates/temper-platform/src/os_apps/mod_test.rs
+++ b/crates/temper-platform/src/os_apps/mod_test.rs
@@ -987,6 +987,96 @@ async fn test_restore_installed_app_heals_pending_specs_on_restart() {
     let _ = std::fs::remove_file(format!("{db_path}-shm"));
 }
 
+#[tokio::test]
+async fn test_runtime_recovery_heals_matching_digest_without_hot_reinstall() {
+    let db_path = format!("/tmp/temper-test-runtime-heal-{}.db", uuid::Uuid::new_v4());
+    let db_url = format!("file:{db_path}");
+
+    let turso = temper_store_turso::TursoEventStore::new(&db_url, None)
+        .await
+        .unwrap();
+    let mut state = PlatformState::new(None);
+    state.server.event_store = Some(std::sync::Arc::new(
+        temper_server::event_store::ServerEventStore::Turso(turso),
+    ));
+
+    install_skill(&state, "test-runtime-heal", "project-management")
+        .await
+        .expect("install should succeed");
+
+    let turso_ref = state
+        .server
+        .event_store
+        .as_ref()
+        .unwrap()
+        .platform_turso_store()
+        .unwrap();
+
+    for entity_type in ["Issue", "Project", "Cycle", "Comment", "Label"] {
+        turso_ref
+            .persist_spec_verification(
+                "test-runtime-heal",
+                entity_type,
+                TursoSpecVerificationUpdate {
+                    status: "pending",
+                    verified: false,
+                    levels_passed: None,
+                    levels_total: None,
+                    verification_result_json: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        state.registry.write().unwrap().set_verification_status(
+            &TenantId::new("test-runtime-heal"),
+            entity_type,
+            VerificationStatus::Pending,
+        );
+    }
+
+    let outcome = crate::recovery::recover_installed_app_runtime_state(
+        &state,
+        turso_ref,
+        "test-runtime-heal",
+        "project-management",
+    )
+    .await;
+
+    assert_eq!(
+        outcome,
+        crate::recovery::InstalledAppRuntimeRecoveryOutcome::Healed,
+        "matching digest recovery should heal runtime spec readiness without reinstalling content"
+    );
+
+    let result = reconcile_os_app(&state, "test-runtime-heal", "project-management")
+        .await
+        .expect("unchanged reconcile should succeed after runtime recovery");
+    assert!(
+        matches!(result, OsAppReconcileResult::Skipped { .. }),
+        "runtime-healed app should skip hot reinstall, got {result:?}"
+    );
+
+    let rows = turso_ref.load_specs().await.unwrap();
+    let issue_row = rows
+        .iter()
+        .find(|r| r.tenant == "test-runtime-heal" && r.entity_type == "Issue")
+        .expect("Issue row should exist");
+    assert!(
+        issue_row.verified,
+        "runtime heal should persist verified=true"
+    );
+    assert_ne!(
+        issue_row.verification_status.to_lowercase(),
+        "pending",
+        "runtime heal should durably move matching specs out of pending"
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(format!("{db_path}-wal"));
+    let _ = std::fs::remove_file(format!("{db_path}-shm"));
+}
+
 #[test]
 fn test_reload_picks_up_disk_changes() {
     reload_skills();

--- a/crates/temper-platform/src/os_apps/reconcile.rs
+++ b/crates/temper-platform/src/os_apps/reconcile.rs
@@ -2,8 +2,8 @@ use std::collections::HashSet;
 
 use sha2::{Digest, Sha256};
 use temper_runtime::tenant::TenantId;
-use temper_server::platform_store::InstalledAppRecord;
-use temper_server::registry::VerificationStatus;
+use temper_server::platform_store::{InstalledAppRecord, PlatformStore, SpecVerificationUpdate};
+use temper_server::registry::{EntityLevelSummary, EntityVerificationResult, VerificationStatus};
 use temper_spec::csdl::parse_csdl;
 
 use super::{
@@ -204,22 +204,18 @@ pub fn os_app_bundle_digest(app_name: &str) -> Option<OsAppBundleDigest> {
     get_os_app(app_name).map(|bundle| digest_app_bundle(app_name, &bundle))
 }
 
-fn tenant_has_ready_app_specs_for_bundle(
+pub(crate) fn tenant_has_registered_app_specs_for_bundle(
     state: &PlatformState,
     tenant: &str,
     bundle: &AppBundle,
 ) -> bool {
     let tenant_id = TenantId::new(tenant);
     let registry = state.registry.read().expect("Spec registry lock poisoned");
-    let specs_ready = bundle.specs.iter().all(|(entity_type, _)| {
-        let has_table = registry.get_table(&tenant_id, entity_type).is_some();
-        let is_ready = matches!(
-            registry.get_verification_status(&tenant_id, entity_type),
-            Some(VerificationStatus::Completed(_) | VerificationStatus::Restored(_))
-        );
-        has_table && is_ready
-    });
-    if !specs_ready {
+    let specs_registered = bundle
+        .specs
+        .iter()
+        .all(|(entity_type, _)| registry.get_table(&tenant_id, entity_type).is_some());
+    if !specs_registered {
         return false;
     }
 
@@ -250,6 +246,86 @@ fn tenant_has_ready_app_specs_for_bundle(
     }
 
     true
+}
+
+pub(crate) fn tenant_has_ready_app_specs_for_bundle(
+    state: &PlatformState,
+    tenant: &str,
+    bundle: &AppBundle,
+) -> bool {
+    if !tenant_has_registered_app_specs_for_bundle(state, tenant, bundle) {
+        return false;
+    }
+
+    let tenant_id = TenantId::new(tenant);
+    let registry = state.registry.read().expect("Spec registry lock poisoned");
+    bundle.specs.iter().all(|(entity_type, _)| {
+        matches!(
+            registry.get_verification_status(&tenant_id, entity_type),
+            Some(VerificationStatus::Completed(_) | VerificationStatus::Restored(_))
+        )
+    })
+}
+
+pub(crate) async fn mark_app_specs_restored_from_matching_digest(
+    state: &PlatformState,
+    ps: &dyn PlatformStore,
+    tenant: &str,
+    app_name: &str,
+    bundle: &AppBundle,
+) {
+    if bundle.specs.is_empty() {
+        return;
+    }
+
+    let tenant_id = TenantId::new(tenant);
+    let verified_at = temper_runtime::scheduler::sim_now().to_rfc3339();
+    let result = EntityVerificationResult {
+        all_passed: true,
+        levels: vec![EntityLevelSummary {
+            level: "BundleDigest".to_string(),
+            passed: true,
+            summary: format!("Restored from matching OS app bundle digest ({app_name})"),
+            details: None,
+        }],
+        verified_at,
+    };
+
+    {
+        let mut registry = state.registry.write().expect("Spec registry lock poisoned");
+        for (entity_type, _) in &bundle.specs {
+            registry.set_verification_status(
+                &tenant_id,
+                entity_type,
+                VerificationStatus::Restored(result.clone()),
+            );
+        }
+    }
+
+    for (entity_type, _) in &bundle.specs {
+        if let Err(error) = ps
+            .persist_spec_verification(
+                tenant,
+                entity_type,
+                SpecVerificationUpdate {
+                    status: "passed",
+                    verified: true,
+                    levels_passed: Some(1),
+                    levels_total: Some(1),
+                    verification_result_json: None,
+                },
+            )
+            .await
+        {
+            tracing::warn!(
+                tenant,
+                app = %app_name,
+                entity_type,
+                error = %error,
+                "Failed to persist restored OS app spec verification status"
+            );
+        }
+    }
 }
 
 async fn record_app_install_metadata(
@@ -319,20 +395,49 @@ pub async fn reconcile_os_app(
         .event_store
         .as_ref()
         .and_then(|store| store.platform_store())
-        && let Ok(Some(record)) = ps.get_installed_app(tenant, app_name).await
-        && record.bundle_digest == digest.bundle_digest
-        && tenant_has_ready_app_specs_for_bundle(state, tenant, &bundle)
     {
-        tracing::info!(
-            tenant,
-            app = %app_name,
-            bundle_digest = %digest.bundle_digest,
-            "OS app unchanged; skipping hot reconcile"
-        );
-        return Ok(OsAppReconcileResult::Skipped {
-            app_name: app_name.to_string(),
-            bundle_digest: digest.bundle_digest,
-        });
+        match ps.get_installed_app(tenant, app_name).await {
+            Ok(Some(record)) if record.bundle_digest == digest.bundle_digest => {
+                if tenant_has_ready_app_specs_for_bundle(state, tenant, &bundle) {
+                    tracing::info!(
+                        tenant,
+                        app = %app_name,
+                        bundle_digest = %digest.bundle_digest,
+                        "OS app unchanged; skipping hot reconcile"
+                    );
+                    return Ok(OsAppReconcileResult::Skipped {
+                        app_name: app_name.to_string(),
+                        bundle_digest: digest.bundle_digest,
+                    });
+                }
+
+                if tenant_has_registered_app_specs_for_bundle(state, tenant, &bundle) {
+                    mark_app_specs_restored_from_matching_digest(
+                        state, ps, tenant, app_name, &bundle,
+                    )
+                    .await;
+                    tracing::info!(
+                        tenant,
+                        app = %app_name,
+                        bundle_digest = %digest.bundle_digest,
+                        "OS app unchanged; restored spec readiness and skipped hot reconcile"
+                    );
+                    return Ok(OsAppReconcileResult::Skipped {
+                        app_name: app_name.to_string(),
+                        bundle_digest: digest.bundle_digest,
+                    });
+                }
+            }
+            Ok(Some(_)) | Ok(None) => {}
+            Err(error) => {
+                tracing::warn!(
+                    tenant,
+                    app = %app_name,
+                    error = %error,
+                    "Failed to read OS app digest metadata; falling back to reconcile"
+                );
+            }
+        }
     }
 
     let install = install_os_app_without_dependencies(state, tenant, app_name).await?;

--- a/crates/temper-platform/src/recovery.rs
+++ b/crates/temper-platform/src/recovery.rs
@@ -14,6 +14,31 @@ use temper_server::registry::VerificationStatus;
 use crate::os_apps;
 use crate::state::PlatformState;
 
+/// Runtime-only outcome for installed-app warm restart recovery.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstalledAppRuntimeRecoveryOutcome {
+    /// Specs were already registered and marked usable.
+    Ready,
+    /// Specs were registered and the durable bundle digest matched; runtime
+    /// verification readiness was repaired without reinstalling app content.
+    Healed,
+    /// The app should be reconciled by the digest-aware app reconcile path.
+    NeedsReconcile,
+    /// The durable installed-app row points at an app that is not in the catalog.
+    MissingBundle,
+    /// Durable metadata could not be read, so the caller should reconcile.
+    StoreError,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct InstalledAppsRuntimeRecoverySummary {
+    pub ready: usize,
+    pub healed: usize,
+    pub needs_reconcile: usize,
+    pub missing_bundle: usize,
+    pub store_error: usize,
+}
+
 /// Recover Cedar policies from the platform store into memory.
 ///
 /// Loads all tenant policies from the durable store, validates each one
@@ -78,8 +103,28 @@ pub async fn restore_installed_apps(state: &PlatformState, ps: &dyn PlatformStor
     };
 
     for (tenant, app_name) in installed {
-        // Only skip recovery if the app's specs are both present and in a
-        // stable verified/restored state. Pending specs must be healed.
+        match recover_installed_app_runtime_state(state, ps, &tenant, &app_name).await {
+            InstalledAppRuntimeRecoveryOutcome::Ready => {
+                continue;
+            }
+            InstalledAppRuntimeRecoveryOutcome::Healed => {
+                tracing::info!(
+                    tenant,
+                    app = %app_name,
+                    "Restored installed app runtime readiness without hot content bootstrap"
+                );
+                continue;
+            }
+            InstalledAppRuntimeRecoveryOutcome::NeedsReconcile
+            | InstalledAppRuntimeRecoveryOutcome::MissingBundle
+            | InstalledAppRuntimeRecoveryOutcome::StoreError => {}
+        }
+
+        // Legacy recovery still performs a full install when runtime-only
+        // recovery cannot prove the durable app bundle is unchanged. Startup
+        // callers that need bounded warm restart should call
+        // `recover_installed_apps_runtime_state` and then run
+        // `reconcile_os_app` for their required startup surface.
         if tenant_has_ready_app_specs(state, &tenant, &app_name) {
             continue;
         }
@@ -103,6 +148,90 @@ pub async fn restore_installed_apps(state: &PlatformState, ps: &dyn PlatformStor
             }
         }
     }
+}
+
+/// Recover warm-restart runtime state for one installed app without running the
+/// full OS-app install/bootstrap path.
+///
+/// This is intentionally bounded: it never writes APP.md, skills, agents, ADRs,
+/// system files, or seed entities. If durable metadata cannot prove the bundle
+/// is unchanged, callers get [`InstalledAppRuntimeRecoveryOutcome::NeedsReconcile`]
+/// and should use digest-aware reconcile for the required app surface.
+pub async fn recover_installed_app_runtime_state(
+    state: &PlatformState,
+    ps: &dyn PlatformStore,
+    tenant: &str,
+    app_name: &str,
+) -> InstalledAppRuntimeRecoveryOutcome {
+    let Some(bundle) = os_apps::get_os_app(app_name) else {
+        tracing::warn!(
+            tenant,
+            app = %app_name,
+            "Installed OS app is missing from catalog; runtime recovery cannot restore it"
+        );
+        return InstalledAppRuntimeRecoveryOutcome::MissingBundle;
+    };
+
+    if os_apps::tenant_has_ready_app_specs_for_bundle(state, tenant, &bundle) {
+        return InstalledAppRuntimeRecoveryOutcome::Ready;
+    }
+
+    let Some(digest) = os_apps::os_app_bundle_digest(app_name) else {
+        return InstalledAppRuntimeRecoveryOutcome::MissingBundle;
+    };
+
+    match ps.get_installed_app(tenant, app_name).await {
+        Ok(Some(record))
+            if record.bundle_digest == digest.bundle_digest
+                && os_apps::tenant_has_registered_app_specs_for_bundle(state, tenant, &bundle) =>
+        {
+            os_apps::mark_app_specs_restored_from_matching_digest(
+                state, ps, tenant, app_name, &bundle,
+            )
+            .await;
+            InstalledAppRuntimeRecoveryOutcome::Healed
+        }
+        Ok(Some(_)) | Ok(None) => InstalledAppRuntimeRecoveryOutcome::NeedsReconcile,
+        Err(error) => {
+            tracing::warn!(
+                tenant,
+                app = %app_name,
+                error = %error,
+                "Failed to read installed OS app metadata during runtime recovery"
+            );
+            InstalledAppRuntimeRecoveryOutcome::StoreError
+        }
+    }
+}
+
+/// Recover runtime readiness for all durable installed apps without reinstalling
+/// app content.
+pub async fn recover_installed_apps_runtime_state(
+    state: &PlatformState,
+    ps: &dyn PlatformStore,
+) -> InstalledAppsRuntimeRecoverySummary {
+    let installed = match ps.list_all_installed_apps().await {
+        Ok(apps) => apps,
+        Err(e) => {
+            tracing::warn!("Failed to load installed os-apps for runtime recovery: {e}");
+            return InstalledAppsRuntimeRecoverySummary {
+                store_error: 1,
+                ..InstalledAppsRuntimeRecoverySummary::default()
+            };
+        }
+    };
+
+    let mut summary = InstalledAppsRuntimeRecoverySummary::default();
+    for (tenant, app_name) in installed {
+        match recover_installed_app_runtime_state(state, ps, &tenant, &app_name).await {
+            InstalledAppRuntimeRecoveryOutcome::Ready => summary.ready += 1,
+            InstalledAppRuntimeRecoveryOutcome::Healed => summary.healed += 1,
+            InstalledAppRuntimeRecoveryOutcome::NeedsReconcile => summary.needs_reconcile += 1,
+            InstalledAppRuntimeRecoveryOutcome::MissingBundle => summary.missing_bundle += 1,
+            InstalledAppRuntimeRecoveryOutcome::StoreError => summary.store_error += 1,
+        }
+    }
+    summary
 }
 
 /// Backward-compatible alias.

--- a/docs/adrs/0060-bounded-warm-restart-and-digest-aware-app-reconcile.md
+++ b/docs/adrs/0060-bounded-warm-restart-and-digest-aware-app-reconcile.md
@@ -75,7 +75,28 @@ Temper exposes a reconcile operation for startup callers. The result is explicit
 
 Callers should emit per-app timing, skip/reconcile counts, and startup phase durations around this API instead of inferring health from process liveness.
 
-### 5. Empty trigger target fields are not valid entity ids
+### 5. Runtime recovery is not content bootstrap
+
+Warm restart recovery has a runtime-only installed-app path.
+
+That path may:
+
+- recover Cedar policies
+- reload persisted WASM modules
+- inspect durable installed-app metadata
+- repair in-memory and durable spec readiness when the bundle digest matches and specs are registered
+
+That path must not write `APP.md`, agents, skills, system files, ADR files, or seed entities. If durable metadata cannot prove that an app bundle is unchanged, runtime recovery reports that reconcile is needed. The startup caller then runs digest-aware app reconcile for the required startup app surface.
+
+This separation prevents stale verification metadata from forcing a hot full install while still allowing changed app content to reconcile intentionally.
+
+### 6. Runtime indexes recover before content helpers
+
+Runtime entity indexes are recovered before app reconcile can run any content bootstrap helpers.
+
+App helpers that ensure files, directories, workspaces, agents, or seed entities exist must not make create/update decisions against an empty post-restart in-memory index. A changed or cold app may still need content bootstrap, but it now runs after durable entity state has been replayed into runtime indexes.
+
+### 7. Empty trigger target fields are not valid entity ids
 
 Trigger target resolution treats empty string fields as missing values.
 
@@ -85,12 +106,14 @@ This prevents invalid persistence ids with empty id segments and forces create-i
 
 1. **Phase 0** — Add durable installed-app digest metadata, deduped startup app ordering, digest-aware reconcile, and empty trigger-target guards.
 2. **Phase 1** — Move TemperPaw startup to the reconcile API and emit per-phase/per-app startup telemetry.
-3. **Phase 2** — Gate production readiness on the configured required surfaces for each deployment while keeping `/healthz` as process liveness.
-4. **Phase 3** — Move bulky content reconcile off the hot path where app semantics allow asynchronous post-ready repair.
+3. **Phase 2** — Use runtime-only installed-app recovery in the warm restart hot path, recover runtime indexes before app reconcile, and keep bulky content bootstrap behind digest-aware reconcile.
+4. **Phase 3** — Gate production readiness on the configured required surfaces for each deployment while keeping `/healthz` as process liveness.
+5. **Phase 4** — Move optional bulky content repair off the hot path where app semantics allow asynchronous post-ready repair.
 
 ## Readiness Gates
 
 - A warm restart must recover durable app metadata before app helpers rely on process-local indexes.
+- Runtime indexes must be recovered before any content helper performs an existence check.
 - A configured startup app must be either skipped with matching digest and ready specs or reconciled successfully.
 - Deployment readiness must not be satisfied by process liveness alone.
 - Required transports and external user-facing surfaces must report connected/usable status before the deployment marks itself ready.


### PR DESCRIPTION
## Summary
- add runtime-only installed app recovery that heals matching digest spec readiness without replaying app content bootstrap
- teach digest-aware reconcile to heal stale restored spec readiness and still skip unchanged apps
- update ADR-0060 with runtime recovery/index recovery ordering

## Tests
- cargo test -p temper-platform
