### PR TITLE
Add type-scoped runtime index recovery

### DIFF
--- a/crates/temper-platform/src/os_apps/agent_bootstrap.rs
+++ b/crates/temper-platform/src/os_apps/agent_bootstrap.rs
@@ -131,7 +131,7 @@ pub(super) async fn bootstrap_agents(
             continue;
         }
 
-        let existing_ids = state.server.list_entity_ids(tenant_id, "Soul");
+        let existing_ids = state.server.list_entity_ids_lazy(tenant_id, "Soul").await;
         let mut found_soul_id: Option<String> = None;
         for id in &existing_ids {
             if let Ok(resp) = state
@@ -316,7 +316,7 @@ async fn set_agent_source_app(
     agent_name: &str,
     app_id: &str,
 ) {
-    let agent_ids = state.server.list_entity_ids(tenant_id, "Agent");
+    let agent_ids = state.server.list_entity_ids_lazy(tenant_id, "Agent").await;
     for id in &agent_ids {
         if let Ok(resp) = state
             .server

--- a/crates/temper-platform/src/os_apps/mod.rs
+++ b/crates/temper-platform/src/os_apps/mod.rs
@@ -1649,7 +1649,7 @@ async fn bootstrap_app_entity(
     let agent_ctx = temper_server::request_context::AgentContext::for_service("platform-bootstrap");
 
     // Look for an existing App entity with this name.
-    let existing_ids = state.server.list_entity_ids(tenant_id, "App");
+    let existing_ids = state.server.list_entity_ids_lazy(tenant_id, "App").await;
     let mut existing_app_id = None;
     for id in &existing_ids {
         if let Ok(resp) = state

--- a/crates/temper-runtime/src/persistence/mod.rs
+++ b/crates/temper-runtime/src/persistence/mod.rs
@@ -92,6 +92,13 @@ pub trait EventStore: Send + Sync + 'static {
         &self,
         tenant: &str,
     ) -> impl std::future::Future<Output = Result<Vec<(String, String)>, PersistenceError>> + Send;
+
+    /// List distinct entity IDs for one `(tenant, entity_type)` pair.
+    fn list_entity_ids_by_type(
+        &self,
+        tenant: &str,
+        entity_type: &str,
+    ) -> impl std::future::Future<Output = Result<Vec<String>, PersistenceError>> + Send;
 }
 
 /// A persisted event with metadata.

--- a/crates/temper-server/src/event_store.rs
+++ b/crates/temper-server/src/event_store.rs
@@ -365,4 +365,19 @@ impl EventStore for ServerEventStore {
             Self::Sim(store, _) => store.list_entity_ids(tenant).await,
         }
     }
+
+    async fn list_entity_ids_by_type(
+        &self,
+        tenant: &str,
+        entity_type: &str,
+    ) -> Result<Vec<String>, PersistenceError> {
+        match self {
+            Self::Postgres(store) => store.list_entity_ids_by_type(tenant, entity_type).await,
+            Self::Turso(store) => store.list_entity_ids_by_type(tenant, entity_type).await,
+            Self::Redis(store) => store.list_entity_ids_by_type(tenant, entity_type).await,
+            Self::TenantRouted(router) => router.list_entity_ids_by_type(tenant, entity_type).await,
+            #[cfg(feature = "sim")]
+            Self::Sim(store, _) => store.list_entity_ids_by_type(tenant, entity_type).await,
+        }
+    }
 }

--- a/crates/temper-server/src/state/entity_ops.rs
+++ b/crates/temper-server/src/state/entity_ops.rs
@@ -213,7 +213,10 @@ impl ServerState {
         match store.list_entity_ids(tenant.as_str()).await {
             Ok(entities) => {
                 {
-                    let mut index = self.entity_index.write().unwrap(); // ci-ok: infallible lock
+                    let mut index = self
+                        .entity_index
+                        .write()
+                        .expect("entity index lock poisoned");
                     for (entity_type, entity_id) in &entities {
                         let index_key = format!("{tenant}:{entity_type}");
                         index
@@ -235,6 +238,59 @@ impl ServerState {
                     error = %e,
                     "failed to populate entity index from event store"
                 );
+            }
+        }
+    }
+
+    /// Populate `entity_index` for one entity type from the event store.
+    #[instrument(skip_all, fields(
+        otel.name = "entity.populate_index_from_store_by_type",
+        tenant = %tenant,
+        entity_type,
+    ))]
+    pub async fn populate_index_from_store_by_type(
+        &self,
+        tenant: &TenantId,
+        entity_type: &str,
+    ) -> usize {
+        let Some(store) = self.event_store.as_ref() else {
+            return 0;
+        };
+
+        match store
+            .list_entity_ids_by_type(tenant.as_str(), entity_type)
+            .await
+        {
+            Ok(entity_ids) => {
+                let count = entity_ids.len();
+                {
+                    let mut index = self
+                        .entity_index
+                        .write()
+                        .expect("entity index lock poisoned");
+                    let index_key = format!("{tenant}:{entity_type}");
+                    let ids = index.entry(index_key).or_default();
+                    for entity_id in entity_ids {
+                        ids.insert(entity_id);
+                    }
+                }
+                tracing::info!(
+                    tenant = %tenant,
+                    entity_type,
+                    count,
+                    "populated typed entity index from event store"
+                );
+                runtime_metrics::record_server_state_metrics(self);
+                count
+            }
+            Err(e) => {
+                tracing::error!(
+                    tenant = %tenant,
+                    entity_type,
+                    error = %e,
+                    "failed to populate typed entity index from event store"
+                );
+                0
             }
         }
     }
