### PR TITLE
Expose resource attributes to Cedar policies

### DIFF
--- a/crates/temper-authz/src/engine/mod.rs
+++ b/crates/temper-authz/src/engine/mod.rs
@@ -446,23 +446,66 @@ impl AuthzEngine {
             insert_json_as_cedar(&mut principal_attrs, key.clone(), value);
         }
 
-        // Entity schema validation is intentionally None: principal attributes
-        // include tenant-defined custom attrs that can't be predicted by a
-        // static schema. Policy-level type checking suffices.
+        let mut resource_entity_attrs: HashMap<String, cedar_policy::RestrictedExpression> =
+            HashMap::new();
+        for (key, value) in resource_attrs {
+            insert_json_as_cedar(&mut resource_entity_attrs, key.clone(), value);
+        }
 
-        let entities = match Entity::new(principal_uid.clone(), principal_attrs, HashSet::new()) {
-            Ok(entity) => match Entities::from_entities([entity], None) {
+        // Entity schema validation is intentionally None: app specs define
+        // tenant-specific attributes that cannot be predicted by a static
+        // platform schema. Policy-level type checks still apply.
+        let principal_entity = match Entity::new(
+            principal_uid.clone(),
+            principal_attrs.clone(),
+            HashSet::new(),
+        ) {
+            Ok(entity) => entity,
+            Err(e) => {
+                return AuthzDecision::Deny(AuthzDenial::EngineError(format!(
+                    "failed to build principal entity: {e}"
+                )));
+            }
+        };
+        let resource_entity = if resource_uid == principal_uid {
+            let mut merged_attrs = principal_attrs;
+            merged_attrs.extend(resource_entity_attrs);
+            match Entity::new(resource_uid.clone(), merged_attrs, HashSet::new()) {
+                Ok(entity) => entity,
+                Err(e) => {
+                    return AuthzDecision::Deny(AuthzDenial::EngineError(format!(
+                        "failed to build merged principal/resource entity: {e}"
+                    )));
+                }
+            }
+        } else {
+            match Entity::new(resource_uid.clone(), resource_entity_attrs, HashSet::new()) {
+                Ok(entity) => entity,
+                Err(e) => {
+                    return AuthzDecision::Deny(AuthzDenial::EngineError(format!(
+                        "failed to build resource entity: {e}"
+                    )));
+                }
+            }
+        };
+
+        let entities = if resource_uid == principal_uid {
+            match Entities::from_entities([resource_entity], None) {
                 Ok(e) => e,
                 Err(e) => {
                     return AuthzDecision::Deny(AuthzDenial::EngineError(format!(
                         "failed to build entity store: {e}"
                     )));
                 }
-            },
-            Err(e) => {
-                return AuthzDecision::Deny(AuthzDenial::EngineError(format!(
-                    "failed to build principal entity: {e}"
-                )));
+            }
+        } else {
+            match Entities::from_entities([principal_entity, resource_entity], None) {
+                Ok(e) => e,
+                Err(e) => {
+                    return AuthzDecision::Deny(AuthzDenial::EngineError(format!(
+                        "failed to build entity store: {e}"
+                    )));
+                }
             }
         };
 

--- a/crates/temper-authz/src/engine/tests.rs
+++ b/crates/temper-authz/src/engine/tests.rs
@@ -370,6 +370,59 @@ fn test_principal_attribute_access_in_policy() {
 }
 
 #[test]
+fn test_resource_attribute_access_in_policy() {
+    // Temper app policies gate claimed work on entity state, e.g.
+    // `principal.id == resource.worker_id`.
+    let policy = r#"
+        permit(
+            principal is Agent,
+            action == Action::"StartLocal",
+            resource is WorkerRun
+        ) when {
+            principal.agent_type == "worker" &&
+            resource has worker_id &&
+            principal.id == resource.worker_id
+        };
+    "#;
+    let engine = AuthzEngine::new(policy).unwrap();
+
+    let worker_ctx = SecurityContext::from_headers(&[
+        (
+            "X-Temper-Principal-Id".to_string(),
+            "local-codex-worker".to_string(),
+        ),
+        ("X-Temper-Principal-Kind".to_string(), "agent".to_string()),
+        ("X-Temper-Agent-Type".to_string(), "worker".to_string()),
+    ]);
+    let mut attrs = HashMap::new();
+    attrs.insert("id".to_string(), serde_json::json!("wr-1"));
+    attrs.insert(
+        "worker_id".to_string(),
+        serde_json::json!("local-codex-worker"),
+    );
+
+    let decision = engine.authorize(&worker_ctx, "StartLocal", "WorkerRun", &attrs);
+    assert!(
+        decision.is_allowed(),
+        "claimed worker should be allowed through resource.worker_id: {decision:?}"
+    );
+
+    let other_ctx = SecurityContext::from_headers(&[
+        (
+            "X-Temper-Principal-Id".to_string(),
+            "other-worker".to_string(),
+        ),
+        ("X-Temper-Principal-Kind".to_string(), "agent".to_string()),
+        ("X-Temper-Agent-Type".to_string(), "worker".to_string()),
+    ]);
+    let decision = engine.authorize(&other_ctx, "StartLocal", "WorkerRun", &attrs);
+    assert!(
+        !decision.is_allowed(),
+        "different worker must not satisfy resource.worker_id"
+    );
+}
+
+#[test]
 fn test_principal_agent_type_set_membership_filtering() {
     let policy = r#"
         permit(


### PR DESCRIPTION
## Summary
- attach Temper resource attributes to the Cedar resource entity, not only to request context
- enables Patrol policies like `principal.id == resource.worker_id` / `resource.reviewer_id` to evaluate correctly
- adds a regression test for resource attribute access in policy evaluation

## Verification
- GitHub CI passed: https://github.com/nerdsane/temper/actions/runs/25359608259
- `cargo test -p temper-authz test_resource_attribute_access_in_policy -- --nocapture`
- local pre-push verification passed before push: rustfmt, clippy, readability ratchet, full test suite, doctests

## Needed by
- nerdsane/temperpaw#218
