### PR TITLE
[codex] authorize outbound WASM streaming host calls

### DIFF
--- a/crates/temper-wasm/src/authorized_host.rs
+++ b/crates/temper-wasm/src/authorized_host.rs
@@ -192,6 +192,81 @@ impl WasmHost for AuthorizedWasmHost {
         }
     }
 
+    async fn http_stream_begin_outbound(
+        &self,
+        request: crate::http_stream::HttpRequestHead,
+    ) -> Result<crate::http_stream::HttpStreamHandles, String> {
+        let domain = extract_domain(&request.url);
+        match self
+            .gate
+            .authorize_http_call(domain, &request.method, &request.url, &self.ctx)
+        {
+            WasmAuthzDecision::Allow => self.inner.http_stream_begin_outbound(request).await,
+            WasmAuthzDecision::Deny(reason) => {
+                tracing::warn!(
+                    tenant = %self.ctx.tenant,
+                    module = %self.ctx.module_name,
+                    entity_type = %self.ctx.entity_type,
+                    trigger_action = %self.ctx.trigger_action,
+                    domain = %domain,
+                    http_method = %request.method,
+                    reason = %reason,
+                    "WASM host authorization denied outbound streaming HTTP call"
+                );
+                Err(format!(
+                    "authorization denied for http_stream_begin_outbound to {domain}: {reason}"
+                ))
+            }
+        }
+    }
+
+    async fn http_stream_read(
+        &self,
+        handle: crate::http_stream::StreamHandle,
+    ) -> Result<Vec<u8>, crate::http_stream::StreamError> {
+        self.inner.http_stream_read(handle).await
+    }
+
+    async fn http_stream_read_bounded(
+        &self,
+        handle: crate::http_stream::StreamHandle,
+        max_bytes: usize,
+    ) -> Result<Vec<u8>, crate::http_stream::StreamError> {
+        self.inner.http_stream_read_bounded(handle, max_bytes).await
+    }
+
+    async fn http_stream_try_write(
+        &self,
+        handle: crate::http_stream::StreamHandle,
+        chunk: Vec<u8>,
+    ) -> Result<usize, crate::http_stream::StreamError> {
+        self.inner.http_stream_try_write(handle, chunk).await
+    }
+
+    async fn http_stream_close(
+        &self,
+        handle: crate::http_stream::StreamHandle,
+    ) -> Result<(), crate::http_stream::StreamError> {
+        self.inner.http_stream_close(handle).await
+    }
+
+    async fn http_stream_response_head(
+        &self,
+        response_body: crate::http_stream::StreamHandle,
+    ) -> Result<crate::http_stream::HttpResponseHead, String> {
+        self.inner.http_stream_response_head(response_body).await
+    }
+
+    async fn http_stream_send_response_head(
+        &self,
+        response_body: crate::http_stream::StreamHandle,
+        head: crate::http_stream::HttpResponseHead,
+    ) -> Result<(), crate::http_stream::StreamError> {
+        self.inner
+            .http_stream_send_response_head(response_body, head)
+            .await
+    }
+
     fn get_secret(&self, key: &str) -> Result<String, String> {
         match self.gate.authorize_secret_access(key, &self.ctx) {
             WasmAuthzDecision::Allow => self.inner.get_secret(key),

--- a/crates/temper-wasm/src/host_trait.rs
+++ b/crates/temper-wasm/src/host_trait.rs
@@ -1284,6 +1284,7 @@ impl WasmHost for ProductionWasmHost {
         request: crate::http_stream::HttpRequestHead,
     ) -> Result<crate::http_stream::HttpStreamHandles, String> {
         use futures_util::StreamExt;
+        use tracing::Instrument;
 
         let exchange = self.http_streams.open_outbound_exchange().await;
         let guest = exchange.guest_handles();
@@ -1292,6 +1293,18 @@ impl WasmHost for ProductionWasmHost {
         let head_tx = exchange.bridge_head_sender;
         let streams = self.http_streams.clone();
         let client = self.client.clone();
+        let (filtered_headers, span_hints) = split_span_hint_headers(&request.headers);
+        let span = tracing::info_span!(
+            "wasm.host.http_stream",
+            otel.name = "wasm.host.http_stream",
+            http.method = %request.method,
+            http.url = %telemetry_url(&request.url),
+            header_count = filtered_headers.len() as u64,
+            status_code = tracing::field::Empty,
+            response_bytes = tracing::field::Empty,
+            duration_ms = tracing::field::Empty,
+        );
+        apply_span_hints(&span, &span_hints);
 
         // Build the request head before moving into the task so we
         // can surface malformed-method errors synchronously.
@@ -1304,63 +1317,83 @@ impl WasmHost for ProductionWasmHost {
             other => return Err(format!("unsupported HTTP method: {other}")),
         };
         let mut builder = builder;
-        for (k, v) in &request.headers {
+        for (k, v) in &filtered_headers {
             builder = builder.header(k.as_str(), v.as_str());
         }
+        if !filtered_headers
+            .iter()
+            .any(|(k, _)| k.eq_ignore_ascii_case("traceparent"))
+            && let Some(traceparent) = current_traceparent_header(&span, self.trace_id.as_deref())
+        {
+            builder = builder.header("traceparent", traceparent);
+        }
 
-        tokio::spawn(async move {
-            // Pull request body chunks from the registry; wrap as a
-            // Stream<Item = Result<Bytes, _>> for reqwest.
-            let req_streams = streams.clone();
-            let body_stream = async_stream::stream! {
-                loop {
-                    match req_streams.read(bridge_req).await {
-                        Ok(chunk) if chunk.is_empty() => break, // EOF
-                        Ok(chunk) => yield Ok::<_, std::io::Error>(bytes::Bytes::from(chunk)),
+        tokio::spawn(
+            async move {
+                let started = Instant::now();
+                // Pull request body chunks from the registry; wrap as a
+                // Stream<Item = Result<Bytes, _>> for reqwest.
+                let req_streams = streams.clone();
+                let body_stream = async_stream::stream! {
+                    loop {
+                        match req_streams.read(bridge_req).await {
+                            Ok(chunk) if chunk.is_empty() => break, // EOF
+                            Ok(chunk) => yield Ok::<_, std::io::Error>(bytes::Bytes::from(chunk)),
+                            Err(_) => break,
+                        }
+                    }
+                };
+                let req_body = reqwest::Body::wrap_stream(body_stream);
+
+                let send_result = builder.body(req_body).send().await;
+                let resp = match send_result {
+                    Ok(r) => r,
+                    Err(e) => {
+                        tracing::Span::current().record("status_code", 0u64);
+                        tracing::Span::current()
+                            .record("duration_ms", started.elapsed().as_millis() as u64);
+                        let _ = head_tx.send(crate::http_stream::HttpResponseHead {
+                            status: 0,
+                            headers: vec![("x-temper-stream-error".into(), format!("{e}"))],
+                        });
+                        let _ = streams.close(bridge_resp).await;
+                        return;
+                    }
+                };
+
+                let status = resp.status().as_u16();
+                tracing::Span::current().record("status_code", status);
+                let headers: Vec<(String, String)> = resp
+                    .headers()
+                    .iter()
+                    .filter_map(|(k, v)| {
+                        v.to_str()
+                            .ok()
+                            .map(|s| (k.as_str().to_string(), s.to_string()))
+                    })
+                    .collect();
+                let _ = head_tx.send(crate::http_stream::HttpResponseHead { status, headers });
+
+                let mut body_stream = resp.bytes_stream();
+                let mut response_bytes = 0u64;
+                while let Some(chunk) = body_stream.next().await {
+                    match chunk {
+                        Ok(bytes) => {
+                            response_bytes += bytes.len() as u64;
+                            if streams.write(bridge_resp, bytes.to_vec()).await.is_err() {
+                                break; // guest hung up
+                            }
+                        }
                         Err(_) => break,
                     }
                 }
-            };
-            let req_body = reqwest::Body::wrap_stream(body_stream);
-
-            let send_result = builder.body(req_body).send().await;
-            let resp = match send_result {
-                Ok(r) => r,
-                Err(e) => {
-                    let _ = head_tx.send(crate::http_stream::HttpResponseHead {
-                        status: 0,
-                        headers: vec![("x-temper-stream-error".into(), format!("{e}"))],
-                    });
-                    let _ = streams.close(bridge_resp).await;
-                    return;
-                }
-            };
-
-            let status = resp.status().as_u16();
-            let headers: Vec<(String, String)> = resp
-                .headers()
-                .iter()
-                .filter_map(|(k, v)| {
-                    v.to_str()
-                        .ok()
-                        .map(|s| (k.as_str().to_string(), s.to_string()))
-                })
-                .collect();
-            let _ = head_tx.send(crate::http_stream::HttpResponseHead { status, headers });
-
-            let mut body_stream = resp.bytes_stream();
-            while let Some(chunk) = body_stream.next().await {
-                match chunk {
-                    Ok(bytes) => {
-                        if streams.write(bridge_resp, bytes.to_vec()).await.is_err() {
-                            break; // guest hung up
-                        }
-                    }
-                    Err(_) => break,
-                }
+                tracing::Span::current().record("response_bytes", response_bytes);
+                tracing::Span::current()
+                    .record("duration_ms", started.elapsed().as_millis() as u64);
+                let _ = streams.close(bridge_resp).await;
             }
-            let _ = streams.close(bridge_resp).await;
-        });
+            .instrument(span),
+        );
 
         Ok(guest)
     }

--- a/crates/temper-wasm/tests/authorized_host_streaming.rs
+++ b/crates/temper-wasm/tests/authorized_host_streaming.rs
@@ -1,0 +1,222 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use temper_wasm::http_stream::{
+    HttpRequestHead, HttpResponseHead, HttpStreamHandles, StreamError, StreamHandle,
+};
+use temper_wasm::{
+    AuthorizedWasmHost, WasmAuthzContext, WasmAuthzDecision, WasmAuthzGate, WasmHost,
+};
+
+struct DenyAllGate;
+
+impl WasmAuthzGate for DenyAllGate {
+    fn authorize_http_call(
+        &self,
+        _domain: &str,
+        _method: &str,
+        _url: &str,
+        _ctx: &WasmAuthzContext,
+    ) -> WasmAuthzDecision {
+        WasmAuthzDecision::Deny("denied by policy".into())
+    }
+
+    fn authorize_secret_access(&self, _key: &str, _ctx: &WasmAuthzContext) -> WasmAuthzDecision {
+        WasmAuthzDecision::Deny("denied by policy".into())
+    }
+}
+
+struct AllowAllGate;
+
+impl WasmAuthzGate for AllowAllGate {
+    fn authorize_http_call(
+        &self,
+        _domain: &str,
+        _method: &str,
+        _url: &str,
+        _ctx: &WasmAuthzContext,
+    ) -> WasmAuthzDecision {
+        WasmAuthzDecision::Allow
+    }
+
+    fn authorize_secret_access(&self, _key: &str, _ctx: &WasmAuthzContext) -> WasmAuthzDecision {
+        WasmAuthzDecision::Allow
+    }
+}
+
+#[derive(Default)]
+struct RecordingStreamHost {
+    begin_requests: Mutex<Vec<HttpRequestHead>>,
+    read_calls: Mutex<Vec<StreamHandle>>,
+    try_write_calls: Mutex<Vec<(StreamHandle, Vec<u8>)>>,
+    close_calls: Mutex<Vec<StreamHandle>>,
+    response_head_calls: Mutex<Vec<StreamHandle>>,
+}
+
+#[async_trait]
+impl WasmHost for RecordingStreamHost {
+    async fn http_call(
+        &self,
+        _method: &str,
+        _url: &str,
+        _headers: &[(String, String)],
+        _body: &str,
+    ) -> Result<(u16, String), String> {
+        Ok((200, String::new()))
+    }
+
+    fn get_secret(&self, _key: &str) -> Result<String, String> {
+        Ok(String::new())
+    }
+
+    async fn http_call_binary(
+        &self,
+        _method: &str,
+        _url: &str,
+        _headers: &[(String, String)],
+        _body: &[u8],
+    ) -> Result<(u16, Vec<u8>), String> {
+        Ok((200, Vec::new()))
+    }
+
+    fn log(&self, _level: &str, _message: &str) {}
+
+    async fn http_stream_begin_outbound(
+        &self,
+        request: HttpRequestHead,
+    ) -> Result<HttpStreamHandles, String> {
+        self.begin_requests.lock().unwrap().push(request);
+        Ok(HttpStreamHandles {
+            request_body: StreamHandle(11),
+            response_body: StreamHandle(12),
+        })
+    }
+
+    async fn http_stream_read(&self, handle: StreamHandle) -> Result<Vec<u8>, StreamError> {
+        self.read_calls.lock().unwrap().push(handle);
+        Ok(Vec::new())
+    }
+
+    async fn http_stream_read_bounded(
+        &self,
+        handle: StreamHandle,
+        _max_bytes: usize,
+    ) -> Result<Vec<u8>, StreamError> {
+        self.read_calls.lock().unwrap().push(handle);
+        Ok(b"chunk".to_vec())
+    }
+
+    async fn http_stream_try_write(
+        &self,
+        handle: StreamHandle,
+        chunk: Vec<u8>,
+    ) -> Result<usize, StreamError> {
+        self.try_write_calls
+            .lock()
+            .unwrap()
+            .push((handle, chunk.clone()));
+        Ok(chunk.len())
+    }
+
+    async fn http_stream_close(&self, handle: StreamHandle) -> Result<(), StreamError> {
+        self.close_calls.lock().unwrap().push(handle);
+        Ok(())
+    }
+
+    async fn http_stream_response_head(
+        &self,
+        response_body: StreamHandle,
+    ) -> Result<HttpResponseHead, String> {
+        self.response_head_calls.lock().unwrap().push(response_body);
+        Ok(HttpResponseHead {
+            status: 200,
+            headers: vec![("content-type".into(), "text/event-stream".into())],
+        })
+    }
+}
+
+fn test_ctx() -> WasmAuthzContext {
+    WasmAuthzContext {
+        tenant: "test-tenant".into(),
+        module_name: "provider_caller".into(),
+        agent_id: Some("agent-1".into()),
+        session_id: None,
+        entity_type: "SessionTurn".into(),
+        trigger_action: "PreparedContextReady".into(),
+    }
+}
+
+#[tokio::test]
+async fn deny_gate_blocks_http_stream_begin_outbound() {
+    let inner = Arc::new(RecordingStreamHost::default());
+    let gate = Arc::new(DenyAllGate);
+    let host = AuthorizedWasmHost::new(inner.clone(), gate, test_ctx());
+
+    let result = host
+        .http_stream_begin_outbound(HttpRequestHead {
+            method: "POST".into(),
+            url: "https://api.openai.com/v1/responses".into(),
+            headers: vec![],
+        })
+        .await;
+
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("authorization denied"));
+    assert!(inner.begin_requests.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn allow_gate_delegates_http_stream_methods() {
+    let inner = Arc::new(RecordingStreamHost::default());
+    let gate = Arc::new(AllowAllGate);
+    let host = AuthorizedWasmHost::new(inner.clone(), gate, test_ctx());
+
+    let handles = host
+        .http_stream_begin_outbound(HttpRequestHead {
+            method: "POST".into(),
+            url: "https://api.openai.com/v1/responses".into(),
+            headers: vec![("accept".into(), "text/event-stream".into())],
+        })
+        .await
+        .expect("stream begin should delegate");
+
+    assert_eq!(handles.request_body, StreamHandle(11));
+    assert_eq!(handles.response_body, StreamHandle(12));
+    assert_eq!(
+        inner.begin_requests.lock().unwrap()[0].url,
+        "https://api.openai.com/v1/responses"
+    );
+
+    let written = host
+        .http_stream_try_write(handles.request_body, b"body".to_vec())
+        .await
+        .expect("stream write should delegate");
+    assert_eq!(written, 4);
+
+    let head = host
+        .http_stream_response_head(handles.response_body)
+        .await
+        .expect("response head should delegate");
+    assert_eq!(head.status, 200);
+
+    let chunk = host
+        .http_stream_read_bounded(handles.response_body, 16)
+        .await
+        .expect("stream read should delegate");
+    assert_eq!(chunk, b"chunk");
+
+    host.http_stream_close(handles.response_body)
+        .await
+        .expect("stream close should delegate");
+
+    assert_eq!(
+        inner.try_write_calls.lock().unwrap()[0],
+        (StreamHandle(11), b"body".to_vec())
+    );
+    assert_eq!(
+        inner.response_head_calls.lock().unwrap()[0],
+        StreamHandle(12)
+    );
+    assert_eq!(inner.read_calls.lock().unwrap()[0], StreamHandle(12));
+    assert_eq!(inner.close_calls.lock().unwrap()[0], StreamHandle(12));
+}

--- a/crates/temper-wasm/tests/http_stream_outbound.rs
+++ b/crates/temper-wasm/tests/http_stream_outbound.rs
@@ -28,9 +28,25 @@ async fn echo_handler(req: Request) -> impl IntoResponse {
     Body::from_stream(out_stream)
 }
 
+/// Axum handler that reports which headers arrived upstream.
+async fn header_echo_handler(req: Request) -> impl IntoResponse {
+    let span_hint_present = req.headers().contains_key("x-temper-span-name")
+        || req
+            .headers()
+            .contains_key("x-temper-span-attr-gen_ai.system");
+    let regular_header = req
+        .headers()
+        .get("x-regular")
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("");
+    format!("span_hint_present={span_hint_present};regular={regular_header}")
+}
+
 /// Bind axum on 127.0.0.1:0 (random port), return the bound addr.
 async fn spawn_echo_server() -> String {
-    let app = Router::new().route("/echo", post(echo_handler));
+    let app = Router::new()
+        .route("/echo", post(echo_handler))
+        .route("/headers", post(header_echo_handler));
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     tokio::spawn(async move {
@@ -80,6 +96,47 @@ async fn outbound_streaming_echoes_request_body() {
 
     let expected: Vec<u8> = chunks.into_iter().flat_map(|c| c.to_vec()).collect();
     assert_eq!(echoed, expected, "echoed bytes must match sent");
+}
+
+#[tokio::test]
+async fn outbound_streaming_strips_temper_span_hint_headers() {
+    let base = spawn_echo_server().await;
+    let host = Arc::new(ProductionWasmHost::new(BTreeMap::new()));
+
+    let handles = host
+        .http_stream_begin_outbound(HttpRequestHead {
+            method: "POST".into(),
+            url: format!("{base}/headers"),
+            headers: vec![
+                ("x-regular".into(), "kept".into()),
+                ("X-Temper-Span-Name".into(), "tool.llm_call.test".into()),
+                (
+                    "X-Temper-Span-Attr-gen_ai.system".into(),
+                    "test-provider".into(),
+                ),
+            ],
+        })
+        .await
+        .unwrap();
+
+    host.http_stream_close(handles.request_body).await.unwrap();
+    let head = host
+        .http_stream_response_head(handles.response_body)
+        .await
+        .unwrap();
+    assert_eq!(head.status, 200);
+
+    let mut body = Vec::new();
+    loop {
+        let chunk = host.http_stream_read(handles.response_body).await.unwrap();
+        if chunk.is_empty() {
+            break;
+        }
+        body.extend_from_slice(&chunk);
+    }
+    let body = String::from_utf8(body).unwrap();
+
+    assert_eq!(body, "span_hint_present=false;regular=kept");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Authorizes `http_stream_begin_outbound` through `AuthorizedWasmHost` using the existing outbound HTTP policy gate.
- Delegates stream read, bounded read, write, close, response-head read, and response-head send operations to the wrapped host.
- Keeps streaming span hint headers out of upstream HTTP requests while preserving regular headers and stream telemetry.
- Moves streaming authorization coverage into an integration test so `authorized_host.rs` stays below the readability ratchet threshold.

## Validation

- `cargo test -p temper-wasm http_stream -- --nocapture`
- `cargo test -p temper-wasm --test authorized_host_streaming -- --nocapture`
- `cargo test -p temper-wasm --test http_stream_outbound -- --nocapture`
- Pre-push gates: rustfmt, clippy, readability ratchet, full test suite, doctests
