### PR TITLE
perf(odata): catalog-first entity_set materialization

### DIFF
--- a/crates/temper-server/src/odata/read_support.rs
+++ b/crates/temper-server/src/odata/read_support.rs
@@ -1,5 +1,6 @@
 //! Shared helpers for OData read handlers.
 
+use std::collections::HashMap;
 use std::sync::OnceLock;
 
 use futures_util::stream::{self, StreamExt};
@@ -7,12 +8,24 @@ use temper_runtime::tenant::TenantId;
 
 use crate::blobs::hydrate_blob_refs_for_tenant;
 use crate::state::ServerState;
+use crate::storage::EntityCatalogRow;
 
 fn env_usize(name: &str, default: usize) -> usize {
     std::env::var(name) // determinism-ok: read once at startup
         .ok()
         .and_then(|v| v.trim().parse::<usize>().ok())
         .filter(|v| *v > 0)
+        .unwrap_or(default)
+}
+
+fn env_bool(name: &str, default: bool) -> bool {
+    std::env::var(name) // determinism-ok: read once at startup
+        .ok()
+        .and_then(|v| match v.trim().to_ascii_lowercase().as_str() {
+            "1" | "true" | "yes" | "on" => Some(true),
+            "0" | "false" | "no" | "off" => Some(false),
+            _ => None,
+        })
         .unwrap_or(default)
 }
 
@@ -32,6 +45,77 @@ fn entity_set_materialization_concurrency() -> usize {
         .get_or_init(|| env_usize("TEMPER_ODATA_ENTITY_SET_MATERIALIZATION_CONCURRENCY", 16))
 }
 
