### PR TITLE
Bound Turso write retry stalls

### DIFF
--- a/crates/temper-store-turso/src/retry.rs
+++ b/crates/temper-store-turso/src/retry.rs
@@ -26,6 +26,14 @@ use crate::metrics::record_turso_write_retry;
 /// typical Turso transient-error recovery windows.
 pub(crate) const RETRY_DELAYS_MS: &[u64] = &[250, 500, 1000, 2000];
 
+pub(crate) fn retry_delay_ms(retry_index: usize) -> u64 {
+    RETRY_DELAYS_MS
+        .get(retry_index)
+        .copied()
+        .or_else(|| RETRY_DELAYS_MS.last().copied())
+        .unwrap_or(0)
+}
+
 /// Returns true if `err_msg` looks like a transient Turso/libSQL failure
 /// that retry with backoff can reasonably recover from.
 ///
@@ -84,6 +92,7 @@ fn error_text(err: &PersistenceError) -> Option<&str> {
 /// Not intended for reads — those are typically idempotent but also
 /// rarely benefit from retry in the same way (they're not the root of
 /// entity-state correctness). Scoped to write paths explicitly.
+#[cfg(test)]
 pub(crate) async fn retry_persistence<F, Fut, T>(
     operation: &'static str,
     mut f: F,
@@ -92,12 +101,24 @@ where
     F: FnMut() -> Fut,
     Fut: std::future::Future<Output = Result<T, PersistenceError>>,
 {
-    let total_attempts = RETRY_DELAYS_MS.len() + 1;
+    retry_persistence_with_max_attempts(operation, RETRY_DELAYS_MS.len() + 1, &mut f).await
+}
+
+pub(crate) async fn retry_persistence_with_max_attempts<F, Fut, T>(
+    operation: &'static str,
+    max_attempts: usize,
+    mut f: F,
+) -> Result<T, PersistenceError>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T, PersistenceError>>,
+{
+    let total_attempts = max_attempts.max(1);
     let mut last_err: Option<PersistenceError> = None;
 
     for attempt in 0..total_attempts {
         if attempt > 0 {
-            let delay_ms = RETRY_DELAYS_MS[attempt - 1];
+            let delay_ms = retry_delay_ms(attempt - 1);
             tokio::time::sleep(Duration::from_millis(delay_ms)).await;
         }
 

--- a/crates/temper-store-turso/src/store/event_store.rs
+++ b/crates/temper-store-turso/src/store/event_store.rs
@@ -11,7 +11,7 @@ use tracing::{instrument, warn};
 use super::TursoEventStore;
 use super::instrumentation::record_turso_query_duration;
 use crate::metrics::record_turso_write_retry;
-use crate::retry::{RETRY_DELAYS_MS, is_transient_write_error};
+use crate::retry::{RETRY_DELAYS_MS, is_transient_write_error, retry_delay_ms};
 
 impl EventStore for TursoEventStore {
     #[instrument(skip_all, fields(persistence_id, otel.name = "turso.append"))]
@@ -28,11 +28,11 @@ impl EventStore for TursoEventStore {
         // erroring, the retry's pre-check detects it as ConcurrencyViolation
         // (non-transient, propagates to caller via normal event-store contract).
         let attempt_timeout = append_attempt_timeout();
-        let total_attempts = RETRY_DELAYS_MS.len() + 1;
+        let total_attempts = append_max_attempts();
         let mut last_err: Option<PersistenceError> = None;
         for attempt in 0..total_attempts {
             if attempt > 0 {
-                tokio::time::sleep(Duration::from_millis(RETRY_DELAYS_MS[attempt - 1])).await;
+                tokio::time::sleep(Duration::from_millis(retry_delay_ms(attempt - 1))).await;
             }
             let attempt_result = tokio::time::timeout(
                 attempt_timeout,
@@ -233,6 +233,16 @@ fn append_attempt_timeout() -> Duration {
         .unwrap_or(DEFAULT_APPEND_ATTEMPT_TIMEOUT_MS);
 
     Duration::from_millis(configured.max(MIN_APPEND_ATTEMPT_TIMEOUT_MS))
+}
+
+fn append_max_attempts() -> usize {
+    const DEFAULT_APPEND_MAX_ATTEMPTS: usize = RETRY_DELAYS_MS.len() + 1;
+
+    std::env::var("TEMPER_TURSO_APPEND_MAX_ATTEMPTS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(DEFAULT_APPEND_MAX_ATTEMPTS)
+        .max(1)
 }
 
 impl TursoEventStore {

--- a/crates/temper-store-turso/src/store/trajectory.rs
+++ b/crates/temper-store-turso/src/store/trajectory.rs
@@ -1,6 +1,7 @@
 //! Trajectory persistence and query methods.
 
 use libsql::params;
+use std::time::Duration;
 use temper_runtime::persistence::{PersistenceError, storage_error};
 use tracing::instrument;
 
@@ -10,7 +11,7 @@ use super::{
 };
 use crate::TursoTrajectoryInsert;
 use crate::metrics::TursoQueryTimer;
-use crate::retry::retry_persistence;
+use crate::retry::retry_persistence_with_max_attempts;
 
 impl TursoEventStore {
     /// Persist a trajectory entry (all columns including agent/authz fields).
@@ -33,54 +34,79 @@ impl TursoEventStore {
         // duplicate row with identical fields is acceptable and rare. The
         // alternative (losing the trajectory during Turso wobbles) is worse —
         // trajectories are the observability record of what the entity did.
-        retry_persistence("turso.persist_trajectory", || async {
-            let conn = self.configured_connection().await?;
-            let execute_res = conn
-                .execute(
-                "INSERT INTO trajectories \
-                 (tenant, entity_type, entity_id, action, success, from_status, to_status, error, \
-                  agent_id, session_id, authz_denied, denied_resource, denied_module, source, spec_governed, created_at, request_body, intent, matched_policy_ids) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)",
-                params![
-                    entry.tenant,
-                    entry.entity_type,
-                    entry.entity_id,
-                    entry.action,
-                    entry.success as i64,
-                    entry.from_status,
-                    entry.to_status,
-                    entry.error,
-                    entry.agent_id,
-                    entry.session_id,
-                    entry.authz_denied.map(|b| b as i64),
-                    entry.denied_resource,
-                    entry.denied_module,
-                    entry.source,
-                    entry.spec_governed.map(|b| b as i64),
-                    entry.created_at,
-                    entry.request_body,
-                    entry.intent,
-                    entry.matched_policy_ids
-                ],
-            )
-            .await
-            .map_err(storage_error);
-            if let Err(ref error) = execute_res {
-                tracing::warn!(
-                    tenant = entry.tenant,
-                    entity_type = entry.entity_type,
-                    entity_id = entry.entity_id,
-                    action = entry.action,
-                    success = entry.success,
-                    source = ?entry.source,
-                    authz_denied = ?entry.authz_denied,
-                    error = %error,
-                    "trajectory.store.write"
-                );
-            }
-            execute_res?;
-            Ok(())
-        })
+        let attempt_timeout = trajectory_attempt_timeout();
+        retry_persistence_with_max_attempts(
+            "turso.persist_trajectory",
+            trajectory_max_attempts(),
+            || async {
+                tokio::time::timeout(attempt_timeout, async {
+                    let conn = self.configured_connection().await?;
+                    let execute_res = conn
+                        .execute(
+                        "INSERT INTO trajectories \
+                         (tenant, entity_type, entity_id, action, success, from_status, to_status, error, \
+                          agent_id, session_id, authz_denied, denied_resource, denied_module, source, spec_governed, created_at, request_body, intent, matched_policy_ids) \
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)",
+                        params![
+                            entry.tenant,
+                            entry.entity_type,
+                            entry.entity_id,
+                            entry.action,
+                            entry.success as i64,
+                            entry.from_status,
+                            entry.to_status,
+                            entry.error,
+                            entry.agent_id,
+                            entry.session_id,
+                            entry.authz_denied.map(|b| b as i64),
+                            entry.denied_resource,
+                            entry.denied_module,
+                            entry.source,
+                            entry.spec_governed.map(|b| b as i64),
+                            entry.created_at,
+                            entry.request_body,
+                            entry.intent,
+                            entry.matched_policy_ids
+                        ],
+                    )
+                    .await
+                    .map_err(storage_error);
+                    if let Err(ref error) = execute_res {
+                        tracing::warn!(
+                            tenant = entry.tenant,
+                            entity_type = entry.entity_type,
+                            entity_id = entry.entity_id,
+                            action = entry.action,
+                            success = entry.success,
+                            source = ?entry.source,
+                            authz_denied = ?entry.authz_denied,
+                            error = %error,
+                            "trajectory.store.write"
+                        );
+                    }
+                    execute_res?;
+                    Ok(())
+                })
+                .await
+                .unwrap_or_else(|_| {
+                    tracing::warn!(
+                        tenant = entry.tenant,
+                        entity_type = entry.entity_type,
+                        entity_id = entry.entity_id,
+                        action = entry.action,
+                        success = entry.success,
+                        source = ?entry.source,
+                        authz_denied = ?entry.authz_denied,
+                        timeout_ms = attempt_timeout.as_millis() as u64,
+                        "trajectory.store.write timed out"
+                    );
+                    Err(PersistenceError::Storage(format!(
+                        "turso.persist_trajectory timed out after {}ms",
+                        attempt_timeout.as_millis()
+                    )))
+                })
+            },
+        )
         .await?;
         tracing::Span::current().record("rows_written", 1u64);
         tracing::info!(
@@ -462,4 +488,26 @@ impl TursoEventStore {
         tracing::info!(tenant, count = out.len(), "trajectory.store.read");
         Ok(out)
     }
+}
+
+fn trajectory_attempt_timeout() -> Duration {
+    const DEFAULT_TRAJECTORY_ATTEMPT_TIMEOUT_MS: u64 = 1_000;
+    const MIN_TRAJECTORY_ATTEMPT_TIMEOUT_MS: u64 = 100;
+
+    let configured = std::env::var("TEMPER_TURSO_TRAJECTORY_TIMEOUT_MS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_TRAJECTORY_ATTEMPT_TIMEOUT_MS);
+
+    Duration::from_millis(configured.max(MIN_TRAJECTORY_ATTEMPT_TIMEOUT_MS))
+}
+
+fn trajectory_max_attempts() -> usize {
+    const DEFAULT_TRAJECTORY_MAX_ATTEMPTS: usize = 1;
+
+    std::env::var("TEMPER_TURSO_TRAJECTORY_MAX_ATTEMPTS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(DEFAULT_TRAJECTORY_MAX_ATTEMPTS)
+        .max(1)
 }


### PR DESCRIPTION
## Summary
- add TEMPER_TURSO_APPEND_MAX_ATTEMPTS so event appends do not always spend the full 5-attempt retry budget
- bound trajectory persistence with TEMPER_TURSO_TRAJECTORY_TIMEOUT_MS and TEMPER_TURSO_TRAJECTORY_MAX_ATTEMPTS
- keep trajectory writes observable but stop them from adding multi-second latency to user-facing dispatch failures

## Validation
- cargo fmt --check
- cargo check -p temper-store-turso
- cargo test -p temper-store-turso retry::tests -- --nocapture

Admin merge requested for production hotfix.