### PR TITLE
Allow agents to list owned governance decisions

### DIFF
--- a/crates/temper-server/src/api/decisions.rs
+++ b/crates/temper-server/src/api/decisions.rs
@@ -18,7 +18,7 @@ use tracing::instrument;
 
 use temper_runtime::tenant::TenantId;
 
-use super::{empty_decision_list, format_decision_list, require_policy_auth};
+use super::{decisions_access, empty_decision_list, format_decision_list, require_policy_auth};
 use crate::authz::{persist_and_activate_policy, require_observe_auth};
 use crate::request_context::AgentContext;
 use crate::state::{DecisionStatus, PendingDecision, ServerState};
@@ -49,15 +49,16 @@ pub(crate) async fn handle_list_decisions(
     headers: HeaderMap,
     Query(params): Query<DecisionListParams>,
 ) -> impl IntoResponse {
-    if let Some(resp) = require_policy_auth(&state, &headers, &tenant).await {
-        return resp;
-    }
+    let access = match decisions_access::decision_list_access(&state, &headers, &tenant).await {
+        Ok(access) => access,
+        Err(resp) => return resp,
+    };
     if let Some(store) = state.metadata_store_for_tenant(&tenant).await {
         match store
             .query_decisions(&tenant, params.status.as_deref())
             .await
         {
-            Ok(data_strings) => return format_decision_list(data_strings),
+            Ok(data_strings) => return format_decision_list(access.filter(data_strings)),
             Err(e) => {
                 tracing::warn!(error = %e, backend = store.backend_name(), "failed to query decisions");
             }

--- a/crates/temper-server/src/api/decisions_access.rs
+++ b/crates/temper-server/src/api/decisions_access.rs
@@ -1,0 +1,68 @@
+//! Decision read access helpers.
+
+use axum::http::HeaderMap;
+use axum::response::Response;
+use temper_authz::PrincipalKind;
+
+use super::require_policy_auth;
+use crate::authz::security_context_from_headers;
+use crate::state::{PendingDecision, ServerState};
+
+pub(crate) enum DecisionListAccess {
+    Full,
+    Owned {
+        agent_id: String,
+        session_id: Option<String>,
+    },
+}
+
+impl DecisionListAccess {
+    pub(crate) fn filter(&self, data_strings: Vec<String>) -> Vec<String> {
+        match self {
+            Self::Full => data_strings,
+            Self::Owned {
+                agent_id,
+                session_id,
+            } => data_strings
+                .into_iter()
+                .filter(|data| {
+                    serde_json::from_str::<PendingDecision>(data)
+                        .map(|decision| {
+                            let same_session = session_id
+                                .as_deref()
+                                .is_some_and(|id| decision.session_id.as_deref() == Some(id));
+                            decision.agent_id == *agent_id || same_session
+                        })
+                        .unwrap_or(false)
+                })
+                .collect(),
+        }
+    }
+}
+
+pub(crate) async fn decision_list_access(
+    state: &ServerState,
+    headers: &HeaderMap,
+    tenant: &str,
+) -> Result<DecisionListAccess, Response> {
+    let security_ctx = security_context_from_headers(headers, None, None, None);
+    if matches!(security_ctx.principal.kind, PrincipalKind::Admin) {
+        return Ok(DecisionListAccess::Full);
+    }
+
+    if matches!(security_ctx.principal.kind, PrincipalKind::Agent) {
+        return Ok(DecisionListAccess::Owned {
+            agent_id: security_ctx.principal.id,
+            session_id: security_ctx
+                .context_attrs
+                .get("sessionId")
+                .and_then(|value| value.as_str())
+                .map(ToOwned::to_owned),
+        });
+    }
+
+    match require_policy_auth(state, headers, tenant).await {
+        Some(response) => Err(response),
+        None => Ok(DecisionListAccess::Full),
+    }
+}

--- a/crates/temper-server/src/api/mod.rs
+++ b/crates/temper-server/src/api/mod.rs
@@ -6,6 +6,7 @@
 
 mod authorize;
 mod decisions;
+mod decisions_access;
 mod decisions_get;
 mod files;
 mod policies;

--- a/crates/temper-server/src/observe/mod_test.rs
+++ b/crates/temper-server/src/observe/mod_test.rs
@@ -132,6 +132,17 @@ fn agent_post(uri: &str, body: impl Into<Body>) -> Request<Body> {
         .unwrap()
 }
 
+fn agent_get(uri: &str) -> Request<Body> {
+    Request::get(uri)
+        .header("X-Tenant-Id", "default")
+        .header("X-Temper-Principal-Id", "agent-1")
+        .header("X-Temper-Principal-Kind", "agent")
+        .header("X-Temper-Agent-Type", "swe")
+        .header("X-Temper-Ctx-SessionId", "session-1")
+        .body(Body::empty())
+        .unwrap()
+}
+
 const ADMIN_MANAGE_POLICIES_POLICY: &str = r#"
 permit(
   principal is Admin,
@@ -373,6 +384,61 @@ async fn tenant_decision_lookup_returns_known_decision_by_id() {
     assert_eq!(json["id"], decision_id);
     assert_eq!(json["resource_type"], "WasmModule");
     assert_eq!(json["resource_id"], "git_upload_pack");
+}
+
+#[tokio::test]
+async fn tenant_decision_list_allows_agent_to_read_owned_pending_decisions() {
+    let state = test_state_with_turso().await;
+    install_admin_policy(&state);
+
+    let mut owned = crate::state::PendingDecision::from_denial(
+        "default",
+        "agent-1",
+        "manage_wasm",
+        "WasmModule",
+        "git_upload_pack",
+        serde_json::json!({"id":"git_upload_pack"}),
+        "test denial",
+        Some("git_upload_pack".to_string()),
+    );
+    owned.session_id = Some("session-1".to_string());
+    let mut other = crate::state::PendingDecision::from_denial(
+        "default",
+        "agent-2",
+        "manage_wasm",
+        "WasmModule",
+        "git_receive_pack",
+        serde_json::json!({"id":"git_receive_pack"}),
+        "test denial",
+        Some("git_receive_pack".to_string()),
+    );
+    other.session_id = Some("session-2".to_string());
+    let owned_id = owned.id.clone();
+    state
+        .persist_pending_decision(&owned)
+        .await
+        .expect("persist owned pending decision");
+    state
+        .persist_pending_decision(&other)
+        .await
+        .expect("persist other pending decision");
+    let app = build_app_with_state(state);
+
+    let response = app
+        .oneshot(agent_get("/api/tenants/default/decisions?status=pending"))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("decision list JSON");
+    assert_eq!(json["total"], 1);
+    assert_eq!(json["pending_count"], 1);
+    assert_eq!(json["decisions"][0]["id"], owned_id);
+    assert_eq!(json["decisions"][0]["agent_id"], "agent-1");
+    assert_eq!(json["decisions"][0]["session_id"], "session-1");
 }
 
 #[tokio::test]

--- a/docs/adrs/0080-agent-governed-mutation-denials.md
+++ b/docs/adrs/0080-agent-governed-mutation-denials.md
@@ -6,6 +6,7 @@
 - Related:
   - `crates/temper-server/src/authz/helpers.rs`
   - `crates/temper-server/src/observe/wasm.rs`
+  - `crates/temper-server/src/api/decisions_access.rs`
   - `crates/temper-server/src/api/decisions.rs`
 
 ## Context
@@ -18,17 +19,17 @@ Agent/session-scoped mutating requests that can be retried must convert Cedar de
 
 WASM module upload and delete use this governed mutation path. The resource is `WasmModule::{module_name}` and the action remains `manage_wasm`.
 
-Requests without resumable agent context, cross-tenant observe/admin reads, streams, and passive list/detail endpoints continue to return ordinary 403 responses. They are not converted into decisions because there is no safe session to pause and retry.
+Requests without resumable agent context, cross-tenant observe/admin reads, and streams continue to return ordinary 403 responses. They are not converted into decisions because there is no safe session to pause and retry.
 
 The WASM upload API continues to accept raw WASM bytes. It also accepts JSON `{ "wasm_base64": "..." }` for WASM-host clients that cannot submit binary request bodies.
 
-Tenant-scoped decision lookup is part of the public governance API so agents do not need cross-tenant `/api/decisions` access to poll a decision they already know about.
+Tenant-scoped decision lookup is part of the public governance API so agents do not need cross-tenant `/api/decisions` access to poll a decision they already know about. Tenant-scoped decision lists are owner-filtered for agent principals: an agent may read decisions for its own agent id or current session id, while admins and policy managers retain full list access.
 
 ## Rollout Plan
 
 1. Add tests that show WASM upload/delete denials create pending decisions with `WasmModule::{module_name}`.
 2. Move WASM upload/delete onto the governed mutation helper.
-3. Add JSON base64 upload compatibility and tenant-scoped decision lookup.
+3. Add JSON base64 upload compatibility and tenant-scoped decision lookup/list access.
 4. Update TemperPaw to use tenant-scoped decision routes and pin the merged Temper commit.
 
 ## Consequences


### PR DESCRIPTION
## Summary
- allow agent principals to list tenant decisions they own by agent id or session id
- keep full decision list access for admins/policy managers
- add regression coverage and update ADR-0080

## Verification
- cargo test -p temper-server --features observe tenant_decision_list_allows_agent_to_read_owned_pending_decisions -- --nocapture
- cargo test -p temper-server --features observe wasm_
- cargo test -p temper-server --features observe tenant_decision
- cargo clippy -p temper-server --features observe -- -D warnings
- RUST_TEST_THREADS=1 git push pre-push hook: rustfmt, clippy, readability ratchet, full workspace tests/doctests