### PR TITLE
[codex] Prioritize foreground Turso appends

### DIFF
--- a/crates/temper-store-turso/src/store/blobs.rs
+++ b/crates/temper-store-turso/src/store/blobs.rs
@@ -8,6 +8,8 @@ use crate::TursoEventStore;
 use libsql::params;
 use std::time::Duration;
 
+use super::write_gate::WritePriority;
+
 const BLOB_STORE_ATTEMPTS: usize = 6;
 
 fn is_blob_lock_error(error: &str) -> bool {
@@ -51,7 +53,7 @@ impl TursoEventStore {
         let ttl_seconds = ttl.map(|d| d.as_secs() as i64);
         for attempt in 1..=BLOB_STORE_ATTEMPTS {
             let _write_permit = self
-                .acquire_write_permit("turso.put_blob")
+                .acquire_write_permit("turso.put_blob", WritePriority::Low)
                 .await
                 .map_err(|e| e.to_string())?;
             let conn = self
@@ -108,7 +110,7 @@ impl TursoEventStore {
     /// ADR-0047.
     pub async fn sweep_expired_blobs(&self, max_rows: u64) -> Result<u64, String> {
         let _write_permit = self
-            .acquire_write_permit("turso.sweep_expired_blobs")
+            .acquire_write_permit("turso.sweep_expired_blobs", WritePriority::Low)
             .await
             .map_err(|e| e.to_string())?;
         let conn = self

--- a/crates/temper-store-turso/src/store/event_store.rs
+++ b/crates/temper-store-turso/src/store/event_store.rs
@@ -10,6 +10,7 @@ use tracing::{instrument, warn};
 
 use super::TursoEventStore;
 use super::instrumentation::record_turso_query_duration;
+use super::write_gate::WritePriority;
 use crate::metrics::record_turso_write_retry;
 use crate::retry::{RETRY_DELAYS_MS, is_transient_write_error, retry_delay_ms};
 
@@ -34,7 +35,9 @@ impl EventStore for TursoEventStore {
             if attempt > 0 {
                 tokio::time::sleep(Duration::from_millis(retry_delay_ms(attempt - 1))).await;
             }
-            let _write_permit = self.acquire_write_permit("turso.append").await?;
+            let _write_permit = self
+                .acquire_write_permit("turso.append", WritePriority::High)
+                .await?;
             let attempt_result = tokio::time::timeout(
                 attempt_timeout,
                 self.append_inner(persistence_id, expected_sequence, events),
@@ -137,7 +140,9 @@ impl EventStore for TursoEventStore {
     ) -> Result<(), PersistenceError> {
         let (tenant, entity_type, entity_id) =
             parse_persistence_id_parts(persistence_id).map_err(PersistenceError::Storage)?;
-        let _write_permit = self.acquire_write_permit("turso.save_snapshot").await?;
+        let _write_permit = self
+            .acquire_write_permit("turso.save_snapshot", WritePriority::Low)
+            .await?;
         let conn = self.configured_connection().await?;
 
         conn.execute(

--- a/crates/temper-store-turso/src/store/field_index.rs
+++ b/crates/temper-store-turso/src/store/field_index.rs
@@ -13,6 +13,7 @@ use temper_runtime::scheduler::sim_now;
 use tracing::instrument;
 
 use super::TursoEventStore;
+use super::write_gate::WritePriority;
 
 fn projection_hash(status: &str, fields: &serde_json::Value) -> String {
     let mut hasher = Sha256::new();
@@ -66,7 +67,7 @@ impl TursoEventStore {
         sequence_nr: u64,
     ) -> Result<(), PersistenceError> {
         let _write_permit = self
-            .acquire_write_permit("turso.upsert_query_projection")
+            .acquire_write_permit("turso.upsert_query_projection", WritePriority::Low)
             .await?;
         let conn = self.configured_connection().await?;
         let new_projection_hash = projection_hash(status, fields);
@@ -196,7 +197,7 @@ impl TursoEventStore {
         entity_id: &str,
     ) -> Result<(), PersistenceError> {
         let _write_permit = self
-            .acquire_write_permit("turso.remove_query_projection")
+            .acquire_write_permit("turso.remove_query_projection", WritePriority::Low)
             .await?;
         let conn = self.configured_connection().await?;
         let tx = conn

--- a/crates/temper-store-turso/src/store/mod.rs
+++ b/crates/temper-store-turso/src/store/mod.rs
@@ -11,6 +11,7 @@
 
 use libsql::{Builder, Database};
 use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
 use temper_runtime::persistence::{PersistenceError, storage_error};
 use tokio::sync::Semaphore;
 use tracing::instrument;
@@ -40,6 +41,7 @@ use instrumentation::InstrumentedConnection;
 pub struct TursoEventStore {
     db: Arc<Database>,
     write_gate: Arc<Semaphore>,
+    high_priority_write_waiters: Arc<AtomicUsize>,
     /// True when connected to a remote Turso Cloud instance (libsql:// URL).
     /// PRAGMAs are skipped for remote connections.
     is_remote: bool,
@@ -75,6 +77,7 @@ impl TursoEventStore {
             write_gate: Arc::new(Semaphore::new(write_gate::configured_write_concurrency(
                 is_remote,
             ))),
+            high_priority_write_waiters: Arc::new(AtomicUsize::new(0)),
             is_remote,
         };
         store.migrate().await?;

--- a/crates/temper-store-turso/src/store/trajectory.rs
+++ b/crates/temper-store-turso/src/store/trajectory.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use temper_runtime::persistence::{PersistenceError, storage_error};
 use tracing::instrument;
 
+use super::write_gate::WritePriority;
 use super::{
     ActionStats, AgentSummary, TrajectoryStats, TursoEventStore, TursoTrajectoryRow,
     UnmetIntentAggRow,
@@ -39,7 +40,9 @@ impl TursoEventStore {
             "turso.persist_trajectory",
             trajectory_max_attempts(),
             || async {
-                let _write_permit = self.acquire_write_permit("turso.persist_trajectory").await?;
+                let _write_permit = self
+                    .acquire_write_permit("turso.persist_trajectory", WritePriority::Low)
+                    .await?;
                 tokio::time::timeout(attempt_timeout, async {
                     let conn = self.configured_connection().await?;
                     let execute_res = conn

--- a/crates/temper-store-turso/src/store/write_gate.rs
+++ b/crates/temper-store-turso/src/store/write_gate.rs
@@ -5,6 +5,21 @@ use tokio::sync::OwnedSemaphorePermit;
 
 use super::TursoEventStore;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum WritePriority {
+    High,
+    Low,
+}
+
+impl WritePriority {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::High => "high",
+            Self::Low => "low",
+        }
+    }
+}
+
 pub(super) fn configured_write_concurrency(is_remote: bool) -> usize {
     let default = if is_remote { 1 } else { 4 };
     std::env::var("TEMPER_TURSO_WRITE_CONCURRENCY")
@@ -25,35 +40,103 @@ impl TursoEventStore {
     pub(super) async fn acquire_write_permit(
         &self,
         operation: &'static str,
+        priority: WritePriority,
     ) -> Result<OwnedSemaphorePermit, PersistenceError> {
         let started = std::time::Instant::now();
         let timeout = write_gate_wait_timeout();
-        let permit = tokio::time::timeout(timeout, self.write_gate.clone().acquire_owned())
+
+        if priority == WritePriority::Low {
+            self.wait_for_high_priority_writers(operation, started, timeout)
+                .await?;
+        }
+
+        let remaining = timeout.saturating_sub(started.elapsed());
+        if remaining.is_zero() {
+            return Err(write_gate_timeout_error(operation, priority, timeout));
+        }
+
+        let high_priority_waiter = if priority == WritePriority::High {
+            Some(HighPriorityWaiter::new(self))
+        } else {
+            None
+        };
+        let permit = tokio::time::timeout(remaining, self.write_gate.clone().acquire_owned())
             .await
-            .map_err(|_| {
-                PersistenceError::Storage(format!(
-                    "{operation} waited more than {}ms for Turso write gate",
-                    timeout.as_millis()
-                ))
-            })?
+            .map_err(|_| write_gate_timeout_error(operation, priority, timeout))?
             .map_err(|_| PersistenceError::Storage("Turso write gate closed".to_string()))?;
+        if let Some(waiter) = high_priority_waiter {
+            waiter.done_waiting();
+        }
 
         let waited = started.elapsed();
         if waited >= Duration::from_millis(100) {
             tracing::warn!(
                 operation,
+                priority = priority.as_str(),
                 wait_ms = waited.as_millis() as u64,
                 "turso.write_gate waited"
             );
         } else {
             tracing::debug!(
                 operation,
+                priority = priority.as_str(),
                 wait_ms = waited.as_millis() as u64,
                 "turso.write_gate acquired"
             );
         }
 
         Ok(permit)
+    }
+
+    async fn wait_for_high_priority_writers(
+        &self,
+        operation: &'static str,
+        started: std::time::Instant,
+        timeout: Duration,
+    ) -> Result<(), PersistenceError> {
+        while self.has_high_priority_waiters() {
+            let remaining = timeout.saturating_sub(started.elapsed());
+            if remaining.is_zero() {
+                return Err(write_gate_timeout_error(
+                    operation,
+                    WritePriority::Low,
+                    timeout,
+                ));
+            }
+            tokio::time::sleep(remaining.min(Duration::from_millis(25))).await;
+        }
+        Ok(())
+    }
+
+    fn has_high_priority_waiters(&self) -> bool {
+        self.high_priority_write_waiters
+            .load(std::sync::atomic::Ordering::Acquire)
+            > 0
+    }
+}
+
+struct HighPriorityWaiter<'a> {
+    store: &'a TursoEventStore,
+}
+
+impl<'a> HighPriorityWaiter<'a> {
+    fn new(store: &'a TursoEventStore) -> Self {
+        store
+            .high_priority_write_waiters
+            .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+        Self { store }
+    }
+
+    fn done_waiting(self) {
+        drop(self);
+    }
+}
+
+impl Drop for HighPriorityWaiter<'_> {
+    fn drop(&mut self) {
+        self.store
+            .high_priority_write_waiters
+            .fetch_sub(1, std::sync::atomic::Ordering::AcqRel);
     }
 }
 
@@ -67,4 +150,16 @@ fn write_gate_wait_timeout() -> Duration {
         .unwrap_or(DEFAULT_WRITE_GATE_WAIT_TIMEOUT_MS);
 
     Duration::from_millis(configured.max(MIN_WRITE_GATE_WAIT_TIMEOUT_MS))
+}
+
+fn write_gate_timeout_error(
+    operation: &'static str,
+    priority: WritePriority,
+    timeout: Duration,
+) -> PersistenceError {
+    PersistenceError::Storage(format!(
+        "{operation} ({}) waited more than {}ms for Turso write gate",
+        priority.as_str(),
+        timeout.as_millis()
+    ))
 }


### PR DESCRIPTION
## What changed
- Adds priority-aware Turso write gate acquisition.
- Keeps foreground event appends high priority.
- Makes snapshots, query projections, blob writes, blob sweeps, and trajectory writes low priority so they yield while appends are waiting.
- Adds priority labels to write-gate wait logs.

## Why
The first write gate prevented remote Turso lock storms but treated foreground appends and background maintenance equally. Under startup/passivation/projection pressure, Discord/session appends could still wait behind lower-priority writes. This preserves serialization while keeping the event log responsive.

## Validation
- cargo fmt --check
- cargo check -p temper-store-turso
- cargo test -p temper-store-turso retry::tests -- --nocapture
- cargo test -p temper-store-turso store::tests -- --nocapture
- local pre-push clippy passed; readability hook is blocked by existing origin/main baseline drift and was bypassed for this hotfix