### PR TITLE
observe: fix os-apps page — useSSERefresh, not removed usePolling

### DIFF
--- a/ui/observe/app/(observe)/os-apps/page.tsx
+++ b/ui/observe/app/(observe)/os-apps/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useEffect, useMemo } from "react";
 import { fetchOsApps, installOsApp, fetchSpecs } from "@/lib/api";
-import { usePolling } from "@/lib/hooks";
+import { useSSERefresh } from "@/lib/hooks";
 import type { SkillsResponse, SpecSummary } from "@/lib/types";
 import ErrorDisplay from "@/components/ErrorDisplay";
 import StatCard from "@/components/StatCard";
@@ -29,15 +29,15 @@ export default function OsAppsPage() {
     loadInitial();
   }, [loadInitial]);
 
-  const appsPoll = usePolling<SkillsResponse>({
+  const appsPoll = useSSERefresh<SkillsResponse>({
     fetcher: fetchOsApps,
-    interval: 10000,
+    sseKinds: ["OsApps", "Entities"],
     enabled: !initialLoading && !initialError,
   });
 
-  const specsPoll = usePolling<SpecSummary[]>({
+  const specsPoll = useSSERefresh<SpecSummary[]>({
     fetcher: fetchSpecs,
-    interval: 10000,
+    sseKinds: ["Specs"],
     enabled: !initialLoading && !initialError,
   });
 


### PR DESCRIPTION
## Summary

The os-apps page imported `usePolling` from `@/lib/hooks` but that hook was renamed to `useSSERefresh` and the call signature changed (`interval` → `sseKinds`). Every other SSE-driven page was migrated; this one got missed.

Clicking Apps in the Observe UI threw:

```
TypeError: (0 , _lib_hooks__WEBPACK_IMPORTED_MODULE_3__.usePolling) is not a function
```

Fix: import \`useSSERefresh\`, switch the two call sites to its signature, and use the SSE kinds the rest of the codebase emits for app/spec changes.

## Test plan

- [x] Hard-refreshed Apps tab in local Observe UI — renders without error
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)