### PR TITLE
fix(projection): skip oversized fields from index, propagate write failures

### DIFF
--- a/crates/temper-server/src/state/entity_ops.rs
+++ b/crates/temper-server/src/state/entity_ops.rs
@@ -658,13 +658,26 @@ impl ServerState {
                 )
                 .await
             {
-                tracing::warn!(
+                // Surface the projection failure instead of swallowing it.
+                // Previously this was a `warn` followed by `Ok(response)`,
+                // which produced HTTP 201 even when the entity wasn't
+                // discoverable via $filter — silently corrupting any caller
+                // that does write-then-read-back. Returning Err propagates
+                // up through the OData write handler to a 5xx so the client
+                // knows to retry. The event is already durable in the
+                // events table; on retry the actor's idempotent UPSERT into
+                // entity_catalog/entity_field_index will succeed (or fail
+                // again loudly).
+                tracing::error!(
                     error = %e,
                     tenant = %tenant,
                     entity_type = %entity_type,
                     entity_id = %entity_id,
                     "failed to update query projection during create"
                 );
+                return Err(format!(
+                    "query projection write failed during create: {e}"
+                ));
             }
         }
 
@@ -718,13 +731,19 @@ impl ServerState {
                 )
                 .await
             {
-                tracing::warn!(
+                // Same reasoning as create: don't ack a write that won't be
+                // visible via $filter. Propagate so OData returns 5xx and
+                // clients can retry against the idempotent upsert.
+                tracing::error!(
                     error = %e,
                     tenant = %tenant,
                     entity_type = %entity_type,
                     entity_id = %entity_id,
                     "failed to update query projection during field update"
                 );
+                return Err(format!(
+                    "query projection write failed during update: {e}"
+                ));
             }
         }
 
@@ -761,12 +780,17 @@ impl ServerState {
                     .remove_projection(tenant.as_str(), entity_type, entity_id)
                     .await
             {
-                tracing::warn!(
+                // Delete is idempotent against the projection: a stale row
+                // surviving in entity_field_index after the tombstone is a
+                // visibility leak, not data corruption. Log loudly so it's
+                // greppable but don't block the delete from completing —
+                // the actor and event journal already reflect the tombstone.
+                tracing::error!(
                     error = %e,
                     tenant = %tenant,
                     entity_type = %entity_type,
                     entity_id = %entity_id,
-                    "failed to remove query projection during delete"
+                    "failed to remove query projection during delete (stale projection row will linger until next successful upsert/delete)"
                 );
             }
 

--- a/crates/temper-server/src/state/entity_ops.rs
+++ b/crates/temper-server/src/state/entity_ops.rs
@@ -675,9 +675,7 @@ impl ServerState {
                     entity_id = %entity_id,
                     "failed to update query projection during create"
                 );
-                return Err(format!(
-                    "query projection write failed during create: {e}"
-                ));
+                return Err(format!("query projection write failed during create: {e}"));
             }
         }
 
@@ -741,9 +739,7 @@ impl ServerState {
                     entity_id = %entity_id,
                     "failed to update query projection during field update"
                 );
-                return Err(format!(
-                    "query projection write failed during update: {e}"
-                ));
+                return Err(format!("query projection write failed during update: {e}"));
             }
         }
 

--- a/crates/temper-store-postgres/src/platform.rs
+++ b/crates/temper-store-postgres/src/platform.rs
@@ -11,6 +11,13 @@ use crate::PostgresEventStore;
 
 const DISTINCT_RESOURCE_IDS_BUDGET: usize = 100;
 
+/// Maximum bytes for a single value to be indexed into `entity_field_index`.
+/// Postgres btree (idx_efi_lookup) rejects keys that exceed roughly 2704 bytes
+/// (one third of an 8KB page). Anything larger can't be indexed at all, so we
+/// skip it from the per-field index — the full value remains in
+/// `entity_catalog.fields` (jsonb, no size cap) for direct reads.
+const MAX_INDEXABLE_FIELD_VALUE_BYTES: usize = 2000;
+
 #[derive(Clone, Copy, Debug)]
 pub struct PostgresSpecVerificationUpdate<'a> {
     pub status: &'a str,
