### PR TITLE
[codex] Add delta OS app reconcile

### DIFF
--- a/.proofs/2026-04-27-delta-os-app-reconcile.md
+++ b/.proofs/2026-04-27-delta-os-app-reconcile.md
@@ -1,0 +1,107 @@
+# Delta OS-App Reconcile Proof
+
+Date: 2026-04-27
+
+Worktree: `/Users/seshendranalla/Development/temper-worktrees/os-app-delta-reconcile`
+
+## Red Tests
+
+Added failing tests before implementation:
+
+- `upsert_specs_and_commit_preserves_identical_spec_version`
+- `upsert_wasm_module_preserves_version_for_identical_hash`
+- `upsert_wasm_module_stores_artifact_outside_metadata_row`
+- `test_reconcile_plan_for_wasm_only_digest_skips_unrelated_phases`
+- `test_reconcile_os_app_repairs_spec_content_drift_despite_matching_digest`
+
+Initial failures on `main` behavior:
+
+- identical spec commit bumped version from `1` to `2`
+- identical WASM upsert bumped version from `1` to `2`
+- new WASM metadata row stored `7` inline bytes instead of `0`
+- reconcile plan API did not exist yet
+- matching installed bundle digest skipped hot reconcile even when live runtime
+  spec content had drifted
+
+## Verification Commands
+
+```bash
+cargo test -p temper-store-turso
+```
+
+Result: passed. `34` unit tests, `5` blob TTL e2e tests, and doctests passed.
+
+```bash
+cargo test -p temper-platform os_apps::mod_test
+```
+
+Result: passed. `52` OS-app platform tests passed.
+
+```bash
+cargo run -p temper-cli -- --help
+```
+
+Result: passed. The Temper CLI built and printed help.
+
+## Local Server Smoke
+
+Started a local Temper server with a temp Turso DB and the project-management app:
+
+```bash
+rm -f /tmp/temper-delta-reconcile-e2e.db /tmp/temper-delta-reconcile-e2e.db-wal /tmp/temper-delta-reconcile-e2e.db-shm
+TURSO_URL=file:/tmp/temper-delta-reconcile-e2e.db \
+  cargo run -p temper-cli -- serve --storage turso --no-observe --port 39876 --skill project-management
+```
+
+Observed:
+
+- server listened on `http://0.0.0.0:39876`
+- `curl -fsS http://127.0.0.1:39876/healthz` exited successfully
+- project-management installed for tenant `default`
+
+Queried the local DB:
+
+```bash
+sqlite3 /tmp/temper-delta-reconcile-e2e.db \
+  "select app_name, length(bundle_digest)>0 as has_bundle, length(spec_digest)>0 as has_spec from tenant_installed_apps where tenant_id='default';
+   select entity_type, version, committed from specs where tenant='default' order by entity_type;"
+```
+
+Observed:
+
+- `tenant_installed_apps` had `project-management` with bundle and spec digests present
+- committed specs for `default` included `Comment`, `Cycle`, `Issue`, `Label`, and `Project`
+- project-management spec versions were `1` and committed
+
+Stopped the server with `SIGTERM` and confirmed no matching process remained.
+
+## Notes
+
+The local smoke run is a cold install because it starts from an empty DB. Delta reconcile behavior is covered by the OS-app tests:
+
+- `test_reconcile_os_app_delta_content_change_skips_specs` forces a changed bundle/content digest with matching spec/policy/WASM/seed digests and verifies reconcile does not classify or bootstrap specs.
+- `test_install_plan_without_spec_phase_does_not_reclassify_specs` verifies the installer obeys a plan with the spec phase disabled.
+- `test_reconcile_os_app_repairs_spec_content_drift_despite_matching_digest` verifies a matching installed bundle record does not hide drifted live spec content.
+
+## OpenPaw Live E2E
+
+Ran OpenPaw in a disposable worktree using patched local Temper crates via
+Cargo `[patch]` entries, a disposable home, and a file-backed Turso DB.
+
+Cold boot from an empty DB:
+
+- `/readyz` returned HTTP `200`
+- `phase_6b_os_app_reconcile`: `11,813ms`
+- startup time to ready: `12,227ms`
+- `wasm_modules`: `31` rows, `31` metadata-only rows, `31` blob artifacts,
+  `15,272,520` bytes in blobs, min/max metadata version `1/1`
+- `specs`: `default` had `32` committed specs, min/max version `1/1`;
+  `temper-system` had `13` committed specs, min/max version `1/1`
+
+Warm boot using the same DB and `TEMPERPAW_WASM_STARTUP_POLICY=load-only`:
+
+- `/readyz` returned HTTP `200`
+- all six startup apps logged `Skipped unchanged OS app`
+- `phase_6b_os_app_reconcile`: `1,267ms`
+- startup time to ready: `1,862ms`
+- `wasm_modules` and `specs` row counts and versions stayed unchanged

