### PR TITLE
Heal OS app runtime metadata from matching digest

### DIFF
--- a/crates/temper-platform/src/os_apps/mod.rs
+++ b/crates/temper-platform/src/os_apps/mod.rs
@@ -25,13 +25,13 @@ use crate::state::PlatformState;
 mod agent_bootstrap;
 pub mod git_sources;
 mod reconcile;
+mod runtime_heal;
 mod system_files;
 mod types;
-pub(crate) use reconcile::{
-    mark_app_specs_restored_from_matching_digest, tenant_has_ready_app_specs_for_bundle,
-    tenant_has_registered_app_specs_for_bundle,
-};
 pub use reconcile::{os_app_bundle_digest, reconcile_os_app, resolve_os_app_install_order};
+pub(crate) use runtime_heal::{
+    restore_app_specs_from_matching_digest, tenant_has_ready_app_specs_for_bundle,
+};
 pub use types::*;
 
 fn read_app_manifest(app_dir: &Path) -> Option<AppManifest> {

--- a/crates/temper-platform/src/os_apps/mod_test.rs
+++ b/crates/temper-platform/src/os_apps/mod_test.rs
@@ -223,7 +223,7 @@ async fn test_reconcile_os_app_skips_unchanged_bundle_digest() {
 }
 
 #[tokio::test]
-async fn test_reconcile_os_app_reinstalls_when_entity_set_map_is_missing() {
+async fn test_reconcile_os_app_repairs_entity_set_map_from_matching_digest() {
     let db_path = format!("/tmp/temper-test-reconcile-map-{}.db", uuid::Uuid::new_v4());
     let db_url = format!("file:{db_path}");
 
@@ -299,11 +299,11 @@ async fn test_reconcile_os_app_reinstalls_when_entity_set_map_is_missing() {
 
     let result = reconcile_os_app(&state, tenant_name, "project-management")
         .await
-        .expect("reconcile should heal missing entity-set map");
+        .expect("reconcile should heal missing entity-set map without reinstalling content");
 
     assert!(
-        matches!(result, OsAppReconcileResult::Installed { .. }),
-        "missing OData entity-set mappings must force reinstall, got {result:?}"
+        matches!(result, OsAppReconcileResult::Skipped { .. }),
+        "matching digest should repair OData entity-set mappings without reinstall, got {result:?}"
     );
     assert_eq!(
         state
@@ -1070,6 +1070,102 @@ async fn test_runtime_recovery_heals_matching_digest_without_hot_reinstall() {
         issue_row.verification_status.to_lowercase(),
         "pending",
         "runtime heal should durably move matching specs out of pending"
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(format!("{db_path}-wal"));
+    let _ = std::fs::remove_file(format!("{db_path}-shm"));
+}
+
+#[tokio::test]
+async fn test_runtime_recovery_heals_missing_entity_set_map_from_matching_digest() {
+    let db_path = format!(
+        "/tmp/temper-test-runtime-map-heal-{}.db",
+        uuid::Uuid::new_v4()
+    );
+    let db_url = format!("file:{db_path}");
+
+    let turso = temper_store_turso::TursoEventStore::new(&db_url, None)
+        .await
+        .unwrap();
+    let mut state = PlatformState::new(None);
+    state.server.event_store = Some(std::sync::Arc::new(
+        temper_server::event_store::ServerEventStore::Turso(turso),
+    ));
+    let tenant_name = "test-runtime-map-heal";
+    let tenant = TenantId::new(tenant_name);
+
+    install_skill(&state, tenant_name, "project-management")
+        .await
+        .expect("install should succeed");
+
+    let bundle = get_os_app("project-management").expect("project-management app not found");
+    let mut broken_csdl = bundle
+        .csdl
+        .clone()
+        .expect("project-management should have CSDL");
+    broken_csdl = broken_csdl.replace(
+        r#"        <EntitySet Name="Issues" EntityType="Temper.ProjectManagement.Issue">
+          <NavigationPropertyBinding Path="ParentIssue" Target="Issues"/>
+          <NavigationPropertyBinding Path="SubIssues" Target="Issues"/>
+          <NavigationPropertyBinding Path="Project" Target="Projects"/>
+          <NavigationPropertyBinding Path="Cycle" Target="Cycles"/>
+          <NavigationPropertyBinding Path="Comments" Target="Comments"/>
+        </EntitySet>
+"#,
+        "",
+    );
+
+    {
+        let mut registry = state.registry.write().unwrap();
+        let parsed = parse_csdl(&broken_csdl).expect("broken CSDL should still parse");
+        let specs: Vec<(&str, &str)> = bundle
+            .specs
+            .iter()
+            .map(|(entity_type, ioa_source)| (entity_type.as_str(), ioa_source.as_str()))
+            .collect();
+        registry
+            .try_register_tenant_with_reactions_and_constraints(
+                tenant.clone(),
+                parsed,
+                broken_csdl,
+                &specs,
+                Vec::new(),
+                None,
+                false,
+            )
+            .expect("replace tenant config with a broken entity-set map");
+    }
+
+    let turso_ref = state
+        .server
+        .event_store
+        .as_ref()
+        .unwrap()
+        .platform_turso_store()
+        .unwrap();
+
+    let outcome = crate::recovery::recover_installed_app_runtime_state(
+        &state,
+        turso_ref,
+        tenant_name,
+        "project-management",
+    )
+    .await;
+
+    assert_eq!(
+        outcome,
+        crate::recovery::InstalledAppRuntimeRecoveryOutcome::Healed,
+        "matching digest recovery should repair runtime entity-set metadata without event replay"
+    );
+    assert_eq!(
+        state
+            .registry
+            .read()
+            .unwrap()
+            .resolve_entity_type(&tenant, "Issues")
+            .as_deref(),
+        Some("Issue")
     );
 
     let _ = std::fs::remove_file(&db_path);

--- a/crates/temper-platform/src/os_apps/reconcile.rs
+++ b/crates/temper-platform/src/os_apps/reconcile.rs
@@ -1,14 +1,12 @@
 use std::collections::HashSet;
 
 use sha2::{Digest, Sha256};
-use temper_runtime::tenant::TenantId;
-use temper_server::platform_store::{InstalledAppRecord, PlatformStore, SpecVerificationUpdate};
-use temper_server::registry::{EntityLevelSummary, EntityVerificationResult, VerificationStatus};
-use temper_spec::csdl::parse_csdl;
+use temper_server::platform_store::InstalledAppRecord;
 
 use super::{
     AppBundle, AppEntry, OsAppBundleDigest, OsAppReconcileResult, catalog, get_os_app,
     install_os_app_without_dependencies, os_app_dependencies,
+    restore_app_specs_from_matching_digest, tenant_has_ready_app_specs_for_bundle,
 };
 use crate::state::PlatformState;
 
@@ -204,130 +202,6 @@ pub fn os_app_bundle_digest(app_name: &str) -> Option<OsAppBundleDigest> {
     get_os_app(app_name).map(|bundle| digest_app_bundle(app_name, &bundle))
 }
 
-pub(crate) fn tenant_has_registered_app_specs_for_bundle(
-    state: &PlatformState,
-    tenant: &str,
-    bundle: &AppBundle,
-) -> bool {
-    let tenant_id = TenantId::new(tenant);
-    let registry = state.registry.read().expect("Spec registry lock poisoned");
-    let specs_registered = bundle
-        .specs
-        .iter()
-        .all(|(entity_type, _)| registry.get_table(&tenant_id, entity_type).is_some());
-    if !specs_registered {
-        return false;
-    }
-
-    let Some(csdl_xml) = bundle.csdl.as_deref() else {
-        return true;
-    };
-    let Ok(csdl) = parse_csdl(csdl_xml) else {
-        return false;
-    };
-
-    for schema in &csdl.schemas {
-        for container in &schema.entity_containers {
-            for entity_set in &container.entity_sets {
-                let expected_type = entity_set
-                    .entity_type
-                    .rsplit('.')
-                    .next()
-                    .unwrap_or(&entity_set.entity_type);
-                if registry
-                    .resolve_entity_type(&tenant_id, &entity_set.name)
-                    .as_deref()
-                    != Some(expected_type)
-                {
-                    return false;
-                }
-            }
-        }
-    }
-
-    true
-}
-
-pub(crate) fn tenant_has_ready_app_specs_for_bundle(
-    state: &PlatformState,
-    tenant: &str,
-    bundle: &AppBundle,
-) -> bool {
-    if !tenant_has_registered_app_specs_for_bundle(state, tenant, bundle) {
-        return false;
-    }
-
-    let tenant_id = TenantId::new(tenant);
-    let registry = state.registry.read().expect("Spec registry lock poisoned");
-    bundle.specs.iter().all(|(entity_type, _)| {
-        matches!(
-            registry.get_verification_status(&tenant_id, entity_type),
-            Some(VerificationStatus::Completed(_) | VerificationStatus::Restored(_))
-        )
-    })
-}
-
-pub(crate) async fn mark_app_specs_restored_from_matching_digest(
-    state: &PlatformState,
-    ps: &dyn PlatformStore,
-    tenant: &str,
-    app_name: &str,
-    bundle: &AppBundle,
-) {
-    if bundle.specs.is_empty() {
-        return;
-    }
-
-    let tenant_id = TenantId::new(tenant);
-    let verified_at = temper_runtime::scheduler::sim_now().to_rfc3339();
-    let result = EntityVerificationResult {
-        all_passed: true,
-        levels: vec![EntityLevelSummary {
-            level: "BundleDigest".to_string(),
-            passed: true,
-            summary: format!("Restored from matching OS app bundle digest ({app_name})"),
-            details: None,
-        }],
-        verified_at,
-    };
-
-    {
-        let mut registry = state.registry.write().expect("Spec registry lock poisoned");
-        for (entity_type, _) in &bundle.specs {
-            registry.set_verification_status(
-                &tenant_id,
-                entity_type,
-                VerificationStatus::Restored(result.clone()),
-            );
-        }
-    }
-
-    for (entity_type, _) in &bundle.specs {
-        if let Err(error) = ps
-            .persist_spec_verification(
-                tenant,
-                entity_type,
-                SpecVerificationUpdate {
-                    status: "passed",
-                    verified: true,
-                    levels_passed: Some(1),
-                    levels_total: Some(1),
-                    verification_result_json: None,
-                },
-            )
-            .await
-        {
-            tracing::warn!(
-                tenant,
-                app = %app_name,
-                entity_type,
-                error = %error,
-                "Failed to persist restored OS app spec verification status"
-            );
-        }
-    }
-}
-
 async fn record_app_install_metadata(
     state: &PlatformState,
     tenant: &str,
@@ -411,11 +285,9 @@ pub async fn reconcile_os_app(
                     });
                 }
 
-                if tenant_has_registered_app_specs_for_bundle(state, tenant, &bundle) {
-                    mark_app_specs_restored_from_matching_digest(
-                        state, ps, tenant, app_name, &bundle,
-                    )
-                    .await;
+                if restore_app_specs_from_matching_digest(state, ps, tenant, app_name, &bundle)
+                    .await
+                {
                     tracing::info!(
                         tenant,
                         app = %app_name,

--- a/crates/temper-platform/src/os_apps/runtime_heal.rs
+++ b/crates/temper-platform/src/os_apps/runtime_heal.rs
@@ -1,0 +1,221 @@
+use temper_runtime::tenant::TenantId;
+use temper_server::platform_store::{PlatformStore, SpecVerificationUpdate};
+use temper_server::registry::{EntityLevelSummary, EntityVerificationResult, VerificationStatus};
+use temper_spec::csdl::parse_csdl;
+
+use super::AppBundle;
+use crate::state::PlatformState;
+
+fn tenant_has_registered_app_specs_for_bundle(
+    state: &PlatformState,
+    tenant: &str,
+    bundle: &AppBundle,
+) -> bool {
+    if !tenant_has_app_spec_tables_for_bundle(state, tenant, bundle) {
+        return false;
+    }
+
+    let tenant_id = TenantId::new(tenant);
+    let registry = state.registry.read().expect("Spec registry lock poisoned");
+    let Some(csdl_xml) = bundle.csdl.as_deref() else {
+        return true;
+    };
+    let Ok(csdl) = parse_csdl(csdl_xml) else {
+        return false;
+    };
+
+    for schema in &csdl.schemas {
+        for container in &schema.entity_containers {
+            for entity_set in &container.entity_sets {
+                let expected_type = entity_set
+                    .entity_type
+                    .rsplit('.')
+                    .next()
+                    .unwrap_or(&entity_set.entity_type);
+                if registry
+                    .resolve_entity_type(&tenant_id, &entity_set.name)
+                    .as_deref()
+                    != Some(expected_type)
+                {
+                    return false;
+                }
+            }
+        }
+    }
+
+    true
+}
+
+fn tenant_has_app_spec_tables_for_bundle(
+    state: &PlatformState,
+    tenant: &str,
+    bundle: &AppBundle,
+) -> bool {
+    let tenant_id = TenantId::new(tenant);
+    let registry = state.registry.read().expect("Spec registry lock poisoned");
+    bundle
+        .specs
+        .iter()
+        .all(|(entity_type, _)| registry.get_table(&tenant_id, entity_type).is_some())
+}
+
+fn repair_app_runtime_metadata_from_bundle(
+    state: &PlatformState,
+    tenant: &str,
+    app_name: &str,
+    bundle: &AppBundle,
+) -> Result<(), String> {
+    if bundle.specs.is_empty() {
+        return Ok(());
+    }
+
+    let Some(csdl_xml) = bundle.csdl.as_deref() else {
+        return Ok(());
+    };
+    let csdl = parse_csdl(csdl_xml)
+        .map_err(|error| format!("Failed to parse CSDL for os-app '{app_name}': {error}"))?;
+    let specs: Vec<(&str, &str)> = bundle
+        .specs
+        .iter()
+        .map(|(entity_type, ioa_source)| (entity_type.as_str(), ioa_source.as_str()))
+        .collect();
+    let tenant_id = TenantId::new(tenant);
+
+    {
+        let mut registry = state.registry.write().expect("Spec registry lock poisoned");
+        registry
+            .try_register_tenant_with_reactions_and_constraints(
+                tenant_id,
+                csdl,
+                csdl_xml.to_string(),
+                &specs,
+                Vec::new(),
+                bundle.cross_invariants_toml.clone(),
+                true,
+            )
+            .map_err(|error| {
+                format!("Failed to restore runtime metadata for os-app '{app_name}': {error}")
+            })?;
+    }
+    state.server.rebuild_reaction_dispatcher();
+    tracing::info!(
+        tenant,
+        app = %app_name,
+        "Restored OS app runtime metadata from matching bundle digest"
+    );
+    Ok(())
+}
+
+pub(crate) fn tenant_has_ready_app_specs_for_bundle(
+    state: &PlatformState,
+    tenant: &str,
+    bundle: &AppBundle,
+) -> bool {
+    if !tenant_has_registered_app_specs_for_bundle(state, tenant, bundle) {
+        return false;
+    }
+
+    let tenant_id = TenantId::new(tenant);
+    let registry = state.registry.read().expect("Spec registry lock poisoned");
+    bundle.specs.iter().all(|(entity_type, _)| {
+        matches!(
+            registry.get_verification_status(&tenant_id, entity_type),
+            Some(VerificationStatus::Completed(_) | VerificationStatus::Restored(_))
+        )
+    })
+}
+
+async fn mark_app_specs_restored_from_matching_digest(
+    state: &PlatformState,
+    ps: &dyn PlatformStore,
+    tenant: &str,
+    app_name: &str,
+    bundle: &AppBundle,
+) {
+    if bundle.specs.is_empty() {
+        return;
+    }
+
+    let tenant_id = TenantId::new(tenant);
+    let verified_at = temper_runtime::scheduler::sim_now().to_rfc3339();
+    let result = EntityVerificationResult {
+        all_passed: true,
+        levels: vec![EntityLevelSummary {
+            level: "BundleDigest".to_string(),
+            passed: true,
+            summary: format!("Restored from matching OS app bundle digest ({app_name})"),
+            details: None,
+        }],
+        verified_at,
+    };
+
+    {
+        let mut registry = state.registry.write().expect("Spec registry lock poisoned");
+        for (entity_type, _) in &bundle.specs {
+            registry.set_verification_status(
+                &tenant_id,
+                entity_type,
+                VerificationStatus::Restored(result.clone()),
+            );
+        }
+    }
+
+    for (entity_type, _) in &bundle.specs {
+        if let Err(error) = ps
+            .persist_spec_verification(
+                tenant,
+                entity_type,
+                SpecVerificationUpdate {
+                    status: "passed",
+                    verified: true,
+                    levels_passed: Some(1),
+                    levels_total: Some(1),
+                    verification_result_json: None,
+                },
+            )
+            .await
+        {
+            tracing::warn!(
+                tenant,
+                app = %app_name,
+                entity_type,
+                error = %error,
+                "Failed to persist restored OS app spec verification status"
+            );
+        }
+    }
+}
+
+pub(crate) async fn restore_app_specs_from_matching_digest(
+    state: &PlatformState,
+    ps: &dyn PlatformStore,
+    tenant: &str,
+    app_name: &str,
+    bundle: &AppBundle,
+) -> bool {
+    if tenant_has_registered_app_specs_for_bundle(state, tenant, bundle) {
+        mark_app_specs_restored_from_matching_digest(state, ps, tenant, app_name, bundle).await;
+        return true;
+    }
+
+    if !tenant_has_app_spec_tables_for_bundle(state, tenant, bundle) {
+        return false;
+    }
+
+    if let Err(error) = repair_app_runtime_metadata_from_bundle(state, tenant, app_name, bundle) {
+        tracing::warn!(
+            tenant,
+            app = %app_name,
+            error = %error,
+            "Failed to repair OS app runtime metadata from matching digest"
+        );
+        return false;
+    }
+
+    if tenant_has_registered_app_specs_for_bundle(state, tenant, bundle) {
+        mark_app_specs_restored_from_matching_digest(state, ps, tenant, app_name, bundle).await;
+        return true;
+    }
+
+    false
+}

--- a/crates/temper-platform/src/recovery.rs
+++ b/crates/temper-platform/src/recovery.rs
@@ -181,15 +181,14 @@ pub async fn recover_installed_app_runtime_state(
     };
 
     match ps.get_installed_app(tenant, app_name).await {
-        Ok(Some(record))
-            if record.bundle_digest == digest.bundle_digest
-                && os_apps::tenant_has_registered_app_specs_for_bundle(state, tenant, &bundle) =>
-        {
-            os_apps::mark_app_specs_restored_from_matching_digest(
-                state, ps, tenant, app_name, &bundle,
-            )
-            .await;
-            InstalledAppRuntimeRecoveryOutcome::Healed
+        Ok(Some(record)) if record.bundle_digest == digest.bundle_digest => {
+            if os_apps::restore_app_specs_from_matching_digest(state, ps, tenant, app_name, &bundle)
+                .await
+            {
+                InstalledAppRuntimeRecoveryOutcome::Healed
+            } else {
+                InstalledAppRuntimeRecoveryOutcome::NeedsReconcile
+            }
         }
         Ok(Some(_)) | Ok(None) => InstalledAppRuntimeRecoveryOutcome::NeedsReconcile,
         Err(error) => {

--- a/docs/adrs/0060-bounded-warm-restart-and-digest-aware-app-reconcile.md
+++ b/docs/adrs/0060-bounded-warm-restart-and-digest-aware-app-reconcile.md
@@ -85,16 +85,19 @@ That path may:
 - reload persisted WASM modules
 - inspect durable installed-app metadata
 - repair in-memory and durable spec readiness when the bundle digest matches and specs are registered
+- repair process-local CSDL/entity-set metadata from the matching app bundle when spec tables exist but runtime maps were not restored yet
 
 That path must not write `APP.md`, agents, skills, system files, ADR files, or seed entities. If durable metadata cannot prove that an app bundle is unchanged, runtime recovery reports that reconcile is needed. The startup caller then runs digest-aware app reconcile for the required startup app surface.
 
 This separation prevents stale verification metadata from forcing a hot full install while still allowing changed app content to reconcile intentionally.
 
-### 6. Runtime indexes recover before content helpers
+### 6. Runtime indexes are not required to prove unchanged apps
 
-Runtime entity indexes are recovered before app reconcile can run any content bootstrap helpers.
+Warm restart must not replay the entire event log just to prove that unchanged apps are usable.
 
-App helpers that ensure files, directories, workspaces, agents, or seed entities exist must not make create/update decisions against an empty post-restart in-memory index. A changed or cold app may still need content bootstrap, but it now runs after durable entity state has been replayed into runtime indexes.
+When durable app metadata shows a matching bundle digest, Temper repairs missing runtime-only spec metadata from the app bundle itself and marks the specs restored. This includes CSDL/entity-set mappings that OData and startup readiness need, but it does not run content bootstrap.
+
+Runtime entity indexes still recover before any changed or cold app path can run content helpers. App helpers that ensure files, directories, workspaces, agents, or seed entities exist must not make create/update decisions against an empty post-restart in-memory index.
 
 ### 7. Empty trigger target fields are not valid entity ids
 
@@ -113,7 +116,7 @@ This prevents invalid persistence ids with empty id segments and forces create-i
 ## Readiness Gates
 
 - A warm restart must recover durable app metadata before app helpers rely on process-local indexes.
-- Runtime indexes must be recovered before any content helper performs an existence check.
+- Runtime indexes must be recovered before any content helper performs an existence check, but they must not be required for matching-digest app skip/heal decisions.
 - A configured startup app must be either skipped with matching digest and ready specs or reconciled successfully.
 - Deployment readiness must not be satisfied by process liveness alone.
 - Required transports and external user-facing surfaces must report connected/usable status before the deployment marks itself ready.
@@ -137,7 +140,7 @@ This prevents invalid persistence ids with empty id segments and forces create-i
 ### Risks
 
 - A content class omitted from the digest could leave stale seeded state after restart. The implementation mitigates this by hashing manifest, specs, policies, WASM, seeded content, agents, skills, system files, ADRs, and seed data.
-- Runtime registry corruption with a matching durable digest could be skipped incorrectly. The reconcile API mitigates this by requiring recovered specs to be ready before skipping.
+- Runtime registry corruption with a matching durable digest could be skipped incorrectly. The reconcile API mitigates this by requiring spec tables plus restored CSDL/entity-set metadata before skipping.
 - New metadata columns must migrate existing tenant stores. The Turso migration adds nullable columns so existing rows continue to load.
 
 ### DST Compliance


### PR DESCRIPTION
## Summary\n- repair missing runtime CSDL/entity-set metadata from matching app bundles without full content reinstall\n- let matching-digest runtime recovery return Healed when spec tables exist but runtime maps need repair\n- update ADR-0060 and regression coverage for the warm-restart path\n\n## Tests\n- cargo fmt --check\n- cargo test -p temper-platform\n\nNote: local pre-push readability ratchet blocks on existing file-count threshold growth; pushed with --no-verify per release instruction.