### PR TITLE
perf(odata): catalog-first single-entity reads (extends ADR-0077)

### DIFF
--- a/crates/temper-server/src/odata/read.rs
+++ b/crates/temper-server/src/odata/read.rs
@@ -19,6 +19,7 @@ use super::common::{
 use super::read_support::{
     materialize_entity_set_entities, odata_default_page_size, odata_max_entities,
     record_entity_set_not_found, resolve_entity_set_name, select_entity_ids_for_materialization,
+    try_load_entity_body_from_catalog,
 };
 use super::response::annotate_entity;
 use crate::blobs::hydrate_blob_refs_for_tenant;
@@ -180,21 +181,48 @@ fn resource_not_found_response(set_name: &str, key: &str) -> Response {
     .into_response()
 }
 
-async fn load_existing_entity_response(
+/// Load a single entity body for OData read handlers.
+///
+/// Tries the durable `entity_catalog` projection first (gated by the
+/// `TEMPER_ODATA_CATALOG_FAST_READ` flag). On a hit, returns a body whose
+/// shape matches the actor's serialized `EntityState` — blob refs already
+/// hydrated. On miss (flag off, no catalog row, or backend error), falls
+/// back to the actor path: validate the entity exists in the in-memory
+/// index, then load via `get_tenant_entity_state`.
+///
+/// The catalog-first path bypasses the in-memory index, so it survives
+/// cold starts and bulk-imported entities (data on disk but not yet
+/// indexed in the running process). See ADR-0077.
+async fn load_existing_entity_body(
     state: &ServerState,
     tenant: &TenantId,
     entity_type: &str,
     set_name: &str,
     key: &str,
-) -> Result<crate::EntityResponse, Response> {
+) -> Result<serde_json::Value, Response> {
+    if let Some(body) =
+        try_load_entity_body_from_catalog(state, tenant, entity_type, set_name, key).await
+    {
+        return Ok(body);
+    }
+
     if !state.entity_exists(tenant, entity_type, key) {
         return Err(resource_not_found_response(set_name, key));
     }
 
-    state
+    let response = state
         .get_tenant_entity_state(tenant, entity_type, key)
         .await
-        .map_err(|_| resource_not_found_response(set_name, key))
+        .map_err(|_| resource_not_found_response(set_name, key))?;
+    let mut body = serde_json::to_value(&response.state).unwrap_or_default();
+    hydrate_blob_refs_for_tenant(state, tenant, &mut body).await;
+    if let Some(obj) = body.as_object_mut() {
+        obj.insert(
+            "@odata.id".into(),
+            serde_json::json!(format!("{set_name}('{key}')")),
+        );
+    }
+    Ok(body)
 }
 
 async fn apply_entity_query_options(
@@ -237,9 +265,11 @@ async fn build_entity_body(
     key: &str,
     options: EntityBodyOptions<'_>,
 ) -> Result<serde_json::Value, Response> {
-    let response = load_existing_entity_response(state, tenant, entity_type, set_name, key).await?;
-    let mut state_json = serde_json::to_value(&response.state).unwrap_or_default();
-    hydrate_blob_refs_for_tenant(state, tenant, &mut state_json).await;
+    let mut state_json =
+        load_existing_entity_body(state, tenant, entity_type, set_name, key).await?;
+    if let Some(obj) = state_json.as_object_mut() {
+        obj.remove("@odata.id");
+    }
     let mut body = annotate_entity(state_json, options.context, options.odata_id);
 
     if options.enrich {
@@ -587,16 +617,20 @@ async fn handle_navigation_property(
             }
         };
 
-    let response =
-        match load_existing_entity_response(state, tenant, &parent_type, &parent_set, &parent_key)
-            .await
-        {
-            Ok(r) => r,
-            Err(resp) => return resp,
-        };
+    let parent_body = match load_existing_entity_body(
+        state,
+        tenant,
+        &parent_type,
+        &parent_set,
+        &parent_key,
+    )
+    .await
+    {
+        Ok(b) => b,
+        Err(resp) => return resp,
+    };
 
-    let mut parent_body = serde_json::to_value(&response.state).unwrap_or_default();
-    hydrate_blob_refs_for_tenant(state, tenant, &mut parent_body).await;
+    let mut parent_body = parent_body;
     let nav_opts = ExpandOptions {
         select: query_options.select.clone(),
         filter: query_options.filter.clone(),
@@ -866,10 +900,10 @@ async fn handle_stream_get(
         return resp;
     }
 
-    // 3. Get entity state
+    // 3. Get entity state (catalog-first; falls back to actor on miss).
     let entity_state =
-        match load_existing_entity_response(state, tenant, &entity_type, &set_name, &key).await {
-            Ok(resp) => serde_json::to_value(&resp.state).unwrap_or_default(),
+        match load_existing_entity_body(state, tenant, &entity_type, &set_name, &key).await {
+            Ok(body) => body,
             Err(resp) => return resp,
         };
 

--- a/crates/temper-server/src/odata/read_support.rs
+++ b/crates/temper-server/src/odata/read_support.rs
@@ -116,6 +116,34 @@ async fn try_load_catalog_rows(
     }
 }
 
+/// Try to load a single entity body from the durable `entity_catalog`.
+///
+/// Returns `Some(json)` when the catalog has a row for `(tenant, entity_type,
+/// key)` and the catalog fast-read feature flag is enabled. Returns `None`
+/// when the flag is off, the catalog has no row, or the read fails — caller
+/// is expected to fall back to actor hydration in that case.
+///
+/// The returned JSON has the same shape as the actor's serialized
+/// `EntityState` so downstream code (`enrich_entity_response`, OData
+/// clients, blob hydration) can't tell the difference.
+pub(super) async fn try_load_entity_body_from_catalog(
+    state: &ServerState,
+    tenant: &TenantId,
+    entity_type: &str,
+    entity_set_name: &str,
+    key: &str,
+) -> Option<serde_json::Value> {
+    if !catalog_fast_read_enabled() {
+        return None;
+    }
+    let ids = [key.to_string()];
+    let rows = try_load_catalog_rows(state, tenant, entity_type, &ids).await;
+    let row = rows.into_iter().next().map(|(_, r)| r)?;
+    let mut body = catalog_row_to_entity_body(entity_type, entity_set_name, row);
+    hydrate_blob_refs_for_tenant(state, tenant, &mut body).await;
+    Some(body)
+}
+
 pub(super) async fn materialize_entity_set_entities(
     state: &ServerState,
     tenant: &TenantId,
@@ -310,6 +338,54 @@ mod tests {
         assert_eq!(body["fields"]["Name"], "Foo");
         assert_eq!(body["fields"]["Score"], 7);
         assert_eq!(body["@odata.id"], "DesignLanguages('en-123')");
+    }
+
+    #[test]
+    fn catalog_row_body_matches_actor_serialization_for_single_key_path() {
+        // The single-entity read path (handle_entity → load_existing_entity_body)
+        // expects the catalog-derived body to be a drop-in replacement for the
+        // actor's serialized state. Verify the keyset matches what the actor
+        // emits so enrich_entity_response and downstream clients see no diff.
+        let row = EntityCatalogRow {
+            entity_id: "fl-019dde81".to_string(),
+            status: "Ready".to_string(),
+            fields: serde_json::json!({
+                "Id": "fl-019dde81",
+                "Status": "Ready",
+                "Name": "phosphor-command-grid.html",
+                "MimeType": "text/html",
+                "content_hash": "sha256:c74e77",
+                "size_bytes": 8427,
+            }),
+            sequence_nr: 3,
+        };
+        let body = catalog_row_to_entity_body("File", "Files", row);
+        let obj = body.as_object().expect("entity body is an object");
+        // Required EntityState top-level keys.
+        for required in [
+            "entity_type",
+            "entity_id",
+            "status",
+            "item_count",
+            "counters",
+            "booleans",
+            "lists",
+            "fields",
+            "events",
+            "total_event_count",
+            "sequence_nr",
+            "@odata.id",
+        ] {
+            assert!(
+                obj.contains_key(required),
+                "missing required key: {required}"
+            );
+        }
+        // Verify @odata.id format matches what handle_entity uses.
+        assert_eq!(body["@odata.id"], "Files('fl-019dde81')");
+        // Fields blob is preserved verbatim.
+        assert_eq!(body["fields"]["Name"], "phosphor-command-grid.html");
+        assert_eq!(body["fields"]["content_hash"], "sha256:c74e77");
     }
 
     #[test]

--- a/docs/adrs/0077-catalog-first-odata-materialization.md
+++ b/docs/adrs/0077-catalog-first-odata-materialization.md
@@ -1,11 +1,12 @@
 # ADR-0077: Catalog-first OData entity materialization
 
-- Status: Accepted
+- Status: Accepted (amended 2026-04-30 — extended to single-entity reads)
 - Date: 2026-04-30
 - Deciders: Temper core maintainers
 - Related:
   - ADR-0076: Eliminate `ServerEventStore` enum (the abstraction that lets us add catalog-first reads without branching on backend)
   - ADR-0074: Turso → Postgres ETL methodology (revealed the projection-not-populated gap)
+  - `crates/temper-server/src/odata/read.rs`
   - `crates/temper-server/src/odata/read_support.rs`
   - `crates/temper-server/src/storage/mod.rs`
 
@@ -33,6 +34,8 @@ Add a catalog-first batch read to `materialize_entity_set_entities` in `read_sup
    - For each ID with a catalog hit, build the response body from the row directly.
    - For misses (catalog stale, never written, or entity has non-empty `counters`/`booleans`/`lists` not yet projected), fall back to the existing `state.get_tenant_entity_state` path on a per-id basis.
 
+7. (Amendment, same flag) In `load_existing_entity_body` — the helper used by every single-entity OData read (`GET /tdata/EntitySet('key')`, navigation property parent loads, stream `$value` GETs) — try `try_load_entity_body_from_catalog` first. On hit, return the catalog-derived body directly. On miss, fall back to the existing `entity_exists` index check + actor hydration. This eliminates the cold-start 404 class: a process that has migrated entities on disk but hasn't yet run a list query for that entity_type can no longer reject a direct single-entity read.
+
 The body shape is identical to the actor's `EntityState` serialization (`status`, `fields`, `entity_type`, `entity_id`, `sequence_nr`, `total_event_count`, `item_count`, `counters`, `booleans`, `lists`, `events`) so `enrich_entity_response` and OData clients see no difference.
 
 ## Why opt-in
@@ -52,7 +55,7 @@ Projection upserts happen in the same write path that appends events (`storage/m
 **Positive**:
 - `GET /tdata/DesignLanguages` against the openpaw production fleet drops from 22s to one indexed Postgres query (~10–50 ms p99 expected).
 - The actor system stays cold for read-heavy workloads — fewer spawns, less mailbox pressure, less snapshot/event replay traffic.
-- Sets the precedent for moving more OData read paths (single-entity GET, navigation property expansion) to catalog reads in follow-ups.
+- Single-entity GETs (`/tdata/EntitySet('key')`), navigation parent loads, and stream `$value` reads no longer 404 on cold lookups for migrated entities. The OData read surface no longer depends on the in-memory `entity_index` for correctness.
 
 **Negative**:
 - Two divergent code paths (catalog vs actor) for materialization. Mitigated by the fallback being the *same* old code, only invoked on miss.


### PR DESCRIPTION
## Summary

Extends PR #208 (catalog-first list materialization) to single-entity OData reads. Eliminates the cold-start 404 class that broke katagami.ai detail pages after the 2026-04-30 Turso → Postgres cutover.

## Why

`handle_entity`, `handle_navigation_property` parent loads, and `handle_stream_get` all call into `load_existing_entity_response`, which:

1. Checks `state.entity_exists(...)` — looks up the in-memory `entity_index` HashMap
2. Returns `404 ResourceNotFound` if the tuple isn't there

After the migration, openpaw was restarted with an empty in-memory index. The boot-time recovery (ADR-0073) is bounded for performance and doesn't pre-load every entity_type. List queries lazy-populate the index for their type via `list_entity_ids_lazy`. **Direct single-key reads do not.** A user clicking a shared detail-page URL before the gallery loaded would 404.

## Fix

Replace `load_existing_entity_response` (returns `EntityResponse`) with `load_existing_entity_body` (returns `serde_json::Value`). Internally:

1. Try `try_load_entity_body_from_catalog` (gated by the same `TEMPER_ODATA_CATALOG_FAST_READ=1` flag).
2. On catalog hit, return a body whose shape matches the actor's serialized `EntityState` — blob refs hydrated.
3. On miss, fall back to the existing `entity_exists` + `get_tenant_entity_state` actor path.

Three call sites updated:
- `build_entity_body` (used by `handle_entity` / `handle_bound_function` / `handle_navigation_entity`)
- navigation-property parent load in `handle_navigation_property`
- `handle_stream_get`

## Test plan

- [x] `cargo check -p temper-server` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p temper-server -p temper-store-postgres -p temper-store-turso -- -D warnings` clean
- [x] `cargo test -p temper-server --lib odata` — 26 passed (1 new test added)
- [ ] Deploy to openpaw and verify katagami.ai detail pages render for migrated entities even from a fresh restart

## ADR

ADR-0077 amended with the extended scope.