### PR TITLE
[codex] Authorize internal outbound streams

### DIFF
--- a/crates/temper-wasm/src/host_trait.rs
+++ b/crates/temper-wasm/src/host_trait.rs
@@ -541,6 +541,77 @@ impl ProductionWasmHost {
         self
     }
 
+    fn is_internal_temper_url(&self, url: &str) -> bool {
+        self.internal_api_base_url
+            .as_ref()
+            .is_some_and(|api_url| url.starts_with(api_url.trim_end_matches('/')))
+            || self
+                .secrets
+                .get("temper_api_url")
+                .is_some_and(|api_url| url.starts_with(api_url.trim_end_matches('/')))
+    }
+
+    fn add_internal_temper_headers(
+        &self,
+        mut builder: reqwest::RequestBuilder,
+        url: &str,
+        headers: &[(String, String)],
+    ) -> reqwest::RequestBuilder {
+        if !self.is_internal_temper_url(url) {
+            return builder;
+        }
+
+        let Some(ref inv_ctx) = self.invocation_context else {
+            return builder;
+        };
+
+        let has_tenant = headers
+            .iter()
+            .any(|(k, _)| k.eq_ignore_ascii_case("x-tenant-id"));
+        let has_principal = headers
+            .iter()
+            .any(|(k, _)| k.eq_ignore_ascii_case("x-temper-principal-kind"));
+        let has_authorization = headers
+            .iter()
+            .any(|(k, _)| k.eq_ignore_ascii_case("authorization"));
+
+        if !has_tenant {
+            builder = builder.header("x-tenant-id", inv_ctx.tenant.as_str());
+        }
+
+        if !has_principal {
+            let agent_type = if inv_ctx.entity_type.eq_ignore_ascii_case("Session") {
+                "agent"
+            } else {
+                "system"
+            };
+            let principal_id = inv_ctx
+                .agent_id
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .unwrap_or(inv_ctx.entity_id.as_str());
+            builder = builder
+                .header("x-temper-principal-kind", "agent")
+                .header("x-temper-principal-id", principal_id)
+                .header("x-temper-agent-type", agent_type);
+            if let Some(ref sid) = inv_ctx.session_id {
+                builder = builder.header("x-temper-ctx-sessionid", sid.as_str());
+            }
+        }
+
+        if !has_authorization
+            && let Some(key) = self
+                .internal_api_key
+                .as_ref()
+                .or_else(|| self.secrets.get("temper_api_key"))
+                .filter(|k| !k.is_empty())
+        {
+            builder = builder.header("authorization", format!("Bearer {key}"));
+        }
+
+        add_workflow_observability_headers(builder, headers, inv_ctx)
+    }
+
     fn build_guest_wide_event(&self, event_json: &str) -> Result<WideEvent, String> {
         let payload: GuestWideEventInput = serde_json::from_str(event_json)
             .map_err(|e| format!("invalid guest wide event payload: {e}"))?;
@@ -684,67 +755,8 @@ impl WasmHost for ProductionWasmHost {
             builder = builder.header(k.as_str(), v.as_str());
         }
 
-        // Auto-inject Temper auth headers for internal API calls (ADR-0043).
-        // Internal = URL starts with temper_api_url from secrets.
-        //
-        // Principal headers and bearer auth are handled independently:
-        // guests may deliberately set a service principal, but still need the
-        // local API key so bearer auth accepts the request.
-        let is_internal = self
-            .internal_api_base_url
-            .as_ref()
-            .is_some_and(|api_url| url.starts_with(api_url))
-            || self
-                .secrets
-                .get("temper_api_url")
-                .is_some_and(|api_url| url.starts_with(api_url.trim_end_matches('/')));
-        if is_internal && let Some(ref inv_ctx) = self.invocation_context {
-            let has_tenant = filtered_headers
-                .iter()
-                .any(|(k, _)| k.eq_ignore_ascii_case("x-tenant-id"));
-            let has_principal = filtered_headers
-                .iter()
-                .any(|(k, _)| k.eq_ignore_ascii_case("x-temper-principal-kind"));
-            let has_authorization = filtered_headers
-                .iter()
-                .any(|(k, _)| k.eq_ignore_ascii_case("authorization"));
-
-            if !has_tenant {
-                builder = builder.header("x-tenant-id", inv_ctx.tenant.as_str());
-            }
-
-            if !has_principal {
-                let agent_type = if inv_ctx.entity_type.eq_ignore_ascii_case("Session") {
-                    "agent"
-                } else {
-                    "system"
-                };
-                let principal_id = inv_ctx
-                    .agent_id
-                    .as_deref()
-                    .filter(|s| !s.is_empty())
-                    .unwrap_or(inv_ctx.entity_id.as_str());
-                builder = builder
-                    .header("x-temper-principal-kind", "agent")
-                    .header("x-temper-principal-id", principal_id)
-                    .header("x-temper-agent-type", agent_type);
-                if let Some(ref sid) = inv_ctx.session_id {
-                    builder = builder.header("x-temper-ctx-sessionid", sid.as_str());
-                }
-            }
-
-            if !has_authorization
-                && let Some(key) = self
-                    .internal_api_key
-                    .as_ref()
-                    .or_else(|| self.secrets.get("temper_api_key"))
-                    .filter(|k| !k.is_empty())
-            {
-                builder = builder.header("authorization", format!("Bearer {key}"));
-            }
-
-            builder = add_workflow_observability_headers(builder, &filtered_headers, inv_ctx);
-        }
+        let is_internal = self.is_internal_temper_url(url);
+        builder = self.add_internal_temper_headers(builder, url, &filtered_headers);
         // determinism-ok: is_internal check uses non-deterministic URL comparison,
         // but this runs in WasmHost (not simulation), so wall-clock/network access is fine.
 
@@ -1320,6 +1332,7 @@ impl WasmHost for ProductionWasmHost {
         for (k, v) in &filtered_headers {
             builder = builder.header(k.as_str(), v.as_str());
         }
+        builder = self.add_internal_temper_headers(builder, &request.url, &filtered_headers);
         if !filtered_headers
             .iter()
             .any(|(k, _)| k.eq_ignore_ascii_case("traceparent"))

--- a/crates/temper-wasm/tests/http_stream_outbound.rs
+++ b/crates/temper-wasm/tests/http_stream_outbound.rs
@@ -10,15 +10,17 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use axum::Router;
-use axum::body::Body;
+use axum::body::{Body, to_bytes};
 use axum::extract::Request;
 use axum::response::IntoResponse;
-use axum::routing::post;
+use axum::routing::{post, put};
 use futures_util::StreamExt;
+use serde_json::Value;
 
 use temper_wasm::WasmHost;
 use temper_wasm::host_trait::ProductionWasmHost;
-use temper_wasm::http_stream::HttpRequestHead;
+use temper_wasm::http_stream::{HttpRequestHead, StreamError};
+use temper_wasm::types::WasmInvocationContext;
 
 /// Axum handler that streams request body bytes back verbatim.
 async fn echo_handler(req: Request) -> impl IntoResponse {
@@ -42,17 +44,113 @@ async fn header_echo_handler(req: Request) -> impl IntoResponse {
     format!("span_hint_present={span_hint_present};regular={regular_header}")
 }
 
+/// Axum handler that reports auth/context headers plus streamed body bytes.
+async fn internal_header_echo_handler(req: Request) -> impl IntoResponse {
+    let (parts, body) = req.into_parts();
+    let body = to_bytes(body, 1024 * 1024).await.unwrap();
+    let header = |name: &str| {
+        parts
+            .headers
+            .get(name)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or("")
+            .to_string()
+    };
+    format!(
+        "authorization={};tenant={};principal_kind={};principal_id={};workflow_type={};body={}",
+        header("authorization"),
+        header("x-tenant-id"),
+        header("x-temper-principal-kind"),
+        header("x-temper-principal-id"),
+        header("x-temper-workflow-root-entity-type"),
+        String::from_utf8_lossy(&body)
+    )
+}
+
 /// Bind axum on 127.0.0.1:0 (random port), return the bound addr.
 async fn spawn_echo_server() -> String {
     let app = Router::new()
         .route("/echo", post(echo_handler))
-        .route("/headers", post(header_echo_handler));
+        .route("/headers", post(header_echo_handler))
+        .route("/internal", put(internal_header_echo_handler));
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     tokio::spawn(async move {
         axum::serve(listener, app).await.unwrap();
     });
     format!("http://{addr}")
+}
+
+#[tokio::test]
+async fn outbound_streaming_injects_internal_auth_headers() {
+    let base = spawn_echo_server().await;
+
+    let mut secrets = BTreeMap::new();
+    secrets.insert("temper_api_url".to_string(), base.clone());
+    secrets.insert("temper_api_key".to_string(), "secret123".to_string());
+
+    let host = Arc::new(ProductionWasmHost::new(secrets).with_invocation_context(
+        WasmInvocationContext {
+            tenant: "default".to_string(),
+            entity_type: "Workspace".to_string(),
+            entity_id: "ws-1".to_string(),
+            trigger_action: "CreateFile".to_string(),
+            trigger_params: Value::Null,
+            entity_state: Value::Null,
+            agent_id: Some("operator".to_string()),
+            session_id: None,
+            integration_config: BTreeMap::new(),
+            trace_id: String::new(),
+            workflow_root_entity_type: Some("CurationQuery".to_string()),
+            workflow_root_entity_id: Some("cq-1".to_string()),
+            workflow_run_id: Some("CurationQuery:cq-1".to_string()),
+            http_request: None,
+        },
+    ));
+
+    let handles = host
+        .http_stream_begin_outbound(HttpRequestHead {
+            method: "PUT".into(),
+            url: format!("{base}/internal"),
+            headers: vec![("content-type".into(), "image/png".into())],
+        })
+        .await
+        .unwrap();
+
+    loop {
+        match host
+            .http_stream_try_write(handles.request_body, b"raw-image-bytes".to_vec())
+            .await
+        {
+            Ok(_) => break,
+            Err(StreamError::WouldBlock) => tokio::task::yield_now().await,
+            Err(error) => panic!("unexpected write error: {error:?}"),
+        }
+    }
+    host.http_stream_close(handles.request_body).await.unwrap();
+
+    let head = host
+        .http_stream_response_head(handles.response_body)
+        .await
+        .unwrap();
+    assert_eq!(head.status, 200);
+
+    let mut body = Vec::new();
+    loop {
+        let chunk = host.http_stream_read(handles.response_body).await.unwrap();
+        if chunk.is_empty() {
+            break;
+        }
+        body.extend_from_slice(&chunk);
+    }
+    let body = String::from_utf8(body).unwrap();
+
+    assert!(body.contains("authorization=Bearer secret123"));
+    assert!(body.contains("tenant=default"));
+    assert!(body.contains("principal_kind=agent"));
+    assert!(body.contains("principal_id=operator"));
+    assert!(body.contains("workflow_type=CurationQuery"));
+    assert!(body.contains("body=raw-image-bytes"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Teach the production WASM host to recognize internal Temper API URLs for streaming outbound calls.
- Share internal auth/header injection between regular HTTP calls and streaming calls.
- Cover `http_stream_begin_outbound` with a regression test that writes request bytes and verifies tenant, principal, workflow, and bearer headers reach the internal route.

## Why

TemperPaw image uploads should use Temper's native `Files(...)/$value` stream endpoint. The app-layer workaround failed because WASM streaming calls were not receiving the same internal API authentication headers as non-streaming calls.

## Validation

- `bash scripts/readability-ratchet.sh check .ci/readability-baseline.env`
- `cargo test -p temper-wasm`
- Pre-push gate: rustfmt, clippy, readability ratchet, full test suite, doctests