### PR TITLE
fix: replace stale hot-uploaded wasm on bundle updates

### DIFF
--- a/crates/temper-platform/src/os_apps/app_catalog.rs
+++ b/crates/temper-platform/src/os_apps/app_catalog.rs
@@ -1,0 +1,300 @@
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::{OnceLock, RwLock};
+
+use temper_spec::automaton;
+
+use super::{
+    AppEntry, StartupInstallMode, extract_description, find_ioa_files, read_app_guide,
+    read_app_manifest,
+};
+
+pub(crate) struct AppCatalog {
+    /// Directory containing app bundles.
+    pub(super) apps_dir: PathBuf,
+    /// Additional app directories merged into the catalog.
+    additional_dirs: Vec<PathBuf>,
+    /// Catalog entries (lightweight metadata).
+    pub(super) entries: Vec<AppEntry>,
+    /// Mapping from app name to its directory path on disk.
+    pub(super) paths: BTreeMap<String, PathBuf>,
+}
+
+/// Global catalog, initialized on first access.
+static CATALOG: OnceLock<RwLock<AppCatalog>> = OnceLock::new();
+
+/// Get or initialize the global app catalog.
+pub fn catalog() -> &'static RwLock<AppCatalog> {
+    CATALOG.get_or_init(|| RwLock::new(AppCatalog::discover()))
+}
+
+/// Override the OS apps directory. Must be called before any catalog access.
+///
+/// If the catalog was already initialized, it is replaced.
+pub fn set_os_apps_dir(dir: PathBuf) {
+    let new_catalog = AppCatalog::from_dir(dir);
+    match CATALOG.get() {
+        Some(lock) => {
+            *lock.write().unwrap() = new_catalog; // ci-ok: infallible lock
+        }
+        None => {
+            let _ = CATALOG.set(RwLock::new(new_catalog));
+        }
+    }
+}
+
+/// Add an additional directory of apps to the catalog.
+///
+/// Scans the directory and merges discovered apps into the existing catalog.
+/// Apps in the new directory do NOT replace existing apps with the same name.
+/// Use this to register reference apps or project-specific apps alongside
+/// the main os-apps directory.
+pub fn add_os_apps_dir(dir: PathBuf) {
+    let additional = AppCatalog::from_dir(dir);
+    let cat = catalog();
+    let mut lock = cat.write().unwrap(); // ci-ok: infallible lock
+    lock.merge_catalog(additional);
+}
+
+/// Re-scan the OS apps directory and refresh the catalog.
+///
+/// Call this after modifying app files on disk to pick up changes
+/// without restarting the server.
+pub fn reload_os_apps() {
+    let cat = catalog().read().unwrap(); // ci-ok: infallible lock
+    let dir = cat.apps_dir.clone();
+    let additional_dirs: Vec<PathBuf> = cat
+        .additional_dirs
+        .iter()
+        .filter(|dir| dir.is_dir())
+        .cloned()
+        .collect();
+    drop(cat);
+    let mut new = AppCatalog::from_dir(dir);
+    for additional_dir in additional_dirs {
+        new.merge_dir(additional_dir);
+    }
+    *catalog().write().unwrap() = new; // ci-ok: infallible lock
+}
+
+/// Backward-compatible alias.
+pub fn set_skills_dir(dir: PathBuf) {
+    set_os_apps_dir(dir);
+}
+
+/// Backward-compatible alias.
+pub fn reload_skills() {
+    reload_os_apps();
+}
+
+/// List OS apps that belong to the default startup surface.
+pub fn list_startup_os_apps() -> Vec<String> {
+    let cat = match catalog().read() {
+        Ok(cat) => cat,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    let mut apps: Vec<String> = cat
+        .entries
+        .iter()
+        .filter(|entry| entry.startup_install == StartupInstallMode::Core)
+        .map(|entry| entry.name.clone())
+        .collect();
+    apps.sort();
+    apps
+}
+
+impl AppCatalog {
+    /// Discover the apps directory and scan it.
+    fn discover() -> Self {
+        // Priority 1: TEMPER_OS_APPS_DIR env var.
+        if let Ok(dir) = std::env::var("TEMPER_OS_APPS_DIR") {
+            // determinism-ok: env var read at startup for configuration
+            let path = PathBuf::from(dir);
+            if path.is_dir() {
+                tracing::info!(
+                    "Loading OS apps from TEMPER_OS_APPS_DIR: {}",
+                    path.display()
+                );
+                return Self::from_dir(path);
+            }
+        }
+
+        // Priority 1b: legacy TEMPER_SKILLS_DIR env var.
+        if let Ok(dir) = std::env::var("TEMPER_SKILLS_DIR") {
+            let path = PathBuf::from(dir);
+            if path.is_dir() {
+                tracing::info!(
+                    "Loading OS apps from legacy TEMPER_SKILLS_DIR: {}",
+                    path.display()
+                );
+                return Self::from_dir(path);
+            }
+        }
+
+        // Priority 2: Relative to this crate's source (works in dev and cargo test).
+        let compile_time_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("os-apps");
+        if compile_time_dir.is_dir() {
+            let canonical = compile_time_dir
+                .canonicalize()
+                .unwrap_or(compile_time_dir.clone());
+            tracing::info!("Loading OS apps from workspace: {}", canonical.display());
+            return Self::from_dir(canonical);
+        }
+
+        // Priority 3: ./os-apps/ relative to CWD.
+        let cwd_dir = PathBuf::from("os-apps");
+        if cwd_dir.is_dir() {
+            let canonical = cwd_dir.canonicalize().unwrap_or(cwd_dir.clone());
+            tracing::info!("Loading OS apps from CWD: {}", canonical.display());
+            return Self::from_dir(canonical);
+        }
+
+        // Priority 4: ./skills/ (legacy fallback).
+        let legacy_cwd_dir = PathBuf::from("skills");
+        if legacy_cwd_dir.is_dir() {
+            let canonical = legacy_cwd_dir
+                .canonicalize()
+                .unwrap_or(legacy_cwd_dir.clone());
+            tracing::info!(
+                "Loading OS apps from legacy CWD skills/: {}",
+                canonical.display()
+            );
+            return Self::from_dir(canonical);
+        }
+
+        tracing::warn!(
+            "No os-apps directory found. Set TEMPER_OS_APPS_DIR (or legacy TEMPER_SKILLS_DIR)."
+        );
+        Self {
+            apps_dir: PathBuf::new(),
+            additional_dirs: Vec::new(),
+            entries: Vec::new(),
+            paths: BTreeMap::new(),
+        }
+    }
+
+    fn from_dir(dir: PathBuf) -> Self {
+        let mut entries = Vec::new();
+        let mut paths = BTreeMap::new();
+
+        let read_dir = match std::fs::read_dir(&dir) {
+            Ok(rd) => rd,
+            Err(e) => {
+                tracing::warn!("Failed to read apps directory {}: {e}", dir.display());
+                return Self {
+                    apps_dir: dir,
+                    additional_dirs: Vec::new(),
+                    entries,
+                    paths,
+                };
+            }
+        };
+
+        let mut app_dirs: Vec<_> = read_dir
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().is_dir())
+            .collect();
+        app_dirs.sort_by_key(|e| e.file_name());
+
+        for entry in app_dirs {
+            let app_dir = entry.path();
+            let dir_name = entry.file_name().to_string_lossy().to_string();
+
+            let manifest = match read_app_manifest(&app_dir) {
+                Some(m) => m,
+                None => {
+                    tracing::warn!(
+                        app = %dir_name,
+                        path = %app_dir.display(),
+                        "Skipping app directory — missing required app.toml"
+                    );
+                    continue;
+                }
+            };
+
+            let app_guide = match read_app_guide(&app_dir) {
+                Some(guide) => Some(guide),
+                None => {
+                    tracing::warn!(
+                        app = %manifest.name,
+                        path = %app_dir.display(),
+                        "Skipping app — missing required APP.md"
+                    );
+                    continue;
+                }
+            };
+
+            let app_name = manifest.name.clone();
+            let ioa_files = find_ioa_files(&app_dir);
+            let entity_types: Vec<String> = ioa_files
+                .iter()
+                .filter_map(|(_, ioa_path)| {
+                    let source = std::fs::read_to_string(ioa_path).ok()?;
+                    let parsed = automaton::parse_automaton(&source).ok()?;
+                    Some(parsed.automaton.name)
+                })
+                .collect();
+
+            let description = if !manifest.description.is_empty() {
+                manifest.description.clone()
+            } else {
+                app_guide
+                    .as_ref()
+                    .and_then(|guide| extract_description(guide))
+                    .unwrap_or_else(|| format!("App: {app_name}"))
+            };
+
+            let version = manifest.version.clone();
+            let startup_install = manifest.startup_install;
+            let dependencies = manifest.dependencies.clone();
+
+            let app_path = app_dir.clone();
+            paths.insert(app_name.clone(), app_path.clone());
+            if dir_name != app_name {
+                paths.entry(dir_name).or_insert(app_path);
+            }
+            entries.push(AppEntry {
+                name: app_name,
+                description,
+                entity_types,
+                version,
+                startup_install,
+                app_guide,
+                dependencies,
+            });
+        }
+
+        Self {
+            apps_dir: dir,
+            additional_dirs: Vec::new(),
+            entries,
+            paths,
+        }
+    }
+
+    fn merge_dir(&mut self, dir: PathBuf) {
+        let additional = AppCatalog::from_dir(dir);
+        self.merge_catalog(additional);
+    }
+
+    fn merge_catalog(&mut self, additional: AppCatalog) {
+        if additional.apps_dir.is_dir() && !self.additional_dirs.contains(&additional.apps_dir) {
+            self.additional_dirs.push(additional.apps_dir.clone());
+        }
+        for (name, path) in additional.paths {
+            self.paths.entry(name).or_insert(path);
+        }
+        for entry in additional.entries {
+            if !self
+                .entries
+                .iter()
+                .any(|existing| existing.name == entry.name)
+            {
+                self.entries.push(entry);
+            }
+        }
+    }
+}

