### PR TITLE
Record governed agent mutation denials

### DIFF
--- a/crates/temper-authz/src/context.rs
+++ b/crates/temper-authz/src/context.rs
@@ -96,7 +96,14 @@ impl SecurityContext {
                     );
                 }
                 k if k.starts_with("x-temper-ctx-") => {
-                    let ctx_name = k.strip_prefix("x-temper-ctx-").unwrap(); // ci-ok: guarded by starts_with
+                    let raw_ctx_name = k.strip_prefix("x-temper-ctx-").unwrap(); // ci-ok: guarded by starts_with
+                    let ctx_name = match raw_ctx_name {
+                        "agentid" => "agentId",
+                        "agenttype" => "agentType",
+                        "agenttypeverified" => "agentTypeVerified",
+                        "sessionid" => "sessionId",
+                        other => other,
+                    };
                     context_attrs.insert(
                         ctx_name.to_string(),
                         serde_json::Value::String(value.clone()),
@@ -295,6 +302,24 @@ mod tests {
         assert_eq!(ctx.principal.kind, PrincipalKind::Admin);
         assert!(ctx.principal.attributes.contains_key("approvallimit"));
         assert!(ctx.context_attrs.contains_key("ratelimitexceeded"));
+    }
+
+    #[test]
+    fn test_context_from_headers_normalizes_session_id() {
+        let headers = vec![
+            ("X-Temper-Principal-Id".to_string(), "agent-1".to_string()),
+            ("X-Temper-Principal-Kind".to_string(), "agent".to_string()),
+            (
+                "x-temper-ctx-sessionid".to_string(),
+                "session-1".to_string(),
+            ),
+        ];
+
+        let ctx = SecurityContext::from_headers(&headers);
+        assert_eq!(
+            ctx.context_attrs.get("sessionId"),
+            Some(&serde_json::Value::String("session-1".to_string()))
+        );
     }
 
     #[test]

--- a/crates/temper-server/src/api/decisions_get.rs
+++ b/crates/temper-server/src/api/decisions_get.rs
@@ -1,0 +1,60 @@
+//! Tenant-scoped decision lookup.
+
+use axum::extract::{Path, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::IntoResponse;
+use temper_authz::PrincipalKind;
+use tracing::instrument;
+
+use super::require_policy_auth;
+use crate::authz::security_context_from_headers;
+use crate::state::{PendingDecision, ServerState};
+
+/// GET /api/tenants/{tenant}/decisions/{id} — fetch one decision by ID.
+#[instrument(skip_all, fields(tenant, id, otel.name = "GET /api/tenants/{tenant}/decisions/{id}"))]
+pub(crate) async fn handle_get_decision(
+    State(state): State<ServerState>,
+    Path((tenant, id)): Path<(String, String)>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    let Some(store) = state.metadata_store_for_tenant(&tenant).await else {
+        tracing::error!("durable metadata backend not configured for get decision");
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "durable metadata backend not configured",
+        )
+            .into_response();
+    };
+    let decision: PendingDecision = match store.get_pending_decision(&id).await {
+        Ok(Some(data_str)) => match serde_json::from_str::<PendingDecision>(&data_str) {
+            Ok(d) if d.tenant == tenant => d,
+            _ => return (StatusCode::NOT_FOUND, "Decision not found").into_response(),
+        },
+        Ok(None) => return (StatusCode::NOT_FOUND, "Decision not found").into_response(),
+        Err(e) => {
+            tracing::error!(error = %e, backend = store.backend_name(), "failed to load decision");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to load decision: {e}"),
+            )
+                .into_response();
+        }
+    };
+
+    let security_ctx = security_context_from_headers(&headers, None, None, None);
+    let session_id = security_ctx
+        .context_attrs
+        .get("sessionId")
+        .and_then(|v| v.as_str());
+    let owner_agent = matches!(security_ctx.principal.kind, PrincipalKind::Agent)
+        && (security_ctx.principal.id == decision.agent_id
+            || session_id.is_some() && session_id == decision.session_id.as_deref());
+    if !matches!(security_ctx.principal.kind, PrincipalKind::Admin)
+        && !owner_agent
+        && let Some(resp) = require_policy_auth(&state, &headers, &tenant).await
+    {
+        return resp;
+    }
+
+    (StatusCode::OK, axum::Json(decision)).into_response()
+}

--- a/crates/temper-server/src/api/mod.rs
+++ b/crates/temper-server/src/api/mod.rs
@@ -6,6 +6,7 @@
 
 mod authorize;
 mod decisions;
+mod decisions_get;
 mod files;
 mod policies;
 mod repl;
@@ -127,6 +128,10 @@ pub fn build_api_router() -> Router<ServerState> {
         .route(
             "/tenants/{tenant}/decisions/stream",
             get(decisions::handle_decision_stream),
+        )
+        .route(
+            "/tenants/{tenant}/decisions/{id}",
+            get(decisions_get::handle_get_decision),
         )
         .route(
             "/tenants/{tenant}/decisions/{id}/approve",

--- a/crates/temper-server/src/authz/helpers.rs
+++ b/crates/temper-server/src/authz/helpers.rs
@@ -4,7 +4,9 @@
 //! used across OData bindings, policy management, spec submission, and WASM
 //! authz gates.
 
-use axum::http::HeaderMap;
+use std::collections::BTreeMap;
+
+use axum::http::{HeaderMap, StatusCode};
 use temper_authz::SecurityContext;
 use temper_runtime::scheduler::{sim_now, sim_uuid};
 use temper_runtime::tenant::TenantId;
@@ -141,6 +143,103 @@ pub(crate) struct DenialInput<'a> {
     pub module_name: Option<String>,
     /// Entity status at the time of denial.
     pub from_status: Option<String>,
+}
+
+/// Input for a resumable management mutation authorization check.
+pub(crate) struct GovernedMutationAuth<'a> {
+    pub tenant: &'a str,
+    pub action: &'a str,
+    pub resource_type: &'a str,
+    pub resource_id: &'a str,
+    pub resource_attrs: BTreeMap<String, serde_json::Value>,
+    pub module_name: Option<&'a str>,
+    pub from_status: Option<&'a str>,
+}
+
+/// Authorize a resumable management mutation and record agent denials.
+///
+/// This helper is for mutating HTTP endpoints whose denied operation can be
+/// retried after a human approval. Agent requests with session context become
+/// `PendingDecision` records. Non-agent or sessionless denials stay ordinary
+/// `403 Forbidden` responses so passive/admin surfaces do not generate noisy
+/// approval work.
+pub(crate) async fn require_governed_mutation_auth(
+    state: &crate::state::ServerState,
+    headers: &HeaderMap,
+    mut input: GovernedMutationAuth<'_>,
+) -> Option<(StatusCode, String)> {
+    let security_ctx = security_context_from_headers(headers, None, None, None);
+    if matches!(
+        security_ctx.principal.kind,
+        temper_authz::PrincipalKind::Admin
+    ) {
+        return None;
+    }
+
+    input
+        .resource_attrs
+        .entry("id".to_string())
+        .or_insert_with(|| serde_json::Value::String(input.resource_id.to_string()));
+
+    let Err(denial) = state.authorize_with_context(
+        &security_ctx,
+        input.action,
+        input.resource_type,
+        &input.resource_attrs,
+        input.tenant,
+    ) else {
+        return None;
+    };
+
+    let reason = denial.to_string();
+    let session_id = security_ctx
+        .context_attrs
+        .get("sessionId")
+        .and_then(|v| v.as_str());
+    if matches!(
+        security_ctx.principal.kind,
+        temper_authz::PrincipalKind::Agent
+    ) && session_id.is_some()
+    {
+        let resource_attrs_json =
+            serde_json::to_value(&input.resource_attrs).unwrap_or_else(|_| serde_json::json!({}));
+        let pd = record_authz_denial(
+            state,
+            DenialInput {
+                tenant: input.tenant,
+                security_ctx: &security_ctx,
+                agent_id_override: None,
+                action: input.action,
+                resource_type: input.resource_type,
+                resource_id: input.resource_id,
+                resource_attrs: resource_attrs_json,
+                reason: &reason,
+                module_name: input.module_name.map(str::to_string),
+                from_status: input.from_status.map(str::to_string),
+            },
+        )
+        .await;
+        return Some((
+            StatusCode::FORBIDDEN,
+            serde_json::json!({
+                "decision_id": pd.id,
+                "error": {
+                    "code": "AuthorizationDenied",
+                    "message": format!("{reason} Decision {}", pd.id),
+                }
+            })
+            .to_string(),
+        ));
+    }
+
+    tracing::warn!(
+        reason = %reason,
+        action = input.action,
+        resource_type = input.resource_type,
+        resource_id = input.resource_id,
+        "unauthorized non-resumable governed mutation"
+    );
+    Some((StatusCode::FORBIDDEN, reason))
 }
 
 /// Record result of an authorization denial.

--- a/crates/temper-server/src/authz/mod.rs
+++ b/crates/temper-server/src/authz/mod.rs
@@ -6,8 +6,8 @@ pub mod wasm_gate;
 
 #[allow(unused_imports)] // Used by observe/ handlers via crate::authz::observe_tenant_scope
 pub(crate) use helpers::{
-    DenialInput, observe_tenant_scope, record_authz_denial, require_observe_auth,
-    security_context_from_headers,
+    DenialInput, GovernedMutationAuth, observe_tenant_scope, record_authz_denial,
+    require_governed_mutation_auth, require_observe_auth, security_context_from_headers,
 };
 pub use policy_persistence::{load_and_activate_tenant_policies, persist_and_activate_policy};
 pub use wasm_gate::{CedarWasmAuthzGate, PermissiveWasmAuthzGate};

--- a/crates/temper-server/src/observe/mod_test.rs
+++ b/crates/temper-server/src/observe/mod_test.rs
@@ -18,6 +18,7 @@ use crate::storage::StorageStack;
 
 const CSDL_XML: &str = include_str!("../../../../test-fixtures/specs/model.csdl.xml");
 const ORDER_IOA: &str = include_str!("../../../../test-fixtures/specs/order.ioa.toml");
+const VALID_EMPTY_WASM: &[u8] = b"\0asm\x01\0\0\0";
 
 fn test_state_with_registry() -> ServerState {
     let csdl = parse_csdl(CSDL_XML).expect("CSDL should parse");
@@ -42,12 +43,19 @@ async fn test_state_with_turso() -> ServerState {
         std::process::id(),
         id,
     );
+    let data_dir = std::path::PathBuf::from(format!(
+        "/tmp/temper-observe-test-{}-{}-data",
+        std::process::id(),
+        id,
+    ));
     // Clean up leftover DB from a previous run.
     let _ = std::fs::remove_file(db_url.strip_prefix("file:").unwrap_or(&db_url));
+    let _ = std::fs::remove_dir_all(&data_dir);
     let turso = TursoEventStore::new(&db_url, None)
         .await
         .expect("create local turso db");
     let mut state = test_state_with_registry();
+    state.data_dir = data_dir;
     state.set_storage_stack(StorageStack::from_turso(turso));
     state
 }
@@ -113,6 +121,17 @@ fn admin_post(uri: &str, body: &str) -> Request<Body> {
         .unwrap()
 }
 
+fn agent_post(uri: &str, body: impl Into<Body>) -> Request<Body> {
+    Request::post(uri)
+        .header("X-Tenant-Id", "default")
+        .header("X-Temper-Principal-Id", "agent-1")
+        .header("X-Temper-Principal-Kind", "agent")
+        .header("X-Temper-Agent-Type", "swe")
+        .header("X-Temper-Ctx-SessionId", "session-1")
+        .body(body.into())
+        .unwrap()
+}
+
 const ADMIN_MANAGE_POLICIES_POLICY: &str = r#"
 permit(
   principal is Admin,
@@ -148,6 +167,212 @@ fn build_app_with_state(state: ServerState) -> Router {
         .nest("/observe", build_observe_router())
         .nest("/api", crate::api::build_api_router())
         .with_state(state)
+}
+
+#[tokio::test]
+async fn wasm_upload_denial_creates_pending_decision_for_module_resource() {
+    let state = test_state_with_turso().await;
+    install_admin_policy(&state);
+    let app = build_app_with_state(state.clone());
+
+    let response = app
+        .oneshot(agent_post(
+            "/api/wasm/modules/git_upload_pack",
+            Body::from(VALID_EMPTY_WASM.to_vec()),
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("denial response JSON");
+    let decision_id = json["decision_id"].as_str().expect("top-level decision_id");
+
+    let turso = state.platform_turso_store().expect("turso configured");
+    let data_str = turso
+        .get_pending_decision(decision_id)
+        .await
+        .expect("query decision")
+        .expect("decision should be persisted");
+    let decision: crate::state::PendingDecision =
+        serde_json::from_str(&data_str).expect("deserialize pending decision");
+
+    assert_eq!(decision.tenant, "default");
+    assert_eq!(decision.agent_id, "agent-1");
+    assert_eq!(decision.action, "manage_wasm");
+    assert_eq!(decision.resource_type, "WasmModule");
+    assert_eq!(decision.resource_id, "git_upload_pack");
+    assert_eq!(decision.resource_attrs["id"], "git_upload_pack");
+    assert_eq!(decision.module_name.as_deref(), Some("git_upload_pack"));
+    assert_eq!(decision.session_id.as_deref(), Some("session-1"));
+    assert_eq!(decision.status, crate::state::DecisionStatus::Pending);
+}
+
+#[tokio::test]
+async fn wasm_delete_denial_creates_pending_decision_for_module_resource() {
+    let state = test_state_with_turso().await;
+    install_admin_policy(&state);
+    let app = build_app_with_state(state.clone());
+
+    let response = app
+        .oneshot(
+            Request::delete("/api/wasm/modules/git_receive_pack")
+                .header("X-Tenant-Id", "default")
+                .header("X-Temper-Principal-Id", "agent-1")
+                .header("X-Temper-Principal-Kind", "agent")
+                .header("X-Temper-Agent-Type", "swe")
+                .header("X-Temper-Ctx-SessionId", "session-1")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("denial response JSON");
+    let decision_id = json["decision_id"].as_str().expect("top-level decision_id");
+
+    let turso = state.platform_turso_store().expect("turso configured");
+    let data_str = turso
+        .get_pending_decision(decision_id)
+        .await
+        .expect("query decision")
+        .expect("decision should be persisted");
+    let decision: crate::state::PendingDecision =
+        serde_json::from_str(&data_str).expect("deserialize pending decision");
+    assert_eq!(decision.action, "manage_wasm");
+    assert_eq!(decision.resource_type, "WasmModule");
+    assert_eq!(decision.resource_id, "git_receive_pack");
+    assert_eq!(decision.module_name.as_deref(), Some("git_receive_pack"));
+}
+
+#[tokio::test]
+async fn wasm_upload_accepts_json_base64_body() {
+    use base64::Engine;
+
+    let state = test_state_with_turso().await;
+    let app = build_app_with_state(state);
+    let payload = serde_json::json!({
+        "wasm_base64": base64::engine::general_purpose::STANDARD.encode(VALID_EMPTY_WASM),
+    });
+
+    let response = app
+        .oneshot(admin_post(
+            "/api/wasm/modules/base64_module",
+            &payload.to_string(),
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("upload response JSON");
+    assert_eq!(json["module_name"], "base64_module");
+    assert_eq!(json["size_bytes"], VALID_EMPTY_WASM.len());
+}
+
+#[tokio::test]
+async fn approved_wasm_upload_decision_allows_agent_retry() {
+    let state = test_state_with_turso().await;
+    install_admin_policy(&state);
+    let app = build_app_with_state(state);
+
+    let denied = app
+        .clone()
+        .oneshot(agent_post(
+            "/api/wasm/modules/git_upload_pack",
+            Body::from(VALID_EMPTY_WASM.to_vec()),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(denied.status(), StatusCode::FORBIDDEN);
+    let denied_body = axum::body::to_bytes(denied.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let denied_json: serde_json::Value =
+        serde_json::from_slice(&denied_body).expect("denial response JSON");
+    let decision_id = denied_json["decision_id"]
+        .as_str()
+        .expect("top-level decision_id");
+
+    let approved = app
+        .clone()
+        .oneshot(
+            Request::post(format!(
+                "/api/tenants/default/decisions/{decision_id}/approve"
+            ))
+            .header("content-type", "application/json")
+            .header("x-temper-principal-id", "admin-1")
+            .header("x-temper-principal-kind", "admin")
+            .body(Body::from(r#"{"scope":{"principal":"this_agent","action":"this_action","resource":"this_resource","duration":"always"},"decided_by":"admin-1"}"#))
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(approved.status(), StatusCode::OK);
+
+    let retried = app
+        .oneshot(agent_post(
+            "/api/wasm/modules/git_upload_pack",
+            Body::from(VALID_EMPTY_WASM.to_vec()),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(retried.status(), StatusCode::OK);
+    let retried_body = axum::body::to_bytes(retried.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let retried_json: serde_json::Value =
+        serde_json::from_slice(&retried_body).expect("retry response JSON");
+    assert_eq!(retried_json["module_name"], "git_upload_pack");
+}
+
+#[tokio::test]
+async fn tenant_decision_lookup_returns_known_decision_by_id() {
+    let state = test_state_with_turso().await;
+    install_admin_policy(&state);
+    let pending = crate::state::PendingDecision::from_denial(
+        "default",
+        "agent-1",
+        "manage_wasm",
+        "WasmModule",
+        "git_upload_pack",
+        serde_json::json!({"id":"git_upload_pack"}),
+        "test denial",
+        Some("git_upload_pack".to_string()),
+    );
+    let decision_id = pending.id.clone();
+    state
+        .persist_pending_decision(&pending)
+        .await
+        .expect("persist pending decision");
+    let app = build_app_with_state(state);
+
+    let response = app
+        .oneshot(
+            Request::get(format!("/api/tenants/default/decisions/{decision_id}"))
+                .header("X-Temper-Principal-Kind", "admin")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("decision JSON");
+    assert_eq!(json["id"], decision_id);
+    assert_eq!(json["resource_type"], "WasmModule");
+    assert_eq!(json["resource_id"], "git_upload_pack");
 }
 
 #[tokio::test]

--- a/crates/temper-server/src/observe/wasm.rs
+++ b/crates/temper-server/src/observe/wasm.rs
@@ -2,18 +2,28 @@
 //!
 //! Upload, download, delete, and list WASM integration modules.
 
+use std::collections::BTreeMap;
+
 use axum::extract::Path;
 use axum::extract::{Query, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::Json;
+use base64::Engine;
 use serde::{Deserialize, Serialize};
-use temper_authz::PrincipalKind;
 
 use tracing::instrument;
 
-use crate::authz::{observe_tenant_scope, require_observe_auth, security_context_from_headers};
+use crate::authz::{
+    GovernedMutationAuth, observe_tenant_scope, require_governed_mutation_auth,
+    require_observe_auth,
+};
 use crate::odata::extract_tenant;
 use crate::state::ServerState;
+
+#[derive(Deserialize)]
+struct WasmModuleUploadJson {
+    wasm_base64: String,
+}
 
 /// Response for WASM module upload.
 #[derive(Serialize)]
@@ -89,50 +99,72 @@ pub async fn handle_upload_wasm_module(
     body: axum::body::Bytes,
 ) -> Result<Json<WasmModuleUploadResponse>, (StatusCode, String)> {
     let tenant = extract_tenant(&headers, &state)?;
-    // Cedar authorization: admin bypass, others need manage_wasm.
-    let security_ctx = security_context_from_headers(&headers, None, None, None);
-    if !matches!(security_ctx.principal.kind, PrincipalKind::Admin)
-        && let Err(denial) = state.authorize_with_context(
-            &security_ctx,
-            "manage_wasm",
-            "WasmModule",
-            &std::collections::BTreeMap::new(),
-            tenant.as_str(),
-        )
+    let mut resource_attrs = BTreeMap::new();
+    resource_attrs.insert(
+        "id".to_string(),
+        serde_json::Value::String(module_name.clone()),
+    );
+    resource_attrs.insert(
+        "module_name".to_string(),
+        serde_json::Value::String(module_name.clone()),
+    );
+    if let Some(resp) = require_governed_mutation_auth(
+        &state,
+        &headers,
+        GovernedMutationAuth {
+            tenant: tenant.as_str(),
+            action: "manage_wasm",
+            resource_type: "WasmModule",
+            resource_id: &module_name,
+            resource_attrs,
+            module_name: Some(&module_name),
+            from_status: None,
+        },
+    )
+    .await
     {
-        let reason = denial.to_string();
-        tracing::warn!(reason = %reason, "unauthorized WASM upload attempt");
-        return Err((StatusCode::FORBIDDEN, reason));
+        return Err(resp);
     }
 
+    let module_bytes = decode_wasm_upload_body(&headers, body)?;
+
     // TigerStyle: pre-assertion on module size (10 MB budget)
-    if body.len() > temper_wasm::types::MAX_MODULE_SIZE {
-        tracing::warn!(size = body.len(), "WASM module too large");
+    if module_bytes.len() > temper_wasm::types::MAX_MODULE_SIZE {
+        tracing::warn!(size = module_bytes.len(), "WASM module too large");
         return Err((
             StatusCode::PAYLOAD_TOO_LARGE,
             format!(
                 "WASM module too large: {} bytes (max {})",
-                body.len(),
+                module_bytes.len(),
                 temper_wasm::types::MAX_MODULE_SIZE
             ),
         ));
     }
 
     // Compile and cache (must succeed before persisting)
-    let hash = state.wasm_engine.compile_and_cache(&body).map_err(|e| {
-        tracing::warn!(error = %e, "WASM compilation failed");
-        (
-            StatusCode::BAD_REQUEST,
-            format!("WASM compilation failed: {e}"),
-        )
-    })?;
+    let hash = state
+        .wasm_engine
+        .compile_and_cache(&module_bytes)
+        .map_err(|e| {
+            tracing::warn!(error = %e, "WASM compilation failed");
+            (
+                StatusCode::BAD_REQUEST,
+                format!("WASM compilation failed: {e}"),
+            )
+        })?;
 
     // Persist to durable storage first — if durability fails, refuse the upload.
     // This ensures the module survives restarts before we expose it in memory.
     // source="upload" so the os-apps install pipeline won't clobber this row at
     // next boot.
     if let Err(e) = state
-        .upsert_wasm_module(tenant.as_str(), &module_name, &body, &hash, "upload")
+        .upsert_wasm_module(
+            tenant.as_str(),
+            &module_name,
+            &module_bytes,
+            &hash,
+            "upload",
+        )
         .await
     {
         tracing::error!(error = %e, "failed to persist WASM module to durable store");
@@ -149,7 +181,7 @@ pub async fn handle_upload_wasm_module(
         wasm_reg.register(&tenant, &module_name, &hash);
     }
 
-    let size_bytes = body.len();
+    let size_bytes = module_bytes.len();
     tracing::info!(
         tenant = %tenant,
         module = %module_name,
@@ -163,6 +195,38 @@ pub async fn handle_upload_wasm_module(
         sha256_hash: hash,
         size_bytes,
     }))
+}
+
+fn decode_wasm_upload_body(
+    headers: &HeaderMap,
+    body: axum::body::Bytes,
+) -> Result<axum::body::Bytes, (StatusCode, String)> {
+    let content_type = headers
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    if !content_type
+        .split(';')
+        .any(|part| part.trim().eq_ignore_ascii_case("application/json"))
+    {
+        return Ok(body);
+    }
+
+    let payload: WasmModuleUploadJson = serde_json::from_slice(&body).map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("invalid WASM upload JSON body: {e}"),
+        )
+    })?;
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(payload.wasm_base64)
+        .map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                format!("invalid wasm_base64 payload: {e}"),
+            )
+        })?;
+    Ok(axum::body::Bytes::from(decoded))
 }
 
 /// GET /observe/wasm/modules/{module_name} — module info.
@@ -205,20 +269,31 @@ pub async fn handle_delete_wasm_module(
     Path(module_name): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     let tenant = extract_tenant(&headers, &state)?;
-    // Cedar authorization: admin bypass, others need manage_wasm.
-    let security_ctx = security_context_from_headers(&headers, None, None, None);
-    if !matches!(security_ctx.principal.kind, PrincipalKind::Admin)
-        && let Err(denial) = state.authorize_with_context(
-            &security_ctx,
-            "manage_wasm",
-            "WasmModule",
-            &std::collections::BTreeMap::new(),
-            tenant.as_str(),
-        )
+    let mut resource_attrs = BTreeMap::new();
+    resource_attrs.insert(
+        "id".to_string(),
+        serde_json::Value::String(module_name.clone()),
+    );
+    resource_attrs.insert(
+        "module_name".to_string(),
+        serde_json::Value::String(module_name.clone()),
+    );
+    if let Some(resp) = require_governed_mutation_auth(
+        &state,
+        &headers,
+        GovernedMutationAuth {
+            tenant: tenant.as_str(),
+            action: "manage_wasm",
+            resource_type: "WasmModule",
+            resource_id: &module_name,
+            resource_attrs,
+            module_name: Some(&module_name),
+            from_status: None,
+        },
+    )
+    .await
     {
-        let reason = denial.to_string();
-        tracing::warn!(reason = %reason, "unauthorized WASM delete attempt");
-        return Err((StatusCode::FORBIDDEN, reason));
+        return Err(resp);
     }
 
     // Get hash before removing from registry (for cache eviction)

--- a/docs/adrs/0080-agent-governed-mutation-denials.md
+++ b/docs/adrs/0080-agent-governed-mutation-denials.md
@@ -1,0 +1,64 @@
+# ADR-0080: Agent-Governed Mutation Denials
+
+- Status: Accepted
+- Date: 2026-05-11
+- Deciders: Temper core maintainers
+- Related:
+  - `crates/temper-server/src/authz/helpers.rs`
+  - `crates/temper-server/src/observe/wasm.rs`
+  - `crates/temper-server/src/api/decisions.rs`
+
+## Context
+
+Temper already converts some Cedar denials into `PendingDecision` records so a human can approve a narrow policy and the original agent session can resume. OData actions, spec submission, and policy management follow this path. Some management mutations still returned plain `403 Forbidden` responses from local endpoint checks, notably WASM module upload and delete. Those hard denials do not create a decision, so TemperPaw cannot pause the session or surface an approval in Discord.
+
+## Decision
+
+Agent/session-scoped mutating requests that can be retried must convert Cedar denials into governance decisions. Temper remains the authorization authority: the endpoint still calls Cedar through `ServerState`, and the denial is recorded by Temper with the denied action, resource type, resource id, tenant, principal, and session context.
+
+WASM module upload and delete use this governed mutation path. The resource is `WasmModule::{module_name}` and the action remains `manage_wasm`.
+
+Requests without resumable agent context, cross-tenant observe/admin reads, streams, and passive list/detail endpoints continue to return ordinary 403 responses. They are not converted into decisions because there is no safe session to pause and retry.
+
+The WASM upload API continues to accept raw WASM bytes. It also accepts JSON `{ "wasm_base64": "..." }` for WASM-host clients that cannot submit binary request bodies.
+
+Tenant-scoped decision lookup is part of the public governance API so agents do not need cross-tenant `/api/decisions` access to poll a decision they already know about.
+
+## Rollout Plan
+
+1. Add tests that show WASM upload/delete denials create pending decisions with `WasmModule::{module_name}`.
+2. Move WASM upload/delete onto the governed mutation helper.
+3. Add JSON base64 upload compatibility and tenant-scoped decision lookup.
+4. Update TemperPaw to use tenant-scoped decision routes and pin the merged Temper commit.
+
+## Consequences
+
+### Positive
+
+- Agent-facing management mutations use one approval lane.
+- Discord approval routing can work for delegated sessions once Temper creates a decision.
+- WASM uploads from TemperPaw no longer hit a body-format dead end after approval.
+
+### Negative
+
+- Mutation endpoints must classify whether a denial is resumable before recording a decision.
+
+### DST Compliance
+
+This touches `temper-server`. The change does not introduce simulated time, random IDs, or background work beyond existing `record_authz_denial` behavior. Existing `tokio::spawn` approval callbacks are unchanged.
+
+## Non-Goals
+
+- Do not convert passive observe reads, cross-tenant listing, or SSE streams into governance decisions.
+- Do not move Cedar authorization into TemperPaw.
+- Do not create endpoint-specific approval lanes.
+
+## Alternatives Considered
+
+1. **Let TemperPaw synthesize decisions from 403 responses** — rejected because TemperPaw would become a second authorization layer and could not safely recreate Cedar resource scope.
+2. **Grant blanket WASM management permissions to Paw agents** — rejected because it bypasses the human approval model.
+3. **Expose raw binary upload support in every WASM client immediately** — rejected as unnecessary for this fix; JSON base64 compatibility preserves the raw-byte API and unblocks current clients.
+
+## Rollback Policy
+
+Revert the governed mutation helper use from WASM upload/delete and remove JSON base64 parsing. Tenant-scoped decision lookup can remain because it is additive.


### PR DESCRIPTION
## Summary
- route agent/session-scoped mutating authorization denials through PendingDecision records
- cover WASM upload/delete with governed mutation auth and module-scoped resources
- add tenant-scoped decision lookup plus JSON base64 WASM uploads
- document the platform authorization consolidation in ADR-0080

## Verification
- RUST_TEST_THREADS=1 git push pre-push pipeline: rustfmt, clippy, readability ratchet, full cargo test, doctests
- cargo test -p temper-server --features observe wasm_
- cargo test -p temper-server --features observe tenant_decision_lookup_returns_known_decision_by_id
- cargo test -p temper-authz test_context_from_headers_normalizes_session_id