### PR TITLE
ci: split DST smoke coverage from PR runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [main, staging]
   push:
     branches: [main, staging]
+  schedule:
+    - cron: "17 8 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -58,6 +65,7 @@ jobs:
   check:
     name: Compile & Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
 
@@ -88,6 +96,35 @@ jobs:
 
       - name: cargo clippy --workspace --all-targets
         run: cargo clippy --workspace --all-targets -- -D warnings
+
+  # ─────────────────────────────────────────────────────
+  # Gate 1b: Bench compile (non-PR events only)
+  # ─────────────────────────────────────────────────────
+  bench-build:
+    name: Bench Build
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libz3-dev
+
+      - name: Install pinned Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-cargo-bench-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-bench-
 
       - name: cargo bench --workspace --no-run
         run: cargo bench --workspace --no-run
@@ -188,8 +225,7 @@ jobs:
   test:
     name: Tests
     runs-on: ubuntu-latest
-    needs: check
-    timeout-minutes: 360
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:
@@ -222,8 +258,53 @@ jobs:
             (cd "wasm-modules/$module" && cargo build --target wasm32-unknown-unknown --release)
           done
 
-      - name: cargo test --workspace
-        run: cargo test --workspace
+      - name: cargo test --workspace -- --skip dst_
+        run: cargo test --workspace -- --skip dst_
+
+  # ─────────────────────────────────────────────────────
+  # Gate 3b: DST/platform coverage (matrixed)
+  # ─────────────────────────────────────────────────────
+  dst-platform-tests:
+    name: DST/Platform Tests (${{ matrix.suite }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - suite: core
+            command: cargo test -p temper-server --test dst_concurrency_retry --test dst_hotswap --test dst_lifecycle --test dst_multi_tenant --test dst_persistence
+          - suite: platform-boot
+            command: cargo test -p temper-server --test dst_platform_boot
+          - suite: platform-consistency
+            command: cargo test -p temper-server --test dst_platform_cedar --test dst_platform_index --test dst_platform_rollback
+          - suite: platform-random
+            command: cargo test -p temper-server --test dst_platform_random
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libz3-dev
+
+      - name: Install pinned Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-cargo-dst-${{ matrix.suite }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-dst-${{ matrix.suite }}-
+
+      - name: cargo test DST/platform suite
+        env:
+          TEMPER_DST_RANDOM_MODE: ${{ matrix.suite == 'platform-random' && github.event_name == 'pull_request' && 'smoke' || 'full' }}
+        run: ${{ matrix.command }}
 
   # ─────────────────────────────────────────────────────
   # Gate 4: Spec verification (minutes)
@@ -231,7 +312,7 @@ jobs:
   verify-specs:
     name: Spec Verification (L0-L3)
     runs-on: ubuntu-latest
-    needs: check
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 

--- a/crates/temper-server/tests/dst_platform_random.rs
+++ b/crates/temper-server/tests/dst_platform_random.rs
@@ -18,6 +18,41 @@ use common::workload_gen::{WorkloadGenerator, WorkloadOp};
 
 // ── Helpers ──────────────────────────────────────────────────────────────
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RandomMode {
+    Full,
+    Smoke,
+}
+
+impl RandomMode {
+    fn current() -> Self {
+        // determinism-ok: CI mode selection happens before deterministic seeds are installed.
+        match std::env::var("TEMPER_DST_RANDOM_MODE") {
+            Ok(value) if value == "full" => Self::Full,
+            Ok(value) if value == "smoke" => Self::Smoke,
+            Ok(value) => {
+                panic!("TEMPER_DST_RANDOM_MODE must be 'full' or 'smoke', got {value:?}")
+            }
+            Err(std::env::VarError::NotPresent) => Self::Full,
+            Err(err) => panic!("TEMPER_DST_RANDOM_MODE is not valid UTF-8: {err}"),
+        }
+    }
+
+    fn seeds(self, full: u64, smoke: u64) -> u64 {
+        match self {
+            Self::Full => full,
+            Self::Smoke => smoke,
+        }
+    }
+
+    fn ops(self, full: usize, smoke: usize) -> usize {
+        match self {
+            Self::Full => full,
+            Self::Smoke => smoke,
+        }
+    }
+}
+
 /// Run a full workload: generate `num_ops` operations and execute them.
 ///
 /// When `check_invariants_inline` is true, `CheckInvariants` ops actually
@@ -114,11 +149,15 @@ async fn run_workload(
 
 #[tokio::test]
 async fn dst_random_workload_no_faults() {
-    for seed in 0..100 {
+    let mode = RandomMode::current();
+    let seeds = mode.seeds(100, 10);
+    let ops = mode.ops(50, 20);
+
+    for seed in 0..seeds {
         let (_guard, _clock, _id_gen) = install_deterministic_context(seed);
         let mut harness = SimPlatformHarness::no_faults(seed);
 
-        run_workload(&mut harness, seed, 50, true).await;
+        run_workload(&mut harness, seed, ops, true).await;
 
         // Final invariant check after all ops.
         assert_boot_invariants(&harness)
@@ -136,7 +175,11 @@ async fn dst_random_workload_no_faults() {
 
 #[tokio::test]
 async fn dst_random_workload_event_faults() {
-    for seed in 0..50 {
+    let mode = RandomMode::current();
+    let seeds = mode.seeds(50, 5);
+    let ops = mode.ops(30, 15);
+
+    for seed in 0..seeds {
         let (_guard, _clock, _id_gen) = install_deterministic_context(seed);
         let mut harness = SimPlatformHarness::new(
             seed,
@@ -144,7 +187,7 @@ async fn dst_random_workload_event_faults() {
             SimPlatformFaultConfig::none(),
         );
 
-        run_workload(&mut harness, seed, 30, true).await;
+        run_workload(&mut harness, seed, ops, true).await;
 
         // Disable faults before restart so restore succeeds cleanly.
         let prev_event = harness.sim_event_store.disable_faults();
@@ -166,7 +209,11 @@ async fn dst_random_workload_event_faults() {
 
 #[tokio::test]
 async fn dst_random_workload_platform_faults() {
-    for seed in 0..50 {
+    let mode = RandomMode::current();
+    let seeds = mode.seeds(50, 5);
+    let ops = mode.ops(30, 15);
+
+    for seed in 0..seeds {
         let (_guard, _clock, _id_gen) = install_deterministic_context(seed);
         let mut harness = SimPlatformHarness::new(
             seed,
@@ -174,7 +221,7 @@ async fn dst_random_workload_platform_faults() {
             SimPlatformFaultConfig::heavy(),
         );
 
-        run_workload(&mut harness, seed, 30, true).await;
+        run_workload(&mut harness, seed, ops, true).await;
 
         // Disable faults before restart so restore succeeds cleanly.
         let prev_plat = harness.sim_platform_store.disable_faults();
@@ -196,7 +243,11 @@ async fn dst_random_workload_platform_faults() {
 
 #[tokio::test]
 async fn dst_random_workload_combined_faults() {
-    for seed in 0..50 {
+    let mode = RandomMode::current();
+    let seeds = mode.seeds(50, 5);
+    let ops = mode.ops(30, 15);
+
+    for seed in 0..seeds {
         let (_guard, _clock, _id_gen) = install_deterministic_context(seed);
         let mut harness = SimPlatformHarness::new(
             seed,
@@ -204,7 +255,7 @@ async fn dst_random_workload_combined_faults() {
             SimPlatformFaultConfig::heavy(),
         );
 
-        run_workload(&mut harness, seed, 30, true).await;
+        run_workload(&mut harness, seed, ops, true).await;
 
         // Disable ALL faults before restart so restore succeeds cleanly.
         let prev_event = harness.sim_event_store.disable_faults();
@@ -228,14 +279,18 @@ async fn dst_random_workload_combined_faults() {
 
 #[tokio::test]
 async fn dst_random_workload_determinism() {
-    for seed in 0..10 {
+    let mode = RandomMode::current();
+    let seeds = mode.seeds(10, 3);
+    let ops = mode.ops(50, 20);
+
+    for seed in 0..seeds {
         let mut results = Vec::new();
 
         for _run in 0..2 {
             let (_guard, _clock, _id_gen) = install_deterministic_context(seed);
             let mut harness = SimPlatformHarness::no_faults(seed);
 
-            run_workload(&mut harness, seed, 50, false).await;
+            run_workload(&mut harness, seed, ops, false).await;
 
             // Restart so state is fully rebuilt from durable stores.
             harness.restart().await;

--- a/docs/adrs/0079-ci-pr-smoke-and-dst-matrix.md
+++ b/docs/adrs/0079-ci-pr-smoke-and-dst-matrix.md
@@ -1,0 +1,112 @@
+# ADR-0079: CI PR Smoke and DST Matrix
+
+- Status: Proposed
+- Date: 2026-05-04
+- Deciders: Temper core maintainers
+- Related:
+  - `.github/workflows/ci.yml`
+  - `crates/temper-server/tests/dst_platform_random.rs`
+
+## Context
+
+Temper's pull request CI currently serializes expensive phases behind compile and lint,
+and the compile job also builds all benchmarks. That keeps pull request feedback slow
+even when test and spec verification work could run independently.
+
+The `dst_platform_random.rs` suite intentionally runs many deterministic seeds. That is
+valuable coverage, but it is also one of the slowest PR gates. We still need exhaustive
+random coverage before code lands on protected long-lived branches and during unattended
+nightly runs.
+
+## Decision
+
+PR CI will cancel superseded runs with a workflow concurrency group based on pull request
+number or branch ref. The workflow will also support a nightly schedule and manual
+dispatch so full checks can be run without opening a PR.
+
+Compile and lint will stop building benchmark targets. Benchmark compilation moves into
+a separate `Bench Build` job that runs only on non-PR events.
+
+Regular workspace tests and spec verification will no longer depend on compile and lint,
+allowing independent jobs to run in parallel. The regular test job will skip DST tests
+with `cargo test --workspace -- --skip dst_`.
+
+DST and platform tests will move into a dedicated matrix with stable suite names:
+
+- `core`
+- `platform-boot`
+- `platform-consistency`
+- `platform-random`
+
+The `platform-random` suite will read `TEMPER_DST_RANDOM_MODE=smoke|full`. The default
+mode is `full`, preserving the current seed and operation budgets. Pull request CI will
+set `smoke` only for the `platform-random` matrix row. Pushes to `main` and `staging`,
+nightly runs, and manual dispatches will use full mode.
+
+## Rollout Plan
+
+1. **Phase 0 (Immediate)** - Ship the workflow split, benchmark relocation, DST matrix,
+   and `dst_platform_random.rs` mode switch.
+2. **Phase 1 (Follow-up)** - Update branch protection required checks if exact status
+   contexts are configured, adding the new DST matrix contexts while preserving `Tests`.
+3. **Phase 2 (Validation)** - Confirm PR runs use smoke mode and post-merge or nightly
+   runs use full random coverage.
+
+## Readiness Gates
+
+- Workflow YAML parses successfully.
+- `cargo fmt --check` passes.
+- Non-DST workspace tests pass with `cargo test --workspace -- --skip dst_`.
+- `TEMPER_DST_RANDOM_MODE=smoke cargo test -p temper-server --test dst_platform_random`
+  passes.
+- The stable DST matrix commands pass locally or in CI.
+
+## Consequences
+
+### Positive
+
+- Pull requests receive faster, parallel feedback.
+- Superseded CI runs are canceled instead of consuming runner time.
+- Benchmark compilation no longer blocks PR validation.
+- Exhaustive random DST coverage remains available on long-lived branches and nightly runs.
+
+### Negative
+
+- PRs no longer run every `dst_platform_random.rs` seed by default.
+- Branch protection may need a one-time required-check update for the new DST matrix
+  contexts.
+
+### Risks
+
+- A seed-only random regression could escape PR smoke coverage. This is mitigated by
+  preserving full deterministic seed coverage on pushes to `main` and `staging`, nightly
+  schedule runs, and manual workflow dispatch.
+
+### DST Compliance
+
+- Full mode preserves the existing deterministic seed ranges and operation counts.
+- Smoke mode uses deterministic prefixes of the same seed ranges and does not introduce
+  wall clock time, random OS entropy, threads, or unordered iteration.
+
+## Non-Goals
+
+- Changing branch protection settings from code.
+- Reducing full random DST coverage on `main`, `staging`, nightly, or manual workflow
+  runs.
+- Changing test semantics outside CI scheduling and random test budgets.
+
+## Alternatives Considered
+
+1. **Keep all DST tests inside `Tests`** - Rejected because DST-heavy suites would
+   continue to dominate the primary test job and make required status attribution less
+   clear.
+2. **Lower full random budgets globally** - Rejected because it would permanently reduce
+   coverage instead of limiting the tradeoff to PR feedback loops.
+3. **Use ad hoc `--ignore` flags** - Rejected because it would make local and CI behavior
+   less explicit than a named environment mode with a clear default.
+
+## Rollback Policy
+
+Revert the workflow job split and remove the `TEMPER_DST_RANDOM_MODE` handling from
+`dst_platform_random.rs`. Because full mode is the default, removing the PR smoke
+environment variable also restores full random coverage immediately.


### PR DESCRIPTION
## Summary
- add ADR-0079 for the PR smoke and DST matrix CI strategy
- cancel superseded CI runs and add nightly/manual workflow triggers
- move benchmark compilation out of PR CI into a non-PR `Bench Build` job
- let regular tests and spec verification run independently from compile/lint
- split server DST/platform tests into a dedicated matrix
- add `TEMPER_DST_RANDOM_MODE=smoke|full` for `dst_platform_random`, defaulting to full

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml parse ok"'`
- `cargo fmt --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --skip dst_`
- `TEMPER_DST_RANDOM_MODE=smoke cargo test -p temper-server --test dst_platform_random`
- `cargo test -p temper-server --test dst_concurrency_retry --test dst_hotswap --test dst_lifecycle --test dst_multi_tenant --test dst_persistence`
- `cargo test -p temper-server --test dst_platform_boot --test dst_platform_cedar --test dst_platform_index --test dst_platform_rollback`
- pre-push gate passed: `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, readability ratchet, `cargo test --workspace`

## Notes
- PR `DST/Platform Tests (platform-random)` uses smoke mode.
- Pushes to `main`/`staging`, nightly runs, and manual dispatches keep full mode.
- Branch protection may need the new `DST/Platform Tests (...)` contexts added if required checks are pinned exactly.
