### PR TITLE
Move dispatch observability writes off hot path

### DIFF
--- a/crates/temper-server/src/observe/mod_test.rs
+++ b/crates/temper-server/src/observe/mod_test.rs
@@ -71,6 +71,26 @@ fn system_get(uri: &str) -> Request<Body> {
         .unwrap()
 }
 
+async fn observe_json(app: Router, uri: &str) -> serde_json::Value {
+    let response = app.oneshot(system_get(uri)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    serde_json::from_slice(&body).unwrap()
+}
+
+async fn wait_for_trajectory_total(app: Router, uri: &str, min_total: u64) -> serde_json::Value {
+    for _ in 0..50 {
+        let json = observe_json(app.clone(), uri).await;
+        if json["total"].as_u64().unwrap_or(0) >= min_total {
+            return json;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    observe_json(app, uri).await
+}
+
 /// Build a POST request with admin auth headers for observe endpoints.
 fn system_post(uri: &str, body: &str) -> Request<Body> {
     Request::post(uri)
@@ -891,16 +911,7 @@ async fn test_trajectories_records_success_and_failure() {
         .nest("/api", crate::api::build_api_router())
         .with_state(state);
 
-    let response = app
-        .oneshot(system_get("/observe/trajectories"))
-        .await
-        .unwrap();
-
-    assert_eq!(response.status(), StatusCode::OK);
-    let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
-        .await
-        .unwrap();
-    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let json = wait_for_trajectory_total(app, "/observe/trajectories", 2).await;
 
     assert!(json["total"].as_u64().unwrap() >= 2);
     assert!(json["success_count"].as_u64().unwrap() >= 1);
@@ -939,26 +950,12 @@ async fn test_trajectories_filters_by_entity_type() {
         .with_state(state);
 
     // Filter for entity_type=Order should find our entry.
-    let response = app
-        .clone()
-        .oneshot(system_get("/observe/trajectories?entity_type=Order"))
-        .await
-        .unwrap();
-    let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
-        .await
-        .unwrap();
-    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let json =
+        wait_for_trajectory_total(app.clone(), "/observe/trajectories?entity_type=Order", 1).await;
     assert!(json["total"].as_u64().unwrap() >= 1);
 
     // Filter for non-existent entity_type should return 0.
-    let response = app
-        .oneshot(system_get("/observe/trajectories?entity_type=Nonexistent"))
-        .await
-        .unwrap();
-    let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
-        .await
-        .unwrap();
-    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let json = observe_json(app, "/observe/trajectories?entity_type=Nonexistent").await;
     assert_eq!(json["total"], 0);
 }
 

--- a/crates/temper-server/src/state/dispatch/actions.rs
+++ b/crates/temper-server/src/state/dispatch/actions.rs
@@ -501,9 +501,7 @@ impl crate::state::ServerState {
                 if let Some(ref err) = entry.error {
                     tracing::Span::current().record("error_msg", err.as_str());
                 }
-                if let Err(persist_err) = self.persist_trajectory_entry(&entry).await {
-                    tracing::error!(error = %persist_err, "failed to persist trajectory entry");
-                }
+                self.persist_trajectory_entry_background(entry);
                 return Err(DispatchError::from_actor_error(e, outcome.attempts));
             }
         };

--- a/crates/temper-server/src/state/dispatch/effects.rs
+++ b/crates/temper-server/src/state/dispatch/effects.rs
@@ -32,11 +32,46 @@ enum QueryProjectionUpdateMode {
     Background,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DispatchTrajectoryPersistenceMode {
+    Background,
+}
+
 fn query_projection_update_mode() -> QueryProjectionUpdateMode {
     QueryProjectionUpdateMode::Background
 }
 
+fn dispatch_trajectory_persistence_mode() -> DispatchTrajectoryPersistenceMode {
+    DispatchTrajectoryPersistenceMode::Background
+}
+
 impl crate::state::ServerState {
+    pub(super) fn persist_trajectory_entry_background(&self, entry: TrajectoryEntry) {
+        debug_assert_eq!(
+            dispatch_trajectory_persistence_mode(),
+            DispatchTrajectoryPersistenceMode::Background
+        );
+        let state = self.clone();
+        let span = tracing::info_span!(
+            "dispatch.phase.persist_trajectory",
+            otel.name = "dispatch.phase.persist_trajectory",
+            tenant = %entry.tenant,
+            entity_type = %entry.entity_type,
+            entity_id = %entry.entity_id,
+            action = %entry.action,
+            success = entry.success,
+        );
+
+        tokio::spawn(
+            async move {
+                if let Err(e) = state.persist_trajectory_entry(&entry).await {
+                    tracing::error!(error = %e, "failed to persist trajectory entry");
+                }
+            }
+            .instrument(span),
+        );
+    }
+
     fn enqueue_query_projection_update(
         &self,
         ctx: &PostDispatchContext<'_>,
@@ -124,7 +159,7 @@ impl crate::state::ServerState {
     }
 
     /// Record a trajectory entry for a completed dispatch (success or guard failure).
-    pub(crate) async fn record_dispatch_trajectory(
+    pub(crate) fn record_dispatch_trajectory(
         &self,
         ctx: &PostDispatchContext<'_>,
         response: &EntityResponse,
@@ -193,9 +228,7 @@ impl crate::state::ServerState {
                 "unmet_intent"
             );
         }
-        if let Err(e) = self.persist_trajectory_entry(&entry).await {
-            tracing::error!(error = %e, "failed to persist trajectory entry");
-        }
+        self.persist_trajectory_entry_background(entry);
     }
 
     /// Broadcast state change to SSE subscribers and update entity cache.
@@ -410,8 +443,10 @@ impl crate::state::ServerState {
         self.metrics
             .record_transition(ctx.entity_type, ctx.action, response.success);
 
-        // 2. Record trajectory
-        self.record_dispatch_trajectory(ctx, &response).await;
+        // 2. Record trajectory outside the action critical path. The entity
+        // transition is already durable; trajectory persistence is an
+        // observability/audit side effect.
+        self.record_dispatch_trajectory(ctx, &response);
 
         if !response.success {
             return response;
@@ -596,6 +631,14 @@ mod tests {
         assert_eq!(
             query_projection_update_mode(),
             QueryProjectionUpdateMode::Background
+        );
+    }
+
+    #[test]
+    fn dispatch_trajectory_persistence_is_not_on_the_dispatch_critical_path() {
+        assert_eq!(
+            dispatch_trajectory_persistence_mode(),
+            DispatchTrajectoryPersistenceMode::Background
         );
     }
 }

--- a/crates/temper-server/src/state/dispatch/wasm/invocation_artifacts.rs
+++ b/crates/temper-server/src/state/dispatch/wasm/invocation_artifacts.rs
@@ -10,7 +10,7 @@ use crate::state::wasm_invocation_log::WasmInvocationEntry;
 use temper_observe::wide_event;
 use temper_runtime::scheduler::{sim_now, sim_uuid};
 use temper_runtime::tenant::TenantId;
-use tracing::instrument;
+use tracing::{Instrument, instrument};
 
 impl crate::state::ServerState {
     /// Record a WASM invocation (persist log entry + emit observability events).
@@ -39,7 +39,26 @@ impl crate::state::ServerState {
             duration_ms,
             authz_denied,
         };
-        let _ = self.persist_wasm_invocation(&log_entry).await;
+        let state = self.clone();
+        let persist_entry = log_entry.clone();
+        let span = tracing::info_span!(
+            "dispatch.phase.persist_wasm_invocation",
+            otel.name = "dispatch.phase.persist_wasm_invocation",
+            tenant = %persist_entry.tenant,
+            entity_type = %persist_entry.entity_type,
+            entity_id = %persist_entry.entity_id,
+            module_name = %persist_entry.module_name,
+            trigger_action = %persist_entry.trigger_action,
+            success = persist_entry.success,
+        );
+        tokio::spawn(
+            async move {
+                if let Err(e) = state.persist_wasm_invocation(&persist_entry).await {
+                    tracing::error!(error = %e, "failed to persist WASM invocation");
+                }
+            }
+            .instrument(span),
+        );
 
         let wide = wide_event::from_wasm_invocation(wide_event::WasmInvocationInput {
             module_name,


### PR DESCRIPTION
## Summary
- persist dispatch trajectory entries in the background instead of awaiting them on the dispatch critical path
- persist WASM invocation observability records in the background
- keep telemetry spans/metrics so slow observability writes are still visible without blocking entity transitions
- update trajectory tests to account for eventual persistence

## Validation
- cargo test -p temper-server dispatch_trajectory_persistence_is_not_on_the_dispatch_critical_path
- cargo test -p temper-server --all-features test_trajectories
- pre-push full gate: ALL GATES PASSED