### PR TITLE
Add PawFS event-budget observability and catalog exact-read support

### DIFF
--- a/crates/temper-server/src/entity_actor/actor.rs
+++ b/crates/temper-server/src/entity_actor/actor.rs
@@ -39,6 +39,25 @@ use super::types::{
     MAX_ITEMS_PER_ENTITY,
 };
 
+fn event_budget_workspace_id(state: &EntityState) -> String {
+    if state.entity_type == "Workspace" {
+        return state.entity_id.clone();
+    }
+
+    for key in ["WorkspaceId", "workspace_id"] {
+        if let Some(value) = state
+            .fields
+            .get(key)
+            .and_then(serde_json::Value::as_str)
+            .filter(|value| !value.is_empty())
+        {
+            return value.to_string();
+        }
+    }
+
+    String::new()
+}
+
 /// The entity actor -- processes actions through a TransitionTable.
 /// Optionally persists events to the configured backend. Wide events are emitted
 /// via the OTEL SDK (no-op when OTEL is not initialised).
@@ -660,6 +679,24 @@ impl Actor for EntityActor {
 
                 // TigerStyle: Budget enforcement (not just assertions -- hard limits)
                 if state.total_event_count >= MAX_EVENTS_PER_ENTITY {
+                    let workspace_id = event_budget_workspace_id(state);
+                    crate::event_budget_metrics::record_exhausted(
+                        &self.tenant,
+                        &state.entity_type,
+                        &state.entity_id,
+                        &workspace_id,
+                    );
+                    tracing::warn!(
+                        tenant = %self.tenant,
+                        entity_type = %state.entity_type,
+                        entity_id = %state.entity_id,
+                        workspace_id = %workspace_id,
+                        status = %state.status,
+                        action = %name,
+                        events_total = state.total_event_count,
+                        max_events = MAX_EVENTS_PER_ENTITY,
+                        "Event budget exhausted (10000 max)"
+                    );
                     ctx.reply(EntityResponse {
                         success: false,
                         state: state.clone(),

--- a/crates/temper-server/src/entity_actor/actor_test.rs
+++ b/crates/temper-server/src/entity_actor/actor_test.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::collections::BTreeMap;
 use std::time::Duration;
 use temper_jit::table::TransitionTable;
 use temper_runtime::ActorSystem;
@@ -7,6 +8,39 @@ const ORDER_IOA: &str = include_str!("../../../../test-fixtures/specs/order.ioa.
 
 fn order_table() -> Arc<RwLock<TransitionTable>> {
     Arc::new(RwLock::new(TransitionTable::from_ioa_source(ORDER_IOA)))
+}
+
+#[test]
+fn event_budget_workspace_id_uses_workspace_entity_id_or_field() {
+    let workspace_state = EntityState {
+        entity_type: "Workspace".to_string(),
+        entity_id: "ws-1".to_string(),
+        status: "Active".to_string(),
+        item_count: 0,
+        counters: BTreeMap::new(),
+        booleans: BTreeMap::new(),
+        lists: BTreeMap::new(),
+        fields: serde_json::json!({"WorkspaceId": "ignored"}),
+        events: std::collections::VecDeque::new(),
+        total_event_count: 0,
+        sequence_nr: 0,
+    };
+    assert_eq!(event_budget_workspace_id(&workspace_state), "ws-1");
+
+    let file_state = EntityState {
+        entity_type: "File".to_string(),
+        entity_id: "fl-1".to_string(),
+        status: "Ready".to_string(),
+        item_count: 0,
+        counters: BTreeMap::new(),
+        booleans: BTreeMap::new(),
+        lists: BTreeMap::new(),
+        fields: serde_json::json!({"workspace_id": "ws-2"}),
+        events: std::collections::VecDeque::new(),
+        total_event_count: 0,
+        sequence_nr: 0,
+    };
+    assert_eq!(event_budget_workspace_id(&file_state), "ws-2");
 }
 
 // =============================================

--- a/crates/temper-server/src/event_budget_metrics.rs
+++ b/crates/temper-server/src/event_budget_metrics.rs
@@ -1,0 +1,35 @@
+//! Metrics for the hard per-entity event cap.
+
+use std::sync::OnceLock;
+
+use opentelemetry::metrics::Counter;
+use opentelemetry::{KeyValue, global};
+
+fn exhausted_counter() -> &'static Counter<u64> {
+    static COUNTER: OnceLock<Counter<u64>> = OnceLock::new();
+    COUNTER.get_or_init(|| {
+        global::meter("temper.runtime")
+            .u64_counter("temper_entity_event_budget_exhausted_total")
+            .with_description(
+                "Actions refused because the hard per-entity event budget was exhausted.",
+            )
+            .build()
+    })
+}
+
+pub fn record_exhausted(tenant: &str, entity_type: &str, entity_id: &str, workspace_id: &str) {
+    let workspace_id = if workspace_id.is_empty() {
+        "none"
+    } else {
+        workspace_id
+    };
+    exhausted_counter().add(
+        1,
+        &[
+            KeyValue::new("tenant", tenant.to_string()),
+            KeyValue::new("entity_type", entity_type.to_string()),
+            KeyValue::new("entity_id", entity_id.to_string()),
+            KeyValue::new("workspace_id", workspace_id.to_string()),
+        ],
+    );
+}

--- a/crates/temper-server/src/lib.rs
+++ b/crates/temper-server/src/lib.rs
@@ -14,6 +14,7 @@ pub mod blob_sweeper;
 pub mod blobs;
 pub mod channels;
 pub mod entity_actor;
+pub mod event_budget_metrics;
 pub mod events;
 pub mod eventual_invariants;
 pub mod http_endpoint;

--- a/crates/temper-server/src/odata/read.rs
+++ b/crates/temper-server/src/odata/read.rs
@@ -511,6 +511,7 @@ async fn handle_entity_set(
         None // no filter
     };
 
+    let prefer_catalog_materialization = sql_pushdown_ids.is_some();
     let (entity_ids, apply_options, precomputed_count) = if let Some(pushed_ids) = sql_pushdown_ids
     {
         // SQL push-down already filtered — apply pagination only.
@@ -534,8 +535,15 @@ async fn handle_entity_set(
         )
     };
 
-    let entities =
-        materialize_entity_set_entities(state, tenant, &entity_type, name, &entity_ids).await;
+    let entities = materialize_entity_set_entities(
+        state,
+        tenant,
+        &entity_type,
+        name,
+        &entity_ids,
+        prefer_catalog_materialization,
+    )
+    .await;
 
     let (mut result, mut count) = apply_query_options(entities, &apply_options);
     if count.is_none() {

--- a/crates/temper-server/src/odata/read_support.rs
+++ b/crates/temper-server/src/odata/read_support.rs
@@ -54,6 +54,10 @@ fn catalog_fast_read_enabled() -> bool {
     *ENABLED.get_or_init(|| env_bool("TEMPER_ODATA_CATALOG_FAST_READ", false))
 }
 
+fn should_read_catalog_for_materialization(prefer_catalog: bool) -> bool {
+    prefer_catalog || catalog_fast_read_enabled()
+}
+
 /// Build the OData JSON body for a single catalog row.
 ///
 /// Mirrors the actor's serialized `EntityState` shape (`status`, `fields`,
@@ -150,12 +154,14 @@ pub(super) async fn materialize_entity_set_entities(
     entity_type: &str,
     entity_set_name: &str,
     entity_ids: &[String],
+    prefer_catalog: bool,
 ) -> Vec<serde_json::Value> {
-    let mut catalog_hits: HashMap<String, EntityCatalogRow> = if catalog_fast_read_enabled() {
-        try_load_catalog_rows(state, tenant, entity_type, entity_ids).await
-    } else {
-        HashMap::new()
-    };
+    let mut catalog_hits: HashMap<String, EntityCatalogRow> =
+        if should_read_catalog_for_materialization(prefer_catalog) {
+            try_load_catalog_rows(state, tenant, entity_type, entity_ids).await
+        } else {
+            HashMap::new()
+        };
 
     let concurrency = entity_set_materialization_concurrency();
     stream::iter(entity_ids.iter().cloned())
@@ -308,6 +314,7 @@ pub(super) async fn record_entity_set_not_found(state: &ServerState, tenant: &st
 mod tests {
     use super::{
         EntityCatalogRow, catalog_row_to_entity_body, select_entity_ids_for_materialization,
+        should_read_catalog_for_materialization,
     };
     use temper_odata::query::types::{
         FilterExpr, ODataValue, OrderByClause, OrderDirection, QueryOptions,
@@ -386,6 +393,11 @@ mod tests {
         // Fields blob is preserved verbatim.
         assert_eq!(body["fields"]["Name"], "phosphor-command-grid.html");
         assert_eq!(body["fields"]["content_hash"], "sha256:c74e77");
+    }
+
+    #[test]
+    fn pushed_down_filters_prefer_catalog_materialization() {
+        assert!(should_read_catalog_for_materialization(true));
     }
 
     #[test]

--- a/crates/temper-store-turso/src/schema.rs
+++ b/crates/temper-store-turso/src/schema.rs
@@ -197,6 +197,10 @@ pub const ALTER_POLICIES_ADD_ENABLED: &str =
 pub const ALTER_ENTITY_CATALOG_ADD_PROJECTION_HASH: &str =
     "ALTER TABLE entity_catalog ADD COLUMN projection_hash TEXT NOT NULL DEFAULT ''";
 
+/// Migration: add full projected fields JSON to the durable query-plane catalog.
+pub const ALTER_ENTITY_CATALOG_ADD_FIELDS: &str =
+    "ALTER TABLE entity_catalog ADD COLUMN fields TEXT NOT NULL DEFAULT '{}'";
+
 /// Durable per-tenant authorization denial patterns used to reconstruct
 /// policy suggestions across process restarts.
 pub const CREATE_POLICY_DENIAL_PATTERNS_TABLE: &str = "\

--- a/crates/temper-store-turso/src/schema/query_plane.rs
+++ b/crates/temper-store-turso/src/schema/query_plane.rs
@@ -5,6 +5,7 @@ CREATE TABLE IF NOT EXISTS entity_catalog (
     entity_type        TEXT NOT NULL,
     entity_id          TEXT NOT NULL,
     status             TEXT NOT NULL,
+    fields             TEXT NOT NULL DEFAULT '{}',
     updated_at         TEXT NOT NULL,
     sequence_nr        INTEGER NOT NULL DEFAULT 0,
     projection_version INTEGER NOT NULL DEFAULT 2,

--- a/crates/temper-store-turso/src/schema_test.rs
+++ b/crates/temper-store-turso/src/schema_test.rs
@@ -55,3 +55,12 @@ fn wasm_modules_table_has_required_columns() {
         );
     }
 }
+
+#[test]
+fn entity_catalog_stores_full_fields_json() {
+    let sql = CREATE_ENTITY_CATALOG_TABLE.to_uppercase();
+    assert!(
+        sql.contains("FIELDS"),
+        "entity_catalog schema must preserve full projected fields for catalog reads"
+    );
+}

--- a/crates/temper-store-turso/src/store/field_index.rs
+++ b/crates/temper-store-turso/src/store/field_index.rs
@@ -80,13 +80,14 @@ impl TursoEventStore {
             .await?;
         let conn = self.configured_connection().await?;
         let new_projection_hash = projection_hash(status, fields);
+        let fields_json = serde_json::to_string(fields).map_err(storage_error)?;
         let updated_at = sim_now().to_rfc3339();
         let sequence_nr = i64::try_from(sequence_nr).unwrap_or(i64::MAX);
 
         let unchanged_rows = conn
             .execute(
                 "UPDATE entity_catalog \
-                 SET status = ?4, updated_at = ?5, sequence_nr = ?6, projection_version = 2 \
+                 SET status = ?4, updated_at = ?5, sequence_nr = ?6, projection_version = 2, fields = ?8 \
                  WHERE tenant = ?1 AND entity_type = ?2 AND entity_id = ?3 AND projection_hash = ?7",
                 params![
                     tenant,
@@ -96,6 +97,7 @@ impl TursoEventStore {
                     updated_at.as_str(),
                     sequence_nr,
                     new_projection_hash.as_str(),
+                    fields_json.as_str(),
                 ],
             )
             .await
@@ -112,10 +114,11 @@ impl TursoEventStore {
 
         tx.execute(
             "INSERT INTO entity_catalog \
-             (tenant, entity_type, entity_id, status, updated_at, sequence_nr, projection_version, projection_hash) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, 2, ?7) \
+             (tenant, entity_type, entity_id, status, fields, updated_at, sequence_nr, projection_version, projection_hash) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 2, ?8) \
              ON CONFLICT(tenant, entity_type, entity_id) DO UPDATE SET \
                  status = excluded.status, \
+                 fields = excluded.fields, \
                  updated_at = excluded.updated_at, \
                  sequence_nr = excluded.sequence_nr, \
                  projection_version = excluded.projection_version, \
@@ -125,6 +128,7 @@ impl TursoEventStore {
                 entity_type,
                 entity_id,
                 status,
+                fields_json.as_str(),
                 updated_at,
                 sequence_nr,
                 new_projection_hash.as_str(),

--- a/crates/temper-store-turso/src/store/mod.rs
+++ b/crates/temper-store-turso/src/store/mod.rs
@@ -327,6 +327,9 @@ impl TursoEventStore {
         let _ = conn
             .execute(schema::ALTER_ENTITY_CATALOG_ADD_PROJECTION_HASH, ())
             .await;
+        let _ = conn
+            .execute(schema::ALTER_ENTITY_CATALOG_ADD_FIELDS, ())
+            .await;
 
         // Entity field index — EAV table for OData filter push-down.
         conn.execute(schema::CREATE_ENTITY_FIELD_INDEX_TABLE, ())

--- a/crates/temper-store-turso/src/store/tests/mod.rs
+++ b/crates/temper-store-turso/src/store/tests/mod.rs
@@ -716,6 +716,47 @@ async fn load_query_projection_fields_many_returns_requested_fields_by_entity() 
 }
 
 #[tokio::test]
+async fn load_entity_catalog_rows_returns_full_projected_fields() {
+    let store = make_store("entity-catalog-rows-full-fields").await;
+    let tenant = format!("tenant-{}", uuid::Uuid::new_v4());
+
+    store
+        .upsert_query_projection(
+            &tenant,
+            "File",
+            "file-a",
+            "Ready",
+            &serde_json::json!({
+                "Path": "/notes/readme.md",
+                "WorkspaceId": "ws-a",
+                "MimeType": "text/markdown",
+                "HasContent": true,
+            }),
+            7,
+        )
+        .await
+        .expect("upsert file projection");
+
+    let rows = store
+        .load_entity_catalog_rows(
+            &tenant,
+            "File",
+            &["file-a".to_string(), "missing".to_string()],
+        )
+        .await
+        .expect("load catalog rows");
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].entity_id, "file-a");
+    assert_eq!(rows[0].status, "Ready");
+    assert_eq!(rows[0].sequence_nr, 7);
+    assert_eq!(rows[0].fields["Path"], "/notes/readme.md");
+    assert_eq!(rows[0].fields["WorkspaceId"], "ws-a");
+    assert_eq!(rows[0].fields["MimeType"], "text/markdown");
+    assert_eq!(rows[0].fields["HasContent"], true);
+}
+
+#[tokio::test]
 async fn published_artifact_upsert_round_trips_and_updates_by_id() {
     let store = make_store("published-artifacts").await;
     let tenant = format!("tenant-{}", uuid::Uuid::new_v4());


### PR DESCRIPTION
## Summary
- Keep `MAX_EVENTS_PER_ENTITY` unchanged while adding structured event-budget exhaustion logging and metrics.
- Include entity type, entity id, workspace id, action, status, event total, and max events in the exhaustion signal.
- Prefer query-plane catalog materialization for pushed-down OData scalar filters so exact File/Directory lookup does not require capped actor materialization.
- Persist full Turso entity catalog `fields` JSON for fast materialization.

## Verification
- `cargo test -p temper-server pushed_down_filters_prefer_catalog_materialization --quiet`
- `cargo test -p temper-server --lib event_budget_workspace_id_uses_workspace_entity_id_or_field --quiet`
- `cargo test -p temper-store-turso load_entity_catalog_rows_returns_full_projected_fields --quiet`
- `cargo test -p temper-store-turso entity_catalog_stores_full_fields_json --quiet`
- `cargo run --quiet -p temper-server --bin check_instrumentation`
- Full pre-push suite: rustfmt, clippy, readability ratchet, `cargo test --workspace`