+/// When true, list materialization reads each row from the durable
+/// `entity_catalog` projection in a single batch query, avoiding the per-row
+/// actor hydration cost. IDs that are absent from the catalog still fall
+/// back to the actor path on a per-id basis.
+fn catalog_fast_read_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| env_bool("TEMPER_ODATA_CATALOG_FAST_READ", false))
+}
+
+/// Build the OData JSON body for a single catalog row.
+///
+/// Mirrors the actor's serialized `EntityState` shape (`status`, `fields`,
+/// `entity_type`, `entity_id`, `sequence_nr`, `total_event_count`,
+/// `item_count`, `counters`, `booleans`, `lists`, `events`) so downstream
+/// `enrich_entity_response` and OData clients see the same payload as the
+/// actor path. Counters/booleans/lists are emitted as empty maps because the
+/// catalog only persists `status` + `fields`; entity types that depend on
+/// those collections in their OData response should leave the fast-read
+/// flag off until the projection is extended.
+fn catalog_row_to_entity_body(
+    entity_type: &str,
+    entity_set_name: &str,
+    row: EntityCatalogRow,
+) -> serde_json::Value {
+    let id = row.entity_id;
+    serde_json::json!({
+        "entity_type": entity_type,
+        "entity_id": id,
+        "status": row.status,
+        "item_count": 0,
+        "counters": {},
+        "booleans": {},
+        "lists": {},
+        "fields": row.fields,
+        "events": [],
+        "total_event_count": row.sequence_nr,
+        "sequence_nr": row.sequence_nr,
+        "@odata.id": format!("{entity_set_name}('{id}')"),
+    })
+}
+
+async fn try_load_catalog_rows(
+    state: &ServerState,
+    tenant: &TenantId,
+    entity_type: &str,
+    entity_ids: &[String],
+) -> HashMap<String, EntityCatalogRow> {
+    let Some(query_plane) = state.query_plane_store() else {
+        return HashMap::new();
+    };
+    match query_plane
+        .load_entity_catalog_rows(tenant.as_str(), entity_type, entity_ids)
+        .await
+    {
+        Ok(Some(rows)) => rows
+            .into_iter()
+            .map(|row| (row.entity_id.clone(), row))
+            .collect(),
+        Ok(None) => HashMap::new(),
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                tenant = %tenant,
+                entity_type = %entity_type,
+                "catalog fast-read failed; falling back to actor materialization"
+            );
+            HashMap::new()
+        }
+    }
+}
+
 pub(super) async fn materialize_entity_set_entities(
     state: &ServerState,
     tenant: &TenantId,
@@ -39,14 +123,27 @@ pub(super) async fn materialize_entity_set_entities(
     entity_set_name: &str,
     entity_ids: &[String],
 ) -> Vec<serde_json::Value> {
+    let mut catalog_hits: HashMap<String, EntityCatalogRow> = if catalog_fast_read_enabled() {
+        try_load_catalog_rows(state, tenant, entity_type, entity_ids).await
+    } else {
+        HashMap::new()
+    };
+
     let concurrency = entity_set_materialization_concurrency();
     stream::iter(entity_ids.iter().cloned())
         .map(|id| {
+            let catalog_row = catalog_hits.remove(&id);
             let state = state.clone();
             let tenant = tenant.clone();
             let entity_type = entity_type.to_string();
             let entity_set_name = entity_set_name.to_string();
             async move {
+                if let Some(row) = catalog_row {
+                    let mut entity =
+                        catalog_row_to_entity_body(&entity_type, &entity_set_name, row);
+                    hydrate_blob_refs_for_tenant(&state, &tenant, &mut entity).await;
+                    return Some(entity);
+                }
                 match state
                     .get_tenant_entity_state(&tenant, &entity_type, &id)
                     .await
@@ -181,10 +278,39 @@ pub(super) async fn record_entity_set_not_found(state: &ServerState, tenant: &st
 
 #[cfg(test)]
 mod tests {
-    use super::select_entity_ids_for_materialization;
+    use super::{
+        EntityCatalogRow, catalog_row_to_entity_body, select_entity_ids_for_materialization,
+    };
     use temper_odata::query::types::{
         FilterExpr, ODataValue, OrderByClause, OrderDirection, QueryOptions,
     };
+
+    #[test]
+    fn catalog_row_serializes_to_entity_state_shape() {
+        let row = EntityCatalogRow {
+            entity_id: "en-123".to_string(),
+            status: "Published".to_string(),
+            fields: serde_json::json!({"Name": "Foo", "Score": 7}),
+            sequence_nr: 14,
+        };
+        let body = catalog_row_to_entity_body("DesignLanguage", "DesignLanguages", row);
+
+        // Mirrors EntityState serialization keys so enrich_entity_response and
+        // OData clients see no difference between catalog-served and actor-served bodies.
+        assert_eq!(body["entity_type"], "DesignLanguage");
+        assert_eq!(body["entity_id"], "en-123");
+        assert_eq!(body["status"], "Published");
+        assert_eq!(body["sequence_nr"], 14);
+        assert_eq!(body["total_event_count"], 14);
+        assert_eq!(body["item_count"], 0);
+        assert_eq!(body["counters"], serde_json::json!({}));
+        assert_eq!(body["booleans"], serde_json::json!({}));
+        assert_eq!(body["lists"], serde_json::json!({}));
+        assert_eq!(body["events"], serde_json::json!([]));
+        assert_eq!(body["fields"]["Name"], "Foo");
+        assert_eq!(body["fields"]["Score"], 7);
+        assert_eq!(body["@odata.id"], "DesignLanguages('en-123')");
+    }
 
     #[test]
     fn default_pagination_applies_when_top_missing_and_no_filter_orderby() {

--- a/crates/temper-server/src/storage/mod.rs
+++ b/crates/temper-server/src/storage/mod.rs
@@ -246,6 +246,19 @@ pub struct QueryProjectionFieldsRow {
     pub fields: BTreeMap<String, Option<String>>,
 }
 
+/// Full entity row materialized from the durable query-plane catalog.
+///
+/// Returned by [`QueryPlaneStore::load_entity_catalog_rows`] and used by the
+/// OData read path to skip actor hydration on collection materialization.
+#[derive(Clone, Debug, PartialEq)]
+pub struct EntityCatalogRow {
+    pub entity_id: String,
+    pub status: String,
+    /// Raw JSONB fields object as written by the projection upsert.
+    pub fields: serde_json::Value,
+    pub sequence_nr: u64,
+}
+
 /// Backend-neutral row for one granular Cedar policy entry.
 #[derive(Clone, Debug)]
 pub struct PolicyStoreRow {
@@ -321,6 +334,22 @@ pub trait QueryPlaneStore: Send + Sync {
         entity_ids: &[String],
         field_names: &[&str],
     ) -> Result<Option<Vec<QueryProjectionFieldsRow>>, PersistenceError>;
+
+    /// Batch-fetch full entity rows from the projection catalog.
+    ///
+    /// Returns a partial result — only rows present in the catalog. IDs not
+    /// in the catalog (yet to be projected, or never written) are simply
+    /// absent from the response. Returns `None` if the backend cannot
+    /// service catalog reads at all (used by routers that fan out per
+    /// tenant; default impl returns `Some(vec![])`).
+    async fn load_entity_catalog_rows(
+        &self,
+        _tenant: &str,
+        _entity_type: &str,
+        _entity_ids: &[String],
+    ) -> Result<Option<Vec<EntityCatalogRow>>, PersistenceError> {
+        Ok(None)
+    }
 
     async fn projected_entity_counts_by_tenant(
         &self,
@@ -2147,6 +2176,28 @@ impl QueryPlaneStore for PostgresEventStore {
             })
     }
 
+    async fn load_entity_catalog_rows(
+        &self,
+        tenant: &str,
+        entity_type: &str,
+        entity_ids: &[String],
+    ) -> Result<Option<Vec<EntityCatalogRow>>, PersistenceError> {
+        self.load_entity_catalog_rows_pg(tenant, entity_type, entity_ids)
+            .await
+            .map(|rows| {
+                Some(
+                    rows.into_iter()
+                        .map(|row| EntityCatalogRow {
+                            entity_id: row.entity_id,
+                            status: row.status,
+                            fields: row.fields,
+                            sequence_nr: row.sequence_nr,
+                        })
+                        .collect(),
+                )
+            })
+    }
+
     async fn projected_entity_counts_by_tenant(
         &self,
     ) -> Result<Option<Vec<(String, u64)>>, PersistenceError> {
@@ -2209,6 +2260,28 @@ impl QueryPlaneStore for TursoEventStore {
                             entity_id: row.entity_id,
                             status: row.status,
                             fields: row.fields,
+                        })
+                        .collect(),
+                )
+            })
+    }
+
+    async fn load_entity_catalog_rows(
+        &self,
+        tenant: &str,
+        entity_type: &str,
+        entity_ids: &[String],
+    ) -> Result<Option<Vec<EntityCatalogRow>>, PersistenceError> {
+        TursoEventStore::load_entity_catalog_rows(self, tenant, entity_type, entity_ids)
+            .await
+            .map(|rows| {
+                Some(
+                    rows.into_iter()
+                        .map(|row| EntityCatalogRow {
+                            entity_id: row.entity_id,
+                            status: row.status,
+                            fields: row.fields,
+                            sequence_nr: row.sequence_nr,
                         })
                         .collect(),
                 )
@@ -2284,6 +2357,29 @@ impl QueryPlaneStore for TenantStoreRouter {
                             entity_id: row.entity_id,
                             status: row.status,
                             fields: row.fields,
+                        })
+                        .collect(),
+                )
+            })
+    }
+
+    async fn load_entity_catalog_rows(
+        &self,
+        tenant: &str,
+        entity_type: &str,
+        entity_ids: &[String],
+    ) -> Result<Option<Vec<EntityCatalogRow>>, PersistenceError> {
+        let store = self.store_for_tenant(tenant).await?;
+        TursoEventStore::load_entity_catalog_rows(&store, tenant, entity_type, entity_ids)
+            .await
+            .map(|rows| {
+                Some(
+                    rows.into_iter()
+                        .map(|row| EntityCatalogRow {
+                            entity_id: row.entity_id,
+                            status: row.status,
+                            fields: row.fields,
+                            sequence_nr: row.sequence_nr,
                         })
                         .collect(),
                 )

--- a/crates/temper-store-postgres/src/platform.rs
+++ b/crates/temper-store-postgres/src/platform.rs
@@ -127,6 +127,15 @@ pub struct PostgresProjectedEntityFieldsRow {
     pub fields: BTreeMap<String, Option<String>>,
 }
 
+/// One row from `entity_catalog`, with the full JSONB fields blob preserved.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PostgresEntityCatalogRow {
+    pub entity_id: String,
+    pub status: String,
+    pub fields: serde_json::Value,
+    pub sequence_nr: u64,
+}
+
 pub type PostgresSecretRow = (String, Vec<u8>, Vec<u8>);
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -505,6 +514,45 @@ impl PostgresEventStore {
         Ok(rows
             .into_iter()
             .map(|(tenant, count)| (tenant, count as u64))
+            .collect())
+    }
+
+    /// Batch-load full entity catalog rows for a list of entity IDs.
+    ///
+    /// Returns only rows that exist in the catalog. IDs without a row in the
+    /// projection are silently omitted from the result, leaving the caller
+    /// free to fall back to the actor path on a per-id basis.
+    pub async fn load_entity_catalog_rows_pg(
+        &self,
+        tenant: &str,
+        entity_type: &str,
+        entity_ids: &[String],
+    ) -> Result<Vec<crate::platform::PostgresEntityCatalogRow>, PersistenceError> {
+        if entity_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let rows: Vec<(String, String, serde_json::Value, i64)> = sqlx::query_as(
+            "SELECT entity_id, status, fields, sequence_nr \
+             FROM entity_catalog \
+             WHERE tenant = $1 AND entity_type = $2 AND entity_id = ANY($3) \
+             ORDER BY entity_id",
+        )
+        .bind(tenant)
+        .bind(entity_type)
+        .bind(entity_ids)
+        .fetch_all(self.pool())
+        .await
+        .map_err(storage_error)?;
+        Ok(rows
+            .into_iter()
+            .map(
+                |(entity_id, status, fields, seq)| crate::platform::PostgresEntityCatalogRow {
+                    entity_id,
+                    status,
+                    fields,
+                    sequence_nr: seq.max(0) as u64,
+                },
+            )
             .collect())
     }
 

--- a/crates/temper-store-turso/src/store/field_index.rs
+++ b/crates/temper-store-turso/src/store/field_index.rs
@@ -47,6 +47,15 @@ pub struct ProjectedEntityFieldsRow {
     pub fields: BTreeMap<String, Option<String>>,
 }
 
+/// One row from `entity_catalog`, with the full JSON fields blob preserved.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EntityCatalogRow {
+    pub entity_id: String,
+    pub status: String,
+    pub fields: serde_json::Value,
+    pub sequence_nr: u64,
+}
+
 impl TursoEventStore {
     /// Upsert the durable query-plane projection for a single entity.
     ///
@@ -462,6 +471,60 @@ impl TursoEventStore {
             counts.push((tenant, count.max(0) as u64));
         }
         Ok(counts)
+    }
+
+    /// Batch-load full entity catalog rows for a list of entity IDs.
+    ///
+    /// Returns only rows that exist in the catalog; missing IDs are silently
+    /// omitted. Mirrors the Postgres impl so the OData read path can stay
+    /// backend-agnostic.
+    #[instrument(skip_all, fields(
+        otel.name = "turso.load_entity_catalog_rows",
+        tenant, entity_type,
+        entity_count = entity_ids.len(),
+    ))]
+    pub async fn load_entity_catalog_rows(
+        &self,
+        tenant: &str,
+        entity_type: &str,
+        entity_ids: &[String],
+    ) -> Result<Vec<EntityCatalogRow>, PersistenceError> {
+        if entity_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let conn = self.configured_connection().await?;
+        let placeholders = std::iter::repeat_n("?", entity_ids.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "SELECT entity_id, status, fields, sequence_nr \
+             FROM entity_catalog \
+             WHERE tenant = ? AND entity_type = ? AND entity_id IN ({placeholders}) \
+             ORDER BY entity_id"
+        );
+        let mut params: Vec<libsql::Value> = Vec::with_capacity(entity_ids.len() + 2);
+        params.push(libsql::Value::Text(tenant.to_string()));
+        params.push(libsql::Value::Text(entity_type.to_string()));
+        for id in entity_ids {
+            params.push(libsql::Value::Text(id.clone()));
+        }
+        let mut rows = conn.query(&sql, params).await.map_err(storage_error)?;
+        let mut out = Vec::new();
+        while let Some(row) = rows.next().await.map_err(storage_error)? {
+            let entity_id: String = row.get(0).map_err(storage_error)?;
+            let status: String = row.get(1).map_err(storage_error)?;
+            let fields_text: String = row.get(2).map_err(storage_error)?;
+            let sequence_nr: i64 = row.get(3).map_err(storage_error)?;
+            let fields: serde_json::Value = serde_json::from_str(&fields_text)
+                .map_err(|err| PersistenceError::Storage(err.to_string()))?;
+            out.push(EntityCatalogRow {
+                entity_id,
+                status,
+                fields,
+                sequence_nr: sequence_nr.max(0) as u64,
+            });
+        }
+        Ok(out)
     }
 }
 