@@ -808,7 +864,8 @@ impl ServerState {
         if self.event_store.is_none() {
             return ids;
         }
-        self.populate_index_from_store(tenant).await;
+        self.populate_index_from_store_by_type(tenant, entity_type)
+            .await;
 
         self.list_entity_ids(tenant, entity_type)
     }

--- a/crates/temper-server/tests/ensure_entity_loaded.rs
+++ b/crates/temper-server/tests/ensure_entity_loaded.rs
@@ -107,6 +107,70 @@ async fn ensure_entity_loaded_returns_true_for_indexed_entity_without_persistenc
 }
 
 #[tokio::test]
+async fn list_entity_ids_lazy_populates_only_requested_type() {
+    let db_path = std::env::temp_dir().join(format!(
+        "temper-lazy-list-scoped-{}.db",
+        uuid::Uuid::new_v4()
+    ));
+    let db_url = format!("file:{}", db_path.display());
+    let store = TursoEventStore::new(&db_url, None)
+        .await
+        .expect("create local turso db");
+
+    store
+        .append(
+            "tenant-a:Order:ord-1",
+            0,
+            &[PersistenceEnvelope {
+                sequence_nr: 0,
+                event_type: "Created".to_string(),
+                payload: serde_json::json!({"id": "ord-1"}),
+                metadata: EventMetadata {
+                    event_id: uuid::Uuid::new_v4(),
+                    causation_id: uuid::Uuid::new_v4(),
+                    correlation_id: uuid::Uuid::new_v4(),
+                    timestamp: sim_now(),
+                    actor_id: "tenant-a:Order:ord-1".to_string(),
+                },
+            }],
+        )
+        .await
+        .expect("append order event");
+    store
+        .append(
+            "tenant-a:Task:task-1",
+            0,
+            &[PersistenceEnvelope {
+                sequence_nr: 0,
+                event_type: "Created".to_string(),
+                payload: serde_json::json!({"id": "task-1"}),
+                metadata: EventMetadata {
+                    event_id: uuid::Uuid::new_v4(),
+                    causation_id: uuid::Uuid::new_v4(),
+                    correlation_id: uuid::Uuid::new_v4(),
+                    timestamp: sim_now(),
+                    actor_id: "tenant-a:Task:task-1".to_string(),
+                },
+            }],
+        )
+        .await
+        .expect("append task event");
+
+    let state = build_state_with_turso("test-lazy-list-scoped", store);
+    let tenant = TenantId::new("tenant-a");
+
+    let order_ids = state.list_entity_ids_lazy(&tenant, "Order").await;
+
+    assert_eq!(order_ids, vec!["ord-1".to_string()]);
+    assert!(
+        state.list_entity_ids(&tenant, "Task").is_empty(),
+        "lazy listing one entity type should not populate unrelated types"
+    );
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
 async fn delete_writes_tombstone_and_deleted_entity_stays_out_of_list_after_restart() {
     let db_path = std::env::temp_dir().join(format!(
         "temper-delete-tombstone-list-{}.db",

--- a/crates/temper-store-postgres/src/store.rs
+++ b/crates/temper-store-postgres/src/store.rs
@@ -231,6 +231,36 @@ impl EventStore for PostgresEventStore {
 
         Ok(rows)
     }
+
+    /// List distinct entity IDs for one entity type in the given tenant.
+    async fn list_entity_ids_by_type(
+        &self,
+        tenant: &str,
+        entity_type: &str,
+    ) -> Result<Vec<String>, PersistenceError> {
+        let rows: Vec<String> = sqlx::query_scalar(
+            "SELECT DISTINCT e.entity_id \
+             FROM events e \
+             WHERE e.tenant = $1 \
+               AND e.entity_type = $2 \
+               AND NOT EXISTS ( \
+                 SELECT 1 \
+                 FROM events d \
+                 WHERE d.tenant = e.tenant \
+                   AND d.entity_type = e.entity_type \
+                   AND d.entity_id = e.entity_id \
+                   AND d.event_type = 'Deleted' \
+               ) \
+             ORDER BY e.entity_id",
+        )
+        .bind(tenant)
+        .bind(entity_type)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| PersistenceError::Storage(e.to_string()))?;
+
+        Ok(rows)
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/temper-store-redis/src/event_store.rs
+++ b/crates/temper-store-redis/src/event_store.rs
@@ -298,6 +298,28 @@ impl EventStore for RedisEventStore {
         out.dedup();
         Ok(out)
     }
+
+    async fn list_entity_ids_by_type(
+        &self,
+        tenant: &str,
+        entity_type: &str,
+    ) -> Result<Vec<String>, PersistenceError> {
+        let key = Self::tenant_entities_key(tenant);
+        let members: Vec<String> = self.client.smembers(&key).await.map_err(storage_error)?;
+
+        let mut out = Vec::new();
+        for encoded in members {
+            let entity_ref: EntityRef = serde_json::from_str(&encoded)
+                .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
+            if entity_ref.entity_type == entity_type {
+                out.push(entity_ref.entity_id);
+            }
+        }
+
+        out.sort();
+        out.dedup();
+        Ok(out)
+    }
 }
 
 #[cfg(test)]

--- a/crates/temper-store-sim/src/lib.rs
+++ b/crates/temper-store-sim/src/lib.rs
@@ -445,6 +445,28 @@ impl EventStore for SimEventStore {
 
         Ok(result)
     }
+
+    async fn list_entity_ids_by_type(
+        &self,
+        tenant: &str,
+        entity_type: &str,
+    ) -> Result<Vec<String>, PersistenceError> {
+        let inner = self.inner.lock().expect("SimEventStore lock poisoned"); // ci-ok: infallible lock
+        let mut result = Vec::new();
+        let mut seen = std::collections::BTreeSet::new();
+
+        for persistence_id in inner.journals.keys() {
+            if let Ok((t, found_type, entity_id)) = parse_persistence_id_parts(persistence_id)
+                && t == tenant
+                && found_type == entity_type
+                && seen.insert(entity_id.to_string())
+            {
+                result.push(entity_id.to_string());
+            }
+        }
+
+        Ok(result)
+    }
 }
 
 #[cfg(test)]

--- a/crates/temper-store-turso/src/router.rs
+++ b/crates/temper-store-turso/src/router.rs
@@ -705,6 +705,16 @@ impl EventStore for TenantStoreRouter {
         let store = self.store_for_tenant(tenant).await?;
         store.list_entity_ids(tenant).await
     }
+
+    #[instrument(skip_all, fields(tenant, entity_type, otel.name = "router.list_entity_ids_by_type"))]
+    async fn list_entity_ids_by_type(
+        &self,
+        tenant: &str,
+        entity_type: &str,
+    ) -> Result<Vec<String>, PersistenceError> {
+        let store = self.store_for_tenant(tenant).await?;
+        store.list_entity_ids_by_type(tenant, entity_type).await
+    }
 }
 
 #[cfg(test)]

--- a/crates/temper-store-turso/src/store/append_config.rs
+++ b/crates/temper-store-turso/src/store/append_config.rs
@@ -1,0 +1,27 @@
+//! Append retry configuration.
+
+use std::time::Duration;
+
+use crate::retry::RETRY_DELAYS_MS;
+
+pub(crate) fn append_attempt_timeout() -> Duration {
+    const DEFAULT_APPEND_ATTEMPT_TIMEOUT_MS: u64 = 5_000;
+    const MIN_APPEND_ATTEMPT_TIMEOUT_MS: u64 = 500;
+
+    let configured = std::env::var("TEMPER_TURSO_APPEND_TIMEOUT_MS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_APPEND_ATTEMPT_TIMEOUT_MS);
+
+    Duration::from_millis(configured.max(MIN_APPEND_ATTEMPT_TIMEOUT_MS))
+}
+
+pub(crate) fn append_max_attempts() -> usize {
+    const DEFAULT_APPEND_MAX_ATTEMPTS: usize = RETRY_DELAYS_MS.len() + 1;
+
+    std::env::var("TEMPER_TURSO_APPEND_MAX_ATTEMPTS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(DEFAULT_APPEND_MAX_ATTEMPTS)
+        .max(1)
+}

--- a/crates/temper-store-turso/src/store/entity_listing.rs
+++ b/crates/temper-store-turso/src/store/entity_listing.rs
@@ -1,0 +1,66 @@
+//! Entity listing helpers for Turso/libSQL-backed runtime recovery.
+
+use libsql::params;
+use temper_runtime::persistence::{PersistenceError, storage_error};
+use tracing::instrument;
+
+use super::TursoEventStore;
+
+impl TursoEventStore {
+    #[instrument(skip_all, fields(
+        tenant,
+        entity_type,
+        otel.name = "turso.list_entity_ids_by_type"
+    ))]
+    pub(crate) async fn list_entity_ids_by_type_catalog_first(
+        &self,
+        tenant: &str,
+        entity_type: &str,
+    ) -> Result<Vec<String>, PersistenceError> {
+        let conn = self.configured_connection().await?;
+        let mut rows = conn
+            .query(
+                "SELECT entity_id
+                 FROM entity_catalog
+                 WHERE tenant = ?1 AND entity_type = ?2
+                 ORDER BY entity_id",
+                params![tenant, entity_type],
+            )
+            .await
+            .map_err(storage_error)?;
+
+        let mut catalog_ids = Vec::new();
+        while let Some(row) = rows.next().await.map_err(storage_error)? {
+            catalog_ids.push(row.get::<String>(0).map_err(storage_error)?);
+        }
+        if !catalog_ids.is_empty() {
+            return Ok(catalog_ids);
+        }
+
+        let mut rows = conn
+            .query(
+                "SELECT DISTINCT e.entity_id
+                 FROM events e
+                 WHERE e.tenant = ?1
+                   AND e.entity_type = ?2
+                   AND NOT EXISTS (
+                     SELECT 1
+                     FROM events d
+                     WHERE d.tenant = e.tenant
+                       AND d.entity_type = e.entity_type
+                       AND d.entity_id = e.entity_id
+                       AND d.event_type = 'Deleted'
+                   )
+                 ORDER BY e.entity_id",
+                params![tenant, entity_type],
+            )
+            .await
+            .map_err(storage_error)?;
+
+        let mut out = Vec::new();
+        while let Some(row) = rows.next().await.map_err(storage_error)? {
+            out.push(row.get::<String>(0).map_err(storage_error)?);
+        }
+        Ok(out)
+    }
+}

