### PR TITLE
Fill HTTP request context defaults

### DIFF
--- a/crates/temper-server/src/state/mod.rs
+++ b/crates/temper-server/src/state/mod.rs
@@ -951,6 +951,7 @@ impl ServerState {
             session_id: agent_ctx.session_id.clone(),
             integration_config: std::collections::BTreeMap::new(),
             trace_id: agent_ctx.trace_id.clone().unwrap_or_default(),
+            http_request: None,
         };
 
         let wasm_result = self

--- a/crates/temper-wasm/src/host_trait.rs
+++ b/crates/temper-wasm/src/host_trait.rs
@@ -2194,6 +2194,7 @@ mod tests {
                 session_id: None,
                 integration_config: BTreeMap::new(),
                 trace_id: String::new(),
+                http_request: None,
             });
 
         let headers = vec![
@@ -2264,6 +2265,7 @@ mod tests {
                 session_id: None,
                 integration_config: BTreeMap::new(),
                 trace_id: String::new(),
+                http_request: None,
             });
 
         let headers = vec![("X-Tenant-Id".to_string(), "default".to_string())];
@@ -2324,6 +2326,7 @@ mod tests {
                 session_id: Some("ss-1".to_string()),
                 integration_config: BTreeMap::new(),
                 trace_id: String::new(),
+                http_request: None,
             });
 
         let (status, _) = tokio_test::block_on(host.http_call(
@@ -2357,6 +2360,7 @@ mod tests {
             session_id: Some("ss-1".to_string()),
             integration_config: BTreeMap::new(),
             trace_id: "0123456789abcdef0123456789abcdef".to_string(),
+            http_request: None,
         };
 
         let attrs = guest_log_span_attrs(
@@ -2417,6 +2421,7 @@ mod tests {
             session_id: Some("ss-1".to_string()),
             integration_config: BTreeMap::new(),
             trace_id: "0123456789abcdef0123456789abcdef".to_string(),
+            http_request: None,
         };
 
         {


### PR DESCRIPTION
## Summary
- add missing http_request: None fields to non-HTTP WasmInvocationContext initializers
- restores temper-wasm test-target compilation and server checks after the HttpDispatchContext field addition

## Verification
- cargo test -p temper-wasm http_stream
- cargo test -p temper-authz
- cargo check -p temper-authz -p temper-server -p temper-wasm
- cargo test -p temper-server test_blob_ingest_raw_route_streams_body_without_path_param
- cargo test -p temper-server test_post_entity_creation_uses_odata_id_property
- release temper-cli build used for live temper-git harness