--- a/docs/adrs/0077-catalog-first-odata-materialization.md
+++ b/docs/adrs/0077-catalog-first-odata-materialization.md
@@ -1,0 +1,73 @@
+# ADR-0077: Catalog-first OData entity materialization
+
+- Status: Accepted
+- Date: 2026-04-30
+- Deciders: Temper core maintainers
+- Related:
+  - ADR-0076: Eliminate `ServerEventStore` enum (the abstraction that lets us add catalog-first reads without branching on backend)
+  - ADR-0074: Turso → Postgres ETL methodology (revealed the projection-not-populated gap)
+  - `crates/temper-server/src/odata/read_support.rs`
+  - `crates/temper-server/src/storage/mod.rs`
+
+## Context
+
+The OData read path on `/tdata/{EntitySet}` materializes a list response by calling `state.get_tenant_entity_state(tenant, entity_type, id)` once per result row. Each call spawns or wakes the entity actor and replays its event stream from snapshot.
+
+Production trace `9713e924e7c1e0428e2c82b5fbb1b215` (2026-04-30 18:23 UTC) on the openpaw deployment showed `GET /tdata/DesignLanguages` taking 22.14 seconds against 210 entities — a per-row median of ~700 ms with several rows above 2 s. The katagami.ai SSR awaits this call on every uncached homepage request.
+
+The platform already maintains `entity_catalog`, a wide projection upserted on every transition (`crates/temper-server/src/storage/mod.rs:2102, 2170, 2240`). Each row contains `(tenant, entity_type, entity_id, status, fields JSONB, sequence_nr, ...)`. For a list view the projection holds exactly the data the OData response needs — but the read path does not query it.
+
+This is the reason `entity_catalog` exists. The cost of per-row actor hydration is the cost of bypassing it.
+
+## Decision
+
+Add a catalog-first batch read to `materialize_entity_set_entities` in `read_support.rs`:
+
+1. Define `EntityCatalogRow` (entity_id, status, fields, sequence_nr) in `crates/temper-server/src/storage/mod.rs` as a backend-neutral type.
+2. Add `QueryPlaneStore::load_entity_catalog_rows(tenant, entity_type, entity_ids) -> Result<Option<Vec<EntityCatalogRow>>>` to the trait, with default impl `Ok(None)` so non-catalog backends opt out cleanly.
+3. Implement on `PostgresEventStore` via `SELECT entity_id, status, fields, sequence_nr FROM entity_catalog WHERE tenant=$1 AND entity_type=$2 AND entity_id = ANY($3)`.
+4. Implement on `TursoEventStore` with the equivalent `IN (?, ?, ...)` libsql query.
+5. `TenantStoreRouter` delegates per tenant.
+6. In `materialize_entity_set_entities`, when `TEMPER_ODATA_CATALOG_FAST_READ=1`:
+   - Issue one batch catalog read for the page's IDs.
+   - For each ID with a catalog hit, build the response body from the row directly.
+   - For misses (catalog stale, never written, or entity has non-empty `counters`/`booleans`/`lists` not yet projected), fall back to the existing `state.get_tenant_entity_state` path on a per-id basis.
+
+The body shape is identical to the actor's `EntityState` serialization (`status`, `fields`, `entity_type`, `entity_id`, `sequence_nr`, `total_event_count`, `item_count`, `counters`, `booleans`, `lists`, `events`) so `enrich_entity_response` and OData clients see no difference.
+
+## Why opt-in
+
+Default `TEMPER_ODATA_CATALOG_FAST_READ=false`. Reasoning:
+
+- Entity types that store state in `counters`/`booleans`/`lists` (not just `fields`) would render as empty maps when read from the catalog, since the projection schema only persists `status` + `fields`. Most temper entities don't use those collections, but the platform doesn't statically know which do.
+- A flag-controlled rollout lets operators flip the fast path on per-deployment after verifying the entities they expose don't depend on the unprojected collections.
+- Future work: extend `entity_catalog` to include the full `EntityState` JSONB (or add a parallel `entity_state_full` projection) so the flag can default on and apply universally.
+
+## Why catalog freshness is acceptable here
+
+Projection upserts happen in the same write path that appends events (`storage/mod.rs::*upsert_query_projection`), inside the same actor turn. There is no async lag. A reader sees catalog state as fresh as the actor would have served it, modulo a single in-flight transition (which the actor path also sees mid-flight). For OData reads the difference is below the threshold callers can detect.
+
+## Consequences
+
+**Positive**:
+- `GET /tdata/DesignLanguages` against the openpaw production fleet drops from 22s to one indexed Postgres query (~10–50 ms p99 expected).
+- The actor system stays cold for read-heavy workloads — fewer spawns, less mailbox pressure, less snapshot/event replay traffic.
+- Sets the precedent for moving more OData read paths (single-entity GET, navigation property expansion) to catalog reads in follow-ups.
+
+**Negative**:
+- Two divergent code paths (catalog vs actor) for materialization. Mitigated by the fallback being the *same* old code, only invoked on miss.
+- Entity types using `counters`/`booleans`/`lists` need either flag-off or the projection extension. Documented in the env-var description.
+- Adds a new SQL query per list response (one batch). Trivial cost compared to the 210-actor spawn it replaces.
+
+## Migration
+
+No data migration required for new deployments — the projection is populated on every transition since ADR-0076.
+
+For deployments that were migrated from another backend (e.g., Turso → Postgres ETL): the ETL must populate `entity_catalog` directly from `snapshots`, since migrated snapshots never replay through the live transition path. The openpaw 2026-04-30 cutover discovered this gap and backfilled `entity_catalog` (1287 rows) and `entity_field_index` (11363 rows) post-hoc; the methodology is captured in ADR-0074.
+
+## Alternatives considered
+
+- **Vercel ISR + revalidate** on katagami: caches the SSR'd HTML at the edge for N seconds. Mitigation, not a root fix; first request after revalidation still pays the 22s cost. Composes with this ADR but does not replace it.
+- **OData response caching at the openpaw layer** (e.g., `Cache-Control: s-maxage=60`): same shape — moves the cost to background revalidation but does not eliminate it.
+- **Eager actor warmup** at boot: paid once at startup but doesn't survive passivation; cold-actor cost returns after `TEMPER_ACTOR_IDLE_TIMEOUT_SECS`. Doesn't scale to tenants with many entity types.
+- **Replace `entity_catalog` JSONB with the full serialized `EntityState`**: cleaner but changes the projection write path's invariants. Deferred — the current decision keeps the schema unchanged and the fast-read opt-in.