--- a/crates/temper-store-turso/src/store/event_store.rs
+++ b/crates/temper-store-turso/src/store/event_store.rs
@@ -9,10 +9,11 @@ use temper_runtime::tenant::parse_persistence_id_parts;
 use tracing::{instrument, warn};
 
 use super::TursoEventStore;
+use super::append_config::{append_attempt_timeout, append_max_attempts};
 use super::instrumentation::record_turso_query_duration;
 use super::write_gate::WritePriority;
 use crate::metrics::record_turso_write_retry;
-use crate::retry::{RETRY_DELAYS_MS, is_transient_write_error, retry_delay_ms};
+use crate::retry::{is_transient_write_error, retry_delay_ms};
 
 impl EventStore for TursoEventStore {
     #[instrument(skip_all, fields(persistence_id, otel.name = "turso.append"))]
@@ -244,28 +245,15 @@ impl EventStore for TursoEventStore {
         }
         Ok(out)
     }
-}
 
-fn append_attempt_timeout() -> Duration {
-    const DEFAULT_APPEND_ATTEMPT_TIMEOUT_MS: u64 = 5_000;
-    const MIN_APPEND_ATTEMPT_TIMEOUT_MS: u64 = 500;
-
-    let configured = std::env::var("TEMPER_TURSO_APPEND_TIMEOUT_MS")
-        .ok()
-        .and_then(|value| value.parse::<u64>().ok())
-        .unwrap_or(DEFAULT_APPEND_ATTEMPT_TIMEOUT_MS);
-
-    Duration::from_millis(configured.max(MIN_APPEND_ATTEMPT_TIMEOUT_MS))
-}
-
-fn append_max_attempts() -> usize {
-    const DEFAULT_APPEND_MAX_ATTEMPTS: usize = RETRY_DELAYS_MS.len() + 1;
-
-    std::env::var("TEMPER_TURSO_APPEND_MAX_ATTEMPTS")
-        .ok()
-        .and_then(|value| value.parse::<usize>().ok())
-        .unwrap_or(DEFAULT_APPEND_MAX_ATTEMPTS)
-        .max(1)
+    async fn list_entity_ids_by_type(
+        &self,
+        tenant: &str,
+        entity_type: &str,
+    ) -> Result<Vec<String>, PersistenceError> {
+        self.list_entity_ids_by_type_catalog_first(tenant, entity_type)
+            .await
+    }
 }
 
 impl TursoEventStore {

--- a/crates/temper-store-turso/src/store/mod.rs
+++ b/crates/temper-store-turso/src/store/mod.rs
@@ -18,9 +18,11 @@ use tracing::instrument;
 
 use crate::schema;
 
+mod append_config;
 mod authz;
 mod blobs;
 mod constraints;
+mod entity_listing;
 mod event_store;
 mod evolution;
 pub mod field_index;

--- a/crates/temper-store-turso/src/store/tests/mod.rs
+++ b/crates/temper-store-turso/src/store/tests/mod.rs
@@ -238,6 +238,88 @@ async fn list_entity_ids_returns_distinct_pairs() {
 }
 
 #[tokio::test]
+async fn list_entity_ids_by_type_uses_entity_catalog() {
+    let store = make_store("entity-list-by-type-catalog").await;
+    let tenant = format!("tenant-{}", uuid::Uuid::new_v4());
+
+    store
+        .upsert_query_projection(
+            &tenant,
+            "AgentRoute",
+            "route-main",
+            "Ready",
+            &serde_json::json!({ "Name": "main" }),
+            3,
+        )
+        .await
+        .expect("upsert AgentRoute projection");
+    store
+        .upsert_query_projection(
+            &tenant,
+            "Session",
+            "session-1",
+            "Completed",
+            &serde_json::json!({ "Name": "session" }),
+            1,
+        )
+        .await
+        .expect("upsert Session projection");
+
+    let ids = store
+        .list_entity_ids_by_type(&tenant, "AgentRoute")
+        .await
+        .expect("list AgentRoute IDs by type");
+
+    assert_eq!(ids, vec!["route-main".to_string()]);
+}
+
+#[tokio::test]
+async fn list_entity_ids_by_type_falls_back_to_events_and_excludes_deleted() {
+    let store = make_store("entity-list-by-type-events").await;
+    let tenant = format!("tenant-{}", uuid::Uuid::new_v4());
+
+    let deleted_order = format!("{tenant}:Order:ord-deleted");
+    let active_order = format!("{tenant}:Order:ord-active");
+    let task = format!("{tenant}:Task:task-1");
+
+    store
+        .append(
+            &deleted_order,
+            0,
+            &[test_envelope("Created", serde_json::json!({}))],
+        )
+        .await
+        .unwrap();
+    store
+        .append(
+            &deleted_order,
+            1,
+            &[test_envelope("Deleted", serde_json::json!({}))],
+        )
+        .await
+        .unwrap();
+    store
+        .append(
+            &active_order,
+            0,
+            &[test_envelope("Created", serde_json::json!({}))],
+        )
+        .await
+        .unwrap();
+    store
+        .append(&task, 0, &[test_envelope("Created", serde_json::json!({}))])
+        .await
+        .unwrap();
+
+    let ids = store
+        .list_entity_ids_by_type(&tenant, "Order")
+        .await
+        .expect("list Order IDs by type from event fallback");
+
+    assert_eq!(ids, vec!["ord-active".to_string()]);
+}
+
+#[tokio::test]
 async fn list_entity_ids_excludes_entities_with_deleted_tombstones() {
     let store = make_store("entity-list-deleted").await;
     let tenant = format!("tenant-{}", uuid::Uuid::new_v4());


### PR DESCRIPTION
## Summary
- Add EventStore::list_entity_ids_by_type and Turso catalog-first implementation.
- Make lazy runtime collection reads populate only the requested entity type instead of replaying the whole tenant catalog.
- Switch OS app bootstrap call sites to the lazy typed path.

## Root cause
Collection reads such as /tdata/AgentRoutes could trigger full tenant runtime index recovery when the in-memory index was cold. In production that meant a user-visible request could sit behind a multi-minute list_entity_ids scan.

## Validation
- cargo test -p temper-store-turso list_entity_ids_by_type -- --nocapture
- cargo test -p temper-server --test ensure_entity_loaded list_entity_ids_lazy_populates_only_requested_type -- --nocapture