### PR TITLE
Make spec persistence idempotent

### DIFF
--- a/crates/temper-cli/src/serve/bootstrap.rs
+++ b/crates/temper-cli/src/serve/bootstrap.rs
@@ -488,7 +488,7 @@ pub(super) async fn bootstrap_tenants(state: &PlatformState, apps: &[(String, St
     if let Some(ref store) = state.server.event_store
         && let Some(turso) = store.turso_for_tenant("temper-system").await
     {
-        temper_platform::persist_system_verification(&turso, &sys_hashes).await;
+        temper_platform::persist_system_verification(&turso, &sys_hashes, &sys_cache).await;
     }
 
     let default_cache = load_verified_cache(state, "default").await;
@@ -497,7 +497,13 @@ pub(super) async fn bootstrap_tenants(state: &PlatformState, apps: &[(String, St
     if let Some(ref store) = state.server.event_store
         && let Some(turso) = store.turso_for_tenant("default").await
     {
-        temper_platform::persist_agent_verification(&turso, "default", &default_hashes).await;
+        temper_platform::persist_agent_verification(
+            &turso,
+            "default",
+            &default_hashes,
+            &default_cache,
+        )
+        .await;
     }
 
     for (tenant, _dir) in apps {
@@ -508,7 +514,7 @@ pub(super) async fn bootstrap_tenants(state: &PlatformState, apps: &[(String, St
         if let Some(ref store) = state.server.event_store
             && let Some(turso) = store.turso_for_tenant(tenant).await
         {
-            temper_platform::persist_agent_verification(&turso, tenant, &hashes).await;
+            temper_platform::persist_agent_verification(&turso, tenant, &hashes, &cache).await;
         }
     }
     // In TenantRouted mode, bootstrap agent specs for all registered tenants.
@@ -522,7 +528,7 @@ pub(super) async fn bootstrap_tenants(state: &PlatformState, apps: &[(String, St
             let cache = load_verified_cache(state, &tenant).await;
             let hashes = temper_platform::bootstrap_agent_specs(state, &tenant, true, &cache);
             if let Some(turso) = store.turso_for_tenant(&tenant).await {
-                temper_platform::persist_agent_verification(&turso, &tenant, &hashes).await;
+                temper_platform::persist_agent_verification(&turso, &tenant, &hashes, &cache).await;
             }
         }
     }

--- a/crates/temper-cli/src/serve/mod.rs
+++ b/crates/temper-cli/src/serve/mod.rs
@@ -594,7 +594,7 @@ fn emit_ephemeral_info(message: &str) {
 /// updates the registry while persisting workflow history/status to Postgres.
 async fn spawn_background_verification(state: &PlatformState, specs_dir: &str, tenant: &str) {
     let specs_path = Path::new(specs_dir);
-    let ioa_sources = match read_ioa_sources(specs_path) {
+    let mut ioa_sources = match read_ioa_sources(specs_path) {
         Ok(sources) => sources,
         Err(e) => {
             eprintln!("Warning: failed to read IOA sources for background verification: {e}");
@@ -605,6 +605,18 @@ async fn spawn_background_verification(state: &PlatformState, specs_dir: &str, t
     let registry = state.registry.clone();
     let server = state.server.clone();
     let tenant_str = tenant.to_string();
+    let verification_cache = match server.persistent_store_for_tenant(tenant).await {
+        Some(store) => match store.load_verification_cache(tenant).await {
+            Ok(cache) => cache,
+            Err(e) => {
+                eprintln!(
+                    "Warning: failed to load verification cache for background verification ({tenant}): {e}"
+                );
+                BTreeMap::new()
+            }
+        },
+        None => BTreeMap::new(),
+    };
 
     // Emit spec_loaded events for each entity
     for entity_name in ioa_sources.keys() {
@@ -626,6 +638,15 @@ async fn spawn_background_verification(state: &PlatformState, specs_dir: &str, t
                 "Warning: failed to persist/emit spec_loaded for {tenant_str}/{entity_name}: {e}"
             );
         }
+    }
+
+    let source_count = ioa_sources.len();
+    ioa_sources = ioa_sources_requiring_background_verification(ioa_sources, &verification_cache);
+    let skipped_count = source_count.saturating_sub(ioa_sources.len());
+    if skipped_count > 0 {
+        println!(
+            "  [verify] Skipped {skipped_count} unchanged verified specs for tenant {tenant_str}"
+        );
     }
 
     for (entity_name, ioa_source) in ioa_sources {
@@ -876,9 +897,26 @@ async fn spawn_background_verification(state: &PlatformState, specs_dir: &str, t
     }
 }
 
+fn ioa_sources_requiring_background_verification(
+    ioa_sources: HashMap<String, String>,
+    verification_cache: &BTreeMap<String, (String, bool)>,
+) -> HashMap<String, String> {
+    ioa_sources
+        .into_iter()
+        .filter(|(entity_name, ioa_source)| {
+            !verification_cache
+                .get(entity_name)
+                .is_some_and(|(cached_hash, verified)| {
+                    *verified && cached_hash == &temper_store_turso::spec_content_hash(ioa_source)
+                })
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
-    use super::cache_platform_secret_if_present;
+    use super::{cache_platform_secret_if_present, ioa_sources_requiring_background_verification};
+    use std::collections::{BTreeMap, HashMap};
     use temper_server::secrets::vault::SecretsVault;
 
     fn test_vault() -> SecretsVault {
@@ -904,5 +942,42 @@ mod tests {
         cache_platform_secret_if_present(&vault, "exa_api_key", None);
 
         assert_eq!(vault.get_platform_secret("exa_api_key"), None);
+    }
+
+    #[test]
+    fn background_verification_skips_cached_verified_hashes() {
+        let mut ioa_sources = HashMap::new();
+        ioa_sources.insert(
+            "Issue".to_string(),
+            "[automaton]\nname = \"Issue\"\n".to_string(),
+        );
+        ioa_sources.insert(
+            "Task".to_string(),
+            "[automaton]\nname = \"Task\"\n".to_string(),
+        );
+
+        let mut verification_cache = BTreeMap::new();
+        verification_cache.insert(
+            "Issue".to_string(),
+            (
+                temper_store_turso::spec_content_hash(
+                    ioa_sources.get("Issue").expect("Issue source"),
+                ),
+                true,
+            ),
+        );
+        verification_cache.insert(
+            "Task".to_string(),
+            (
+                temper_store_turso::spec_content_hash("different source"),
+                true,
+            ),
+        );
+
+        let pending =
+            ioa_sources_requiring_background_verification(ioa_sources, &verification_cache);
+
+        assert_eq!(pending.len(), 1);
+        assert!(pending.contains_key("Task"));
     }
 }

--- a/crates/temper-platform/src/bootstrap.rs
+++ b/crates/temper-platform/src/bootstrap.rs
@@ -290,8 +290,12 @@ pub(crate) async fn persist_bootstrap_verification(
     specs: &[(&str, &str)],
     csdl_source: &str,
     hashes: &[(String, String)],
+    verified_cache: &BTreeMap<String, (String, bool)>,
 ) {
-    for (entity_type, content_hash) in hashes {
+    let hashes_to_persist = hashes_requiring_persistence(hashes, verified_cache);
+    let mut wrote_specs = false;
+
+    for (entity_type, content_hash) in &hashes_to_persist {
         // Find the IOA source for this entity type.
         let ioa_source = specs
             .iter()
@@ -307,6 +311,7 @@ pub(crate) async fn persist_bootstrap_verification(
             tracing::warn!("Failed to persist bootstrap spec {tenant}/{entity_type}: {e}");
             continue;
         }
+        wrote_specs = true;
 
         // Mark as verified (bootstrap panics on failure, so all specs here passed).
         if let Err(e) = store
@@ -330,14 +335,41 @@ pub(crate) async fn persist_bootstrap_verification(
     // `upsert_spec` marks rows as uncommitted while content is rewritten. Once
     // bootstrap verification succeeds, promote the tenant's spec set back to a
     // durable committed state so restart recovery can actually see the rows.
-    if let Err(e) = store.commit_specs(tenant).await {
+    if wrote_specs && let Err(e) = store.commit_specs(tenant).await {
         tracing::warn!("Failed to commit bootstrap specs for tenant '{tenant}': {e}");
     }
 }
 
+fn hashes_requiring_persistence(
+    hashes: &[(String, String)],
+    verified_cache: &BTreeMap<String, (String, bool)>,
+) -> Vec<(String, String)> {
+    hashes
+        .iter()
+        .filter(|(entity_type, content_hash)| {
+            !verified_cache
+                .get(entity_type)
+                .is_some_and(|(cached_hash, verified)| *verified && cached_hash == content_hash)
+        })
+        .cloned()
+        .collect()
+}
+
 /// Persist system tenant spec verification to the platform store.
-pub async fn persist_system_verification(store: &dyn PlatformStore, hashes: &[(String, String)]) {
-    persist_bootstrap_verification(store, SYSTEM_TENANT, SYSTEM_SPECS, SYSTEM_CSDL, hashes).await;
+pub async fn persist_system_verification(
+    store: &dyn PlatformStore,
+    hashes: &[(String, String)],
+    verified_cache: &BTreeMap<String, (String, bool)>,
+) {
+    persist_bootstrap_verification(
+        store,
+        SYSTEM_TENANT,
+        SYSTEM_SPECS,
+        SYSTEM_CSDL,
+        hashes,
+        verified_cache,
+    )
+    .await;
 }
 
 /// Persist agent spec verification to the platform store.
@@ -345,8 +377,17 @@ pub async fn persist_agent_verification(
     store: &dyn PlatformStore,
     tenant: &str,
     hashes: &[(String, String)],
+    verified_cache: &BTreeMap<String, (String, bool)>,
 ) {
-    persist_bootstrap_verification(store, tenant, AGENT_SPECS, AGENT_CSDL, hashes).await;
+    persist_bootstrap_verification(
+        store,
+        tenant,
+        AGENT_SPECS,
+        AGENT_CSDL,
+        hashes,
+        verified_cache,
+    )
+    .await;
 }
 
 /// Auto-register an `AgentCredential` for the global API key on bootstrap.
@@ -706,6 +747,28 @@ initial = "Created"
             registry.resolve_entity_type(&tenant, "Widgets").as_deref(),
             Some("Widget"),
             "existing app entity-set mapping should survive merged bootstrap"
+        );
+    }
+
+    #[test]
+    fn test_hashes_requiring_persistence_skip_cached_verified_specs() {
+        let hashes = vec![
+            ("Agent".to_string(), "sha256:agent".to_string()),
+            ("Plan".to_string(), "sha256:plan".to_string()),
+            ("Task".to_string(), "sha256:task".to_string()),
+        ];
+        let mut verified_cache = BTreeMap::new();
+        verified_cache.insert("Agent".to_string(), ("sha256:agent".to_string(), true));
+        verified_cache.insert("Plan".to_string(), ("sha256:plan".to_string(), false));
+
+        let pending = hashes_requiring_persistence(&hashes, &verified_cache);
+
+        assert_eq!(
+            pending,
+            vec![
+                ("Plan".to_string(), "sha256:plan".to_string()),
+                ("Task".to_string(), "sha256:task".to_string()),
+            ]
         );
     }
 

--- a/crates/temper-platform/src/os_apps/mod.rs
+++ b/crates/temper-platform/src/os_apps/mod.rs
@@ -1436,6 +1436,7 @@ pub(super) async fn install_os_app_with_plan(
                     &specs_to_bootstrap,
                     merged,
                     &spec_hashes,
+                    &verified_cache,
                 )
                 .await;
             }

--- a/crates/temper-store-turso/src/store/specs.rs
+++ b/crates/temper-store-turso/src/store/specs.rs
@@ -1,5 +1,7 @@
 //! Spec persistence: upsert, verification updates, and startup loading.
 
+use std::collections::BTreeMap;
+
 use libsql::{TransactionBehavior, params};
 use temper_runtime::persistence::{PersistenceError, storage_error};
 use tracing::instrument;
@@ -7,6 +9,13 @@ use tracing::instrument;
 use super::{TursoEventStore, TursoInstalledAppRow, TursoSpecRow, write_gate::WritePriority};
 use crate::TursoSpecVerificationUpdate;
 use crate::metrics::TursoQueryTimer;
+
+#[derive(Debug)]
+struct ExistingSpecFingerprint {
+    content_hash: Option<String>,
+    csdl_xml: Option<String>,
+    committed: bool,
+}
 
 impl TursoEventStore {
     /// Upsert a spec source (IOA + CSDL) for a tenant/entity_type.
@@ -89,16 +98,27 @@ impl TursoEventStore {
         app_name: &str,
     ) -> Result<(), PersistenceError> {
         let _query_timer = TursoQueryTimer::start("turso.upsert_specs_and_commit");
+        let conn = self.configured_connection().await?;
+        let spec_indices = self
+            .spec_indices_requiring_upsert(&conn, tenant, specs)
+            .await?;
+        let policy_needs_write = Self::tenant_policy_needs_write(&conn, tenant, policy).await?;
+        let app_needs_write = Self::installed_app_needs_write(&conn, tenant, app_name).await?;
+
+        if spec_indices.is_empty() && !policy_needs_write && !app_needs_write {
+            return Ok(());
+        }
+
         let _write_permit = self
             .acquire_write_permit("turso.upsert_specs_and_commit", WritePriority::High)
             .await?;
-        let conn = self.configured_connection().await?;
         let tx = conn
             .transaction_with_behavior(TransactionBehavior::Immediate)
             .await
             .map_err(storage_error)?;
 
-        for (entity_type, ioa_source, csdl_xml, content_hash) in specs {
+        for index in spec_indices {
+            let (entity_type, ioa_source, csdl_xml, content_hash) = specs[index];
             tx.execute(
                 "INSERT INTO specs (tenant, entity_type, ioa_source, csdl_xml, content_hash, committed, version, verified, verification_status, updated_at)
                  VALUES (?1, ?2, ?3, ?4, ?5, 1, 1, 0, 'pending', datetime('now'))
@@ -140,7 +160,7 @@ impl TursoEventStore {
             .map_err(storage_error)?;
         }
 
-        if let Some(policy_text) = policy {
+        if policy_needs_write && let Some(policy_text) = policy {
             tx.execute(
                 "INSERT INTO tenant_policies (tenant, policy_text, updated_at) \
                  VALUES (?1, ?2, datetime('now')) \
@@ -151,15 +171,137 @@ impl TursoEventStore {
             .map_err(storage_error)?;
         }
 
-        tx.execute(
-            "INSERT OR IGNORE INTO tenant_installed_apps (tenant_id, app_name) VALUES (?1, ?2)",
-            params![tenant, app_name],
-        )
-        .await
-        .map_err(storage_error)?;
+        if app_needs_write {
+            tx.execute(
+                "INSERT OR IGNORE INTO tenant_installed_apps (tenant_id, app_name) VALUES (?1, ?2)",
+                params![tenant, app_name],
+            )
+            .await
+            .map_err(storage_error)?;
+        }
 
         tx.commit().await.map_err(storage_error)?;
         Ok(())
+    }
+
+    async fn spec_indices_requiring_upsert(
+        &self,
+        conn: &libsql::Connection,
+        tenant: &str,
+        specs: &[(&str, &str, &str, &str)],
+    ) -> Result<Vec<usize>, PersistenceError> {
+        if specs.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let entity_types = specs
+            .iter()
+            .map(|(entity_type, _, _, _)| *entity_type)
+            .collect::<Vec<_>>();
+        let existing = Self::load_spec_fingerprints(conn, tenant, &entity_types).await?;
+        Ok(specs
+            .iter()
+            .enumerate()
+            .filter_map(
+                |(index, (entity_type, _ioa_source, csdl_xml, content_hash))| {
+                    let needs_upsert = existing.get(*entity_type).is_none_or(|fingerprint| {
+                        fingerprint.content_hash.as_deref() != Some(*content_hash)
+                            || fingerprint.csdl_xml.as_deref() != Some(*csdl_xml)
+                            || !fingerprint.committed
+                    });
+                    needs_upsert.then_some(index)
+                },
+            )
+            .collect())
+    }
+
+    async fn load_spec_fingerprints(
+        conn: &libsql::Connection,
+        tenant: &str,
+        entity_types: &[&str],
+    ) -> Result<BTreeMap<String, ExistingSpecFingerprint>, PersistenceError> {
+        if entity_types.is_empty() {
+            return Ok(BTreeMap::new());
+        }
+
+        let placeholders = (2..entity_types.len() + 2)
+            .map(|index| format!("?{index}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "SELECT entity_type, content_hash, csdl_xml, committed \
+             FROM specs \
+             WHERE tenant = ?1 AND entity_type IN ({placeholders})"
+        );
+        let mut values: Vec<libsql::Value> = vec![tenant.to_string().into()];
+        values.extend(
+            entity_types
+                .iter()
+                .map(|entity_type| (*entity_type).to_string().into()),
+        );
+
+        let mut rows = conn
+            .query(&sql, libsql::params_from_iter(values))
+            .await
+            .map_err(storage_error)?;
+        let mut existing = BTreeMap::new();
+        while let Some(row) = rows.next().await.map_err(storage_error)? {
+            let entity_type: String = row.get(0).map_err(storage_error)?;
+            let content_hash: Option<String> = row.get(1).map_err(storage_error)?;
+            let csdl_xml: Option<String> = row.get(2).map_err(storage_error)?;
+            let committed = row
+                .get::<Option<i64>>(3)
+                .map_err(storage_error)?
+                .unwrap_or(1)
+                != 0;
+            existing.insert(
+                entity_type,
+                ExistingSpecFingerprint {
+                    content_hash,
+                    csdl_xml,
+                    committed,
+                },
+            );
+        }
+        Ok(existing)
+    }
+
+    async fn tenant_policy_needs_write(
+        conn: &libsql::Connection,
+        tenant: &str,
+        policy: Option<&str>,
+    ) -> Result<bool, PersistenceError> {
+        let Some(policy_text) = policy else {
+            return Ok(false);
+        };
+
+        let mut rows = conn
+            .query(
+                "SELECT policy_text FROM tenant_policies WHERE tenant = ?1 LIMIT 1",
+                params![tenant],
+            )
+            .await
+            .map_err(storage_error)?;
+        let Some(row) = rows.next().await.map_err(storage_error)? else {
+            return Ok(true);
+        };
+        let existing: String = row.get(0).map_err(storage_error)?;
+        Ok(existing != policy_text)
+    }
+
+    async fn installed_app_needs_write(
+        conn: &libsql::Connection,
+        tenant: &str,
+        app_name: &str,
+    ) -> Result<bool, PersistenceError> {
+        let mut rows = conn
+            .query(
+                "SELECT 1 FROM tenant_installed_apps WHERE tenant_id = ?1 AND app_name = ?2 LIMIT 1",
+                params![tenant, app_name],
+            )
+            .await
+            .map_err(storage_error)?;
+        Ok(rows.next().await.map_err(storage_error)?.is_none())
     }
 
     /// Delete a spec for a given tenant/entity_type.
@@ -198,7 +340,20 @@ impl TursoEventStore {
                  levels_total = ?6,
                  verification_result = ?7,
                  updated_at = datetime('now')
-             WHERE tenant = ?1 AND entity_type = ?2",
+             WHERE tenant = ?1 AND entity_type = ?2
+               AND (
+                   verified IS NOT ?3
+                   OR verification_status IS NOT ?4
+                   OR levels_passed IS NOT ?5
+                   OR levels_total IS NOT ?6
+                   OR CASE
+                       WHEN verification_result IS NULL AND ?7 IS NULL THEN 0
+                       WHEN verification_result IS NULL OR ?7 IS NULL THEN 1
+                       WHEN json_valid(verification_result) != 0 AND json_valid(?7) != 0
+                       THEN json_remove(verification_result, '$.verified_at') IS NOT json_remove(?7, '$.verified_at')
+                       ELSE verification_result IS NOT ?7
+                   END
+               )",
             params![
                 tenant,
                 entity_type,
@@ -227,7 +382,7 @@ impl TursoEventStore {
         let conn = self.configured_connection().await?;
         let mut rows = conn
             .query(
-                "SELECT entity_type, content_hash, verified FROM specs WHERE tenant = ?1",
+                "SELECT entity_type, content_hash, verified FROM specs WHERE tenant = ?1 AND committed = 1",
                 params![tenant],
             )
             .await
@@ -459,7 +614,7 @@ impl TursoEventStore {
         let _query_timer = TursoQueryTimer::start("turso.commit_specs");
         let conn = self.configured_connection().await?;
         conn.execute(
-            "UPDATE specs SET committed = 1, updated_at = datetime('now') WHERE tenant = ?1",
+            "UPDATE specs SET committed = 1, updated_at = datetime('now') WHERE tenant = ?1 AND committed != 1",
             params![tenant],
         )
         .await

--- a/crates/temper-store-turso/src/store/tests/mod.rs
+++ b/crates/temper-store-turso/src/store/tests/mod.rs
@@ -827,6 +827,294 @@ async fn upsert_specs_and_commit_preserves_identical_spec_version() {
 }
 
 #[tokio::test]
+async fn upsert_specs_and_commit_bypasses_write_gate_for_identical_app_specs() {
+    let mut store = make_store("spec-idempotent-bypasses-gate").await;
+    let tenant = format!("tenant-{}", uuid::Uuid::new_v4());
+    let ioa_source = "[automaton]\nname = \"Issue\"\n";
+    let csdl_xml = "<Schema Namespace=\"Temper.Tests\" />";
+    let content_hash = "sha256:issue-v1";
+    let policy = r#"permit(principal, action, resource);"#;
+
+    store
+        .upsert_specs_and_commit(
+            &tenant,
+            &[("Issue", ioa_source, csdl_xml, content_hash)],
+            Some(policy),
+            "test-app",
+        )
+        .await
+        .expect("initial spec commit");
+
+    store.write_gate = std::sync::Arc::new(tokio::sync::Semaphore::new(1));
+    let held_gate = store
+        .write_gate
+        .clone()
+        .acquire_owned()
+        .await
+        .expect("hold gate");
+
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        store.upsert_specs_and_commit(
+            &tenant,
+            &[("Issue", ioa_source, csdl_xml, content_hash)],
+            Some(policy),
+            "test-app",
+        ),
+    )
+    .await;
+    drop(held_gate);
+
+    result
+        .expect("identical app spec commit should bypass the write gate")
+        .expect("identical app spec commit should succeed");
+}
+
+#[tokio::test]
+async fn persist_spec_verification_keeps_updated_at_for_identical_result() {
+    let store = make_store("spec-verification-idempotent").await;
+    let tenant = format!("tenant-{}", uuid::Uuid::new_v4());
+    let ioa_source = "[automaton]\nname = \"Issue\"\n";
+    let csdl_xml = "<Schema Namespace=\"Temper.Tests\" />";
+    let content_hash = "sha256:issue-v1";
+    let result_json = r#"{"all_passed":true}"#;
+
+    store
+        .upsert_specs_and_commit(
+            &tenant,
+            &[("Issue", ioa_source, csdl_xml, content_hash)],
+            None,
+            "test-app",
+        )
+        .await
+        .expect("initial spec commit");
+    let update = TursoSpecVerificationUpdate {
+        status: "passed",
+        verified: true,
+        levels_passed: Some(1),
+        levels_total: Some(1),
+        verification_result_json: Some(result_json),
+    };
+    store
+        .persist_spec_verification(&tenant, "Issue", update)
+        .await
+        .expect("persist verification");
+
+    let conn = store.connection().expect("connection");
+    conn.execute(
+        "UPDATE specs SET updated_at = 'fixed-time' WHERE tenant = ?1 AND entity_type = 'Issue'",
+        params![tenant.as_str()],
+    )
+    .await
+    .expect("pin updated_at");
+
+    store
+        .persist_spec_verification(&tenant, "Issue", update)
+        .await
+        .expect("persist identical verification");
+
+    let mut rows = conn
+        .query(
+            "SELECT updated_at FROM specs WHERE tenant = ?1 AND entity_type = 'Issue'",
+            params![tenant.as_str()],
+        )
+        .await
+        .expect("query spec updated_at");
+    let row = rows
+        .next()
+        .await
+        .expect("row result")
+        .expect("spec row exists");
+    let updated_at: String = row.get(0).expect("updated_at");
+
+    assert_eq!(
+        updated_at, "fixed-time",
+        "identical verification persistence must not rewrite the spec row"
+    );
+}
+
+#[tokio::test]
+async fn persist_spec_verification_ignores_verified_at_only_changes() {
+    let store = make_store("spec-verification-verified-at-idempotent").await;
+    let tenant = format!("tenant-{}", uuid::Uuid::new_v4());
+    let ioa_source = "[automaton]\nname = \"Issue\"\n";
+    let csdl_xml = "<Schema Namespace=\"Temper.Tests\" />";
+    let content_hash = "sha256:issue-v1";
+    let first_result = r#"{"all_passed":true,"levels":[],"verified_at":"2026-04-28T17:00:00Z"}"#;
+    let second_result = r#"{"all_passed":true,"levels":[],"verified_at":"2026-04-28T17:01:00Z"}"#;
+
+    store
+        .upsert_specs_and_commit(
+            &tenant,
+            &[("Issue", ioa_source, csdl_xml, content_hash)],
+            None,
+            "test-app",
+        )
+        .await
+        .expect("initial spec commit");
+    store
+        .persist_spec_verification(
+            &tenant,
+            "Issue",
+            TursoSpecVerificationUpdate {
+                status: "passed",
+                verified: true,
+                levels_passed: Some(1),
+                levels_total: Some(1),
+                verification_result_json: Some(first_result),
+            },
+        )
+        .await
+        .expect("persist first verification");
+
+    let conn = store.connection().expect("connection");
+    conn.execute(
+        "UPDATE specs SET updated_at = 'fixed-time' WHERE tenant = ?1 AND entity_type = 'Issue'",
+        params![tenant.as_str()],
+    )
+    .await
+    .expect("pin updated_at");
+
+    store
+        .persist_spec_verification(
+            &tenant,
+            "Issue",
+            TursoSpecVerificationUpdate {
+                status: "passed",
+                verified: true,
+                levels_passed: Some(1),
+                levels_total: Some(1),
+                verification_result_json: Some(second_result),
+            },
+        )
+        .await
+        .expect("persist timestamp-only verification change");
+
+    let mut rows = conn
+        .query(
+            "SELECT updated_at, verification_result FROM specs WHERE tenant = ?1 AND entity_type = 'Issue'",
+            params![tenant.as_str()],
+        )
+        .await
+        .expect("query spec updated_at");
+    let row = rows
+        .next()
+        .await
+        .expect("row result")
+        .expect("spec row exists");
+    let updated_at: String = row.get(0).expect("updated_at");
+    let verification_result: String = row.get(1).expect("verification_result");
+
+    assert_eq!(
+        updated_at, "fixed-time",
+        "verified_at-only verification changes must not rewrite the spec row"
+    );
+    assert_eq!(
+        verification_result, first_result,
+        "stored verification_result should remain stable when only verified_at changes"
+    );
+}
+
+#[tokio::test]
+async fn commit_specs_keeps_updated_at_when_specs_are_already_committed() {
+    let store = make_store("spec-commit-idempotent").await;
+    let tenant = format!("tenant-{}", uuid::Uuid::new_v4());
+    let ioa_source = "[automaton]\nname = \"Issue\"\n";
+    let csdl_xml = "<Schema Namespace=\"Temper.Tests\" />";
+    let content_hash = "sha256:issue-v1";
+
+    store
+        .upsert_specs_and_commit(
+            &tenant,
+            &[("Issue", ioa_source, csdl_xml, content_hash)],
+            None,
+            "test-app",
+        )
+        .await
+        .expect("initial spec commit");
+
+    let conn = store.connection().expect("connection");
+    conn.execute(
+        "UPDATE specs SET updated_at = 'fixed-time' WHERE tenant = ?1 AND entity_type = 'Issue'",
+        params![tenant.as_str()],
+    )
+    .await
+    .expect("pin updated_at");
+
+    store
+        .commit_specs(&tenant)
+        .await
+        .expect("commit already committed specs");
+
+    let mut rows = conn
+        .query(
+            "SELECT updated_at FROM specs WHERE tenant = ?1 AND entity_type = 'Issue'",
+            params![tenant.as_str()],
+        )
+        .await
+        .expect("query spec updated_at");
+    let row = rows
+        .next()
+        .await
+        .expect("row result")
+        .expect("spec row exists");
+    let updated_at: String = row.get(0).expect("updated_at");
+
+    assert_eq!(
+        updated_at, "fixed-time",
+        "committing already committed specs must not rewrite them"
+    );
+}
+
+#[tokio::test]
+async fn load_verification_cache_ignores_uncommitted_specs() {
+    let store = make_store("verification-cache-committed-only").await;
+    let tenant = format!("tenant-{}", uuid::Uuid::new_v4());
+    let ioa_source = "[automaton]\nname = \"Issue\"\n";
+    let csdl_xml = "<Schema Namespace=\"Temper.Tests\" />";
+    let content_hash = "sha256:issue-v1";
+
+    store
+        .upsert_spec(&tenant, "Issue", ioa_source, csdl_xml, content_hash)
+        .await
+        .expect("upsert uncommitted spec");
+    store
+        .persist_spec_verification(
+            &tenant,
+            "Issue",
+            TursoSpecVerificationUpdate {
+                status: "passed",
+                verified: true,
+                levels_passed: Some(1),
+                levels_total: Some(1),
+                verification_result_json: Some(r#"{"all_passed":true}"#),
+            },
+        )
+        .await
+        .expect("persist verification");
+
+    let cache = store
+        .load_verification_cache(&tenant)
+        .await
+        .expect("load verification cache");
+    assert!(
+        !cache.contains_key("Issue"),
+        "uncommitted specs must not be used to skip bootstrap persistence"
+    );
+
+    store.commit_specs(&tenant).await.expect("commit spec");
+    let cache = store
+        .load_verification_cache(&tenant)
+        .await
+        .expect("load committed verification cache");
+    assert_eq!(
+        cache.get("Issue"),
+        Some(&(content_hash.to_string(), true)),
+        "committed verified specs should populate the verification cache"
+    );
+}
+
+#[tokio::test]
 async fn upsert_wasm_module_preserves_version_for_identical_hash() {
     let store = make_store("wasm-idempotent").await;
 

--- a/docs/adrs/0064-idempotent-spec-persistence.md
+++ b/docs/adrs/0064-idempotent-spec-persistence.md
@@ -1,0 +1,143 @@
+# ADR-0064: Idempotent Spec Persistence
+
+- Status: Accepted
+- Date: 2026-04-28
+- Deciders: Temper core maintainers
+- Related:
+  - ADR-0030: Hash-Gated Verification
+  - ADR-0060: Bounded Warm Restart and Digest-Aware App Reconcile
+  - ADR-0062: Delta OS-App Reconcile and WASM Artifacts
+  - ADR-0063: Object Store for Blob Bytes
+  - `crates/temper-store-turso/src/store/specs.rs`
+  - `crates/temper-platform/src/bootstrap.rs`
+  - `crates/temper-platform/src/os_apps/mod.rs`
+  - `crates/temper-cli/src/serve/mod.rs`
+
+## Context
+
+After moving WASM bytes out of SQL-backed blob storage, production startup traces
+showed that WASM metadata persistence was no longer the dominant cost. On the
+2026-04-28 Railway deployment of OpenPaw service version
+`0208e97add4a8046eb833cfc01bac1fcf42724ad`, Datadog showed
+`turso.upsert_wasm_module` at 25 calls with max duration about 595 ms.
+
+The remaining startup and boot-recovery cost was spec persistence and
+verification bookkeeping. The expensive spans were almost entirely idle wait,
+not CPU:
+
+- `turso.upsert_specs_and_commit`: one startup span at about 5.36 s with about
+  4.4 ms busy CPU.
+- `turso.persist_spec_verification`: 25 spans, max about 19.9 s, total about
+  35.1 s.
+- `turso.commit_specs`: three spans, max about 12.7 s, total about 26.6 s.
+- `turso.load_verification_cache`: two spans, max about 9.5 s.
+
+The implementation was still asking Turso to participate in write transactions
+for rows that were already byte-for-byte identical and already verified. This
+kept warm startup proportional to the number of specs in the tenant instead of
+the number of changed specs.
+
+## Decision
+
+### 1. Identical app spec commits are read-only
+
+`upsert_specs_and_commit` first reads fingerprints for the incoming app specs:
+content hash, CSDL, and committed status. It also checks whether the tenant
+policy text and installed-app marker need writes. If nothing changed, the
+function returns before acquiring the process write gate and before opening a
+SQL transaction.
+
+If some specs changed, only those specs are upserted in the transaction. The
+transaction still preserves the existing semantics for real changes: changed
+specs reset verification and bump version, while unchanged specs keep version
+and verification state.
+
+### 2. Verification persistence is idempotent
+
+`persist_spec_verification` now updates a row only when the verification fields
+would actually change. Replaying the same successful verification result does
+not rewrite `updated_at` and does not create avoidable write contention. The
+comparison intentionally ignores `verification_result.verified_at`, because an
+otherwise identical verification pass should not become a durable write solely
+because the verifier ran at a new wall-clock time.
+
+### 3. Spec commit only promotes uncommitted rows
+
+`commit_specs` now updates rows only when `committed != 1`. Calling it for a
+tenant whose specs are already committed is a no-op instead of a tenant-wide
+rewrite.
+
+### 4. Verification cache only trusts committed rows
+
+`load_verification_cache` filters to `committed = 1`. This preserves crash
+safety: a row that was verified but not yet committed is not allowed to skip the
+next bootstrap persistence pass.
+
+### 5. Bootstrap persistence skips cached verified specs
+
+System, agent, and OS-app bootstrap still parse and register specs into memory,
+but durable spec persistence is limited to hashes missing from the committed,
+verified cache. A warm boot with unchanged verified specs no longer runs the
+`upsert_spec -> persist_spec_verification -> commit_specs` loop.
+
+### 6. Background verification skips cached verified app specs
+
+The `temper serve` background verifier uses the same committed verification
+cache. App specs whose IOA hash is unchanged and already verified are not
+flipped from `passed` to `running` and back to `passed` on warm boot. This
+keeps warm boot from turning a no-op verification pass into two durable writes
+per app spec.
+
+## Consequences
+
+### Positive
+
+- Warm startup avoids spec write-gate contention when specs are unchanged.
+- Reconcile work becomes proportional to changed specs, not installed specs.
+- Crash safety is preserved because only committed specs can populate the cache.
+- Datadog spans distinguish real spec changes from no-op boot bookkeeping.
+- Warm `temper serve` no longer re-verifies unchanged app specs solely to
+  refresh design-time verification status.
+
+### Negative
+
+- `upsert_specs_and_commit` performs small preflight reads before deciding
+  whether a transaction is needed.
+- Spec persistence has more idempotency conditions to keep covered by tests.
+
+### Risks
+
+- A stale verification cache could skip persistence incorrectly if it included
+  uncommitted rows. This is mitigated by filtering cache reads to committed
+  specs only.
+- Concurrent app installs can race between the preflight read and transaction.
+  The write path remains idempotent, uses unique keys, and preserves existing
+  `INSERT OR IGNORE` behavior for installed-app markers.
+
+## Rollout Plan
+
+1. Add red tests for write-gate bypass, idempotent verification updates
+   including `verified_at`-only changes, idempotent spec commits, and
+   committed-only verification cache reads.
+2. Make Turso spec persistence no-op before the write gate when all incoming
+   app data is unchanged.
+3. Pass the verified cache into bootstrap persistence so warm boots skip
+   unchanged verified spec rows.
+4. Make background verification skip app specs whose cached hash is still
+   verified.
+5. Verify locally, update OpenPaw to the new Temper revision, deploy, and
+   compare Datadog startup spans for `turso.upsert_specs_and_commit`,
+   `turso.persist_spec_verification`, and `turso.commit_specs`.
+
+## Non-Goals
+
+- Changing the entity-first Temper app architecture.
+- Marking `/readyz` healthy before required startup apps are usable.
+- Replacing all SQL reads in startup recovery.
+- Changing WASM artifact storage; ADR-0063 owns that boundary.
+
+## Rollback Policy
+
+Reverting this ADR returns to the previous behavior of writing all bootstrap and
+app spec rows on every persistence pass. Because the schema is unchanged, rollback
+requires only code rollback.

--- a/docs/proofs/2026-04-28-idempotent-spec-persistence-local-e2e.md
+++ b/docs/proofs/2026-04-28-idempotent-spec-persistence-local-e2e.md
@@ -1,0 +1,63 @@
+# 2026-04-28 Idempotent Spec Persistence Local E2E
+
+## Build and Tests
+
+- `cargo test -p temper-store-turso --lib -- --nocapture`
+  - Result: 41 passed.
+- `cargo test -p temper-platform test_hashes_requiring_persistence_skip_cached_verified_specs -- --nocapture`
+  - Result: passed.
+- `cargo test -p temper-cli -- --nocapture`
+  - Result: 44 passed.
+- `cargo check -p temper-cli -p temper-platform -p temper-store-turso`
+  - Result: passed.
+- `cargo build -p temper-cli`
+  - Result: passed.
+
+## Live E2E
+
+Started `temper serve` twice against the same file-backed Turso/libSQL database
+with an isolated home directory:
+
+```bash
+HOME=/tmp/temper-spec-e2e-home \
+XDG_DATA_HOME=/tmp/temper-spec-e2e-xdg \
+TURSO_URL=file:/tmp/temper-spec-e2e-clean.db \
+RUST_LOG=error \
+./target/debug/temper serve \
+  --storage turso \
+  --no-observe \
+  --app pipeline=docs/examples/pipeline-specs \
+  --port 3123
+```
+
+First boot:
+
+- `/healthz`: 200
+- Spec counts:
+  - `default|8|8|8`
+  - `pipeline|12|12|12`
+  - `temper-system|13|13|13`
+- Snapshot saved from:
+  - `tenant`
+  - `entity_type`
+  - `updated_at`
+  - `version`
+  - `verified`
+  - `committed`
+  - `content_hash`
+
+Second boot:
+
+- `/healthz`: 200
+- Log evidence: `[verify] Skipped 4 unchanged verified specs for tenant pipeline`
+- Spec counts:
+  - `default|8|8|8`
+  - `pipeline|12|12|12`
+  - `temper-system|13|13|13`
+- `diff -u /tmp/temper-spec-e2e-before.tsv /tmp/temper-spec-e2e-after.tsv`
+  returned no diff.
+
+## Result
+
+Warm boot with unchanged verified specs did not rewrite any persisted spec rows,
+including `updated_at`, `version`, `verified`, `committed`, and `content_hash`.


### PR DESCRIPTION
## Summary

- Makes Turso spec app commits preflight unchanged specs/policies/app markers and return before the write gate when nothing changed.
- Makes verification persistence, spec commits, bootstrap persistence, and `temper serve` background verification idempotent for unchanged verified specs.
- Adds ADR-0064 and a local live E2E proof for the two-boot warm-start behavior.

## Why

OpenPaw production traces showed `turso.upsert_specs_and_commit`, `turso.persist_spec_verification`, and `turso.commit_specs` spending seconds in mostly idle SQL wait during warm startup. The root cause was no-op app/spec verification paths still opening write transactions or flipping unchanged specs through `running` and back to `passed`.

## Validation

- `cargo test -p temper-store-turso --lib -- --nocapture`
- `cargo test -p temper-platform test_hashes_requiring_persistence_skip_cached_verified_specs -- --nocapture`
- `cargo test -p temper-cli -- --nocapture`
- `cargo check -p temper-cli -p temper-platform -p temper-store-turso`
- `cargo build -p temper-cli`
- Local live E2E: two `temper serve` boots against the same file-backed Turso DB; second boot returned `/healthz` 200, logged `Skipped 4 unchanged verified specs for tenant pipeline`, and produced an empty spec-row diff.