### PR DESCRIPTION
## Summary

- Drops `GET /tdata/{EntitySet}` from O(n) actor hydrations to one batched indexed read against `entity_catalog`. Production trace on openpaw showed `/tdata/DesignLanguages` for 210 entities taking **22.1s** because the read path walked each row through `entity.get_tenant_entity_state`, paying snapshot + replay per row.
- Adds `QueryPlaneStore::load_entity_catalog_rows` (default impl returns `Ok(None)` so non-catalog backends opt out cleanly). Implemented on Postgres, Turso, and the tenant router.
- `materialize_entity_set_entities` now does one batch catalog read up front and falls back to the actor path on a per-id basis for misses.
- Gated behind `TEMPER_ODATA_CATALOG_FAST_READ=1` (default off). Entity types using counters/booleans/lists in their OData response should leave the flag off until the projection is extended.

## ADR
[ADR-0077](docs/adrs/0077-catalog-first-odata-materialization.md) documents the decision and migration story for deployments that ETL'd snapshots without populating the catalog.

## Test plan

- [x] `cargo check -p temper-store-postgres -p temper-store-turso -p temper-server` clean
- [x] `cargo test -p temper-server --lib odata` — 25 passed, 0 failed
- [x] `cargo test -p temper-store-postgres -p temper-store-turso --lib` — 43 passed, 0 failed
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] Readability ratchet — all blocking metrics OK
- [ ] Deploy to openpaw production with `TEMPER_ODATA_CATALOG_FAST_READ=1` and verify `/tdata/DesignLanguages` drops from 22s to <100ms