--- a/crates/temper-platform/src/os_apps/mod.rs
+++ b/crates/temper-platform/src/os_apps/mod.rs
@@ -11,7 +11,6 @@
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
-use std::sync::{OnceLock, RwLock};
 
 use serde::Serialize;
 use sha2::{Digest, Sha256};
@@ -23,11 +22,17 @@ use crate::bootstrap;
 use crate::state::PlatformState;
 
 mod agent_bootstrap;
+mod app_catalog;
 pub mod git_sources;
 mod reconcile;
 mod runtime_heal;
 mod system_files;
 mod types;
+pub(super) use app_catalog::catalog;
+pub use app_catalog::{
+    add_os_apps_dir, list_startup_os_apps, reload_os_apps, reload_skills, set_os_apps_dir,
+    set_skills_dir,
+};
 pub use reconcile::{os_app_bundle_digest, reconcile_os_app, resolve_os_app_install_order};
 pub(crate) use runtime_heal::{
     restore_app_specs_from_matching_digest, tenant_has_ready_app_specs_for_bundle,
@@ -149,276 +154,6 @@ pub type SkillBundle = AppBundle;
 // Backward-compatible type aliases.
 pub type OsAppEntry = AppEntry;
 pub type OsAppBundle = AppBundle;
-
-// ── App Catalog (disk-loaded, cached) ───────────────────────────────
-
-/// In-memory cache of discovered apps.
-struct AppCatalog {
-    /// Directory containing app bundles.
-    apps_dir: PathBuf,
-    /// Catalog entries (lightweight metadata).
-    entries: Vec<AppEntry>,
-    /// Mapping from app name to its directory path on disk.
-    paths: BTreeMap<String, PathBuf>,
-}
-
-/// Global catalog, initialized on first access.
-static CATALOG: OnceLock<RwLock<AppCatalog>> = OnceLock::new();
-
-/// Get or initialize the global app catalog.
-fn catalog() -> &'static RwLock<AppCatalog> {
-    CATALOG.get_or_init(|| RwLock::new(AppCatalog::discover()))
-}
-
-/// Override the OS apps directory. Must be called before any catalog access.
-///
-/// If the catalog was already initialized, it is replaced.
-pub fn set_os_apps_dir(dir: PathBuf) {
-    let new_catalog = AppCatalog::from_dir(dir);
-    match CATALOG.get() {
-        Some(lock) => {
-            *lock.write().unwrap() = new_catalog; // ci-ok: infallible lock
-        }
-        None => {
-            let _ = CATALOG.set(RwLock::new(new_catalog));
-        }
-    }
-}
-
-/// Add an additional directory of apps to the catalog.
-///
-/// Scans the directory and merges discovered apps into the existing catalog.
-/// Apps in the new directory do NOT replace existing apps with the same name.
-/// Use this to register reference apps or project-specific apps alongside
-/// the main os-apps directory.
-pub fn add_os_apps_dir(dir: PathBuf) {
-    let additional = AppCatalog::from_dir(dir);
-    let cat = catalog();
-    let mut lock = cat.write().unwrap(); // ci-ok: infallible lock
-    for (name, path) in additional.paths {
-        lock.paths.entry(name.clone()).or_insert(path);
-    }
-    for entry in additional.entries {
-        if !lock.entries.iter().any(|e| e.name == entry.name) {
-            lock.entries.push(entry);
-        }
-    }
-}
-
-/// Re-scan the OS apps directory and refresh the catalog.
-///
-/// Call this after modifying app files on disk to pick up changes
-/// without restarting the server.
-pub fn reload_os_apps() {
-    let cat = catalog().read().unwrap(); // ci-ok: infallible lock
-    let dir = cat.apps_dir.clone();
-    drop(cat);
-    let new = AppCatalog::from_dir(dir);
-    *catalog().write().unwrap() = new; // ci-ok: infallible lock
-}
-
-/// Backward-compatible alias.
-pub fn set_skills_dir(dir: PathBuf) {
-    set_os_apps_dir(dir);
-}
-
-/// Backward-compatible alias.
-pub fn reload_skills() {
-    reload_os_apps();
-}
-
-/// List OS apps that belong to the default startup surface.
-pub fn list_startup_os_apps() -> Vec<String> {
-    let cat = match catalog().read() {
-        Ok(cat) => cat,
-        Err(poisoned) => poisoned.into_inner(),
-    };
-    let mut apps: Vec<String> = cat
-        .entries
-        .iter()
-        .filter(|entry| entry.startup_install == StartupInstallMode::Core)
-        .map(|entry| entry.name.clone())
-        .collect();
-    apps.sort();
-    apps
-}
-
-impl AppCatalog {
-    /// Discover the apps directory and scan it.
-    fn discover() -> Self {
-        // Priority 1: TEMPER_OS_APPS_DIR env var.
-        if let Ok(dir) = std::env::var("TEMPER_OS_APPS_DIR") {
-            // determinism-ok: env var read at startup for configuration
-            let path = PathBuf::from(dir);
-            if path.is_dir() {
-                tracing::info!(
-                    "Loading OS apps from TEMPER_OS_APPS_DIR: {}",
-                    path.display()
-                );
-                return Self::from_dir(path);
-            }
-        }
-
-        // Priority 1b: legacy TEMPER_SKILLS_DIR env var.
-        if let Ok(dir) = std::env::var("TEMPER_SKILLS_DIR") {
-            let path = PathBuf::from(dir);
-            if path.is_dir() {
-                tracing::info!(
-                    "Loading OS apps from legacy TEMPER_SKILLS_DIR: {}",
-                    path.display()
-                );
-                return Self::from_dir(path);
-            }
-        }
-
-        // Priority 2: Relative to this crate's source (works in dev and cargo test).
-        let compile_time_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("..")
-            .join("..")
-            .join("os-apps");
-        if compile_time_dir.is_dir() {
-            let canonical = compile_time_dir
-                .canonicalize()
-                .unwrap_or(compile_time_dir.clone());
-            tracing::info!("Loading OS apps from workspace: {}", canonical.display());
-            return Self::from_dir(canonical);
-        }
-
-        // Priority 3: ./os-apps/ relative to CWD.
-        let cwd_dir = PathBuf::from("os-apps");
-        if cwd_dir.is_dir() {
-            let canonical = cwd_dir.canonicalize().unwrap_or(cwd_dir.clone());
-            tracing::info!("Loading OS apps from CWD: {}", canonical.display());
-            return Self::from_dir(canonical);
-        }
-
-        // Priority 4: ./skills/ (legacy fallback).
-        let legacy_cwd_dir = PathBuf::from("skills");
-        if legacy_cwd_dir.is_dir() {
-            let canonical = legacy_cwd_dir
-                .canonicalize()
-                .unwrap_or(legacy_cwd_dir.clone());
-            tracing::info!(
-                "Loading OS apps from legacy CWD skills/: {}",
-                canonical.display()
-            );
-            return Self::from_dir(canonical);
-        }
-
-        tracing::warn!(
-            "No os-apps directory found. Set TEMPER_OS_APPS_DIR (or legacy TEMPER_SKILLS_DIR)."
-        );
-        Self {
-            apps_dir: PathBuf::new(),
-            entries: Vec::new(),
-            paths: BTreeMap::new(),
-        }
-    }
-
-    /// Build catalog from a specific directory.
-    fn from_dir(dir: PathBuf) -> Self {
-        let mut entries = Vec::new();
-        let mut paths = BTreeMap::new();
-
-        let read_dir = match std::fs::read_dir(&dir) {
-            Ok(rd) => rd,
-            Err(e) => {
-                tracing::warn!("Failed to read apps directory {}: {e}", dir.display());
-                return Self {
-                    apps_dir: dir,
-                    entries,
-                    paths,
-                };
-            }
-        };
-
-        let mut app_dirs: Vec<_> = read_dir
-            .filter_map(|e| e.ok())
-            .filter(|e| e.path().is_dir())
-            .collect();
-        // Deterministic ordering.
-        app_dirs.sort_by_key(|e| e.file_name());
-
-        for entry in app_dirs {
-            let app_dir = entry.path();
-            let dir_name = entry.file_name().to_string_lossy().to_string();
-
-            // app.toml is required — skip directories without it.
-            let manifest = match read_app_manifest(&app_dir) {
-                Some(m) => m,
-                None => {
-                    tracing::warn!(
-                        app = %dir_name,
-                        path = %app_dir.display(),
-                        "Skipping app directory — missing required app.toml"
-                    );
-                    continue;
-                }
-            };
-
-            // APP.md is required — skip directories without it.
-            let app_guide = match read_app_guide(&app_dir) {
-                Some(guide) => Some(guide),
-                None => {
-                    tracing::warn!(
-                        app = %manifest.name,
-                        path = %app_dir.display(),
-                        "Skipping app — missing required APP.md"
-                    );
-                    continue;
-                }
-            };
-
-            let app_name = manifest.name.clone();
-
-            // Scan for IOA specs to determine entity types.
-            let ioa_files = find_ioa_files(&app_dir);
-            let entity_types: Vec<String> = ioa_files
-                .iter()
-                .filter_map(|(_, ioa_path)| {
-                    let source = std::fs::read_to_string(ioa_path).ok()?;
-                    let parsed = automaton::parse_automaton(&source).ok()?;
-                    Some(parsed.automaton.name)
-                })
-                .collect();
-
-            // Description from manifest (required), fallback to APP.md extract.
-            let description = if !manifest.description.is_empty() {
-                manifest.description.clone()
-            } else {
-                app_guide
-                    .as_ref()
-                    .and_then(|guide| extract_description(guide))
-                    .unwrap_or_else(|| format!("App: {app_name}"))
-            };
-
-            let version = manifest.version.clone();
-            let startup_install = manifest.startup_install;
-            let dependencies = manifest.dependencies.clone();
-
-            let app_path = app_dir.clone();
-            paths.insert(app_name.clone(), app_path.clone());
-            if dir_name != app_name {
-                paths.entry(dir_name).or_insert(app_path);
-            }
-            entries.push(AppEntry {
-                name: app_name,
-                description,
-                entity_types,
-                version,
-                startup_install,
-                app_guide,
-                dependencies,
-            });
-        }
-
-        Self {
-            apps_dir: dir,
-            entries,
-            paths,
-        }
-    }
-}
 
 /// Find all IOA spec files in an app directory.
 ///