@@ -365,6 +372,22 @@ impl PostgresEventStore {
         if let Some(object) = fields.as_object() {
             for (field_name, value) in object {
                 if let Some(field_value) = scalar_field_value(value) {
+                    // Postgres btree caps an indexed key at ~2704 bytes (compressed).
+                    // Inserting a longer value into entity_field_index errors out and
+                    // poisons the whole transaction, which then rolls back the
+                    // entity_catalog upsert above too — silently dropping the entire
+                    // row from both projections. Long fields can't be btree-indexed
+                    // by Postgres in any case, so they're meaningless to $filter
+                    // pushdown; the full value is still in entity_catalog.fields
+                    // (jsonb) for read-by-id and catalog-fast-read. Skipping them
+                    // here keeps the projection consistent.
+                    // Skip silently — this is normal for any field whose
+                    // serialized scalar exceeds Postgres' btree key cap.
+                    // The full value is preserved in entity_catalog.fields
+                    // jsonb, which is what reads return.
+                    if field_value.len() > MAX_INDEXABLE_FIELD_VALUE_BYTES {
+                        continue;
+                    }
                     sqlx::query(
                         "INSERT INTO entity_field_index \
                          (tenant, entity_type, entity_id, field_name, field_value, status) \


### PR DESCRIPTION
## Summary

Two bugs producing silent SessionEntry write loss in production. POST `/tdata/SessionEntries` returned HTTP 201 but the row was missing from `entity_catalog` and `entity_field_index`, so `$filter` queries couldn't find it. Datadog confirmed 42 occurrences in 3 hours, correlating 1:1 with `WRITE LOST` errors from the openpaw `wasm-helpers` read-back-verify.

### Bug 1 — index size limit poisons the whole projection transaction

`upsert_query_projection` (`platform.rs:327-388`) writes `entity_catalog` and all `entity_field_index` rows in **one Postgres transaction**. The btree index `idx_efi_lookup` over `(tenant, entity_type, field_name, field_value)` caps a key at ~2704 bytes (compressed). Long field values (e.g., `SessionEntry.Content` carrying 8KB JSON, `DesignLanguage.philosophy/tokens` blobs) error on INSERT with:

```
index row size 2776 exceeds btree version 4 maximum 2704 for index "idx_efi_lookup"
index row requires 9224 bytes, maximum size is 8191
```

Postgres rolls back the whole transaction — including the `entity_catalog` UPSERT that ran first. Both projections lose the row.

**Fix**: skip field-index INSERTs whose value exceeds 2000 bytes (under the 2704 limit). Long fields still live in `entity_catalog.fields` jsonb (no size cap) and are returned by direct entity reads + catalog-fast-read. They were never queryable via `$filter` pushdown anyway — Postgres flat-out refuses to btree-index them.

### Bug 2 — projection failure swallowed as warn, response still 2xx

Three call sites in `entity_ops.rs` (create / update / delete) caught `upsert_projection` errors, logged `tracing::warn!`, and returned `Ok(response)`. The OData handler returned 201. Clients doing write-then-read-back saw "successful" writes that weren't visible to `$filter`, producing runaway sessions, orphan `parent_entry_id` chains, and the `WRITE LOST` instrumentation we already shipped in `wasm-helpers::create_session_entry`.

**Fix**:
- create / update: propagate the projection error so OData returns 5xx. The events table is already durable; on retry the idempotent UPSERT lands the projection (or fails again loudly).
- delete: stale projection rows after a successful tombstone are a visibility leak, not corruption. Upgraded to `tracing::error!` but kept the success path so the delete still completes.

Together these eliminate the write-loss class entirely. After the size-skip fix the projection should never fail for size reasons; if any other failure mode (pool exhaustion, etc.) shows up, propagation makes it loud instead of silent.

## Test plan
- [x] `cargo build --release -p temper-store-postgres -p temper-server` — clean
- [ ] Deploy to openpaw production and verify the `failed to update query projection` warn/error log volume drops to ~zero
- [ ] Verify `WRITE LOST` errors from `wasm-helpers::create_session_entry` stop appearing
- [ ] Send a long-Content tool_result through Discord and confirm the SessionEntry is queryable via `\$filter=SessionId eq … and EntryId eq …`

🤖 Generated with [Claude Code](https://claude.com/claude-code)