### PR TITLE
[codex] Store blob bytes outside SQL

### DIFF
--- a/crates/temper-platform/src/os_apps/mod_test.rs
+++ b/crates/temper-platform/src/os_apps/mod_test.rs
@@ -1035,6 +1035,11 @@ async fn test_skill_install_survives_restart() {
     let turso = TursoEventStore::new(&db_url, None).await.unwrap();
     let mut state = PlatformState::new(None);
     state.server.event_store = Some(Arc::new(ServerEventStore::Turso(turso)));
+    state.server.data_dir = std::path::PathBuf::from(format!(
+        "/tmp/temper-adr-test-{}-data",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&state.server.data_dir).unwrap();
 
     let result = install_skill(&state, "test-ws", "project-management").await;
     assert!(result.is_ok(), "install failed: {:?}", result.err());
@@ -1711,6 +1716,11 @@ async fn test_install_app_bootstraps_adrs_into_temper_fs() {
     let turso = TursoEventStore::new(&db_url, None).await.unwrap();
     let mut state = PlatformState::new(None);
     state.server.event_store = Some(Arc::new(ServerEventStore::Turso(turso)));
+    state.server.data_dir = std::path::PathBuf::from(format!(
+        "/tmp/temper-adr-test-{}-data",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&state.server.data_dir).unwrap();
 
     // Re-add the temp dir before each install — the concurrent
     // `test_reload_picks_up_disk_changes` test calls `reload_skills()`
@@ -1958,6 +1968,11 @@ async fn test_local_stream_uploads_create_real_file_version_lineage() {
     let turso = TursoEventStore::new(&db_url, None).await.unwrap();
     let mut state = PlatformState::new(None);
     state.server.event_store = Some(Arc::new(ServerEventStore::Turso(turso)));
+    state.server.data_dir = std::path::PathBuf::from(format!(
+        "/tmp/temper-file-version-lineage-{}-data",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&state.server.data_dir).unwrap();
 
     install_os_app(&state, "test-file-lineage", "temper-fs")
         .await

--- a/crates/temper-server/src/blob_store.rs
+++ b/crates/temper-server/src/blob_store.rs
@@ -1,0 +1,509 @@
+//! Object storage for durable blob bytes.
+//!
+//! New blob writes go through this boundary. The Turso `blobs` table remains a
+//! legacy read fallback for installations that already wrote blob bytes there.
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+
+use hmac::{Hmac, Mac};
+use reqwest::header::{AUTHORIZATION, HOST, HeaderMap, HeaderValue};
+use reqwest::{Method, StatusCode};
+use sha2::{Digest, Sha256};
+use temper_runtime::tenant::TenantId;
+use tokio::sync::Semaphore;
+
+use crate::state::ServerState;
+
+type HmacSha256 = Hmac<Sha256>;
+
+const DEFAULT_BLOB_IO_MAX_CONCURRENCY: usize = 32;
+pub(crate) const DEFAULT_BLOB_BUCKET: &str = "temper-fs";
+pub(crate) const WASM_ARTIFACT_PREFIX: &str = "wasm-modules/";
+
+pub(crate) fn wasm_artifact_key(sha256_hash: &str) -> String {
+    format!("{WASM_ARTIFACT_PREFIX}{sha256_hash}")
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct BlobStore {
+    backend: BlobStoreBackend,
+}
+
+#[derive(Clone, Debug)]
+enum BlobStoreBackend {
+    LocalFs { root: PathBuf },
+    S3(S3BlobStore),
+}
+
+#[derive(Clone, Debug)]
+struct S3BlobStore {
+    endpoint: String,
+    bucket: String,
+    access_key: Option<String>,
+    secret_key: Option<String>,
+    client: reqwest::Client,
+}
+
+fn blob_io_semaphore() -> &'static Semaphore {
+    static SEMAPHORE: OnceLock<Semaphore> = OnceLock::new();
+    SEMAPHORE.get_or_init(|| {
+        let limit = std::env::var("TEMPER_BLOB_IO_MAX_CONCURRENCY")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|v| *v > 0)
+            .unwrap_or(DEFAULT_BLOB_IO_MAX_CONCURRENCY);
+        Semaphore::new(limit)
+    })
+}
+
+impl BlobStore {
+    pub(crate) fn local_fs(root: impl Into<PathBuf>) -> Self {
+        Self {
+            backend: BlobStoreBackend::LocalFs { root: root.into() },
+        }
+    }
+
+    pub(crate) fn s3(
+        endpoint: impl Into<String>,
+        bucket: impl Into<String>,
+        access_key: Option<String>,
+        secret_key: Option<String>,
+    ) -> Self {
+        Self {
+            backend: BlobStoreBackend::S3(S3BlobStore {
+                endpoint: endpoint.into().trim_end_matches('/').to_string(),
+                bucket: bucket.into().trim_matches('/').to_string(),
+                access_key,
+                secret_key,
+                client: reqwest::Client::new(),
+            }),
+        }
+    }
+
+    pub(crate) async fn put_if_absent(
+        &self,
+        key: &str,
+        body: &[u8],
+        ttl: Option<Duration>,
+    ) -> Result<(), String> {
+        let queued_at = Instant::now();
+        let _permit = blob_io_semaphore()
+            .acquire()
+            .await
+            .expect("blob semaphore closed"); // ci-ok: process-global and never closed
+        let wait_duration = queued_at.elapsed();
+        crate::runtime_metrics::record_blob_io_wait_duration(wait_duration, "put");
+        if wait_duration.as_millis() > 0 {
+            tracing::info!(path = %key, wait_ms = wait_duration.as_millis() as u64, "blob put queued");
+        }
+        if ttl.is_some() {
+            tracing::debug!(
+                path = %key,
+                ttl_seconds = ttl.map(|duration| duration.as_secs()),
+                "object blob store write received TTL; retention is delegated to the object store"
+            );
+        }
+
+        match &self.backend {
+            BlobStoreBackend::LocalFs { root } => put_local_blob(root, key, body).await,
+            BlobStoreBackend::S3(store) => store.put_if_absent(key, body).await,
+        }
+    }
+
+    pub(crate) async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, String> {
+        let queued_at = Instant::now();
+        let _permit = blob_io_semaphore()
+            .acquire()
+            .await
+            .expect("blob semaphore closed"); // ci-ok: process-global and never closed
+        let wait_duration = queued_at.elapsed();
+        crate::runtime_metrics::record_blob_io_wait_duration(wait_duration, "get");
+        if wait_duration.as_millis() > 0 {
+            tracing::info!(path = %key, wait_ms = wait_duration.as_millis() as u64, "blob get queued");
+        }
+
+        match &self.backend {
+            BlobStoreBackend::LocalFs { root } => get_local_blob(root, key).await,
+            BlobStoreBackend::S3(store) => store.get(key).await,
+        }
+    }
+}
+
+impl ServerState {
+    pub(crate) fn blob_store_for_tenant(&self, tenant: &TenantId) -> Result<BlobStore, String> {
+        if let Some(vault) = self.secrets_vault.as_ref()
+            && let Some(endpoint) = vault.get_secret(tenant.as_str(), "blob_endpoint")
+            && !endpoint.trim().is_empty()
+        {
+            if is_local_internal_blob_endpoint(&endpoint) {
+                return self.local_blob_store().ok_or_else(|| {
+                    "internal DB-backed blob endpoint is disabled; set TEMPER_LOCAL_BLOB_DIR or configure BLOB_ENDPOINT for R2/S3"
+                        .to_string()
+                });
+            }
+
+            let bucket = vault
+                .get_secret(tenant.as_str(), "blob_bucket")
+                .unwrap_or_else(|| DEFAULT_BLOB_BUCKET.to_string());
+            let access_key = vault.get_secret(tenant.as_str(), "blob_access_key");
+            let secret_key = vault.get_secret(tenant.as_str(), "blob_secret_key");
+            return Ok(BlobStore::s3(endpoint, bucket, access_key, secret_key));
+        }
+
+        self.local_blob_store().ok_or_else(|| {
+            "blob object store is not configured; set BLOB_ENDPOINT/BLOB_BUCKET/BLOB_ACCESS_KEY/BLOB_SECRET_KEY or TEMPER_LOCAL_BLOB_DIR"
+                .to_string()
+        })
+    }
+
+    pub(crate) async fn put_blob_object(
+        &self,
+        tenant: &TenantId,
+        key: &str,
+        body: &[u8],
+        ttl: Option<Duration>,
+    ) -> Result<(), String> {
+        let store = self.blob_store_for_tenant(tenant)?;
+        store.put_if_absent(key, body, ttl).await
+    }
+
+    pub(crate) async fn get_blob_with_legacy_fallback(
+        &self,
+        tenant: &TenantId,
+        key: &str,
+    ) -> Result<Option<Vec<u8>>, String> {
+        match self.blob_store_for_tenant(tenant) {
+            Ok(store) => match store.get(key).await {
+                Ok(Some(bytes)) => return Ok(Some(bytes)),
+                Ok(None) => {}
+                Err(error) => {
+                    tracing::warn!(%key, %error, "object blob store read failed; trying legacy DB blob fallback");
+                }
+            },
+            Err(error) => {
+                tracing::debug!(%key, %error, "object blob store unavailable; trying legacy DB blob fallback");
+            }
+        }
+
+        let Some(store) = self.persistent_store_for_tenant(tenant.as_str()).await else {
+            return Ok(None);
+        };
+        store
+            .get_blob(key)
+            .await
+            .map_err(|e| format!("legacy DB blob read failed for '{key}': {e}"))
+    }
+
+    fn local_blob_store(&self) -> Option<BlobStore> {
+        if let Ok(root) = std::env::var("TEMPER_LOCAL_BLOB_DIR")
+            && !root.trim().is_empty()
+        {
+            return Some(BlobStore::local_fs(root));
+        }
+        if !self.data_dir.as_os_str().is_empty() {
+            return Some(BlobStore::local_fs(self.data_dir.join("blobs")));
+        }
+        None
+    }
+}
+
+impl S3BlobStore {
+    async fn put_if_absent(&self, key: &str, body: &[u8]) -> Result<(), String> {
+        if self.exists(key).await? {
+            return Ok(());
+        }
+
+        let url = self.object_url(key);
+        let mut request = self.client.put(&url).body(body.to_vec());
+        let headers = self.signed_headers(Method::PUT, &url)?;
+        for (header_name, header_value) in &headers {
+            request = request.header(header_name, header_value);
+        }
+
+        let response = request
+            .send()
+            .await
+            .map_err(|e| format!("blob PUT request failed for '{key}': {e}"))?;
+        if response.status().is_success() {
+            return Ok(());
+        }
+        Err(format!(
+            "blob PUT failed for '{key}' with HTTP {}",
+            response.status()
+        ))
+    }
+
+    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, String> {
+        let url = self.object_url(key);
+        let mut request = self.client.get(&url);
+        let headers = self.signed_headers(Method::GET, &url)?;
+        for (header_name, header_value) in &headers {
+            request = request.header(header_name, header_value);
+        }
+
+        let response = request
+            .send()
+            .await
+            .map_err(|e| format!("blob GET request failed for '{key}': {e}"))?;
+        if response.status() == StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        if !response.status().is_success() {
+            return Err(format!(
+                "blob GET failed for '{key}' with HTTP {}",
+                response.status()
+            ));
+        }
+
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|e| format!("blob GET body read failed for '{key}': {e}"))?;
+        Ok(Some(bytes.to_vec()))
+    }
+
+    async fn exists(&self, key: &str) -> Result<bool, String> {
+        let url = self.object_url(key);
+        let mut request = self.client.head(&url);
+        let headers = self.signed_headers(Method::HEAD, &url)?;
+        for (header_name, header_value) in &headers {
+            request = request.header(header_name, header_value);
+        }
+
+        let response = request
+            .send()
+            .await
+            .map_err(|e| format!("blob HEAD request failed for '{key}': {e}"))?;
+        match response.status() {
+            StatusCode::OK | StatusCode::NO_CONTENT => Ok(true),
+            StatusCode::NOT_FOUND => Ok(false),
+            status if status.is_success() => Ok(true),
+            status => Err(format!("blob HEAD failed for '{key}' with HTTP {status}")),
+        }
+    }
+
+    fn object_url(&self, key: &str) -> String {
+        format!(
+            "{}/{}/{}",
+            self.endpoint,
+            self.bucket,
+            key.trim_start_matches('/')
+        )
+    }
+
+    fn signed_headers(&self, method: Method, url: &str) -> Result<HeaderMap, String> {
+        let mut headers = HeaderMap::new();
+        let Some(access_key) = self.access_key.as_deref() else {
+            return Ok(headers);
+        };
+        let Some(secret_key) = self.secret_key.as_deref() else {
+            return Ok(headers);
+        };
+
+        let datetime = chrono::Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
+        let date = &datetime[..8];
+        let (host, path) = parse_url_host_path(url);
+        let canonical_uri = uri_encode_path(path);
+        let payload_hash = "UNSIGNED-PAYLOAD";
+        let region = "auto";
+        let service = "s3";
+        let scope = format!("{date}/{region}/{service}/aws4_request");
+        let canonical_headers =
+            format!("host:{host}\nx-amz-content-sha256:{payload_hash}\nx-amz-date:{datetime}\n");
+        let signed_headers = "host;x-amz-content-sha256;x-amz-date";
+        let canonical_request = format!(
+            "{}\n{canonical_uri}\n\n{canonical_headers}\n{signed_headers}\n{payload_hash}",
+            method.as_str()
+        );
+        let canonical_request_hash = sha256_hex(canonical_request.as_bytes());
+        let string_to_sign =
+            format!("AWS4-HMAC-SHA256\n{datetime}\n{scope}\n{canonical_request_hash}");
+        let signing_key = derive_signing_key(secret_key, date, region, service);
+        let signature = hex_encode(&hmac_sha256(&signing_key, string_to_sign.as_bytes()));
+        let authorization = format!(
+            "AWS4-HMAC-SHA256 Credential={access_key}/{scope},SignedHeaders={signed_headers},Signature={signature}"
+        );
+
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&authorization)
+                .map_err(|e| format!("invalid blob authorization header: {e}"))?,
+        );
+        headers.insert(
+            "x-amz-date",
+            HeaderValue::from_str(&datetime)
+                .map_err(|e| format!("invalid x-amz-date header: {e}"))?,
+        );
+        headers.insert(
+            "x-amz-content-sha256",
+            HeaderValue::from_static(payload_hash),
+        );
+        headers.insert(
+            HOST,
+            HeaderValue::from_str(host).map_err(|e| format!("invalid blob host header: {e}"))?,
+        );
+        Ok(headers)
+    }
+}
+
+async fn put_local_blob(root: &Path, key: &str, body: &[u8]) -> Result<(), String> {
+    let path = local_blob_path(root, key)?;
+    if tokio::fs::try_exists(&path)
+        .await
+        .map_err(|e| format!("failed to check local blob '{}': {e}", path.display()))?
+    {
+        return Ok(());
+    }
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await.map_err(|e| {
+            format!(
+                "failed to create local blob dir '{}': {e}",
+                parent.display()
+            )
+        })?;
+    }
+    tokio::fs::write(&path, body)
+        .await
+        .map_err(|e| format!("failed to write local blob '{}': {e}", path.display()))
+}
+
+async fn get_local_blob(root: &Path, key: &str) -> Result<Option<Vec<u8>>, String> {
+    let path = local_blob_path(root, key)?;
+    if !tokio::fs::try_exists(&path)
+        .await
+        .map_err(|e| format!("failed to check local blob '{}': {e}", path.display()))?
+    {
+        return Ok(None);
+    }
+    tokio::fs::read(&path)
+        .await
+        .map(Some)
+        .map_err(|e| format!("failed to read local blob '{}': {e}", path.display()))
+}
+
+fn local_blob_path(root: &Path, key: &str) -> Result<PathBuf, String> {
+    let mut path = root.to_path_buf();
+    let mut saw_component = false;
+    for component in key.split('/') {
+        if component.is_empty()
+            || component == "."
+            || component == ".."
+            || component.contains('\\')
+            || component.starts_with(std::path::MAIN_SEPARATOR)
+        {
+            return Err(format!("invalid blob key '{key}'"));
+        }
+        saw_component = true;
+        path.push(component);
+    }
+    if !saw_component {
+        return Err("invalid empty blob key".to_string());
+    }
+    Ok(path)
+}
+
+pub(crate) fn is_local_internal_blob_endpoint(endpoint: &str) -> bool {
+    let normalized = endpoint.trim_end_matches('/');
+    (normalized.starts_with("http://127.0.0.1:") || normalized.starts_with("http://localhost:"))
+        && normalized.contains("/_internal/blobs")
+}
+
+fn sha256_hex(data: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    hex_encode(&hasher.finalize())
+}
+
+fn derive_signing_key(secret_key: &str, date: &str, region: &str, service: &str) -> Vec<u8> {
+    let k_secret = format!("AWS4{secret_key}");
+    let k_date = hmac_sha256(k_secret.as_bytes(), date.as_bytes());
+    let k_region = hmac_sha256(&k_date, region.as_bytes());
+    let k_service = hmac_sha256(&k_region, service.as_bytes());
+    hmac_sha256(&k_service, b"aws4_request")
+}
+
+fn hmac_sha256(key: &[u8], data: &[u8]) -> Vec<u8> {
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts any key length");
+    mac.update(data);
+    mac.finalize().into_bytes().to_vec()
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for &byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+fn parse_url_host_path(url: &str) -> (&str, &str) {
+    let after_scheme = if let Some(pos) = url.find("://") {
+        &url[pos + 3..]
+    } else {
+        url
+    };
+    if let Some(slash) = after_scheme.find('/') {
+        (&after_scheme[..slash], &after_scheme[slash..])
+    } else {
+        (after_scheme, "/")
+    }
+}
+
+fn uri_encode_path(path: &str) -> String {
+    let mut out = String::with_capacity(path.len() + 16);
+    for byte in path.bytes() {
+        match byte {
+            b'/' | b'-' | b'_' | b'.' | b'~' => out.push(byte as char),
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' => out.push(byte as char),
+            _ => {
+                out.push('%');
+                out.push(b"0123456789ABCDEF"[(byte >> 4) as usize] as char);
+                out.push(b"0123456789ABCDEF"[(byte & 0x0f) as usize] as char);
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn local_blob_store_round_trips_without_database() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = BlobStore::local_fs(dir.path());
+
+        store
+            .put_if_absent("wasm-modules/hash-a", b"hello", None)
+            .await
+            .expect("put");
+
+        let bytes = store
+            .get("wasm-modules/hash-a")
+            .await
+            .expect("get")
+            .expect("present");
+        assert_eq!(bytes, b"hello");
+        assert!(
+            dir.path().join("wasm-modules").join("hash-a").is_file(),
+            "blob is stored in the filesystem object store"
+        );
+    }
+
+    #[tokio::test]
+    async fn local_blob_store_rejects_path_traversal_keys() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = BlobStore::local_fs(dir.path());
+
+        let err = store
+            .put_if_absent("../escape", b"nope", None)
+            .await
+            .expect_err("path traversal rejected");
+        assert!(err.contains("invalid blob key"));
+    }
+}

--- a/crates/temper-server/src/blobs.rs
+++ b/crates/temper-server/src/blobs.rs
@@ -1,22 +1,18 @@
-//! Internal blob storage endpoint for TemperFS.
+//! Internal blob storage endpoint and field-overflow helpers.
 //!
-//! Provides `PUT/GET /_internal/blobs/{*path}` backed by Turso.
-//! The blob_adapter WASM module uploads/downloads through these endpoints
-//! when no external blob storage (R2/S3) is configured.
+//! New writes go through the Temper object-store boundary. Turso DB blobs are
+//! read only as a legacy fallback for data written by older releases.
 
 use axum::body::Bytes;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use serde_json::Value;
-use std::sync::OnceLock;
-use std::time::Instant;
 use temper_runtime::tenant::TenantId;
-use tokio::sync::Semaphore;
 
+use crate::blob_store::BlobStore;
 use crate::state::ServerState;
 
-const DEFAULT_BLOB_IO_MAX_CONCURRENCY: usize = 32;
 pub(crate) const FIELD_OVERFLOW_BLOB_PREFIX: &str = "field-overflow/sha256/";
 pub(crate) const FIELD_OVERFLOW_REF_KEY: &str = "__temper_blob_ref";
 pub(crate) const FIELD_OVERFLOW_SIZE_KEY: &str = "__temper_blob_size";
@@ -31,59 +27,16 @@ pub struct OverflowBlobWrite {
     pub ttl_seconds: Option<u64>,
 }
 
-fn blob_io_semaphore() -> &'static Semaphore {
-    static SEMAPHORE: OnceLock<Semaphore> = OnceLock::new();
-    SEMAPHORE.get_or_init(|| {
-        let limit = std::env::var("TEMPER_BLOB_IO_MAX_CONCURRENCY")
-            .ok()
-            .and_then(|v| v.parse::<usize>().ok())
-            .filter(|v| *v > 0)
-            .unwrap_or(DEFAULT_BLOB_IO_MAX_CONCURRENCY);
-        Semaphore::new(limit)
-    })
-}
-
-pub(crate) async fn put_blob_bytes(
-    store: &temper_store_turso::TursoEventStore,
-    key: &str,
-    body: &[u8],
-) -> Result<(), String> {
-    let queued_at = Instant::now();
-    let _permit = blob_io_semaphore()
-        .acquire()
-        .await
-        .expect("blob semaphore closed"); // ci-ok: semaphore is process-global and never closed
-    let wait_duration = queued_at.elapsed();
-    let wait_ms = wait_duration.as_millis() as u64;
-    crate::runtime_metrics::record_blob_io_wait_duration(wait_duration, "put");
-    if wait_ms > 0 {
-        tracing::info!(path = %key, wait_ms, "blob put queued");
-    }
-
-    store.put_blob(key, body).await
-}
-
+#[cfg(test)]
 pub(crate) async fn get_blob_bytes(
-    store: &temper_store_turso::TursoEventStore,
+    store: &BlobStore,
     key: &str,
 ) -> Result<Option<Vec<u8>>, String> {
-    let queued_at = Instant::now();
-    let _permit = blob_io_semaphore()
-        .acquire()
-        .await
-        .expect("blob semaphore closed"); // ci-ok: semaphore is process-global and never closed
-    let wait_duration = queued_at.elapsed();
-    let wait_ms = wait_duration.as_millis() as u64;
-    crate::runtime_metrics::record_blob_io_wait_duration(wait_duration, "get");
-    if wait_ms > 0 {
-        tracing::info!(path = %key, wait_ms, "blob get queued");
-    }
-
-    store.get_blob(key).await
+    store.get(key).await
 }
 
 pub(crate) async fn put_overflow_blobs(
-    store: &temper_store_turso::TursoEventStore,
+    store: &BlobStore,
     blobs: &[OverflowBlobWrite],
 ) -> Result<(), String> {
     for blob in blobs {
@@ -95,24 +48,12 @@ pub(crate) async fn put_overflow_blobs(
 
 /// TTL-aware variant of `put_blob_bytes` (ADR-0047).
 pub(crate) async fn put_blob_bytes_with_ttl(
-    store: &temper_store_turso::TursoEventStore,
+    store: &BlobStore,
     key: &str,
     body: &[u8],
     ttl: Option<std::time::Duration>,
 ) -> Result<(), String> {
-    let queued_at = Instant::now();
-    let _permit = blob_io_semaphore()
-        .acquire()
-        .await
-        .expect("blob semaphore closed"); // ci-ok: semaphore is process-global and never closed
-    let wait_duration = queued_at.elapsed();
-    let wait_ms = wait_duration.as_millis() as u64;
-    crate::runtime_metrics::record_blob_io_wait_duration(wait_duration, "put");
-    if wait_ms > 0 {
-        tracing::info!(path = %key, wait_ms, ttl = ?ttl, "blob put queued");
-    }
-
-    store.put_blob_with_ttl(key, body, ttl).await
+    store.put_if_absent(key, body, ttl).await
 }
 
 pub(crate) fn blob_ref_value(key: &str, size_bytes: usize) -> Value {
@@ -154,10 +95,30 @@ fn collect_blob_ref_pointers(value: &Value, pointer: &str, out: &mut Vec<String>
     }
 }
 
-pub(crate) async fn hydrate_blob_refs_in_value(
-    store: &temper_store_turso::TursoEventStore,
-    value: &mut Value,
-) {
+enum BlobReadSource<'a> {
+    #[cfg(test)]
+    Store(&'a BlobStore),
+    Tenant {
+        state: &'a ServerState,
+        tenant: &'a TenantId,
+    },
+}
+
+async fn read_blob_ref_bytes(
+    source: &BlobReadSource<'_>,
+    key: &str,
+) -> Result<Option<Vec<u8>>, String> {
+    match source {
+        #[cfg(test)]
+        BlobReadSource::Store(store) => get_blob_bytes(store, key).await,
+        BlobReadSource::Tenant { state, tenant } => {
+            state.get_blob_with_legacy_fallback(tenant, key).await
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) async fn hydrate_blob_refs_in_value(store: &BlobStore, value: &mut Value) {
     // OData callers want full inline hydration regardless of size.
     let _deferred = hydrate_blob_refs_in_value_with_ceiling(store, value, usize::MAX).await;
 }
@@ -167,8 +128,17 @@ pub(crate) async fn hydrate_blob_refs_in_value(
 /// "deferred" set). Callers that hand `value` off to a WASM guest forward
 /// the deferred map as `blob_cache` so guests can resolve oversize fields
 /// via `host_read_field_stream`. See ADR-0046.
+#[cfg(test)]
 pub(crate) async fn hydrate_blob_refs_in_value_with_ceiling(
-    store: &temper_store_turso::TursoEventStore,
+    store: &BlobStore,
+    value: &mut Value,
+    max_inline_bytes: usize,
+) -> std::collections::BTreeMap<String, Vec<u8>> {
+    hydrate_blob_refs_with_source(&BlobReadSource::Store(store), value, max_inline_bytes).await
+}
+
+async fn hydrate_blob_refs_with_source(
+    source: &BlobReadSource<'_>,
     value: &mut Value,
     max_inline_bytes: usize,
 ) -> std::collections::BTreeMap<String, Vec<u8>> {
@@ -211,7 +181,7 @@ pub(crate) async fn hydrate_blob_refs_in_value_with_ceiling(
         if let Some(size) = declared_size
             && size > max_inline_bytes
         {
-            match get_blob_bytes(store, &key).await {
+            match read_blob_ref_bytes(source, &key).await {
                 Ok(Some(bytes)) => {
                     deferred_blobs.insert(key, bytes);
                 }
@@ -225,7 +195,7 @@ pub(crate) async fn hydrate_blob_refs_in_value_with_ceiling(
             continue;
         }
 
-        match get_blob_bytes(store, &key).await {
+        match read_blob_ref_bytes(source, &key).await {
             Ok(Some(bytes)) => {
                 // Post-fetch size check in case the envelope lied (missing size key).
                 if bytes.len() > max_inline_bytes {
@@ -262,10 +232,9 @@ pub(crate) async fn hydrate_blob_refs_for_tenant(
     tenant: &TenantId,
     value: &mut Value,
 ) {
-    let Some(store) = state.persistent_store_for_tenant(tenant.as_str()).await else {
-        return;
-    };
-    hydrate_blob_refs_in_value(&store, value).await;
+    let _deferred =
+        hydrate_blob_refs_with_source(&BlobReadSource::Tenant { state, tenant }, value, usize::MAX)
+            .await;
 }
 
 /// Tenant-scoped variant of `hydrate_blob_refs_in_value_with_ceiling`.
@@ -279,10 +248,12 @@ pub(crate) async fn hydrate_blob_refs_for_tenant_with_ceiling(
     value: &mut Value,
     max_inline_bytes: usize,
 ) -> std::collections::BTreeMap<String, Vec<u8>> {
-    let Some(store) = state.persistent_store_for_tenant(tenant.as_str()).await else {
-        return std::collections::BTreeMap::new();
-    };
-    hydrate_blob_refs_in_value_with_ceiling(&store, value, max_inline_bytes).await
+    hydrate_blob_refs_with_source(
+        &BlobReadSource::Tenant { state, tenant },
+        value,
+        max_inline_bytes,
+    )
+    .await
 }
 
 /// `PUT /_internal/blobs/{*path}` — store a blob.
@@ -291,15 +262,9 @@ pub async fn put_blob(
     Path(path): Path<String>,
     body: Bytes,
 ) -> impl IntoResponse {
-    let Some(store) = state.platform_persistent_store().cloned() else {
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            "Blob storage requires Turso".to_string(),
-        )
-            .into_response();
-    };
+    let tenant = TenantId::new("default");
 
-    match put_blob_bytes(&store, &path, &body).await {
+    match state.put_blob_object(&tenant, &path, &body, None).await {
         Ok(()) => StatusCode::NO_CONTENT.into_response(),
         Err(e) => {
             tracing::error!(error = %e, path = %path, "blob put failed");
@@ -313,15 +278,9 @@ pub async fn get_blob(
     State(state): State<ServerState>,
     Path(path): Path<String>,
 ) -> impl IntoResponse {
-    let Some(store) = state.platform_persistent_store().cloned() else {
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            "Blob storage requires Turso".to_string(),
-        )
-            .into_response();
-    };
+    let tenant = TenantId::new("default");
 
-    match get_blob_bytes(&store, &path).await {
+    match state.get_blob_with_legacy_fallback(&tenant, &path).await {
         Ok(Some(data)) => (
             StatusCode::OK,
             [(axum::http::header::CONTENT_TYPE, "application/octet-stream")],
@@ -344,13 +303,9 @@ mod tests {
     use serde_json::json;
     use tempfile::TempDir;
 
-    async fn open_store() -> (temper_store_turso::TursoEventStore, TempDir) {
+    async fn open_store() -> (BlobStore, TempDir) {
         let dir = tempfile::tempdir().expect("tempdir");
-        let db_path = dir.path().join("e2e.db");
-        let url = format!("file:{}", db_path.display());
-        let store = temper_store_turso::TursoEventStore::new(&url, None)
-            .await
-            .expect("TursoEventStore::new");
+        let store = BlobStore::local_fs(dir.path().join("objects"));
         (store, dir)
     }
 
@@ -510,13 +465,12 @@ mod tests {
     }
 
     /// Per-field `overflow_ttl_seconds` propagates through `OverflowBlobWrite`
-    /// into `put_blob_with_ttl`. The blob should be swept after its TTL
-    /// expires. ADR-0047 Phase 4b.
+    /// into object-store persistence without requiring a DB blob row.
+    /// Object-store retention is delegated to the provider lifecycle policy.
     #[tokio::test]
-    async fn per_field_ttl_propagates_to_sweep() {
+    async fn per_field_ttl_persists_to_object_store() {
         use crate::entity_actor::effects::sync_fields_with_metadata;
         use std::collections::BTreeMap;
-        use std::time::Duration;
         use temper_jit::table::StateVarMetadata;
 
         let (store, _dir) = open_store().await;
@@ -554,18 +508,8 @@ mod tests {
         // The blob should exist immediately.
         let key = &overflow[0].key;
         assert!(
-            store.get_blob(key).await.unwrap().is_some(),
+            store.get(key).await.unwrap().is_some(),
             "freshly-written blob is readable"
-        );
-
-        // Wait past the 1-second TTL + margin, then sweep. Use 2.5s to
-        // clear any sub-second boundary effects in SQLite's datetime('now').
-        tokio::time::sleep(Duration::from_millis(2500)).await;
-        let deleted = store.sweep_expired_blobs(1000).await.unwrap();
-        assert_eq!(deleted, 1, "TTL'd blob swept");
-        assert!(
-            store.get_blob(key).await.unwrap().is_none(),
-            "blob gone after sweep"
         );
     }
 

--- a/crates/temper-server/src/entity_actor/actor.rs
+++ b/crates/temper-server/src/entity_actor/actor.rs
@@ -61,6 +61,8 @@ pub struct EntityActor {
     /// executing an action whose `idempotency_key` is set, so dispatch-layer
     /// retries that race past the caller's timeout cannot double-execute.
     idempotency_cache: Option<Arc<crate::idempotency::IdempotencyCache>>,
+    /// Object store for field-overflow blob bytes. SQL stores only refs.
+    blob_store: Option<crate::blob_store::BlobStore>,
 }
 
 impl EntityActor {
@@ -162,6 +164,7 @@ impl EntityActor {
             event_store: None,
             trace_id: sim_uuid().to_string(),
             idempotency_cache: None,
+            blob_store: None,
         }
     }
 
@@ -182,6 +185,7 @@ impl EntityActor {
             event_store: Some(store),
             trace_id: sim_uuid().to_string(),
             idempotency_cache: None,
+            blob_store: None,
         }
     }
 
@@ -199,6 +203,25 @@ impl EntityActor {
     ) -> Self {
         self.idempotency_cache = Some(cache);
         self
+    }
+
+    /// Attach the object store used for field-overflow blob writes.
+    pub(crate) fn with_blob_store(
+        mut self,
+        blob_store: Option<crate::blob_store::BlobStore>,
+    ) -> Self {
+        self.blob_store = blob_store;
+        self
+    }
+
+    async fn persist_overflow_blobs(
+        blob_store: Option<&crate::blob_store::BlobStore>,
+        blobs: &[crate::blobs::OverflowBlobWrite],
+    ) -> Result<(), String> {
+        let Some(blob_store) = blob_store else {
+            return Err("field-overflow blobs require a configured object blob store".to_string());
+        };
+        crate::blobs::put_overflow_blobs(blob_store, blobs).await
     }
 
     /// Persistence ID for this entity: "tenant:EntityType:EntityId".
@@ -288,6 +311,7 @@ impl EntityActor {
         persistence_id: &str,
         state: &mut EntityState,
         tenant: &str,
+        blob_store: Option<&crate::blob_store::BlobStore>,
     ) {
         let replay_start = Instant::now(); // determinism-ok: wall-clock for production replay duration metric only
         let mut from_sequence = 0;
@@ -389,6 +413,7 @@ impl EntityActor {
                                 ServerEventStore::Turso(_) | ServerEventStore::TenantRouted(_) => {
                                     FieldSyncMode::blob_refs_default()
                                 }
+                                _ if blob_store.is_some() => FieldSyncMode::blob_refs_default(),
                                 _ => FieldSyncMode::InlineTruncate,
                             };
                             let overflow_blobs = super::effects::sync_fields_with_metadata(
@@ -404,28 +429,16 @@ impl EntityActor {
                             // is a no-op. If the prior server died between emitting
                             // the event and persisting the blob, this is the
                             // recovery path. See ADR-0040, ADR-0045.
-                            if !overflow_blobs.is_empty() {
-                                if let Some(blob_store) = store.turso_for_tenant(tenant).await {
-                                    if let Err(e) = crate::blobs::put_overflow_blobs(
-                                        &blob_store,
-                                        &overflow_blobs,
-                                    )
-                                    .await
-                                    {
-                                        tracing::warn!(
-                                            entity = %state.entity_id,
-                                            error = %e,
-                                            overflow_count = overflow_blobs.len(),
-                                            "failed to persist replayed overflow blobs — blob-ref envelopes may dangle"
-                                        );
-                                    }
-                                } else {
-                                    tracing::warn!(
-                                        entity = %state.entity_id,
-                                        overflow_count = overflow_blobs.len(),
-                                        "replay produced overflow blobs but no Turso store available for tenant"
-                                    );
-                                }
+                            if !overflow_blobs.is_empty()
+                                && let Err(e) =
+                                    Self::persist_overflow_blobs(blob_store, &overflow_blobs).await
+                            {
+                                tracing::warn!(
+                                    entity = %state.entity_id,
+                                    error = %e,
+                                    overflow_count = overflow_blobs.len(),
+                                    "failed to persist replayed overflow blobs — blob-ref envelopes may dangle"
+                                );
                             }
 
                             state.push_event_bounded(event);
@@ -491,10 +504,19 @@ pub(crate) async fn recover_entity_state_from_store(
     table: &TransitionTable,
     store: &ServerEventStore,
     initial_fields: &serde_json::Value,
+    blob_store: Option<&crate::blob_store::BlobStore>,
 ) -> EntityState {
     let persistence_id = format!("{tenant}:{entity_type}:{entity_id}");
     let mut state = EntityActor::build_initial_state(entity_type, entity_id, table, initial_fields);
-    EntityActor::replay_events(table, store, &persistence_id, &mut state, tenant).await;
+    EntityActor::replay_events(
+        table,
+        store,
+        &persistence_id,
+        &mut state,
+        tenant,
+        blob_store,
+    )
+    .await;
     state
 }
 
@@ -525,6 +547,7 @@ impl Actor for EntityActor {
                 &table,
                 store,
                 &self.initial_fields,
+                self.blob_store.as_ref(),
             )
             .await;
         }
@@ -643,6 +666,7 @@ impl Actor for EntityActor {
                     Some(ServerEventStore::Turso(_) | ServerEventStore::TenantRouted(_)) => {
                         FieldSyncMode::blob_refs_default()
                     }
+                    Some(_) if self.blob_store.is_some() => FieldSyncMode::blob_refs_default(),
                     _ => FieldSyncMode::InlineTruncate,
                 };
 
@@ -668,55 +692,24 @@ impl Actor for EntityActor {
                         .clone()
                         .expect("successful process_action always returns event"); // ci-ok: post-assertion, success guarantees Some
 
-                    if !result.overflow_blobs.is_empty() {
-                        let Some(ref store) = self.event_store else {
-                            *state = state_before;
-                            ctx.reply(EntityResponse {
-                                success: false,
-                                state: state.clone(),
-                                error: Some(
-                                    "field-overflow blobs require a Turso-backed store".to_string(),
-                                ),
-                                custom_effects: vec![],
-                                scheduled_actions: vec![],
-                                spawn_requests: vec![],
-                                spec_governed: true,
-                            });
-                            return Ok(());
-                        };
-
-                        let Some(blob_store) = store.turso_for_tenant(&self.tenant).await else {
-                            *state = state_before;
-                            ctx.reply(EntityResponse {
-                                success: false,
-                                state: state.clone(),
-                                error: Some(
-                                    "field-overflow blobs require a Turso-backed store".to_string(),
-                                ),
-                                custom_effects: vec![],
-                                scheduled_actions: vec![],
-                                spawn_requests: vec![],
-                                spec_governed: true,
-                            });
-                            return Ok(());
-                        };
-
-                        if let Err(e) =
-                            crate::blobs::put_overflow_blobs(&blob_store, &result.overflow_blobs)
-                                .await
-                        {
-                            *state = state_before;
-                            ctx.reply(EntityResponse {
-                                success: false,
-                                state: state.clone(),
-                                error: Some(format!("field-overflow blob persistence failed: {e}")),
-                                custom_effects: vec![],
-                                scheduled_actions: vec![],
-                                spawn_requests: vec![],
-                                spec_governed: true,
-                            });
-                            return Ok(());
-                        }
+                    if !result.overflow_blobs.is_empty()
+                        && let Err(e) = Self::persist_overflow_blobs(
+                            self.blob_store.as_ref(),
+                            &result.overflow_blobs,
+                        )
+                        .await
+                    {
+                        *state = state_before;
+                        ctx.reply(EntityResponse {
+                            success: false,
+                            state: state.clone(),
+                            error: Some(format!("field-overflow blob persistence failed: {e}")),
+                            custom_effects: vec![],
+                            scheduled_actions: vec![],
+                            spawn_requests: vec![],
+                            spec_governed: true,
+                        });
+                        return Ok(());
                     }
 
                     // Persist to Postgres (if configured). On
@@ -787,6 +780,7 @@ impl Actor for EntityActor {
                                         &self.persistence_id(),
                                         state,
                                         &self.tenant,
+                                        self.blob_store.as_ref(),
                                     )
                                     .await;
 
@@ -840,35 +834,20 @@ impl Actor for EntityActor {
                                         .expect("successful process_action always returns event"); // ci-ok: post-assertion, success guarantees Some
 
                                     // Overflow blobs for the re-evaluated result.
-                                    if !retry_result.overflow_blobs.is_empty() {
-                                        match store.turso_for_tenant(&self.tenant).await {
-                                            Some(blob_store) => {
-                                                if let Err(e) = crate::blobs::put_overflow_blobs(
-                                                    &blob_store,
-                                                    &retry_result.overflow_blobs,
-                                                )
-                                                .await
-                                                {
-                                                    retry_final = Some((
-                                                        crate::runtime_metrics::ConcurrencyRetryOutcome::Exhausted,
-                                                        Some(format!(
-                                                            "field-overflow blob persistence failed during retry: {e}"
-                                                        )),
-                                                    ));
-                                                    break;
-                                                }
-                                            }
-                                            None => {
-                                                retry_final = Some((
-                                                    crate::runtime_metrics::ConcurrencyRetryOutcome::Exhausted,
-                                                    Some(
-                                                        "field-overflow blobs require a Turso-backed store"
-                                                            .to_string(),
-                                                    ),
-                                                ));
-                                                break;
-                                            }
-                                        }
+                                    if !retry_result.overflow_blobs.is_empty()
+                                        && let Err(e) = Self::persist_overflow_blobs(
+                                            self.blob_store.as_ref(),
+                                            &retry_result.overflow_blobs,
+                                        )
+                                        .await
+                                    {
+                                        retry_final = Some((
+                                            crate::runtime_metrics::ConcurrencyRetryOutcome::Exhausted,
+                                            Some(format!(
+                                                "field-overflow blob persistence failed during retry: {e}"
+                                            )),
+                                        ));
+                                        break;
                                     }
 
                                     // Backoff: retry 1 → 10ms, retry 2 → 50ms.

--- a/crates/temper-server/src/lib.rs
+++ b/crates/temper-server/src/lib.rs
@@ -9,6 +9,7 @@ mod admin;
 #[cfg(feature = "observe")]
 mod api;
 pub mod authz;
+pub mod blob_store;
 pub mod blob_sweeper;
 pub mod blobs;
 pub mod channels;

--- a/crates/temper-server/src/state/dispatch/wasm.rs
+++ b/crates/temper-server/src/state/dispatch/wasm.rs
@@ -48,25 +48,20 @@ fn is_http_call_authz_denial(error: &str) -> bool {
     error.contains(HTTP_CALL_AUTHZ_DENIED_PREFIX)
 }
 
-fn is_local_internal_blob_endpoint(endpoint: &str) -> bool {
-    let normalized = endpoint.trim_end_matches('/');
-    (normalized.starts_with("http://127.0.0.1:") || normalized.starts_with("http://localhost:"))
-        && normalized.contains("/_internal/blobs")
-}
-
 fn local_blob_binary_interceptor(
-    store: Option<temper_store_turso::TursoEventStore>,
+    state: crate::state::ServerState,
+    tenant: TenantId,
     blob_endpoint: Option<String>,
 ) -> Option<BinaryHttpInterceptorFn> {
-    let store = store?;
     let endpoint = blob_endpoint?;
-    if !is_local_internal_blob_endpoint(&endpoint) {
+    if !crate::blob_store::is_local_internal_blob_endpoint(&endpoint) {
         return None;
     }
 
     let endpoint = endpoint.trim_end_matches('/').to_string();
     Some(Arc::new(move |method, url, _headers, body| {
-        let store = store.clone();
+        let state = state.clone();
+        let tenant = tenant.clone();
         let endpoint = endpoint.clone();
         Box::pin(async move {
             let prefix = format!("{endpoint}/");
@@ -80,10 +75,12 @@ fn local_blob_binary_interceptor(
             );
 
             let result = match method.as_str() {
-                "PUT" => crate::blobs::put_blob_bytes(&store, &blob_key, &body)
+                "PUT" => state
+                    .put_blob_object(&tenant, &blob_key, &body, None)
                     .await
                     .map(|()| (204, Vec::new())),
-                "GET" => crate::blobs::get_blob_bytes(&store, &blob_key)
+                "GET" => state
+                    .get_blob_with_legacy_fallback(&tenant, &blob_key)
                     .await
                     .map(|maybe| match maybe {
                         Some(bytes) => (200, bytes),
@@ -398,7 +395,8 @@ impl crate::state::ServerState {
         let tenant_secrets =
             self.get_authorized_wasm_secrets(ctx.entity_ref.tenant, &*gate, &authz_ctx);
         let local_blob_interceptor = local_blob_binary_interceptor(
-            self.platform_persistent_store().cloned(),
+            self.clone(),
+            ctx.entity_ref.tenant.clone(),
             tenant_secrets.get("blob_endpoint").cloned(),
         );
         let local_file_interceptor = local_file_value_text_interceptor(
@@ -1000,7 +998,8 @@ impl crate::state::ServerState {
         };
         let tenant_secrets = self.get_authorized_wasm_secrets(tenant, &*base_gate, &authz_ctx);
         let local_blob_interceptor = local_blob_binary_interceptor(
-            self.platform_persistent_store().cloned(),
+            self.clone(),
+            tenant.clone(),
             tenant_secrets.get("blob_endpoint").cloned(),
         );
         let progress_emitter = progress_emitter_fn(

--- a/crates/temper-server/src/state/entity_ops.rs
+++ b/crates/temper-server/src/state/entity_ops.rs
@@ -406,6 +406,7 @@ impl ServerState {
         // Build actor instance (spawn guarded below to avoid duplicate races).
         // ADR-0048 sub-decision 5: every actor gets the shared idempotency
         // cache so it can dedupe duplicate asks produced by retry storms.
+        let tenant_blob_store = self.blob_store_for_tenant(tenant).ok();
         let actor = match &self.event_store {
             Some(store) => EntityActor::with_persistence(
                 entity_type,
@@ -415,10 +416,12 @@ impl ServerState {
                 store.clone(),
             )
             .with_tenant(tenant.as_str())
-            .with_idempotency_cache(self.idempotency_cache.clone()),
+            .with_idempotency_cache(self.idempotency_cache.clone())
+            .with_blob_store(tenant_blob_store.clone()),
             None => EntityActor::new(entity_type, entity_id, table, initial_fields)
                 .with_tenant(tenant.as_str())
-                .with_idempotency_cache(self.idempotency_cache.clone()),
+                .with_idempotency_cache(self.idempotency_cache.clone())
+                .with_blob_store(tenant_blob_store),
         };
 
         // Slow-path: atomically re-check and spawn under write lock.

--- a/crates/temper-server/src/state/file_reads.rs
+++ b/crates/temper-server/src/state/file_reads.rs
@@ -1,26 +1,14 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
 use futures_util::stream::{self, StreamExt};
-use hmac::{Hmac, Mac};
-use reqwest::header::{AUTHORIZATION, HOST, HeaderMap, HeaderValue};
-use sha2::{Digest, Sha256};
 use temper_runtime::tenant::TenantId;
 use temper_store_turso::store::field_index::ProjectedEntityFieldsRow;
 use tracing::instrument;
 
 use super::ServerState;
 
-const DEFAULT_BLOB_BUCKET: &str = "temper-fs";
 const FILE_BATCH_READ_CONCURRENCY: usize = 8;
-
-type HmacSha256 = Hmac<Sha256>;
-
-fn is_local_internal_blob_endpoint(endpoint: &str) -> bool {
-    let normalized = endpoint.trim_end_matches('/');
-    (normalized.starts_with("http://127.0.0.1:") || normalized.starts_with("http://localhost:"))
-        && normalized.contains("/_internal/blobs")
-}
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct TextFileReadResult {
@@ -310,42 +298,49 @@ impl ServerState {
             .secrets_vault
             .as_ref()
             .and_then(|vault| vault.get_secret(tenant.as_str(), "blob_endpoint"));
-
-        let blob_bytes = if let Some(endpoint) = blob_endpoint {
-            if is_local_internal_blob_endpoint(endpoint.as_str())
-                && let Some(store) = self.persistent_store_for_tenant(tenant.as_str()).await
-            {
-                crate::blobs::get_blob_bytes(
-                    &store,
-                    &format!("{DEFAULT_BLOB_BUCKET}/{content_hash}"),
-                )
-                .await
-                .map_err(|e| format!("failed to read local blob '{content_hash}': {e}"))?
-            } else {
-                let bucket = self
-                    .secrets_vault
-                    .as_ref()
-                    .and_then(|vault| vault.get_secret(tenant.as_str(), "blob_bucket"))
-                    .unwrap_or_else(|| DEFAULT_BLOB_BUCKET.to_string());
-                fetch_external_blob_bytes(
-                    self,
-                    tenant,
-                    endpoint.as_str(),
-                    content_hash,
-                    bucket.as_str(),
-                )
-                .await?
+        let blob_key = file_blob_key(blob_endpoint.as_deref(), content_hash);
+        let mut blob_bytes = self
+            .get_blob_with_legacy_fallback(tenant, &blob_key)
+            .await
+            .map_err(|e| format!("failed to read blob '{content_hash}': {e}"))?;
+        if blob_bytes.is_none()
+            && blob_endpoint.as_deref().is_some_and(|endpoint| {
+                !crate::blob_store::is_local_internal_blob_endpoint(endpoint)
+            })
+        {
+            let legacy_local_key = local_file_blob_key(content_hash);
+            if legacy_local_key != blob_key {
+                blob_bytes = self
+                    .get_blob_with_legacy_fallback(tenant, &legacy_local_key)
+                    .await
+                    .map_err(|e| {
+                        format!("failed to read legacy local blob '{content_hash}': {e}")
+                    })?;
             }
-        } else if let Some(store) = self.persistent_store_for_tenant(tenant.as_str()).await {
-            crate::blobs::get_blob_bytes(&store, &format!("{DEFAULT_BLOB_BUCKET}/{content_hash}"))
-                .await
-                .map_err(|e| format!("failed to read local blob '{content_hash}': {e}"))?
-        } else {
-            None
-        };
-
+        }
         Ok(blob_bytes.map(|bytes| String::from_utf8_lossy(&bytes).to_string()))
     }
+}
+
+fn file_blob_key(blob_endpoint: Option<&str>, content_hash: &str) -> String {
+    match blob_endpoint {
+        Some(endpoint) if !crate::blob_store::is_local_internal_blob_endpoint(endpoint) => {
+            // The blob_adapter WASM writes external R2/S3 objects at
+            // `{bucket}/{content_hash}`. Local/internal storage includes the
+            // bucket name in the key because the internal route has no
+            // separate bucket namespace.
+            content_hash.to_string()
+        }
+        _ => local_file_blob_key(content_hash),
+    }
+}
+
+fn local_file_blob_key(content_hash: &str) -> String {
+    format!(
+        "{}/{}",
+        crate::blob_store::DEFAULT_BLOB_BUCKET,
+        content_hash
+    )
 }
 
 fn file_projection_from_row(row: ProjectedEntityFieldsRow) -> FileProjectionMeta {
@@ -425,164 +420,27 @@ fn file_version_projection_from_state(fields: &serde_json::Value) -> FileProject
     }
 }
 
-async fn fetch_external_blob_bytes(
-    state: &ServerState,
-    tenant: &TenantId,
-    endpoint: &str,
-    content_hash: &str,
-    bucket: &str,
-) -> Result<Option<Vec<u8>>, String> {
-    let url = format!(
-        "{}/{}/{}",
-        endpoint.trim_end_matches('/'),
-        bucket.trim_matches('/'),
-        content_hash
-    );
-    let mut request = blob_http_client().get(&url);
-    let headers = build_blob_get_headers(state, tenant, &url)?;
-    for (header_name, header_value) in &headers {
-        request = request.header(header_name, header_value);
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_blob_key_matches_blob_adapter_external_contract() {
+        assert_eq!(
+            file_blob_key(
+                Some("https://example.r2.cloudflarestorage.com"),
+                "sha256:abc"
+            ),
+            "sha256:abc"
+        );
     }
 
-    let response = request
-        .send()
-        .await
-        .map_err(|e| format!("blob GET request failed for '{content_hash}': {e}"))?;
-    if response.status() == reqwest::StatusCode::NOT_FOUND {
-        return Ok(None);
+    #[test]
+    fn file_blob_key_keeps_bucket_prefix_for_internal_store() {
+        assert_eq!(
+            file_blob_key(Some("http://127.0.0.1:4491/_internal/blobs"), "sha256:abc"),
+            "temper-fs/sha256:abc"
+        );
+        assert_eq!(file_blob_key(None, "sha256:abc"), "temper-fs/sha256:abc");
     }
-    if !response.status().is_success() {
-        return Err(format!(
-            "blob GET failed for '{content_hash}' with HTTP {}",
-            response.status()
-        ));
-    }
-
-    let bytes = response
-        .bytes()
-        .await
-        .map_err(|e| format!("blob GET body read failed for '{content_hash}': {e}"))?;
-    Ok(Some(bytes.to_vec()))
-}
-
-fn blob_http_client() -> &'static reqwest::Client {
-    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
-    CLIENT.get_or_init(reqwest::Client::new)
-}
-
-fn build_blob_get_headers(
-    state: &ServerState,
-    tenant: &TenantId,
-    url: &str,
-) -> Result<HeaderMap, String> {
-    let mut headers = HeaderMap::new();
-    let Some(vault) = state.secrets_vault.as_ref() else {
-        return Ok(headers);
-    };
-
-    let Some(access_key) = vault.get_secret(tenant.as_str(), "blob_access_key") else {
-        return Ok(headers);
-    };
-    let Some(secret_key) = vault.get_secret(tenant.as_str(), "blob_secret_key") else {
-        return Ok(headers);
-    };
-
-    let datetime = chrono::Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
-    let date = &datetime[..8];
-    let (host, path) = parse_url_host_path(url);
-    let canonical_uri = uri_encode_path(path);
-    let payload_hash = "UNSIGNED-PAYLOAD";
-    let region = "auto";
-    let service = "s3";
-    let scope = format!("{date}/{region}/{service}/aws4_request");
-    let canonical_headers =
-        format!("host:{host}\nx-amz-content-sha256:{payload_hash}\nx-amz-date:{datetime}\n");
-    let signed_headers = "host;x-amz-content-sha256;x-amz-date";
-    let canonical_request =
-        format!("GET\n{canonical_uri}\n\n{canonical_headers}\n{signed_headers}\n{payload_hash}");
-    let canonical_request_hash = sha256_hex(canonical_request.as_bytes());
-    let string_to_sign = format!("AWS4-HMAC-SHA256\n{datetime}\n{scope}\n{canonical_request_hash}");
-    let signing_key = derive_signing_key(&secret_key, date, region, service);
-    let signature = hex_encode(&hmac_sha256(&signing_key, string_to_sign.as_bytes()));
-    let authorization = format!(
-        "AWS4-HMAC-SHA256 Credential={access_key}/{scope},SignedHeaders={signed_headers},Signature={signature}"
-    );
-
-    headers.insert(
-        AUTHORIZATION,
-        HeaderValue::from_str(&authorization)
-            .map_err(|e| format!("invalid blob authorization header: {e}"))?,
-    );
-    headers.insert(
-        "x-amz-date",
-        HeaderValue::from_str(&datetime).map_err(|e| format!("invalid x-amz-date header: {e}"))?,
-    );
-    headers.insert(
-        "x-amz-content-sha256",
-        HeaderValue::from_static(payload_hash),
-    );
-    headers.insert(
-        HOST,
-        HeaderValue::from_str(host).map_err(|e| format!("invalid blob host header: {e}"))?,
-    );
-    Ok(headers)
-}
-
-fn sha256_hex(data: &[u8]) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(data);
-    hex_encode(&hasher.finalize())
-}
-
-fn derive_signing_key(secret_key: &str, date: &str, region: &str, service: &str) -> Vec<u8> {
-    let k_secret = format!("AWS4{secret_key}");
-    let k_date = hmac_sha256(k_secret.as_bytes(), date.as_bytes());
-    let k_region = hmac_sha256(&k_date, region.as_bytes());
-    let k_service = hmac_sha256(&k_region, service.as_bytes());
-    hmac_sha256(&k_service, b"aws4_request")
-}
-
-fn hmac_sha256(key: &[u8], data: &[u8]) -> Vec<u8> {
-    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts any key length");
-    mac.update(data);
-    mac.finalize().into_bytes().to_vec()
-}
-
-fn hex_encode(bytes: &[u8]) -> String {
-    const HEX: &[u8; 16] = b"0123456789abcdef";
-    let mut out = String::with_capacity(bytes.len() * 2);
-    for &byte in bytes {
-        out.push(HEX[(byte >> 4) as usize] as char);
-        out.push(HEX[(byte & 0x0f) as usize] as char);
-    }
-    out
-}
-
-fn parse_url_host_path(url: &str) -> (&str, &str) {
-    let after_scheme = if let Some(pos) = url.find("://") {
-        &url[pos + 3..]
-    } else {
-        url
-    };
-    if let Some(slash) = after_scheme.find('/') {
-        (&after_scheme[..slash], &after_scheme[slash..])
-    } else {
-        (after_scheme, "/")
-    }
-}
-
-fn uri_encode_path(path: &str) -> String {
-    let mut out = String::with_capacity(path.len() + 16);
-    for byte in path.bytes() {
-        match byte {
-            b'/' | b'-' | b'_' | b'.' | b'~' => out.push(byte as char),
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' => out.push(byte as char),
-            _ => {
-                out.push('%');
-                out.push(b"0123456789ABCDEF"[(byte >> 4) as usize] as char);
-                out.push(b"0123456789ABCDEF"[(byte & 0x0f) as usize] as char);
-            }
-        }
-    }
-    out
 }

--- a/crates/temper-server/src/state/mod.rs
+++ b/crates/temper-server/src/state/mod.rs
@@ -787,8 +787,9 @@ impl ServerState {
             .as_ref()
             .and_then(|vault| vault.get_secret(&tenant.to_string(), "blob_endpoint"));
 
-        if blob_endpoint.is_none()
-            && let Some(store) = self.persistent_store_for_tenant(tenant.as_str()).await
+        if blob_endpoint
+            .as_deref()
+            .is_none_or(crate::blob_store::is_local_internal_blob_endpoint)
         {
             let file_state = self
                 .get_tenant_entity_state(tenant, "File", file_id)
@@ -798,8 +799,7 @@ impl ServerState {
             hasher.update(body);
             let content_hash = format!("sha256:{:x}", hasher.finalize());
             let blob_key = format!("temper-fs/{content_hash}");
-            store
-                .put_blob(&blob_key, body)
+            self.put_blob_object(tenant, &blob_key, body, None)
                 .await
                 .map_err(|e| format!("failed to persist local blob '{blob_key}': {e}"))?;
 

--- a/crates/temper-server/src/state/persistence/mod.rs
+++ b/crates/temper-server/src/state/persistence/mod.rs
@@ -2,6 +2,7 @@
 
 use sqlx::PgPool;
 use temper_runtime::scheduler::sim_now;
+use temper_runtime::tenant::TenantId;
 use temper_store_turso::{TursoEventStore, TursoWasmInvocationInsert};
 
 use super::ServerState;
@@ -62,6 +63,21 @@ impl ServerState {
             return Ok(());
         };
 
+        let effective_hash = if sha256_hash.is_empty() {
+            temper_wasm::WasmEngine::hash_module(wasm_bytes)
+        } else {
+            sha256_hash.to_string()
+        };
+        let tenant_id = TenantId::new(tenant);
+        let artifact_key = crate::blob_store::wasm_artifact_key(&effective_hash);
+        self.put_blob_object(&tenant_id, &artifact_key, wasm_bytes, None)
+            .await
+            .map_err(|e| {
+                format!(
+                    "failed to persist WASM artifact {tenant}/{module_name} to object store: {e}"
+                )
+            })?;
+
         match backend {
             TenantMetadataBackend::Postgres(pool) => {
                 sqlx::query(
@@ -76,8 +92,8 @@ impl ServerState {
                 )
                 .bind(tenant)
                 .bind(module_name)
-                .bind(wasm_bytes)
-                .bind(sha256_hash)
+                .bind(Vec::<u8>::new())
+                .bind(&effective_hash)
                 .bind(wasm_bytes.len() as i32)
                 .execute(&pool)
                 .await
@@ -85,7 +101,7 @@ impl ServerState {
                 .map_err(|e| format!("failed to upsert WASM module {tenant}/{module_name}: {e}"))
             }
             TenantMetadataBackend::Turso(turso) => turso
-                .upsert_wasm_module(tenant, module_name, wasm_bytes, sha256_hash)
+                .upsert_wasm_module(tenant, module_name, wasm_bytes, &effective_hash)
                 .await
                 .map_err(|e| {
                     format!("failed to upsert WASM module {tenant}/{module_name} in turso: {e}")
@@ -169,6 +185,9 @@ impl ServerState {
                         "WASM module '{module_name}' not found in persistence for tenant '{tenant_name}'"
                     ));
                 };
+                let wasm_bytes = self
+                    .resolve_wasm_artifact_bytes(tenant, module_name, &sha256_hash, wasm_bytes)
+                    .await?;
                 (wasm_bytes, sha256_hash)
             }
             TenantMetadataBackend::Turso(turso) => {
@@ -185,7 +204,15 @@ impl ServerState {
                         "WASM module '{module_name}' not found in persistence for tenant '{tenant_name}'"
                     ));
                 };
-                (row.wasm_bytes, row.sha256_hash)
+                let wasm_bytes = self
+                    .resolve_wasm_artifact_bytes(
+                        tenant,
+                        module_name,
+                        &row.sha256_hash,
+                        row.wasm_bytes,
+                    )
+                    .await?;
+                (wasm_bytes, row.sha256_hash)
             }
             TenantMetadataBackend::Redis => {
                 return Err(Self::redis_ephemeral_error("WASM lazy-load"));
@@ -216,6 +243,32 @@ impl ServerState {
             .map_err(|e| {
                 format!(
                     "failed to compile lazy-loaded WASM module {tenant_name}/{module_name}: {e}"
+                )
+            })
+    }
+
+    async fn resolve_wasm_artifact_bytes(
+        &self,
+        tenant: &TenantId,
+        module_name: &str,
+        sha256_hash: &str,
+        inline_bytes: Vec<u8>,
+    ) -> Result<Vec<u8>, String> {
+        if !inline_bytes.is_empty() {
+            return Ok(inline_bytes);
+        }
+        if sha256_hash.is_empty() {
+            return Err(format!(
+                "WASM module '{module_name}' for tenant '{tenant}' has no inline bytes and no artifact hash"
+            ));
+        }
+
+        let artifact_key = crate::blob_store::wasm_artifact_key(sha256_hash);
+        self.get_blob_with_legacy_fallback(tenant, &artifact_key)
+            .await?
+            .ok_or_else(|| {
+                format!(
+                    "WASM artifact missing for tenant '{tenant}' module '{module_name}' at '{artifact_key}'"
                 )
             })
     }

--- a/crates/temper-server/src/state/projection_backfill.rs
+++ b/crates/temper-server/src/state/projection_backfill.rs
@@ -117,6 +117,7 @@ pub(super) async fn populate_field_index_from_snapshots(state: &ServerState, ten
             continue;
         };
 
+        let tenant_blob_store = state.blob_store_for_tenant(tenant).ok();
         let replayed = recover_entity_state_from_store(
             tenant.as_str(),
             entity_type,
@@ -124,6 +125,7 @@ pub(super) async fn populate_field_index_from_snapshots(state: &ServerState, ten
             &table,
             store,
             &serde_json::json!({}),
+            tenant_blob_store.as_ref(),
         )
         .await;
 

--- a/crates/temper-server/tests/wasm_dispatch.rs
+++ b/crates/temper-server/tests/wasm_dispatch.rs
@@ -107,11 +107,18 @@ async fn build_echo_test_state_with_turso() -> ServerState {
     let _ = std::fs::remove_file(db_path);
     let _ = std::fs::remove_file(format!("{db_path}-wal"));
     let _ = std::fs::remove_file(format!("{db_path}-shm"));
+    let data_dir = std::path::PathBuf::from(format!(
+        "/tmp/temper-wasm-dispatch-test-{}-{ts}-data",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&data_dir);
+    std::fs::create_dir_all(&data_dir).expect("create local blob data dir");
     let turso = TursoEventStore::new(&db_url, None)
         .await
         .expect("create local turso db");
     let mut state = build_echo_test_state();
     state.event_store = Some(Arc::new(ServerEventStore::Turso(turso)));
+    state.data_dir = data_dir;
     state
 }
 
@@ -359,17 +366,22 @@ async fn persisted_wasm_modules_are_lazy_compiled_on_first_invoke() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn persisted_wasm_modules_with_missing_hash_still_execute_after_startup_restore() {
+async fn persisted_wasm_modules_with_legacy_db_blob_fallback_execute_after_startup_restore() {
     let state = build_echo_test_state_with_turso().await;
     let tenant = TenantId::default();
     let turso = state
         .platform_persistent_store()
         .expect("turso backend required");
+    let hash = temper_wasm::WasmEngine::hash_module(ECHO_WASM);
 
     turso
-        .upsert_wasm_module("default", "echo_integration", ECHO_WASM, "")
+        .upsert_wasm_module("default", "echo_integration", ECHO_WASM, &hash)
         .await
-        .expect("persist legacy echo module with missing hash");
+        .expect("persist metadata-only echo module");
+    turso
+        .put_blob(&format!("wasm-modules/{hash}"), ECHO_WASM)
+        .await
+        .expect("persist legacy DB-backed artifact");
 
     state
         .load_wasm_modules()
@@ -383,17 +395,14 @@ async fn persisted_wasm_modules_with_missing_hash_still_execute_after_startup_re
             .expect("wasm registry lock"); // ci-ok: infallible lock
         wasm_reg
             .get_hash(&tenant, "echo_integration")
-            .expect("legacy module should still be registered")
+            .expect("legacy DB-backed module should still be registered")
             .to_string()
     };
 
-    assert!(
-        !recovered_hash.is_empty(),
-        "startup restore should recover a usable hash even for legacy rows"
-    );
+    assert_eq!(recovered_hash, hash);
     assert!(
         !state.wasm_engine.is_cached(&recovered_hash),
-        "startup restore should still avoid eager compilation for legacy rows"
+        "startup restore should still avoid eager compilation for legacy DB-backed rows"
     );
 
     let response = state
@@ -421,7 +430,7 @@ async fn persisted_wasm_modules_with_missing_hash_still_execute_after_startup_re
     assert_eq!(final_status, "Done");
     assert!(
         state.wasm_engine.is_cached(&recovered_hash),
-        "legacy recovered modules should still lazy-compile on first invoke"
+        "legacy DB-backed modules should still lazy-compile on first invoke"
     );
 }
 

--- a/crates/temper-store-turso/src/store/tests/mod.rs
+++ b/crates/temper-store-turso/src/store/tests/mod.rs
@@ -745,12 +745,15 @@ async fn load_wasm_module_metadata_all_tenants_returns_metadata_without_bulk_byt
     assert_eq!(rows[1].size_bytes, 7);
     assert!(!rows[1].updated_at.is_empty());
 
-    let full_row = store
+    let metadata_row = store
         .load_wasm_module("tenant-a", "mod-a")
         .await
-        .expect("load full wasm row")
-        .expect("full row should exist");
-    assert_eq!(full_row.wasm_bytes, b"hello-a");
+        .expect("load wasm metadata row")
+        .expect("metadata row should exist");
+    assert!(
+        metadata_row.wasm_bytes.is_empty(),
+        "Turso rows stay metadata-only; artifact bytes live in object storage"
+    );
 }
 
 #[tokio::test]
@@ -855,7 +858,7 @@ async fn upsert_wasm_module_preserves_version_for_identical_hash() {
 }
 
 #[tokio::test]
-async fn upsert_wasm_module_stores_artifact_outside_metadata_row() {
+async fn upsert_wasm_module_stores_metadata_only_without_db_blob() {
     let store = make_store("wasm-artifact").await;
 
     store
@@ -886,14 +889,19 @@ async fn upsert_wasm_module_stores_artifact_outside_metadata_row() {
     let artifact = store
         .get_blob("wasm-modules/hash-a")
         .await
-        .expect("load wasm artifact")
-        .expect("artifact exists");
-    assert_eq!(artifact, b"hello-a");
+        .expect("query legacy db blob");
+    assert!(
+        artifact.is_none(),
+        "new WASM artifacts must not create Turso blob rows"
+    );
 
     let loaded = store
         .load_wasm_module("tenant-a", "mod-a")
         .await
         .expect("load wasm row")
         .expect("wasm row exists");
-    assert_eq!(loaded.wasm_bytes, b"hello-a");
+    assert!(
+        loaded.wasm_bytes.is_empty(),
+        "Turso store should return metadata-only rows for new WASM artifacts"
+    );
 }

--- a/crates/temper-store-turso/src/store/wasm.rs
+++ b/crates/temper-store-turso/src/store/wasm.rs
@@ -11,12 +11,6 @@ use super::{
 use crate::TursoWasmInvocationInsert;
 use crate::metrics::TursoQueryTimer;
 
-const WASM_ARTIFACT_PREFIX: &str = "wasm-modules/";
-
-fn wasm_artifact_key(sha256_hash: &str) -> String {
-    format!("{WASM_ARTIFACT_PREFIX}{sha256_hash}")
-}
-
 impl TursoEventStore {
     /// Upsert a WASM module binary for a tenant.
     ///
@@ -34,7 +28,7 @@ impl TursoEventStore {
         let conn = self.configured_connection().await?;
         let mut existing_rows = conn
             .query(
-                "SELECT sha256_hash, length(wasm_bytes) \
+                "SELECT sha256_hash \
                  FROM wasm_modules \
                  WHERE tenant = ?1 AND module_name = ?2",
                 params![tenant, module_name],
@@ -44,32 +38,11 @@ impl TursoEventStore {
 
         if let Some(row) = existing_rows.next().await.map_err(storage_error)? {
             let existing_hash: String = row.get(0).map_err(storage_error)?;
-            let inline_len: i64 = row
-                .get::<Option<i64>>(1)
-                .map_err(storage_error)?
-                .unwrap_or(0);
             if existing_hash == sha256_hash {
-                if inline_len > 0
-                    || self
-                        .get_blob(&wasm_artifact_key(sha256_hash))
-                        .await
-                        .map_err(PersistenceError::Storage)?
-                        .is_some()
-                {
-                    return Ok(());
-                }
-
-                self.put_blob(&wasm_artifact_key(sha256_hash), wasm_bytes)
-                    .await
-                    .map_err(PersistenceError::Storage)?;
                 return Ok(());
             }
         }
         drop(existing_rows);
-
-        self.put_blob(&wasm_artifact_key(sha256_hash), wasm_bytes)
-            .await
-            .map_err(PersistenceError::Storage)?;
 
         let _write_permit = self
             .acquire_write_permit("turso.upsert_wasm_module", WritePriority::High)
@@ -123,9 +96,7 @@ impl TursoEventStore {
             return Ok(None);
         };
 
-        self.hydrate_wasm_module(Self::row_to_wasm_module(&row)?)
-            .await
-            .map(Some)
+        Self::row_to_wasm_module(&row).map(Some)
     }
 
     /// Load all WASM modules for a tenant.
@@ -149,8 +120,7 @@ impl TursoEventStore {
 
         let mut out = Vec::new();
         while let Some(row) = rows.next().await.map_err(storage_error)? {
-            let row = Self::row_to_wasm_module(&row)?;
-            out.push(self.hydrate_wasm_module(row).await?);
+            out.push(Self::row_to_wasm_module(&row)?);
         }
         Ok(out)
     }
@@ -174,8 +144,7 @@ impl TursoEventStore {
 
         let mut out = Vec::new();
         while let Some(row) = rows.next().await.map_err(storage_error)? {
-            let row = Self::row_to_wasm_module(&row)?;
-            out.push(self.hydrate_wasm_module(row).await?);
+            out.push(Self::row_to_wasm_module(&row)?);
         }
         Ok(out)
     }
@@ -307,28 +276,6 @@ impl TursoEventStore {
             size_bytes: row.get::<i64>(5).map_err(storage_error)? as i32,
             updated_at: row.get::<String>(6).map_err(storage_error)?,
         })
-    }
-
-    async fn hydrate_wasm_module(
-        &self,
-        mut row: TursoWasmModuleRow,
-    ) -> Result<TursoWasmModuleRow, PersistenceError> {
-        if row.wasm_bytes.is_empty() && row.size_bytes > 0 {
-            let artifact_key = wasm_artifact_key(&row.sha256_hash);
-            let artifact = self
-                .get_blob(&artifact_key)
-                .await
-                .map_err(PersistenceError::Storage)?
-                .ok_or_else(|| {
-                    PersistenceError::Storage(format!(
-                        "WASM artifact missing for {}/{} at {artifact_key}",
-                        row.tenant, row.module_name
-                    ))
-                })?;
-            row.wasm_bytes = artifact;
-        }
-
-        Ok(row)
     }
 
     /// Parse a WASM module metadata row from a libsql Row (5 columns).

--- a/docs/adrs/0063-object-store-for-blob-bytes.md
+++ b/docs/adrs/0063-object-store-for-blob-bytes.md
@@ -1,0 +1,59 @@
+# ADR-0063: Object Store for Blob Bytes
+
+Date: 2026-04-28
+
+## Status
+
+Accepted
+
+## Context
+
+Temper had three paths that could write large byte payloads into SQL-backed
+storage:
+
+- WASM module artifacts (`wasm-modules/{sha256}`) were written through the
+  Turso `blobs` table while `wasm_modules` held metadata.
+- Field-overflow values (`field-overflow/sha256/{hash}`) were persisted through
+  the same DB blob table.
+- Local TemperFS fallback used `/_internal/blobs`, which also wrote to Turso.
+
+Production traces showed these writes as mostly idle waits, for example
+`turso.upsert_wasm_module` taking tens of seconds with almost no busy CPU. That
+is the wrong storage shape: SQL should own metadata and transactional state,
+not opaque byte blobs.
+
+## Decision
+
+Blob bytes are stored outside the metadata database.
+
+- Introduce a Temper server `BlobStore` boundary with S3/R2-compatible and
+  local filesystem implementations.
+- Store WASM module bytes in object storage at `wasm-modules/{sha256}`.
+- Store field-overflow bytes in object storage at
+  `field-overflow/sha256/{hash}`.
+- Preserve TemperFS object addressing: external R2/S3 uses
+  `{bucket}/{content_hash}` to match the existing `blob_adapter` WASM contract;
+  local/internal fallback uses `temper-fs/{content_hash}` because the internal
+  route has no separate bucket namespace.
+- Keep SQL rows as metadata only. `wasm_modules.wasm_bytes` is empty for new
+  writes; `size_bytes` and `sha256_hash` remain in SQL.
+- Keep the Turso `blobs` table as a read-only legacy fallback so old deployments
+  can still hydrate data written before this ADR.
+- Production applications must configure an external object store. Local
+  development may use the filesystem object store.
+
+## Consequences
+
+WASM app reconcile no longer pays Turso blob-write latency for every module.
+The remaining SQL work is metadata upsert and version bookkeeping.
+
+Field-overflow hydration reads object storage first and falls back to legacy DB
+blobs only when the object is absent. New field-overflow writes never create DB
+blob rows.
+
+Object-store TTL is delegated to the provider lifecycle policy. The legacy
+Turso blob sweeper remains only for legacy rows.
+
+Local development still works without R2/S3, but local bytes are files under the
+server data directory rather than DB rows. Existing external TemperFS objects
+remain readable at their current `{bucket}/{content_hash}` keys.


### PR DESCRIPTION
## Summary

- add a Temper BlobStore boundary with local filesystem and S3/R2-compatible backends
- persist new WASM, field-overflow, and local TemperFS bytes outside SQL/Turso blob rows
- keep SQL rows metadata-only with legacy DB blob reads as fallback
- document the decision in ADR-0063

## Validation

- cargo check -p temper-server
- cargo clippy --all-targets --all-features -- -D warnings
- local TemperPaw E2E recorded in OpenPaw proof: readyz 200, 31 WASM objects, 0 SQL blob rows, 0 inline WASM bytes