@@ -1227,6 +962,11 @@ pub(super) async fn install_os_app_with_plan(
         )
     })?;
     let tenant_id = TenantId::new(tenant);
+    let replace_uploaded_wasm = if plan.wasm && !bundle.wasm_modules.is_empty() {
+        should_replace_uploaded_wasm_for_bundle_reconcile(state, tenant, app_name, &bundle).await
+    } else {
+        false
+    };
 
     if bundle.adrs.is_empty() {
         tracing::warn!(
@@ -1493,10 +1233,9 @@ pub(super) async fn install_os_app_with_plan(
     //
     // Source-aware preservation: if a (tenant, module) row in the durable store
     // has source='upload' (i.e., a hot upload from `POST /api/wasm/modules/{name}`),
-    // skip every step for that module — upsert (preserved by the store anyway),
-    // registry overwrite (would clobber the upload hash loaded by boot recovery),
-    // and engine warm-up (would cache bundled bytes the registry shouldn't pick).
-    // Without this guard, hot uploads silently revert on every restart.
+    // preserve it across same-bundle restarts. When the installed app metadata
+    // says the bundled WASM digest changed, the bundle is a newer deployment and
+    // must replace stale uploads so production executes the shipped module.
     let mut wasm_registered = Vec::new();
     let mut wasm_skipped = Vec::new();
     let mut wasm_failures = Vec::new();
@@ -1521,22 +1260,44 @@ pub(super) async fn install_os_app_with_plan(
                 && existing_source == "upload"
                 && existing_hash != &hash
             {
-                tracing::info!(
-                    tenant,
-                    module = %module_name,
-                    bundled_hash = %hash,
-                    upload_hash = %existing_hash,
-                    "Skipping bundled install: hot-uploaded module preserved"
-                );
-                wasm_skipped.push(module_name.clone());
-                continue;
+                if replace_uploaded_wasm {
+                    tracing::info!(
+                        tenant,
+                        module = %module_name,
+                        bundled_hash = %hash,
+                        upload_hash = %existing_hash,
+                        "Replacing hot-uploaded WASM module: bundled app WASM digest changed"
+                    );
+                } else {
+                    tracing::info!(
+                        tenant,
+                        module = %module_name,
+                        bundled_hash = %hash,
+                        upload_hash = %existing_hash,
+                        "Skipping bundled install: hot-uploaded module preserved"
+                    );
+                    wasm_skipped.push(module_name.clone());
+                    continue;
+                }
             }
 
-            if let Err(e) = state
-                .server
-                .upsert_wasm_module(tenant, module_name, wasm_bytes, &hash, "bundled")
-                .await
-            {
+            let upsert_result = if replace_uploaded_wasm {
+                state
+                    .server
+                    .upsert_bundled_wasm_module_replacing_upload(
+                        tenant,
+                        module_name,
+                        wasm_bytes,
+                        &hash,
+                    )
+                    .await
+            } else {
+                state
+                    .server
+                    .upsert_wasm_module(tenant, module_name, wasm_bytes, &hash, "bundled")
+                    .await
+            };
+            if let Err(e) = upsert_result {
                 tracing::warn!(
                     tenant,
                     module = %module_name,
@@ -1662,6 +1423,36 @@ pub(super) async fn install_os_app_with_plan(
         adrs_bootstrapped,
         seed_instances: seed_created,
     })
+}
+
+async fn should_replace_uploaded_wasm_for_bundle_reconcile(
+    state: &PlatformState,
+    tenant: &str,
+    app_name: &str,
+    bundle: &AppBundle,
+) -> bool {
+    let Some(ps) = state
+        .server
+        .storage_stack
+        .as_ref()
+        .and_then(|stack| stack.platform.clone())
+    else {
+        return false;
+    };
+    let digest = reconcile::digest_app_bundle(app_name, bundle);
+    match ps.get_installed_app(tenant, app_name).await {
+        Ok(Some(record)) => record.wasm_digest != digest.wasm_digest,
+        Ok(None) => false,
+        Err(error) => {
+            tracing::warn!(
+                tenant,
+                app = %app_name,
+                error = %error,
+                "Failed to read OS app metadata while deciding WASM hot-upload replacement"
+            );
+            false
+        }
+    }
 }
 
 /// Backward-compatible alias.

--- a/crates/temper-platform/src/os_apps/mod_test.rs
+++ b/crates/temper-platform/src/os_apps/mod_test.rs
@@ -1497,6 +1497,242 @@ version = "1.0.0"
     let _ = fs::remove_dir_all(&temp_dir);
 }
 
+#[tokio::test]
+async fn test_reconcile_os_app_replaces_hot_upload_when_bundled_wasm_digest_changes() {
+    use temper_store_turso::TursoEventStore;
+
+    let app_root = std::env::temp_dir().join(format!(
+        "temper-os-apps-wasm-digest-reconcile-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let app_dir = app_root.join("wasm-digest-app");
+    let module_dir = app_dir
+        .join("wasm")
+        .join("echo")
+        .join("target")
+        .join("wasm32-unknown-unknown")
+        .join("release");
+    fs::create_dir_all(&module_dir).unwrap();
+    fs::write(
+        app_dir.join("app.toml"),
+        r#"name = "wasm-digest-app"
+description = "Temporary WASM reconcile test app"
+version = "0.1.0"
+
+[[wasm_modules]]
+name = "echo"
+criticality = "app-required"
+startup_loading = "lazy"
+"#,
+    )
+    .unwrap();
+    fs::write(
+        app_dir.join("APP.md"),
+        "# WASM Digest App\n\nTemporary WASM reconcile test app.\n",
+    )
+    .unwrap();
+
+    let echo_wasm = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../temper-wasm/tests/fixtures/echo_integration.wasm");
+    let reader_wasm = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../temper-wasm/tests/fixtures/sdk_context_reader.wasm");
+    fs::copy(&echo_wasm, module_dir.join("echo.wasm")).unwrap();
+    add_os_apps_dir(app_root.clone());
+
+    let db_path = format!(
+        "/tmp/temper-wasm-digest-reconcile-{}.db",
+        uuid::Uuid::new_v4()
+    );
+    let db_url = format!("file:{db_path}");
+    let turso = TursoEventStore::new(&db_url, None).await.unwrap();
+    let mut state = PlatformState::new(None);
+    state
+        .server
+        .set_storage_stack(temper_server::StorageStack::from_turso(turso));
+    state.server.data_dir = std::path::PathBuf::from(format!(
+        "/tmp/temper-wasm-digest-reconcile-{}-data",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&state.server.data_dir).unwrap();
+    let tenant_name = "test-wasm-digest-reconcile";
+    let tenant = TenantId::new(tenant_name);
+
+    install_os_app(&state, tenant_name, "wasm-digest-app")
+        .await
+        .expect("initial app install should succeed");
+
+    let uploaded_bytes = b"stale hot-uploaded module bytes".to_vec();
+    let uploaded_hash = temper_wasm::WasmEngine::hash_module(&uploaded_bytes);
+    state
+        .server
+        .upsert_wasm_module(
+            tenant_name,
+            "echo",
+            &uploaded_bytes,
+            &uploaded_hash,
+            "upload",
+        )
+        .await
+        .expect("hot upload should persist");
+    state
+        .server
+        .wasm_module_registry
+        .write()
+        .unwrap()
+        .register(&tenant, "echo", &uploaded_hash);
+
+    fs::copy(&reader_wasm, module_dir.join("echo.wasm")).unwrap();
+    add_os_apps_dir(app_root.clone());
+    let expected_bundled_bytes = fs::read(module_dir.join("echo.wasm")).unwrap();
+    let expected_bundled_hash = temper_wasm::WasmEngine::hash_module(&expected_bundled_bytes);
+
+    let result = reconcile_os_app(&state, tenant_name, "wasm-digest-app")
+        .await
+        .expect("reconcile should succeed");
+    let OsAppReconcileResult::Installed { install, .. } = result else {
+        panic!("changed WASM digest should reinstall the app bundle");
+    };
+    assert_eq!(install.wasm_modules, vec!["echo".to_string()]);
+
+    {
+        let registry = state.server.wasm_module_registry.read().unwrap();
+        assert_eq!(
+            registry.get_hash(&tenant, "echo"),
+            Some(expected_bundled_hash.as_str())
+        );
+    }
+
+    let module_sources = state
+        .server
+        .load_wasm_module_sources(tenant_name)
+        .await
+        .expect("load wasm module sources");
+    assert_eq!(
+        module_sources.get("echo"),
+        Some(&(expected_bundled_hash, "bundled".to_string()))
+    );
+
+    let _ = fs::remove_dir_all(&app_root);
+    let _ = fs::remove_dir_all(&state.server.data_dir);
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(format!("{db_path}-wal"));
+    let _ = std::fs::remove_file(format!("{db_path}-shm"));
+}
+
+#[tokio::test]
+async fn test_reconcile_os_app_preserves_hot_upload_when_bundled_wasm_digest_unchanged() {
+    use temper_store_turso::TursoEventStore;
+
+    let app_root = std::env::temp_dir().join(format!(
+        "temper-os-apps-wasm-preserve-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let app_dir = app_root.join("wasm-preserve-app");
+    let module_dir = app_dir
+        .join("wasm")
+        .join("echo")
+        .join("target")
+        .join("wasm32-unknown-unknown")
+        .join("release");
+    fs::create_dir_all(&module_dir).unwrap();
+    fs::write(
+        app_dir.join("app.toml"),
+        r#"name = "wasm-preserve-app"
+description = "Temporary WASM preserve test app"
+version = "0.1.0"
+
+[[wasm_modules]]
+name = "echo"
+criticality = "app-required"
+startup_loading = "lazy"
+"#,
+    )
+    .unwrap();
+    fs::write(
+        app_dir.join("APP.md"),
+        "# WASM Preserve App\n\nTemporary WASM preserve test app.\n",
+    )
+    .unwrap();
+
+    let echo_wasm = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../temper-wasm/tests/fixtures/echo_integration.wasm");
+    fs::copy(&echo_wasm, module_dir.join("echo.wasm")).unwrap();
+    add_os_apps_dir(app_root.clone());
+
+    let db_path = format!("/tmp/temper-wasm-preserve-{}.db", uuid::Uuid::new_v4());
+    let db_url = format!("file:{db_path}");
+    let turso = TursoEventStore::new(&db_url, None).await.unwrap();
+    let mut state = PlatformState::new(None);
+    state
+        .server
+        .set_storage_stack(temper_server::StorageStack::from_turso(turso));
+    state.server.data_dir = std::path::PathBuf::from(format!(
+        "/tmp/temper-wasm-preserve-{}-data",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&state.server.data_dir).unwrap();
+    let tenant_name = "test-wasm-preserve";
+    let tenant = TenantId::new(tenant_name);
+
+    install_os_app(&state, tenant_name, "wasm-preserve-app")
+        .await
+        .expect("initial app install should succeed");
+
+    let uploaded_bytes = b"same bundle hot upload should survive".to_vec();
+    let uploaded_hash = temper_wasm::WasmEngine::hash_module(&uploaded_bytes);
+    state
+        .server
+        .upsert_wasm_module(
+            tenant_name,
+            "echo",
+            &uploaded_bytes,
+            &uploaded_hash,
+            "upload",
+        )
+        .await
+        .expect("hot upload should persist");
+    state
+        .server
+        .wasm_module_registry
+        .write()
+        .unwrap()
+        .register(&tenant, "echo", &uploaded_hash);
+
+    add_os_apps_dir(app_root.clone());
+    let result = reconcile_os_app(&state, tenant_name, "wasm-preserve-app")
+        .await
+        .expect("reconcile should succeed");
+    let OsAppReconcileResult::Installed { install, .. } = result else {
+        panic!("registry drift should run delta install");
+    };
+    assert!(install.wasm_modules.is_empty());
+    assert_eq!(install.wasm_skipped, vec!["echo".to_string()]);
+
+    {
+        let registry = state.server.wasm_module_registry.read().unwrap();
+        assert_eq!(
+            registry.get_hash(&tenant, "echo"),
+            Some(uploaded_hash.as_str())
+        );
+    }
+
+    let module_sources = state
+        .server
+        .load_wasm_module_sources(tenant_name)
+        .await
+        .expect("load wasm module sources");
+    assert_eq!(
+        module_sources.get("echo"),
+        Some(&(uploaded_hash, "upload".to_string()))
+    );
+
+    let _ = fs::remove_dir_all(&app_root);
+    let _ = fs::remove_dir_all(&state.server.data_dir);
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(format!("{db_path}-wal"));
+    let _ = std::fs::remove_file(format!("{db_path}-shm"));
+}
+
 #[test]
 fn test_load_app_bundle_rejects_legacy_reactions_file() {
     let temp_dir = std::env::temp_dir().join(format!(

--- a/crates/temper-platform/src/os_apps/reconcile.rs
+++ b/crates/temper-platform/src/os_apps/reconcile.rs
@@ -92,7 +92,7 @@ fn digest_named_parts(parts: &[(String, Vec<u8>)]) -> String {
     digest_bytes(&parts)
 }
 
-fn digest_app_bundle(app_name: &str, bundle: &AppBundle) -> OsAppBundleDigest {
+pub(super) fn digest_app_bundle(app_name: &str, bundle: &AppBundle) -> OsAppBundleDigest {
     let entry = app_entry(app_name);
     let app_version = entry
         .as_ref()

--- a/crates/temper-server/src/platform_store.rs
+++ b/crates/temper-server/src/platform_store.rs
@@ -193,9 +193,9 @@ pub trait PlatformStore: Send + Sync {
     /// Upsert a WASM module binary for a tenant.
     ///
     /// `source` distinguishes the os-apps install pipeline (`"bundled"`) from
-    /// the hot-upload API (`"upload"`). The store skips overwriting an existing
-    /// `'upload'` row with a `'bundled'` row whose hash differs, so iterative
-    /// hot-uploaded testing survives subsequent restarts.
+    /// the hot-upload API (`"upload"`). Plain bundled installs preserve existing
+    /// upload rows, while OS-app reconcile can explicitly replace stale uploads
+    /// when the installed app's bundled WASM digest changes.
     async fn upsert_wasm_module(
         &self,
         tenant: &str,

--- a/crates/temper-server/src/state/persistence/mod.rs
+++ b/crates/temper-server/src/state/persistence/mod.rs
@@ -21,6 +21,8 @@ pub(crate) enum TenantMetadataBackend {
 mod logs_and_secrets;
 mod spec_metadata;
 
+const BUNDLED_REPLACE_UPLOAD_SOURCE: &str = "bundled-replace-upload";
+
 impl ServerState {
     fn redis_ephemeral_error(operation: &str) -> String {
         format!(
@@ -57,8 +59,9 @@ impl ServerState {
     ///
     /// `source` is `"bundled"` for the os-apps install pipeline and `"upload"`
     /// for the hot-upload API. The store is idempotent on hash and refuses to
-    /// overwrite an existing `'upload'` row with a `'bundled'` row whose hash
-    /// differs — that's how hot-uploaded modules survive subsequent restarts.
+    /// overwrite an existing `'upload'` row with a plain `'bundled'` row whose
+    /// hash differs — that's how hot-uploaded modules survive same-bundle
+    /// restarts.
     pub async fn upsert_wasm_module(
         &self,
         tenant: &str,
@@ -69,6 +72,12 @@ impl ServerState {
     ) -> Result<(), String> {
         let Some(backend) = self.tenant_metadata_backend(tenant).await else {
             return Ok(());
+        };
+        let replace_uploaded_wasm = source == BUNDLED_REPLACE_UPLOAD_SOURCE;
+        let persisted_source = if replace_uploaded_wasm {
+            "bundled"
+        } else {
+            source
         };
 
         let effective_hash = if sha256_hash.is_empty() {
@@ -100,14 +109,15 @@ impl ServerState {
                          updated_at = now(), \
                          source = EXCLUDED.source \
                      WHERE wasm_modules.sha256_hash IS DISTINCT FROM EXCLUDED.sha256_hash \
-                        AND (EXCLUDED.source = 'upload' OR wasm_modules.source = 'bundled')",
+                        AND ($7 OR EXCLUDED.source = 'upload' OR wasm_modules.source = 'bundled')",
                 )
                 .bind(tenant)
                 .bind(module_name)
                 .bind(Vec::<u8>::new())
                 .bind(&effective_hash)
                 .bind(wasm_bytes.len() as i32)
-                .bind(source)
+                .bind(persisted_source)
+                .bind(replace_uploaded_wasm)
                 .execute(&pool)
                 .await
                 .map(|_| ())
@@ -123,9 +133,30 @@ impl ServerState {
         }
     }
 
+    /// Persist a bundled OS-app module while explicitly replacing an existing
+    /// hot-upload row. Use this only when installed-app metadata proves the
+    /// bundled WASM digest changed; normal restart/install paths should preserve
+    /// hot uploads.
+    pub async fn upsert_bundled_wasm_module_replacing_upload(
+        &self,
+        tenant: &str,
+        module_name: &str,
+        wasm_bytes: &[u8],
+        sha256_hash: &str,
+    ) -> Result<(), String> {
+        self.upsert_wasm_module(
+            tenant,
+            module_name,
+            wasm_bytes,
+            sha256_hash,
+            BUNDLED_REPLACE_UPLOAD_SOURCE,
+        )
+        .await
+    }
+
     /// Return `(module_name -> (sha256_hash, source))` for every WASM module
     /// currently persisted for `tenant`. Used by the os-apps install pipeline
-    /// to skip overwriting hot-uploaded modules at boot.
+    /// to decide whether hot-uploaded modules should be preserved or replaced.
     pub async fn load_wasm_module_sources(
         &self,
         tenant: &str,

--- a/crates/temper-store-postgres/src/platform.rs
+++ b/crates/temper-store-postgres/src/platform.rs
@@ -10,6 +10,7 @@ use temper_runtime::persistence::PersistenceError;
 use crate::PostgresEventStore;
 
 const DISTINCT_RESOURCE_IDS_BUDGET: usize = 100;
+const BUNDLED_REPLACE_UPLOAD_SOURCE: &str = "bundled-replace-upload";
 
 /// Maximum bytes for a single value to be indexed into `entity_field_index`.
 /// Postgres btree (idx_efi_lookup) rejects keys that exceed roughly 2704 bytes
@@ -1049,10 +1050,17 @@ impl PostgresEventStore {
         //   - source='upload' callers (hot upload via the API) overwrite anything
         //     so iterative testing works.
         //   - source='bundled' callers (the os-apps install pipeline) only
-        //     overwrite existing 'bundled' rows. They never clobber an 'upload'
-        //     row even if the hash differs — that's how hot uploads survive
-        //     restarts. Bumping `version` only happens on actual hash changes,
-        //     so re-running the same image yields a no-op.
+        //     overwrite existing 'bundled' rows. They preserve hot uploads
+        //     across same-bundle restarts.
+        //   - source='bundled-replace-upload' is an internal reconcile mode:
+        //     persist the row back as 'bundled' while replacing stale uploads
+        //     after the installed app's bundled WASM digest changed.
+        let replace_uploaded_wasm = source == BUNDLED_REPLACE_UPLOAD_SOURCE;
+        let persisted_source = if replace_uploaded_wasm {
+            "bundled"
+        } else {
+            source
+        };
         sqlx::query(
             "INSERT INTO wasm_modules \
              (tenant, module_name, wasm_bytes, sha256_hash, version, size_bytes, updated_at, source) \
@@ -1065,14 +1073,15 @@ impl PostgresEventStore {
                  updated_at = now(), \
                  source = EXCLUDED.source \
              WHERE wasm_modules.sha256_hash IS DISTINCT FROM EXCLUDED.sha256_hash \
-                AND (EXCLUDED.source = 'upload' OR wasm_modules.source = 'bundled')",
+                AND ($7 OR EXCLUDED.source = 'upload' OR wasm_modules.source = 'bundled')",
         )
         .bind(tenant)
         .bind(name)
         .bind(bytes)
         .bind(hash)
         .bind(bytes.len() as i32)
-        .bind(source)
+        .bind(persisted_source)
+        .bind(replace_uploaded_wasm)
         .execute(self.pool())
         .await
         .map_err(storage_error)?;

--- a/crates/temper-store-turso/src/store/wasm.rs
+++ b/crates/temper-store-turso/src/store/wasm.rs
@@ -11,6 +11,8 @@ use super::{
 use crate::TursoWasmInvocationInsert;
 use crate::metrics::TursoQueryTimer;
 
+const BUNDLED_REPLACE_UPLOAD_SOURCE: &str = "bundled-replace-upload";
+
 impl TursoEventStore {
     /// Upsert a WASM module binary for a tenant.
     ///
@@ -28,10 +30,15 @@ impl TursoEventStore {
         let _query_timer = TursoQueryTimer::start("turso.upsert_wasm_module");
         let conn = self.configured_connection().await?;
         // Idempotent + source-aware preservation. See Postgres counterpart for
-        // the full reasoning. Hot uploads (source='upload') always win; the
-        // os-apps install pipeline (source='bundled') skips when an existing
-        // 'upload' row holds a different hash so iterative testing survives
-        // restarts.
+        // the full reasoning. Plain bundled installs preserve hot uploads, but
+        // OS-app reconcile can opt into replacing stale uploads when the
+        // bundled WASM digest changed.
+        let replace_uploaded_wasm = source == BUNDLED_REPLACE_UPLOAD_SOURCE;
+        let persisted_source = if replace_uploaded_wasm {
+            "bundled"
+        } else {
+            source
+        };
         let mut existing_rows = conn
             .query(
                 "SELECT sha256_hash, source \
@@ -50,7 +57,7 @@ impl TursoEventStore {
             if existing_hash == sha256_hash {
                 return Ok(());
             }
-            if existing_source == "upload" && source != "upload" {
+            if existing_source == "upload" && source != "upload" && !replace_uploaded_wasm {
                 tracing::info!(
                     tenant,
                     module_name,
@@ -88,7 +95,7 @@ impl TursoEventStore {
                  source = CASE
                      WHEN wasm_modules.sha256_hash IS NOT excluded.sha256_hash
                      THEN excluded.source ELSE wasm_modules.source END",
-            params![tenant, module_name, Vec::<u8>::new(), sha256_hash, wasm_bytes.len() as i64, source],
+            params![tenant, module_name, Vec::<u8>::new(), sha256_hash, wasm_bytes.len() as i64, persisted_source],
         )
         .await
         .map_err(storage_error)?;


### PR DESCRIPTION
## Summary
- replace hot-uploaded WASM with bundled WASM when installed app metadata shows the bundled WASM digest changed
- preserve hot-uploaded WASM across same-bundle restarts
- keep OS app catalog additional dirs across reloads by moving catalog code out of the large `os_apps/mod.rs`
- avoid unnecessary installed-app metadata reads for apps with no bundled WASM modules

## Verification
- `cargo test -p temper-platform wasm_digest -- --nocapture`
- `cargo test -p temper-platform`
- `cargo test -p temper-server wasm -- --nocapture`
- `cargo test -p temper-store-turso wasm -- --nocapture`
- `cargo test -p temper-store-postgres --lib`
- `cargo test -p temper-server --test dst_platform_rollback dst_rollback_install_failure_is_atomic -- --nocapture`
- pre-push hook: rustfmt, clippy, readability ratchet, full workspace tests and doctests