--- a/crates/temper-platform/src/os_apps/git_sources.rs
+++ b/crates/temper-platform/src/os_apps/git_sources.rs
@@ -164,9 +164,21 @@ pub fn sync_and_register_git_sources(cache_dir: &Path) -> Result<Vec<String>, St
 
 /// Run a git command and return Ok(()) on success, Err(stderr) on failure.
 fn run_git(args: &[&str], working_dir: &Path) -> Result<(), String> {
-    let output = Command::new("git")
-        .args(args)
-        .current_dir(working_dir)
+    let mut command = Command::new("git");
+    command.args(args).current_dir(working_dir);
+    for key in [
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_PREFIX",
+        "GIT_COMMON_DIR",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    ] {
+        command.env_remove(key);
+    }
+
+    let output = command
         .output()
         .map_err(|e| format!("failed to run git {}: {e}", args.first().unwrap_or(&"")))?;
 
@@ -302,7 +314,15 @@ mod tests {
     // ── sync_git_source (integration) ──────────────────────────────────
 
     fn make_temp_dir(prefix: &str) -> PathBuf {
-        let dir = std::env::temp_dir().join(format!("temper-{prefix}-{}", uuid::Uuid::new_v4()));
+        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let root = manifest_dir
+            .parent()
+            .and_then(|path| path.parent())
+            .and_then(|path| path.parent())
+            .map(Path::to_path_buf)
+            .unwrap_or_else(std::env::temp_dir)
+            .join(".temper-test-tmp/temper-platform");
+        let dir = root.join(format!("temper-{prefix}-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&dir).expect("create temp dir");
         dir
     }

--- a/crates/temper-platform/src/os_apps/mod.rs
+++ b/crates/temper-platform/src/os_apps/mod.rs
@@ -1204,6 +1204,15 @@ async fn install_os_app_without_dependencies(
     tenant: &str,
     app_name: &str,
 ) -> Result<InstallResult, String> {
+    install_os_app_with_plan(state, tenant, app_name, OsAppInstallPlan::all()).await
+}
+
+pub(super) async fn install_os_app_with_plan(
+    state: &PlatformState,
+    tenant: &str,
+    app_name: &str,
+    plan: OsAppInstallPlan,
+) -> Result<InstallResult, String> {
     let app_dir = {
         let cat = catalog().read().unwrap(); // ci-ok: infallible lock
         cat.paths.get(app_name).cloned().ok_or_else(|| {
@@ -1228,8 +1237,8 @@ async fn install_os_app_without_dependencies(
     }
 
     // Classify each bundle spec as added / updated / skipped, and compute the
-    // merged CSDL — both require the registry read lock, so we do them together.
-    let (mut added, mut updated, mut skipped, merged_csdl) = {
+    // merged CSDL only when the reconcile plan needs spec work.
+    let (mut added, mut updated, mut skipped, merged_csdl) = if plan.specs {
         let registry = state.registry.read().unwrap(); // ci-ok: infallible lock
         let mut added = Vec::new();
         let mut updated = Vec::new();
@@ -1270,6 +1279,8 @@ async fn install_os_app_without_dependencies(
                 .map(|t| emit_csdl_xml(&t.csdl))
         };
         (added, updated, skipped, merged_csdl)
+    } else {
+        (Vec::new(), Vec::new(), Vec::new(), None)
     };
     // Sort for deterministic output.
     added.sort();
@@ -1277,7 +1288,7 @@ async fn install_os_app_without_dependencies(
     skipped.sort();
 
     // Build the full Cedar policy text for this tenant (existing + new).
-    let combined_policy = if !bundle.cedar_policies.is_empty() {
+    let combined_policy = if plan.policies && !bundle.cedar_policies.is_empty() {
         let combined: String = bundle.cedar_policies.join("\n");
         let policies = state.server.tenant_policies.read().unwrap(); // ci-ok: infallible lock
         let existing = policies.get(tenant).cloned().unwrap_or_default();
@@ -1296,28 +1307,18 @@ async fn install_os_app_without_dependencies(
     if let Some(ref store) = state.server.event_store
         && let Some(turso) = store.platform_turso_store()
     {
-        let mut spec_sources: BTreeMap<String, String> = turso
-            .load_specs()
-            .await
-            .map_err(|e| format!("Failed to load existing specs for tenant '{tenant}': {e}"))?
-            .into_iter()
-            .filter(|row| row.tenant == tenant)
-            .map(|row| (row.entity_type, row.ioa_source))
-            .collect();
-
-        for (entity_type, ioa_source) in &bundle.specs {
-            spec_sources.insert(entity_type.clone(), ioa_source.clone());
-        }
-
-        if let Some(ref merged) = merged_csdl {
-            // Collect all specs with their content hashes for a single
-            // transactional write — eliminates the crash window between
-            // individual upserts (committed=0) and the commit step.
-            let owned: Vec<(String, String, String, String)> = spec_sources
-                .into_iter()
+        if plan.specs
+            && let Some(ref merged) = merged_csdl
+        {
+            // Collect only this app's specs with their content hashes for a
+            // single transactional write. Existing tenant specs are preserved by
+            // the merged CSDL, but no longer re-written on every app install.
+            let owned: Vec<(String, String, String, String)> = bundle
+                .specs
+                .iter()
                 .map(|(et, ioa)| {
-                    let hash = temper_store_turso::spec_content_hash(&ioa);
-                    (et, ioa, merged.clone(), hash)
+                    let hash = temper_store_turso::spec_content_hash(ioa);
+                    (et.clone(), ioa.clone(), merged.clone(), hash)
                 })
                 .collect();
             let refs: Vec<(&str, &str, &str, &str)> = owned
@@ -1328,8 +1329,19 @@ async fn install_os_app_without_dependencies(
                 .upsert_specs_and_commit(tenant, &refs, combined_policy.as_deref(), app_name)
                 .await
                 .map_err(|e| format!("Failed to persist and commit specs: {e}"))?;
+        } else if let Some(ref policy_text) = combined_policy {
+            turso
+                .upsert_tenant_policy(tenant, policy_text)
+                .await
+                .map_err(|e| format!("Failed to persist Cedar policy: {e}"))?;
+            turso
+                .record_installed_app(tenant, app_name)
+                .await
+                .map_err(|e| format!("Failed to record os-app installation: {e}"))?;
         }
-        if let Some(ref cross_invariants_toml) = bundle.cross_invariants_toml {
+        if plan.specs
+            && let Some(ref cross_invariants_toml) = bundle.cross_invariants_toml
+        {
             turso
                 .upsert_tenant_constraints(tenant, cross_invariants_toml)
                 .await
@@ -1338,7 +1350,9 @@ async fn install_os_app_without_dependencies(
     } else if let Some(ref store) = state.server.event_store
         && let Some(ps) = store.platform_store()
     {
-        if let Some(ref merged) = merged_csdl {
+        if plan.specs
+            && let Some(ref merged) = merged_csdl
+        {
             for (entity_type, ioa_source) in &bundle.specs {
                 let hash = temper_store_turso::spec_content_hash(ioa_source);
                 ps.upsert_spec(tenant, entity_type, ioa_source, merged, &hash)
@@ -1351,7 +1365,9 @@ async fn install_os_app_without_dependencies(
                 .await
                 .map_err(|e| format!("Failed to persist Cedar policy: {e}"))?;
         }
-        if let Some(ref cross_invariants_toml) = bundle.cross_invariants_toml {
+        if plan.specs
+            && let Some(ref cross_invariants_toml) = bundle.cross_invariants_toml
+        {
             ps.upsert_tenant_constraints(tenant, cross_invariants_toml)
                 .await
                 .map_err(|e| format!("Failed to persist cross-invariants: {e}"))?;
@@ -1359,16 +1375,18 @@ async fn install_os_app_without_dependencies(
         ps.record_installed_app(tenant, app_name)
             .await
             .map_err(|e| format!("Failed to record os-app installation: {e}"))?;
-        // Commit all specs atomically after all writes succeed.
-        ps.commit_specs(tenant)
-            .await
-            .map_err(|e| format!("Failed to commit specs: {e}"))?;
+        if plan.specs {
+            // Commit only when this path used individual spec writes.
+            ps.commit_specs(tenant)
+                .await
+                .map_err(|e| format!("Failed to commit specs: {e}"))?;
+        }
     }
 
     // ── Step 2: Bootstrap into memory (verification + registry). ────
     // Only process specs whose content has changed (added or updated);
     // skipped specs are already loaded with identical content.
-    if !bundle.specs.is_empty() {
+    if plan.specs && !bundle.specs.is_empty() {
         let specs_to_bootstrap: Vec<(&str, &str)> = bundle
             .specs
             .iter()
@@ -1430,7 +1448,9 @@ async fn install_os_app_without_dependencies(
     // App installs can add or change cross-entity reactions. Refresh the live
     // dispatcher immediately so the newly registered tenant config takes effect
     // without requiring a process restart or a separate specs reload.
-    state.server.rebuild_reaction_dispatcher();
+    if plan.specs {
+        state.server.rebuild_reaction_dispatcher();
+    }
 
     // ── Step 3: Load Cedar policies into memory. ────────────────────
     if let Some(ref policy_text) = combined_policy {
@@ -1454,75 +1474,77 @@ async fn install_os_app_without_dependencies(
     let mut wasm_registered = Vec::new();
     let mut wasm_skipped = Vec::new();
     let mut wasm_failures = Vec::new();
-    for (module_name, wasm_bytes) in &bundle.wasm_modules {
-        let module_config = bundle.wasm_module_configs.get(module_name);
-        let hash = temper_wasm::WasmEngine::hash_module(wasm_bytes);
+    if plan.wasm {
+        for (module_name, wasm_bytes) in &bundle.wasm_modules {
+            let module_config = bundle.wasm_module_configs.get(module_name);
+            let hash = temper_wasm::WasmEngine::hash_module(wasm_bytes);
 
-        if let Err(e) = state
-            .server
-            .upsert_wasm_module(tenant, module_name, wasm_bytes, &hash)
-            .await
-        {
-            tracing::warn!(
-                tenant,
-                module = %module_name,
-                error = %e,
-                "Failed to persist WASM module to durable store (continuing in-memory only)"
-            );
-        }
-        {
-            let mut wasm_reg = state.server.wasm_module_registry.write().unwrap(); // ci-ok: infallible lock
-            wasm_reg.register(&tenant_id, module_name, &hash);
-        }
-
-        if matches!(
-            module_config.map(|config| config.startup_loading),
-            Some(WasmStartupLoading::Eager)
-        ) && let Err(e) = state.server.wasm_engine.compile_and_cache(wasm_bytes)
-        {
-            wasm_failures.push(module_name.clone());
-            tracing::warn!(
-                tenant,
-                module = %module_name,
-                error = %e,
-                "Failed to eagerly compile WASM module from OS app"
-            );
-        }
-
-        tracing::info!(
-            tenant,
-            module = %module_name,
-            hash = %hash,
-            size = wasm_bytes.len(),
-            startup_loading = ?module_config
-                .map(|config| config.startup_loading)
-                .unwrap_or_default(),
-            "WASM module registered from OS app"
-        );
-        wasm_registered.push(module_name.clone());
-    }
-
-    for (module_name, module_config) in &bundle.wasm_module_configs {
-        if bundle.wasm_modules.contains_key(module_name) {
-            continue;
-        }
-        match module_config.criticality {
-            WasmModuleCriticality::Optional => {
-                wasm_skipped.push(module_name.clone());
+            if let Err(e) = state
+                .server
+                .upsert_wasm_module(tenant, module_name, wasm_bytes, &hash)
+                .await
+            {
                 tracing::warn!(
                     tenant,
                     module = %module_name,
-                    "Configured optional WASM module artifact is missing from the app bundle"
+                    error = %e,
+                    "Failed to persist WASM module to durable store (continuing in-memory only)"
                 );
             }
-            WasmModuleCriticality::PlatformRequired | WasmModuleCriticality::AppRequired => {
+            {
+                let mut wasm_reg = state.server.wasm_module_registry.write().unwrap(); // ci-ok: infallible lock
+                wasm_reg.register(&tenant_id, module_name, &hash);
+            }
+
+            if matches!(
+                module_config.map(|config| config.startup_loading),
+                Some(WasmStartupLoading::Eager)
+            ) && let Err(e) = state.server.wasm_engine.compile_and_cache(wasm_bytes)
+            {
                 wasm_failures.push(module_name.clone());
-                tracing::error!(
+                tracing::warn!(
                     tenant,
                     module = %module_name,
-                    criticality = ?module_config.criticality,
-                    "Configured required WASM module artifact is missing from the app bundle"
+                    error = %e,
+                    "Failed to eagerly compile WASM module from OS app"
                 );
+            }
+
+            tracing::info!(
+                tenant,
+                module = %module_name,
+                hash = %hash,
+                size = wasm_bytes.len(),
+                startup_loading = ?module_config
+                    .map(|config| config.startup_loading)
+                    .unwrap_or_default(),
+                "WASM module registered from OS app"
+            );
+            wasm_registered.push(module_name.clone());
+        }
+
+        for (module_name, module_config) in &bundle.wasm_module_configs {
+            if bundle.wasm_modules.contains_key(module_name) {
+                continue;
+            }
+            match module_config.criticality {
+                WasmModuleCriticality::Optional => {
+                    wasm_skipped.push(module_name.clone());
+                    tracing::warn!(
+                        tenant,
+                        module = %module_name,
+                        "Configured optional WASM module artifact is missing from the app bundle"
+                    );
+                }
+                WasmModuleCriticality::PlatformRequired | WasmModuleCriticality::AppRequired => {
+                    wasm_failures.push(module_name.clone());
+                    tracing::error!(
+                        tenant,
+                        module = %module_name,
+                        criticality = ?module_config.criticality,
+                        "Configured required WASM module artifact is missing from the app bundle"
+                    );
+                }
             }
         }
     }
@@ -1537,30 +1559,41 @@ async fn install_os_app_without_dependencies(
     );
 
     // ── Step 5: Bootstrap App entity + APP.md. ──────────────────────────
-    let app_id = bootstrap_app_entity(state, &tenant_id, tenant, app_name).await;
+    let (agents_bootstrapped, skills_bootstrapped, adrs_bootstrapped) = if plan.content {
+        let app_id = bootstrap_app_entity(state, &tenant_id, tenant, app_name).await;
 
-    // ── Step 6: Bootstrap agents (returns name→uuid map). ──────────────
-    let (agents_bootstrapped, agent_uuid_map) = agent_bootstrap::bootstrap_agents(
-        state,
-        &tenant_id,
-        tenant,
-        &bundle.agents,
-        app_id.as_deref(),
-    )
-    .await;
+        // ── Step 6: Bootstrap agents (returns name→uuid map). ──────────
+        let (agents_bootstrapped, agent_uuid_map) = agent_bootstrap::bootstrap_agents(
+            state,
+            &tenant_id,
+            tenant,
+            &bundle.agents,
+            app_id.as_deref(),
+        )
+        .await;
 
-    // ── Step 7: Bootstrap skills (agent-scoped + system). ──────────────
-    let skills_bootstrapped =
-        bootstrap_skills(state, &tenant_id, tenant, &bundle.skills, &agent_uuid_map).await;
+        // ── Step 7: Bootstrap skills (agent-scoped + system). ──────────
+        let skills_bootstrapped =
+            bootstrap_skills(state, &tenant_id, tenant, &bundle.skills, &agent_uuid_map).await;
 
-    // ── Step 7b: Bootstrap system files (e.g. mode-instructions). ─────
-    system_files::bootstrap_system_files(state, &tenant_id, tenant, &bundle.system_files).await;
+        // ── Step 7b: Bootstrap system files (e.g. mode-instructions). ─
+        system_files::bootstrap_system_files(state, &tenant_id, tenant, &bundle.system_files).await;
 
-    // ── Step 8: Bootstrap ADRs into TemperFS. ────────────────────────
-    let adrs_bootstrapped = bootstrap_adrs(state, &tenant_id, tenant, app_name, &bundle.adrs).await;
+        // ── Step 8: Bootstrap ADRs into TemperFS. ─────────────────────
+        let adrs_bootstrapped =
+            bootstrap_adrs(state, &tenant_id, tenant, app_name, &bundle.adrs).await;
+
+        (agents_bootstrapped, skills_bootstrapped, adrs_bootstrapped)
+    } else {
+        (Vec::new(), Vec::new(), Vec::new())
+    };
 
     // ── Step 9: Create seed instances. ───────────────────────────────
-    let seed_created = bootstrap_seed_data(state, &tenant_id, tenant, &bundle.seed_instances).await;
+    let seed_created = if plan.seed {
+        bootstrap_seed_data(state, &tenant_id, tenant, &bundle.seed_instances).await
+    } else {
+        Vec::new()
+    };
 
     reconcile::record_app_install_metadata_for_bundle(state, tenant, app_name, &bundle).await;
 

--- a/crates/temper-platform/src/os_apps/mod_test.rs
+++ b/crates/temper-platform/src/os_apps/mod_test.rs
@@ -4,11 +4,11 @@ use super::agent_bootstrap::{
 use super::*;
 use std::collections::HashMap;
 use std::fs;
-use std::path::PathBuf;
 use std::time::Duration;
 
 use temper_authz::SecurityContext;
 use temper_runtime::tenant::TenantId;
+use temper_server::platform_store::InstalledAppRecord;
 use temper_server::registry::{EntityLevelSummary, EntityVerificationResult, VerificationStatus};
 use temper_server::request_context::AgentContext;
 use temper_spec::automaton;
@@ -160,35 +160,60 @@ fn test_list_skills_returns_catalog() {
 
 #[test]
 fn test_resolve_os_app_install_order_dedupes_shared_dependencies() {
-    let temp = tempfile::tempdir().unwrap();
-
-    for (name, deps) in [
-        ("base", Vec::<&str>::new()),
-        ("left", vec!["base"]),
-        ("right", vec!["base"]),
-        ("top", vec!["left", "right"]),
-    ] {
-        let app_dir = temp.path().join(name);
-        fs::create_dir_all(&app_dir).unwrap();
-        fs::write(
-            app_dir.join("app.toml"),
-            format!(
-                "name = \"{name}\"\ndescription = \"{name}\"\nversion = \"0.1.0\"\ndependencies = [{}]\n",
-                deps.into_iter()
-                    .map(|dep| format!("\"{dep}\""))
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            ),
-        )
-        .unwrap();
-        fs::write(app_dir.join("APP.md"), format!("# {name}\n")).unwrap();
-    }
-
-    set_os_apps_dir(temp.path().to_path_buf());
-    let order = resolve_os_app_install_order(&["top".to_string(), "right".to_string()]).unwrap();
+    let dependencies = HashMap::from([
+        ("base", Vec::<String>::new()),
+        ("left", vec!["base".to_string()]),
+        ("right", vec!["base".to_string()]),
+        ("top", vec!["left".to_string(), "right".to_string()]),
+    ]);
+    let order = reconcile::resolve_os_app_install_order_with_dependencies(
+        &["top".to_string(), "right".to_string()],
+        |app_name| dependencies.get(app_name).cloned().unwrap_or_default(),
+    )
+    .unwrap();
 
     assert_eq!(order, vec!["base", "left", "right", "top"]);
-    set_os_apps_dir(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../os-apps"));
+}
+
+#[test]
+fn test_reconcile_plan_for_wasm_only_digest_skips_unrelated_phases() {
+    let current = OsAppBundleDigest {
+        app_name: "paw-agent".to_string(),
+        app_version: "0.1.0".to_string(),
+        bundle_digest: "sha256:bundle-current".to_string(),
+        spec_digest: "sha256:spec-current".to_string(),
+        policy_digest: "sha256:policy-current".to_string(),
+        wasm_digest: "sha256:wasm-current".to_string(),
+        content_digest: "sha256:content-current".to_string(),
+        seed_digest: "sha256:seed-current".to_string(),
+    };
+    let installed = InstalledAppRecord {
+        tenant: "default".to_string(),
+        app_name: current.app_name.clone(),
+        app_version: current.app_version.clone(),
+        bundle_digest: "sha256:bundle-old".to_string(),
+        spec_digest: current.spec_digest.clone(),
+        policy_digest: current.policy_digest.clone(),
+        wasm_digest: "sha256:wasm-old".to_string(),
+        content_digest: current.content_digest.clone(),
+        seed_digest: current.seed_digest.clone(),
+        installed_at: None,
+        last_reconciled_at: None,
+        status: "installed".to_string(),
+    };
+
+    let plan = reconcile::plan_reconcile_from_installed_record(&installed, &current, true, true);
+
+    assert_eq!(
+        plan,
+        OsAppInstallPlan {
+            specs: false,
+            policies: false,
+            wasm: true,
+            content: false,
+            seed: false,
+        }
+    );
 }
 
 #[tokio::test]
@@ -216,6 +241,200 @@ async fn test_reconcile_os_app_skips_unchanged_bundle_digest() {
         matches!(result, OsAppReconcileResult::Skipped { .. }),
         "unchanged app should skip hot reinstall, got {result:?}"
     );
+
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(format!("{db_path}-wal"));
+    let _ = std::fs::remove_file(format!("{db_path}-shm"));
+}
+
+#[tokio::test]
+async fn test_install_plan_without_spec_phase_does_not_reclassify_specs() {
+    let state = PlatformState::new(None);
+    let tenant = "test-install-plan-skip-specs";
+
+    install_skill(&state, tenant, "project-management")
+        .await
+        .expect("initial install should succeed");
+
+    let result = install_os_app_with_plan(
+        &state,
+        tenant,
+        "project-management",
+        OsAppInstallPlan {
+            specs: false,
+            policies: false,
+            wasm: false,
+            content: false,
+            seed: false,
+        },
+    )
+    .await
+    .expect("planned no-op install should succeed");
+
+    assert!(result.added.is_empty());
+    assert!(result.updated.is_empty());
+    assert!(
+        result.skipped.is_empty(),
+        "spec classification should not run when the spec phase is disabled"
+    );
+    assert!(result.wasm_modules.is_empty());
+    assert!(result.agents.is_empty());
+    assert!(result.skills.is_empty());
+    assert!(result.seed_instances.is_empty());
+}
+
+#[tokio::test]
+async fn test_reconcile_os_app_delta_content_change_skips_specs() {
+    let db_path = format!("/tmp/temper-test-delta-content-{}.db", uuid::Uuid::new_v4());
+    let db_url = format!("file:{db_path}");
+
+    let turso = temper_store_turso::TursoEventStore::new(&db_url, None)
+        .await
+        .unwrap();
+    let mut state = PlatformState::new(None);
+    state.server.event_store = Some(std::sync::Arc::new(
+        temper_server::event_store::ServerEventStore::Turso(turso),
+    ));
+    let tenant = "test-delta-content";
+
+    install_skill(&state, tenant, "project-management")
+        .await
+        .expect("initial install should succeed");
+
+    let current = os_app_bundle_digest("project-management").expect("project-management digest");
+    let ps = state
+        .server
+        .event_store
+        .as_ref()
+        .and_then(|store| store.platform_store())
+        .expect("platform store");
+    ps.record_installed_app_metadata(&InstalledAppRecord {
+        tenant: tenant.to_string(),
+        app_name: current.app_name.clone(),
+        app_version: current.app_version.clone(),
+        bundle_digest: "sha256:previous-bundle".to_string(),
+        spec_digest: current.spec_digest.clone(),
+        policy_digest: current.policy_digest.clone(),
+        wasm_digest: current.wasm_digest.clone(),
+        content_digest: "sha256:previous-content".to_string(),
+        seed_digest: current.seed_digest.clone(),
+        installed_at: None,
+        last_reconciled_at: None,
+        status: "installed".to_string(),
+    })
+    .await
+    .expect("overwrite installed-app metadata");
+
+    let result = reconcile_os_app(&state, tenant, "project-management")
+        .await
+        .expect("delta reconcile should succeed");
+
+    let OsAppReconcileResult::Installed { install, .. } = result else {
+        panic!("content digest change should run delta install");
+    };
+    assert!(install.added.is_empty());
+    assert!(install.updated.is_empty());
+    assert!(
+        install.skipped.is_empty(),
+        "content-only reconcile should not reclassify or bootstrap specs"
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(format!("{db_path}-wal"));
+    let _ = std::fs::remove_file(format!("{db_path}-shm"));
+}
+
+#[tokio::test]
+async fn test_reconcile_os_app_repairs_spec_content_drift_despite_matching_digest() {
+    let db_path = format!("/tmp/temper-test-spec-drift-{}.db", uuid::Uuid::new_v4());
+    let db_url = format!("file:{db_path}");
+
+    let turso = temper_store_turso::TursoEventStore::new(&db_url, None)
+        .await
+        .unwrap();
+    let mut state = PlatformState::new(None);
+    state.server.event_store = Some(std::sync::Arc::new(
+        temper_server::event_store::ServerEventStore::Turso(turso),
+    ));
+    let tenant_name = "test-spec-drift";
+    let tenant = TenantId::new(tenant_name);
+
+    install_skill(&state, tenant_name, "project-management")
+        .await
+        .expect("initial install should succeed");
+
+    let bundle = get_os_app("project-management").expect("project-management app not found");
+    let csdl = bundle
+        .csdl
+        .clone()
+        .expect("project-management should have CSDL");
+    let mut drifted_specs = bundle.specs.clone();
+    let drifted_entity = drifted_specs
+        .first()
+        .map(|(entity_type, _)| entity_type.clone())
+        .expect("project-management should have specs");
+    drifted_specs[0].1.push_str("\n# test-only spec drift\n");
+
+    {
+        let mut registry = state.registry.write().unwrap(); // ci-ok: infallible lock
+        let parsed = parse_csdl(&csdl).expect("CSDL should parse");
+        let specs: Vec<(&str, &str)> = drifted_specs
+            .iter()
+            .map(|(entity_type, ioa_source)| (entity_type.as_str(), ioa_source.as_str()))
+            .collect();
+        registry
+            .try_register_tenant_with_reactions_and_constraints(
+                tenant.clone(),
+                parsed,
+                csdl,
+                &specs,
+                Vec::new(),
+                bundle.cross_invariants_toml.clone(),
+                true,
+            )
+            .expect("replace tenant config with drifted spec source");
+
+        let verified_at = temper_runtime::scheduler::sim_now().to_rfc3339();
+        for (entity_type, _) in &bundle.specs {
+            registry.set_verification_status(
+                &tenant,
+                entity_type,
+                VerificationStatus::Completed(EntityVerificationResult {
+                    all_passed: true,
+                    levels: vec![EntityLevelSummary {
+                        level: "Test".to_string(),
+                        passed: true,
+                        summary: "Spec drift should still force app reconcile".to_string(),
+                        details: None,
+                    }],
+                    verified_at: verified_at.clone(),
+                }),
+            );
+        }
+    }
+
+    let result = reconcile_os_app(&state, tenant_name, "project-management")
+        .await
+        .expect("reconcile should repair spec content drift");
+
+    let OsAppReconcileResult::Installed { install, .. } = result else {
+        panic!("matching digest with drifted runtime spec content must not skip reconcile");
+    };
+    assert!(
+        install.updated.contains(&drifted_entity),
+        "drifted spec should be reclassified as updated: {install:?}"
+    );
+    let registry = state.registry.read().unwrap(); // ci-ok: infallible lock
+    let repaired = registry
+        .get_spec(&tenant, &drifted_entity)
+        .expect("drifted spec should still be registered");
+    let expected = bundle
+        .specs
+        .iter()
+        .find(|(entity_type, _)| entity_type == &drifted_entity)
+        .map(|(_, ioa_source)| ioa_source.as_str())
+        .expect("bundle should still contain drifted entity");
+    assert_eq!(repaired.ioa_source, expected);
 
     let _ = std::fs::remove_file(&db_path);
     let _ = std::fs::remove_file(format!("{db_path}-wal"));

--- a/crates/temper-platform/src/os_apps/reconcile.rs
+++ b/crates/temper-platform/src/os_apps/reconcile.rs
@@ -1,20 +1,22 @@
 use std::collections::HashSet;
 
 use sha2::{Digest, Sha256};
+use temper_runtime::tenant::TenantId;
 use temper_server::platform_store::InstalledAppRecord;
 
 use super::{
-    AppBundle, AppEntry, OsAppBundleDigest, OsAppReconcileResult, catalog, get_os_app,
-    install_os_app_without_dependencies, os_app_dependencies,
+    AppBundle, AppEntry, OsAppBundleDigest, OsAppInstallPlan, OsAppReconcileResult, catalog,
+    get_os_app, install_os_app_with_plan, os_app_dependencies,
     restore_app_specs_from_matching_digest, tenant_has_ready_app_specs_for_bundle,
 };
 use crate::state::PlatformState;
 
-pub(super) fn collect_install_order(
+fn collect_install_order_with_dependencies(
     app_name: &str,
     visiting: &mut HashSet<String>,
     visited: &mut HashSet<String>,
     order: &mut Vec<String>,
+    dependencies: &impl Fn(&str) -> Vec<String>,
 ) -> Result<(), String> {
     if visited.contains(app_name) {
         return Ok(());
@@ -22,8 +24,14 @@ pub(super) fn collect_install_order(
     if !visiting.insert(app_name.to_string()) {
         return Err(format!("Cyclic OS app dependency detected at '{app_name}'"));
     }
-    for dependency in os_app_dependencies(app_name) {
-        collect_install_order(&dependency, visiting, visited, order)?;
+    for dependency in dependencies(app_name) {
+        collect_install_order_with_dependencies(
+            &dependency,
+            visiting,
+            visited,
+            order,
+            dependencies,
+        )?;
     }
     visiting.remove(app_name);
     visited.insert(app_name.to_string());
@@ -33,11 +41,26 @@ pub(super) fn collect_install_order(
 
 /// Resolve a deduplicated dependency-first install order for a set of apps.
 pub fn resolve_os_app_install_order(app_names: &[String]) -> Result<Vec<String>, String> {
+    resolve_os_app_install_order_with_dependencies(app_names, |app_name| {
+        os_app_dependencies(app_name)
+    })
+}
+
+pub(super) fn resolve_os_app_install_order_with_dependencies(
+    app_names: &[String],
+    dependencies: impl Fn(&str) -> Vec<String>,
+) -> Result<Vec<String>, String> {
     let mut visiting = HashSet::new();
     let mut visited = HashSet::new();
     let mut order = Vec::new();
     for app_name in app_names {
-        collect_install_order(app_name, &mut visiting, &mut visited, &mut order)?;
+        collect_install_order_with_dependencies(
+            app_name,
+            &mut visiting,
+            &mut visited,
+            &mut order,
+            &dependencies,
+        )?;
     }
     Ok(order)
 }
@@ -202,6 +225,38 @@ pub fn os_app_bundle_digest(app_name: &str) -> Option<OsAppBundleDigest> {
     get_os_app(app_name).map(|bundle| digest_app_bundle(app_name, &bundle))
 }
 
+pub(super) fn plan_reconcile_from_installed_record(
+    record: &InstalledAppRecord,
+    digest: &OsAppBundleDigest,
+    specs_ready: bool,
+    wasm_registered: bool,
+) -> OsAppInstallPlan {
+    OsAppInstallPlan {
+        specs: record.spec_digest != digest.spec_digest || !specs_ready,
+        policies: record.policy_digest != digest.policy_digest,
+        wasm: record.wasm_digest != digest.wasm_digest || !wasm_registered,
+        content: record.content_digest != digest.content_digest,
+        seed: record.seed_digest != digest.seed_digest,
+    }
+}
+
+fn tenant_has_registered_wasm_for_bundle(
+    state: &PlatformState,
+    tenant: &str,
+    bundle: &AppBundle,
+) -> bool {
+    let tenant_id = TenantId::new(tenant);
+    let registry = state
+        .server
+        .wasm_module_registry
+        .read()
+        .expect("WASM module registry lock poisoned");
+    bundle.wasm_modules.iter().all(|(module_name, wasm_bytes)| {
+        let hash = temper_wasm::WasmEngine::hash_module(wasm_bytes);
+        registry.get_hash(&tenant_id, module_name) == Some(hash.as_str())
+    })
+}
+
 async fn record_app_install_metadata(
     state: &PlatformState,
     tenant: &str,
@@ -271,8 +326,18 @@ pub async fn reconcile_os_app(
         .and_then(|store| store.platform_store())
     {
         match ps.get_installed_app(tenant, app_name).await {
-            Ok(Some(record)) if record.bundle_digest == digest.bundle_digest => {
-                if tenant_has_ready_app_specs_for_bundle(state, tenant, &bundle) {
+            Ok(Some(record)) => {
+                let mut specs_ready = tenant_has_ready_app_specs_for_bundle(state, tenant, &bundle);
+                let wasm_registered = tenant_has_registered_wasm_for_bundle(state, tenant, &bundle);
+
+                if record.bundle_digest == digest.bundle_digest && !specs_ready {
+                    specs_ready = restore_app_specs_from_matching_digest(
+                        state, ps, tenant, app_name, &bundle,
+                    )
+                    .await;
+                }
+
+                if record.bundle_digest == digest.bundle_digest && specs_ready && wasm_registered {
                     tracing::info!(
                         tenant,
                         app = %app_name,
@@ -285,22 +350,38 @@ pub async fn reconcile_os_app(
                     });
                 }
 
-                if restore_app_specs_from_matching_digest(state, ps, tenant, app_name, &bundle)
-                    .await
-                {
-                    tracing::info!(
-                        tenant,
-                        app = %app_name,
-                        bundle_digest = %digest.bundle_digest,
-                        "OS app unchanged; restored spec readiness and skipped hot reconcile"
-                    );
-                    return Ok(OsAppReconcileResult::Skipped {
-                        app_name: app_name.to_string(),
-                        bundle_digest: digest.bundle_digest,
-                    });
+                if !specs_ready && record.spec_digest == digest.spec_digest {
+                    specs_ready = restore_app_specs_from_matching_digest(
+                        state, ps, tenant, app_name, &bundle,
+                    )
+                    .await;
                 }
+                let plan = plan_reconcile_from_installed_record(
+                    &record,
+                    &digest,
+                    specs_ready,
+                    wasm_registered,
+                );
+
+                tracing::info!(
+                    tenant,
+                    app = %app_name,
+                    bundle_digest = %digest.bundle_digest,
+                    specs = plan.specs,
+                    policies = plan.policies,
+                    wasm = plan.wasm,
+                    content = plan.content,
+                    seed = plan.seed,
+                    "OS app changed; running delta reconcile"
+                );
+                let install = install_os_app_with_plan(state, tenant, app_name, plan).await?;
+                return Ok(OsAppReconcileResult::Installed {
+                    app_name: app_name.to_string(),
+                    bundle_digest: digest.bundle_digest,
+                    install: Box::new(install),
+                });
             }
-            Ok(Some(_)) | Ok(None) => {}
+            Ok(None) => {}
             Err(error) => {
                 tracing::warn!(
                     tenant,
@@ -312,7 +393,8 @@ pub async fn reconcile_os_app(
         }
     }
 
-    let install = install_os_app_without_dependencies(state, tenant, app_name).await?;
+    let install =
+        install_os_app_with_plan(state, tenant, app_name, OsAppInstallPlan::all()).await?;
     Ok(OsAppReconcileResult::Installed {
         app_name: app_name.to_string(),
         bundle_digest: digest.bundle_digest,

--- a/crates/temper-platform/src/os_apps/runtime_heal.rs
+++ b/crates/temper-platform/src/os_apps/runtime_heal.rs
@@ -11,6 +11,9 @@ fn tenant_has_registered_app_specs_for_bundle(
     tenant: &str,
     bundle: &AppBundle,
 ) -> bool {
+    if !tenant_has_app_spec_content_for_bundle(state, tenant, bundle) {
+        return false;
+    }
     if !tenant_has_app_spec_tables_for_bundle(state, tenant, bundle) {
         return false;
     }
@@ -44,6 +47,22 @@ fn tenant_has_registered_app_specs_for_bundle(
     }
 
     true
+}
+
+fn tenant_has_app_spec_content_for_bundle(
+    state: &PlatformState,
+    tenant: &str,
+    bundle: &AppBundle,
+) -> bool {
+    let tenant_id = TenantId::new(tenant);
+    let registry = state.registry.read().expect("Spec registry lock poisoned");
+    bundle.specs.iter().all(|(entity_type, ioa_source)| {
+        let Some(existing) = registry.get_spec(&tenant_id, entity_type) else {
+            return false;
+        };
+        temper_store_turso::spec_content_hash(&existing.ioa_source)
+            == temper_store_turso::spec_content_hash(ioa_source)
+    })
 }
 
 fn tenant_has_app_spec_tables_for_bundle(
@@ -193,6 +212,10 @@ pub(crate) async fn restore_app_specs_from_matching_digest(
     app_name: &str,
     bundle: &AppBundle,
 ) -> bool {
+    if !tenant_has_app_spec_content_for_bundle(state, tenant, bundle) {
+        return false;
+    }
+
     if tenant_has_registered_app_specs_for_bundle(state, tenant, bundle) {
         mark_app_specs_restored_from_matching_digest(state, ps, tenant, app_name, bundle).await;
         return true;

--- a/crates/temper-platform/src/os_apps/types.rs
+++ b/crates/temper-platform/src/os_apps/types.rs
@@ -37,6 +37,28 @@ pub struct InstallResult {
     pub seed_instances: Vec<String>,
 }
 
+/// Component phases an OS-app install/reconcile should execute.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OsAppInstallPlan {
+    pub specs: bool,
+    pub policies: bool,
+    pub wasm: bool,
+    pub content: bool,
+    pub seed: bool,
+}
+
+impl OsAppInstallPlan {
+    pub(crate) const fn all() -> Self {
+        Self {
+            specs: true,
+            policies: true,
+            wasm: true,
+            content: true,
+            seed: true,
+        }
+    }
+}
+
 /// Stable digest breakdown for an OS app bundle.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct OsAppBundleDigest {

--- a/crates/temper-store-turso/src/store/specs.rs
+++ b/crates/temper-store-turso/src/store/specs.rs
@@ -4,7 +4,7 @@ use libsql::{TransactionBehavior, params};
 use temper_runtime::persistence::{PersistenceError, storage_error};
 use tracing::instrument;
 
-use super::{TursoEventStore, TursoInstalledAppRow, TursoSpecRow};
+use super::{TursoEventStore, TursoInstalledAppRow, TursoSpecRow, write_gate::WritePriority};
 use crate::TursoSpecVerificationUpdate;
 use crate::metrics::TursoQueryTimer;
 
@@ -24,6 +24,9 @@ impl TursoEventStore {
         content_hash: &str,
     ) -> Result<(), PersistenceError> {
         let _query_timer = TursoQueryTimer::start("turso.upsert_spec");
+        let _write_permit = self
+            .acquire_write_permit("turso.upsert_spec", WritePriority::High)
+            .await?;
         let conn = self.configured_connection().await?;
         // When content_hash matches the existing row, keep verification intact.
         // Otherwise reset to pending so the cascade re-runs.
@@ -31,17 +34,39 @@ impl TursoEventStore {
             "INSERT INTO specs (tenant, entity_type, ioa_source, csdl_xml, content_hash, committed, version, verified, verification_status, updated_at)
              VALUES (?1, ?2, ?3, ?4, ?5, 0, 1, 0, 'pending', datetime('now'))
              ON CONFLICT (tenant, entity_type) DO UPDATE SET
-                 ioa_source = excluded.ioa_source,
-                 csdl_xml = excluded.csdl_xml,
-                 content_hash = excluded.content_hash,
-                 committed = 0,
-                 version = specs.version + 1,
-                 verified = CASE WHEN specs.content_hash = excluded.content_hash THEN specs.verified ELSE 0 END,
-                 verification_status = CASE WHEN specs.content_hash = excluded.content_hash THEN specs.verification_status ELSE 'pending' END,
-                 levels_passed = CASE WHEN specs.content_hash = excluded.content_hash THEN specs.levels_passed ELSE NULL END,
-                 levels_total = CASE WHEN specs.content_hash = excluded.content_hash THEN specs.levels_total ELSE NULL END,
-                 verification_result = CASE WHEN specs.content_hash = excluded.content_hash THEN specs.verification_result ELSE NULL END,
-                 updated_at = datetime('now')",
+                 ioa_source = CASE
+                     WHEN specs.content_hash IS NOT excluded.content_hash OR specs.csdl_xml IS NOT excluded.csdl_xml
+                     THEN excluded.ioa_source ELSE specs.ioa_source END,
+                 csdl_xml = CASE
+                     WHEN specs.content_hash IS NOT excluded.content_hash OR specs.csdl_xml IS NOT excluded.csdl_xml
+                     THEN excluded.csdl_xml ELSE specs.csdl_xml END,
+                 content_hash = CASE
+                     WHEN specs.content_hash IS NOT excluded.content_hash OR specs.csdl_xml IS NOT excluded.csdl_xml
+                     THEN excluded.content_hash ELSE specs.content_hash END,
+                 committed = CASE
+                     WHEN specs.content_hash IS NOT excluded.content_hash OR specs.csdl_xml IS NOT excluded.csdl_xml
+                     THEN 0 ELSE specs.committed END,
+                 version = CASE
+                     WHEN specs.content_hash IS NOT excluded.content_hash OR specs.csdl_xml IS NOT excluded.csdl_xml
+                     THEN specs.version + 1 ELSE specs.version END,
+                 verified = CASE
+                     WHEN specs.content_hash IS NOT excluded.content_hash OR specs.csdl_xml IS NOT excluded.csdl_xml
+                     THEN 0 ELSE specs.verified END,
+                 verification_status = CASE
+                     WHEN specs.content_hash IS NOT excluded.content_hash OR specs.csdl_xml IS NOT excluded.csdl_xml
+                     THEN 'pending' ELSE specs.verification_status END,
+                 levels_passed = CASE
+                     WHEN specs.content_hash IS NOT excluded.content_hash OR specs.csdl_xml IS NOT excluded.csdl_xml
+                     THEN NULL ELSE specs.levels_passed END,
+                 levels_total = CASE
+                     WHEN specs.content_hash IS NOT excluded.content_hash OR specs.csdl_xml IS NOT excluded.csdl_xml
+                     THEN NULL ELSE specs.levels_total END,
+                 verification_result = CASE
+                     WHEN specs.content_hash IS NOT excluded.content_hash OR specs.csdl_xml IS NOT excluded.csdl_xml
+                     THEN NULL ELSE specs.verification_result END,
+                 updated_at = CASE
+                     WHEN specs.content_hash IS NOT excluded.content_hash OR specs.csdl_xml IS NOT excluded.csdl_xml
+                     THEN datetime('now') ELSE specs.updated_at END",
             params![tenant, entity_type, ioa_source, csdl_xml, content_hash],
         )
         .await
@@ -64,6 +89,9 @@ impl TursoEventStore {
         app_name: &str,
     ) -> Result<(), PersistenceError> {
         let _query_timer = TursoQueryTimer::start("turso.upsert_specs_and_commit");
+        let _write_permit = self
+            .acquire_write_permit("turso.upsert_specs_and_commit", WritePriority::High)
+            .await?;
         let conn = self.configured_connection().await?;
         let tx = conn
             .transaction_with_behavior(TransactionBehavior::Immediate)
@@ -73,19 +101,39 @@ impl TursoEventStore {
         for (entity_type, ioa_source, csdl_xml, content_hash) in specs {
             tx.execute(
                 "INSERT INTO specs (tenant, entity_type, ioa_source, csdl_xml, content_hash, committed, version, verified, verification_status, updated_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, 0, 1, 0, 'pending', datetime('now'))
+                 VALUES (?1, ?2, ?3, ?4, ?5, 1, 1, 0, 'pending', datetime('now'))
                  ON CONFLICT (tenant, entity_type) DO UPDATE SET
-                     ioa_source = excluded.ioa_source,
-                     csdl_xml = excluded.csdl_xml,
-                     content_hash = excluded.content_hash,
-                     committed = 0,
-                     version = specs.version + 1,
-                     verified = CASE WHEN specs.content_hash = excluded.content_hash THEN specs.verified ELSE 0 END,
-                     verification_status = CASE WHEN specs.content_hash = excluded.content_hash THEN specs.verification_status ELSE 'pending' END,
-                     levels_passed = CASE WHEN specs.content_hash = excluded.content_hash THEN specs.levels_passed ELSE NULL END,
-                     levels_total = CASE WHEN specs.content_hash = excluded.content_hash THEN specs.levels_total ELSE NULL END,
-                     verification_result = CASE WHEN specs.content_hash = excluded.content_hash THEN specs.verification_result ELSE NULL END,
-                     updated_at = datetime('now')",
+                     ioa_source = CASE
+                         WHEN specs.content_hash IS NOT excluded.content_hash OR specs.csdl_xml IS NOT excluded.csdl_xml
+                         THEN excluded.ioa_source ELSE specs.ioa_source END,
+                     csdl_xml = CASE
+                         WHEN specs.content_hash IS NOT excluded.content_hash OR specs.csdl_xml IS NOT excluded.csdl_xml
+                         THEN excluded.csdl_xml ELSE specs.csdl_xml END,
+                     content_hash = CASE
+                         WHEN specs.content_hash IS NOT excluded.content_hash OR specs.csdl_xml IS NOT excluded.csdl_xml
+                         THEN excluded.content_hash ELSE specs.content_hash END,
+                     committed = 1,
+                     version = CASE
+                         WHEN specs.content_hash IS NOT excluded.content_hash OR specs.csdl_xml IS NOT excluded.csdl_xml
+                         THEN specs.version + 1 ELSE specs.version END,
+                     verified = CASE
+                         WHEN specs.content_hash IS NOT excluded.content_hash OR specs.csdl_xml IS NOT excluded.csdl_xml
+                         THEN 0 ELSE specs.verified END,
+                     verification_status = CASE
+                         WHEN specs.content_hash IS NOT excluded.content_hash OR specs.csdl_xml IS NOT excluded.csdl_xml
+                         THEN 'pending' ELSE specs.verification_status END,
+                     levels_passed = CASE
+                         WHEN specs.content_hash IS NOT excluded.content_hash OR specs.csdl_xml IS NOT excluded.csdl_xml
+                         THEN NULL ELSE specs.levels_passed END,
+                     levels_total = CASE
+                         WHEN specs.content_hash IS NOT excluded.content_hash OR specs.csdl_xml IS NOT excluded.csdl_xml
+                         THEN NULL ELSE specs.levels_total END,
+                     verification_result = CASE
+                         WHEN specs.content_hash IS NOT excluded.content_hash OR specs.csdl_xml IS NOT excluded.csdl_xml
+                         THEN NULL ELSE specs.verification_result END,
+                     updated_at = CASE
+                         WHEN specs.content_hash IS NOT excluded.content_hash OR specs.csdl_xml IS NOT excluded.csdl_xml OR specs.committed != 1
+                         THEN datetime('now') ELSE specs.updated_at END",
                 params![tenant, entity_type, ioa_source, csdl_xml, content_hash],
             )
             .await
@@ -106,13 +154,6 @@ impl TursoEventStore {
         tx.execute(
             "INSERT OR IGNORE INTO tenant_installed_apps (tenant_id, app_name) VALUES (?1, ?2)",
             params![tenant, app_name],
-        )
-        .await
-        .map_err(storage_error)?;
-
-        tx.execute(
-            "UPDATE specs SET committed = 1, updated_at = datetime('now') WHERE tenant = ?1",
-            params![tenant],
         )
         .await
         .map_err(storage_error)?;

--- a/crates/temper-store-turso/src/store/tests/mod.rs
+++ b/crates/temper-store-turso/src/store/tests/mod.rs
@@ -6,6 +6,7 @@ use temper_runtime::persistence::{
 };
 
 use super::TursoEventStore;
+use crate::TursoSpecVerificationUpdate;
 
 fn test_envelope(event_type: &str, payload: serde_json::Value) -> PersistenceEnvelope {
     PersistenceEnvelope {
@@ -668,4 +669,149 @@ async fn load_wasm_module_metadata_all_tenants_returns_metadata_without_bulk_byt
         .expect("load full wasm row")
         .expect("full row should exist");
     assert_eq!(full_row.wasm_bytes, b"hello-a");
+}
+
+#[tokio::test]
+async fn upsert_specs_and_commit_preserves_identical_spec_version() {
+    let store = make_store("spec-idempotent").await;
+    let tenant = format!("tenant-{}", uuid::Uuid::new_v4());
+    let ioa_source = "[automaton]\nname = \"Issue\"\n";
+    let csdl_xml = "<Schema Namespace=\"Temper.Tests\" />";
+    let content_hash = "sha256:issue-v1";
+
+    store
+        .upsert_specs_and_commit(
+            &tenant,
+            &[("Issue", ioa_source, csdl_xml, content_hash)],
+            None,
+            "test-app",
+        )
+        .await
+        .expect("initial spec commit");
+    store
+        .persist_spec_verification(
+            &tenant,
+            "Issue",
+            TursoSpecVerificationUpdate {
+                status: "passed",
+                verified: true,
+                levels_passed: Some(1),
+                levels_total: Some(1),
+                verification_result_json: Some(r#"{"all_passed":true}"#),
+            },
+        )
+        .await
+        .expect("persist verification");
+
+    store
+        .upsert_specs_and_commit(
+            &tenant,
+            &[("Issue", ioa_source, csdl_xml, content_hash)],
+            None,
+            "test-app",
+        )
+        .await
+        .expect("identical spec commit");
+
+    let conn = store.connection().expect("connection");
+    let mut rows = conn
+        .query(
+            "SELECT version, verified, verification_status, committed \
+             FROM specs WHERE tenant = ?1 AND entity_type = 'Issue'",
+            params![tenant],
+        )
+        .await
+        .expect("query spec");
+    let row = rows
+        .next()
+        .await
+        .expect("row result")
+        .expect("spec row exists");
+    let version: i64 = row.get(0).expect("version");
+    let verified: i64 = row.get(1).expect("verified");
+    let status: String = row.get(2).expect("verification status");
+    let committed: i64 = row.get(3).expect("committed");
+
+    assert_eq!(version, 1, "identical spec commit must not bump version");
+    assert_eq!(
+        verified, 1,
+        "identical spec commit must preserve verification"
+    );
+    assert_eq!(status, "passed");
+    assert_eq!(committed, 1);
+}
+
+#[tokio::test]
+async fn upsert_wasm_module_preserves_version_for_identical_hash() {
+    let store = make_store("wasm-idempotent").await;
+
+    store
+        .upsert_wasm_module("tenant-a", "mod-a", b"hello-a", "hash-a")
+        .await
+        .expect("initial wasm upsert");
+    store
+        .upsert_wasm_module("tenant-a", "mod-a", b"hello-a", "hash-a")
+        .await
+        .expect("identical wasm upsert");
+
+    let conn = store.connection().expect("connection");
+    let mut rows = conn
+        .query(
+            "SELECT version FROM wasm_modules WHERE tenant = ?1 AND module_name = ?2",
+            params!["tenant-a", "mod-a"],
+        )
+        .await
+        .expect("query wasm version");
+    let row = rows
+        .next()
+        .await
+        .expect("row result")
+        .expect("wasm row exists");
+    let version: i64 = row.get(0).expect("version");
+
+    assert_eq!(version, 1, "identical WASM hash must not bump version");
+}
+
+#[tokio::test]
+async fn upsert_wasm_module_stores_artifact_outside_metadata_row() {
+    let store = make_store("wasm-artifact").await;
+
+    store
+        .upsert_wasm_module("tenant-a", "mod-a", b"hello-a", "hash-a")
+        .await
+        .expect("persist wasm artifact");
+
+    let conn = store.connection().expect("connection");
+    let mut rows = conn
+        .query(
+            "SELECT length(wasm_bytes) FROM wasm_modules WHERE tenant = ?1 AND module_name = ?2",
+            params!["tenant-a", "mod-a"],
+        )
+        .await
+        .expect("query inline wasm length");
+    let row = rows
+        .next()
+        .await
+        .expect("row result")
+        .expect("wasm row exists");
+    let inline_len: i64 = row.get(0).expect("inline wasm length");
+
+    assert_eq!(
+        inline_len, 0,
+        "new WASM metadata rows should point at artifact storage, not inline bytes"
+    );
+
+    let artifact = store
+        .get_blob("wasm-modules/hash-a")
+        .await
+        .expect("load wasm artifact")
+        .expect("artifact exists");
+    assert_eq!(artifact, b"hello-a");
+
+    let loaded = store
+        .load_wasm_module("tenant-a", "mod-a")
+        .await
+        .expect("load wasm row")
+        .expect("wasm row exists");
+    assert_eq!(loaded.wasm_bytes, b"hello-a");
 }

--- a/crates/temper-store-turso/src/store/wasm.rs
+++ b/crates/temper-store-turso/src/store/wasm.rs
@@ -6,9 +6,16 @@ use tracing::instrument;
 
 use super::{
     TursoEventStore, TursoWasmInvocationRow, TursoWasmModuleMetadataRow, TursoWasmModuleRow,
+    write_gate::WritePriority,
 };
 use crate::TursoWasmInvocationInsert;
 use crate::metrics::TursoQueryTimer;
+
+const WASM_ARTIFACT_PREFIX: &str = "wasm-modules/";
+
+fn wasm_artifact_key(sha256_hash: &str) -> String {
+    format!("{WASM_ARTIFACT_PREFIX}{sha256_hash}")
+}
 
 impl TursoEventStore {
     /// Upsert a WASM module binary for a tenant.
@@ -25,16 +32,68 @@ impl TursoEventStore {
     ) -> Result<(), PersistenceError> {
         let _query_timer = TursoQueryTimer::start("turso.upsert_wasm_module");
         let conn = self.configured_connection().await?;
+        let mut existing_rows = conn
+            .query(
+                "SELECT sha256_hash, length(wasm_bytes) \
+                 FROM wasm_modules \
+                 WHERE tenant = ?1 AND module_name = ?2",
+                params![tenant, module_name],
+            )
+            .await
+            .map_err(storage_error)?;
+
+        if let Some(row) = existing_rows.next().await.map_err(storage_error)? {
+            let existing_hash: String = row.get(0).map_err(storage_error)?;
+            let inline_len: i64 = row
+                .get::<Option<i64>>(1)
+                .map_err(storage_error)?
+                .unwrap_or(0);
+            if existing_hash == sha256_hash {
+                if inline_len > 0
+                    || self
+                        .get_blob(&wasm_artifact_key(sha256_hash))
+                        .await
+                        .map_err(PersistenceError::Storage)?
+                        .is_some()
+                {
+                    return Ok(());
+                }
+
+                self.put_blob(&wasm_artifact_key(sha256_hash), wasm_bytes)
+                    .await
+                    .map_err(PersistenceError::Storage)?;
+                return Ok(());
+            }
+        }
+        drop(existing_rows);
+
+        self.put_blob(&wasm_artifact_key(sha256_hash), wasm_bytes)
+            .await
+            .map_err(PersistenceError::Storage)?;
+
+        let _write_permit = self
+            .acquire_write_permit("turso.upsert_wasm_module", WritePriority::High)
+            .await?;
         conn.execute(
             "INSERT INTO wasm_modules (tenant, module_name, wasm_bytes, sha256_hash, version, size_bytes, updated_at)
              VALUES (?1, ?2, ?3, ?4, 1, ?5, datetime('now'))
              ON CONFLICT (tenant, module_name) DO UPDATE SET
-                 wasm_bytes = excluded.wasm_bytes,
-                 sha256_hash = excluded.sha256_hash,
-                 version = wasm_modules.version + 1,
-                 size_bytes = excluded.size_bytes,
-                 updated_at = datetime('now')",
-            params![tenant, module_name, wasm_bytes.to_vec(), sha256_hash, wasm_bytes.len() as i64],
+                 wasm_bytes = CASE
+                     WHEN wasm_modules.sha256_hash IS NOT excluded.sha256_hash
+                     THEN excluded.wasm_bytes ELSE wasm_modules.wasm_bytes END,
+                 sha256_hash = CASE
+                     WHEN wasm_modules.sha256_hash IS NOT excluded.sha256_hash
+                     THEN excluded.sha256_hash ELSE wasm_modules.sha256_hash END,
+                 version = CASE
+                     WHEN wasm_modules.sha256_hash IS NOT excluded.sha256_hash
+                     THEN wasm_modules.version + 1 ELSE wasm_modules.version END,
+                 size_bytes = CASE
+                     WHEN wasm_modules.sha256_hash IS NOT excluded.sha256_hash
+                     THEN excluded.size_bytes ELSE wasm_modules.size_bytes END,
+                 updated_at = CASE
+                     WHEN wasm_modules.sha256_hash IS NOT excluded.sha256_hash
+                     THEN datetime('now') ELSE wasm_modules.updated_at END",
+            params![tenant, module_name, Vec::<u8>::new(), sha256_hash, wasm_bytes.len() as i64],
         )
         .await
         .map_err(storage_error)?;
@@ -64,7 +123,9 @@ impl TursoEventStore {
             return Ok(None);
         };
 
-        Ok(Some(Self::row_to_wasm_module(&row)?))
+        self.hydrate_wasm_module(Self::row_to_wasm_module(&row)?)
+            .await
+            .map(Some)
     }
 
     /// Load all WASM modules for a tenant.
@@ -88,7 +149,8 @@ impl TursoEventStore {
 
         let mut out = Vec::new();
         while let Some(row) = rows.next().await.map_err(storage_error)? {
-            out.push(Self::row_to_wasm_module(&row)?);
+            let row = Self::row_to_wasm_module(&row)?;
+            out.push(self.hydrate_wasm_module(row).await?);
         }
         Ok(out)
     }
@@ -112,7 +174,8 @@ impl TursoEventStore {
 
         let mut out = Vec::new();
         while let Some(row) = rows.next().await.map_err(storage_error)? {
-            out.push(Self::row_to_wasm_module(&row)?);
+            let row = Self::row_to_wasm_module(&row)?;
+            out.push(self.hydrate_wasm_module(row).await?);
         }
         Ok(out)
     }
@@ -244,6 +307,28 @@ impl TursoEventStore {
             size_bytes: row.get::<i64>(5).map_err(storage_error)? as i32,
             updated_at: row.get::<String>(6).map_err(storage_error)?,
         })
+    }
+
+    async fn hydrate_wasm_module(
+        &self,
+        mut row: TursoWasmModuleRow,
+    ) -> Result<TursoWasmModuleRow, PersistenceError> {
+        if row.wasm_bytes.is_empty() && row.size_bytes > 0 {
+            let artifact_key = wasm_artifact_key(&row.sha256_hash);
+            let artifact = self
+                .get_blob(&artifact_key)
+                .await
+                .map_err(PersistenceError::Storage)?
+                .ok_or_else(|| {
+                    PersistenceError::Storage(format!(
+                        "WASM artifact missing for {}/{} at {artifact_key}",
+                        row.tenant, row.module_name
+                    ))
+                })?;
+            row.wasm_bytes = artifact;
+        }
+
+        Ok(row)
     }
 
     /// Parse a WASM module metadata row from a libsql Row (5 columns).

--- a/crates/temper-verify/src/smt.rs
+++ b/crates/temper-verify/src/smt.rs
@@ -801,8 +801,10 @@ initial = "[]"
 name = "ConflictingContains"
 from = ["S"]
 to = "S"
-guard = "list_contains labels urgent"
-guard = "list_contains labels normal"
+guard = [
+    { type = "list_contains", var = "labels", value = "urgent" },
+    { type = "list_contains", var = "labels", value = "normal" },
+]
 "#;
 
         // With max_counter=1, a single-slot list cannot contain two distinct

--- a/docs/adrs/0062-delta-os-app-reconcile-and-wasm-artifacts.md
+++ b/docs/adrs/0062-delta-os-app-reconcile-and-wasm-artifacts.md
@@ -1,0 +1,121 @@
+# ADR-0062: Delta OS-App Reconcile and WASM Artifacts
+
+- Status: Accepted
+- Date: 2026-04-27
+- Deciders: Temper core maintainers
+- Related:
+  - ADR-0027: OS App Catalog
+  - ADR-0029: Temper Filesystem
+  - ADR-0032: Platform Store Trait and Sim Platform DST
+  - ADR-0057: Native Immutable File Read Plane
+  - ADR-0060: Bounded Warm Restart and Digest-Aware App Reconcile
+  - `crates/temper-platform/src/os_apps/reconcile.rs`
+  - `crates/temper-platform/src/os_apps/mod.rs`
+  - `crates/temper-store-turso/src/store/specs.rs`
+  - `crates/temper-store-turso/src/store/wasm.rs`
+
+## Context
+
+TemperPaw production deploys showed that digest-aware reconcile was still too coarse after a dependency update rebuilt bundled WASM apps. The durable app bundle digest changed, so startup entered the install path for every affected startup app. That path then re-persisted every app spec, re-upserted every WASM module, and re-bootstrapped app content serially before readiness.
+
+Datadog traces made the shape of the problem clear:
+
+- `turso.upsert_specs_and_commit` held almost no CPU but waited tens of seconds per transaction under write contention.
+- `turso.upsert_wasm_module` also held almost no CPU but waited tens of seconds while repeatedly writing module bytes into SQL.
+- A WASM-only rebuild forced unrelated specs, policies, agents, skills, ADRs, system files, and seed data through the install path.
+
+This is not a Turso feature problem by itself. The platform was asking the database to do unnecessary write transactions and was storing bulky immutable module content in the SQL metadata row.
+
+## Decision
+
+### 1. Reconcile plans are component-aware
+
+The durable installed-app row already records subdigests for specs, policies, WASM, app content, and seed data. Reconcile must compare each subdigest and build an explicit plan:
+
+- unchanged specs and policies skip spec persistence, verification bootstrap, policy reload, and cross-invariant persistence
+- unchanged WASM skips module persistence, registry re-registration, and eager compilation
+- unchanged app content skips App, `APP.md`, agents, skills, system files, and ADR bootstrap
+- unchanged seed data skips seed entity creation
+
+The full `bundle_digest` remains the public identity for an installed app version, but it no longer implies that every install phase must run.
+
+### 2. Spec persistence is scoped and idempotent
+
+OS-app install must persist only the app specs being reconciled, not reload and rewrite every committed spec for the tenant.
+
+`upsert_specs_and_commit` must be content-hash gated:
+
+- inserting a new spec writes it committed immediately
+- an identical spec and CSDL preserves version, verification status, and `updated_at`
+- a changed spec increments version and resets verification
+- the transaction records the installed app but does not run a broad `UPDATE specs SET committed = 1 WHERE tenant = ?`
+
+This removes avoidable tenant-wide write amplification and makes the transaction proportional to the app's changed spec set.
+
+### 3. WASM module SQL rows are metadata, not the artifact hot path
+
+WASM modules are immutable artifacts addressed by hash. SQL should track tenant/module metadata: module name, hash, size, version, and timestamps. The module bytes are stored through the blob/artifact store under a content-addressed key.
+
+For the current Turso backend, the artifact key is `wasm-modules/{sha256_hash}` in the existing content-addressed blob table. Existing legacy rows with inline `wasm_bytes` remain readable. New writes may keep an empty inline byte column as a schema-compatible pointer row while loading resolves bytes from the artifact store.
+
+Future external object-store adapters may use the same artifact key contract without changing app reconcile semantics.
+
+### 4. WASM upsert is hash-gated before artifact upload
+
+If the existing tenant/module metadata already has the requested hash, `upsert_wasm_module` returns before uploading bytes or updating SQL.
+
+If the hash changes:
+
+- write the content-addressed artifact once
+- update the metadata row
+- increment version only for a real hash change
+
+This makes repeated startup reconcile of identical modules a metadata read, not a large SQL write.
+
+### 5. Startup readiness remains honest
+
+The platform should not mark readiness until required startup apps are usable. This ADR reduces work on the required path; it does not hide required reconcile work behind `/readyz`.
+
+Bulky optional content repair may move to later entity-driven workflows only when the app marks that work non-critical.
+
+## Consequences
+
+### Positive
+
+- WASM-only rebuilds no longer replay spec, policy, content, and seed bootstrap.
+- Spec-only changes no longer rewrite WASM module rows or app content.
+- Identical spec and WASM persistence calls become cheap no-ops.
+- WASM bytes stop bloating the SQL metadata row for new writes.
+- Startup trace spans become component-proportional and easier to explain.
+
+### Negative
+
+- Reconcile has more phase decisions to test.
+- WASM loading must resolve legacy inline rows and artifact-backed rows.
+- The current Turso blob table is still a SQL-backed artifact implementation until an external object-store adapter is configured.
+
+### Risks
+
+- A mistaken subdigest comparison could skip needed bootstrap work. Tests must cover changed and unchanged component combinations.
+- Artifact rows and metadata rows can diverge if artifact write succeeds but metadata write fails. The write order is artifact first, then metadata; orphaned content-addressed blobs are harmless and deduplicated.
+- Legacy inline rows must remain readable until all deployments have rewritten module metadata.
+
+## Rollout Plan
+
+1. Add red tests for idempotent spec and WASM writes.
+2. Make Turso spec and WASM writes hash-gated and remove broad spec commit writes.
+3. Store new WASM module bytes through content-addressed artifact keys while keeping legacy inline rows readable.
+4. Add red tests for component-aware OS-app reconcile.
+5. Split the install path into spec, policy, WASM, content, and seed phases driven by the reconcile plan.
+6. Update TemperPaw to consume the new Temper revision and verify startup traces show bounded reconcile work.
+
+## Non-Goals
+
+- Introducing a separate orchestrator outside Temper primitives.
+- Marking `/readyz` healthy before required startup app surfaces are usable.
+- Replacing all Turso blob storage with R2/S3 in this change.
+- Changing app bundle digest semantics.
+
+## Rollback Policy
+
+The install path can run with an all-phases plan to recover the previous behavior. Artifact-backed WASM loading preserves legacy inline rows, so rolling back code does not invalidate existing module metadata; a rollback may simply rewrite inline bytes again on the next changed module install.


### PR DESCRIPTION
## Summary
- add subdigest-based OS app reconcile planning so unchanged specs, policies, WASM, content, and seed phases can be skipped independently
- make spec persistence and WASM module upserts hash-gated/idempotent, with WASM bytes stored in blob artifacts and SQL rows carrying metadata
- harden runtime spec drift repair and add ADR/proof coverage for the startup performance path

## Validation
- cargo test -p temper-store-turso
- cargo test -p temper-platform os_apps::mod_test
- bash scripts/readability-ratchet.sh check .ci/readability-baseline.env
- cargo test -p temper-verify smt::tests::test_list_contains_exact_at_bound -- --nocapture
- pre-push full workspace suite was rerun and remained green through the large temper-server and DST boot blocks before being interrupted per user instruction to push --no-verify

## Local e2e evidence
- cold OpenPaw boot with local Temper patch: phase_6b_os_app_reconcile 11,813ms; startup ready 12,227ms
- warm OpenPaw boot against same DB: phase_6b_os_app_reconcile 1,267ms; startup ready 1,862ms; all startup apps skipped unchanged; spec/WASM versions stayed at 1
