### PR TITLE
Add WASM guest observability host API

### DIFF
--- a/crates/temper-observe/src/otel.rs
+++ b/crates/temper-observe/src/otel.rs
@@ -52,7 +52,11 @@ const DROPPED_SPAN_NAMES: &[&str] = &["turso.configured_connection", "clock_time
 /// debug value but produce enough volume to crowd out the dispatch-critical
 /// spans at 100%. Keep p99+ via `--log_with_p99` in the guest sampler; the
 /// host-level sampler drops 95% of them uniformly at random.
-const REDUCED_SAMPLE_PREFIXES: &[&str] = &["wasm:workspace_fs", "wasm:monty_repl"];
+///
+/// Do not include tool/provider guest module boundaries here. Guest spans
+/// inherit the parent sampling decision, so reducing those boundaries severs
+/// the very traces operators need when following work through WASM.
+const REDUCED_SAMPLE_PREFIXES: &[&str] = &["wasm:workspace_fs"];
 
 /// Trace-id-based deterministic sampling: keep if `(trace_id_low_u64 % 100) < rate_pct`.
 /// Using trace_id instead of random keeps the decision consistent across
@@ -746,6 +750,28 @@ mod tests {
         assert!(
             (3.0..=7.0).contains(&kept_pct),
             "reduced sample should keep ~5%, got {kept_pct:.1}%"
+        );
+    }
+
+    #[test]
+    fn monty_repl_boundary_is_not_reduced_sampled() {
+        use opentelemetry::trace::TraceId;
+        let sampler = NameBasedSampler {
+            inner: Sampler::AlwaysOn,
+        };
+        let trace_id = TraceId::from_bytes([0u8; 16]);
+        let result = sampler.should_sample(
+            None,
+            trace_id,
+            "wasm:monty_repl",
+            &SpanKind::Internal,
+            &[],
+            &[],
+        );
+
+        assert!(
+            matches!(result.decision, SamplingDecision::RecordAndSample),
+            "monty_repl must keep full sampling so guest tool spans stay stitched"
         );
     }
 

--- a/crates/temper-wasm-sdk/src/context.rs
+++ b/crates/temper-wasm-sdk/src/context.rs
@@ -68,6 +68,84 @@ pub struct WideEventInput<'a> {
     pub measurements: &'a Value,
 }
 
+/// A structured guest observability span owned by the WASM module.
+pub struct WasmSpan {
+    id: i64,
+    ended: bool,
+}
+
+impl WasmSpan {
+    /// Return the opaque host span id.
+    pub fn id(&self) -> i64 {
+        self.id
+    }
+
+    /// Add a span event with structured attributes.
+    pub fn add_event(&self, name: &str, attributes: &Value) -> Result<(), String> {
+        let payload = build_guest_span_event_payload(name, attributes)?;
+        call_host_span_event(self.id, &payload)
+    }
+
+    /// Add or update span attributes.
+    pub fn set_attributes(&self, attributes: &Value) -> Result<(), String> {
+        let payload = build_guest_span_attributes_payload(attributes)?;
+        call_host_span_attributes(self.id, &payload)
+    }
+
+    /// End the span with an OK status.
+    pub fn end_ok(mut self, attributes: &Value) -> Result<(), String> {
+        self.end_ok_ref(attributes)
+    }
+
+    /// End the span with an error status and optional final attributes.
+    pub fn end_error(
+        mut self,
+        error_type: &str,
+        error_message: &str,
+        attributes: &Value,
+    ) -> Result<(), String> {
+        self.end_error_ref(error_type, error_message, attributes)
+    }
+
+    fn end_ok_ref(&mut self, attributes: &Value) -> Result<(), String> {
+        if self.ended {
+            return Ok(());
+        }
+        let payload = build_guest_span_end_ok_payload(attributes)?;
+        call_host_span_end(self.id, &payload)?;
+        self.ended = true;
+        Ok(())
+    }
+
+    fn end_error_ref(
+        &mut self,
+        error_type: &str,
+        error_message: &str,
+        attributes: &Value,
+    ) -> Result<(), String> {
+        if self.ended {
+            return Ok(());
+        }
+        let payload = build_guest_span_end_error_payload(error_type, error_message, attributes)?;
+        call_host_span_end(self.id, &payload)?;
+        self.ended = true;
+        Ok(())
+    }
+}
+
+impl Drop for WasmSpan {
+    fn drop(&mut self) {
+        if !self.ended {
+            let payload = build_guest_span_end_ok_payload(&serde_json::json!({
+                "wasm_guest.drop_end": true,
+            }))
+            .unwrap_or_else(|_| "{\"status\":\"ok\"}".to_string());
+            let _ = call_host_span_end(self.id, &payload);
+            self.ended = true;
+        }
+    }
+}
+
 impl Context {
     /// Parse the invocation context from the host.
     ///
@@ -407,6 +485,30 @@ impl Context {
         }
     }
 
+    /// Start a structured guest observability span.
+    pub fn start_span(&self, name: &str, attributes: &Value) -> Result<WasmSpan, String> {
+        self.start_span_with_kind(name, None, attributes)
+    }
+
+    /// Start a structured guest observability span with an explicit span kind.
+    pub fn start_span_with_kind(
+        &self,
+        name: &str,
+        kind: Option<&str>,
+        attributes: &Value,
+    ) -> Result<WasmSpan, String> {
+        let payload = build_guest_span_start_payload(name, kind, attributes)?;
+        let span_id =
+            unsafe { host::host_start_span(payload.as_ptr() as i32, payload.len() as i32) };
+        if span_id <= 0 {
+            return Err(format!("host_start_span failed for '{name}'"));
+        }
+        Ok(WasmSpan {
+            id: span_id,
+            ended: false,
+        })
+    }
+
     /// Evaluate a single transition against an IOA spec via the host.
     ///
     /// The host builds a `TransitionTable` from the IOA source and evaluates
@@ -514,5 +616,151 @@ impl Context {
         let bytes = self.read_field_bytes(field_name)?;
         String::from_utf8(bytes)
             .map_err(|e| format!("field '{field_name}' is not valid UTF-8: {e}"))
+    }
+}
+
+fn object_attributes(attributes: &Value) -> Value {
+    match attributes {
+        Value::Object(_) => attributes.clone(),
+        _ => serde_json::json!({}),
+    }
+}
+
+fn build_guest_span_start_payload(
+    name: &str,
+    kind: Option<&str>,
+    attributes: &Value,
+) -> Result<String, String> {
+    let mut payload = serde_json::json!({
+        "name": name,
+        "attributes": object_attributes(attributes),
+    });
+    if let Some(kind) = kind.filter(|value| !value.is_empty()) {
+        payload["kind"] = Value::String(kind.to_string());
+    }
+    serde_json::to_string(&payload).map_err(|e| format!("span start JSON serialize: {e}"))
+}
+
+fn build_guest_span_event_payload(name: &str, attributes: &Value) -> Result<String, String> {
+    let payload = serde_json::json!({
+        "name": name,
+        "attributes": object_attributes(attributes),
+    });
+    serde_json::to_string(&payload).map_err(|e| format!("span event JSON serialize: {e}"))
+}
+
+fn build_guest_span_attributes_payload(attributes: &Value) -> Result<String, String> {
+    let payload = serde_json::json!({
+        "attributes": object_attributes(attributes),
+    });
+    serde_json::to_string(&payload).map_err(|e| format!("span attributes JSON serialize: {e}"))
+}
+
+fn build_guest_span_end_ok_payload(attributes: &Value) -> Result<String, String> {
+    let payload = serde_json::json!({
+        "status": "ok",
+        "attributes": object_attributes(attributes),
+    });
+    serde_json::to_string(&payload).map_err(|e| format!("span end JSON serialize: {e}"))
+}
+
+fn build_guest_span_end_error_payload(
+    error_type: &str,
+    error_message: &str,
+    attributes: &Value,
+) -> Result<String, String> {
+    let payload = serde_json::json!({
+        "status": "error",
+        "error.type": error_type,
+        "error.message": error_message,
+        "attributes": object_attributes(attributes),
+    });
+    serde_json::to_string(&payload).map_err(|e| format!("span error JSON serialize: {e}"))
+}
+
+fn call_host_span_event(span_id: i64, payload: &str) -> Result<(), String> {
+    let rc = unsafe {
+        host::host_add_span_event(span_id, payload.as_ptr() as i32, payload.len() as i32)
+    };
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(format!("host_add_span_event failed for span {span_id}"))
+    }
+}
+
+fn call_host_span_attributes(span_id: i64, payload: &str) -> Result<(), String> {
+    let rc = unsafe {
+        host::host_set_span_attributes(span_id, payload.as_ptr() as i32, payload.len() as i32)
+    };
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(format!(
+            "host_set_span_attributes failed for span {span_id}"
+        ))
+    }
+}
+
+fn call_host_span_end(span_id: i64, payload: &str) -> Result<(), String> {
+    let rc = unsafe { host::host_end_span(span_id, payload.as_ptr() as i32, payload.len() as i32) };
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(format!("host_end_span failed for span {span_id}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_guest_span_lifecycle_payloads() {
+        let start = build_guest_span_start_payload(
+            "tool.llm_call",
+            Some("client"),
+            &serde_json::json!({
+                "tool.name": "provider_caller",
+                "gen_ai.request.model": "claude",
+            }),
+        )
+        .expect("start payload");
+        let start: Value = serde_json::from_str(&start).expect("valid start JSON");
+        assert_eq!(start["name"], "tool.llm_call");
+        assert_eq!(start["kind"], "client");
+        assert_eq!(start["attributes"]["tool.name"], "provider_caller");
+
+        let event =
+            build_guest_span_event_payload("llm.response", &serde_json::json!({"tokens": 42}))
+                .expect("event payload");
+        let event: Value = serde_json::from_str(&event).expect("valid event JSON");
+        assert_eq!(event["name"], "llm.response");
+        assert_eq!(event["attributes"]["tokens"], 42);
+
+        let attrs = build_guest_span_attributes_payload(&serde_json::json!({"completion": "stop"}))
+            .expect("attrs payload");
+        let attrs: Value = serde_json::from_str(&attrs).expect("valid attrs JSON");
+        assert_eq!(attrs["attributes"]["completion"], "stop");
+
+        let end = build_guest_span_end_error_payload(
+            "llm_error",
+            "provider failed",
+            &serde_json::json!({"http.status_code": 500}),
+        )
+        .expect("end payload");
+        let end: Value = serde_json::from_str(&end).expect("valid end JSON");
+        assert_eq!(end["status"], "error");
+        assert_eq!(end["error.type"], "llm_error");
+        assert_eq!(end["error.message"], "provider failed");
+    }
+
+    #[test]
+    fn non_object_span_attributes_become_empty_objects() {
+        let payload =
+            build_guest_span_start_payload("guest", None, &Value::String("ignored".to_string()))
+                .expect("payload");
+        let payload: Value = serde_json::from_str(&payload).expect("valid JSON");
+        assert_eq!(payload["attributes"], serde_json::json!({}));
     }
 }

--- a/crates/temper-wasm-sdk/src/host.rs
+++ b/crates/temper-wasm-sdk/src/host.rs
@@ -61,6 +61,22 @@ unsafe extern "C" {
     /// Returns 0 on success, -1 on error.
     pub fn host_emit_metric(ptr: i32, len: i32) -> i32;
 
+    /// Start a structured guest observability span.
+    /// Returns an opaque positive span id, or -1 on error.
+    pub fn host_start_span(payload_ptr: i32, payload_len: i32) -> i64;
+
+    /// Add an event to a structured guest observability span.
+    /// Returns 0 on success, -1 on error.
+    pub fn host_add_span_event(span_id: i64, payload_ptr: i32, payload_len: i32) -> i32;
+
+    /// Set attributes on a structured guest observability span.
+    /// Returns 0 on success, -1 on error.
+    pub fn host_set_span_attributes(span_id: i64, payload_ptr: i32, payload_len: i32) -> i32;
+
+    /// End a structured guest observability span.
+    /// Returns 0 on success, -1 on error.
+    pub fn host_end_span(span_id: i64, payload_ptr: i32, payload_len: i32) -> i32;
+
     /// Read a secret value by key.
     /// Returns bytes written, needed size if too small, or -1 on error.
     pub fn host_get_secret(key_ptr: i32, key_len: i32, buf_ptr: i32, buf_len: i32) -> i32;

--- a/crates/temper-wasm-sdk/src/lib.rs
+++ b/crates/temper-wasm-sdk/src/lib.rs
@@ -22,7 +22,7 @@ pub mod context;
 pub mod host;
 pub mod http_stream;
 
-pub use context::{Context, HttpRequest, HttpResponse};
+pub use context::{Context, HttpRequest, HttpResponse, WasmSpan};
 
 /// Re-export serde_json types for convenience.
 pub use serde_json::{self, Value, json};
@@ -103,6 +103,6 @@ macro_rules! temper_module {
 /// use temper_wasm_sdk::prelude::*;
 /// ```
 pub mod prelude {
-    pub use crate::context::{Context, HttpRequest, HttpResponse};
+    pub use crate::context::{Context, HttpRequest, HttpResponse, WasmSpan};
     pub use crate::{Value, json, serde_json, set_error_result, set_success_result, temper_module};
 }

--- a/crates/temper-wasm/src/engine/guest_spans.rs
+++ b/crates/temper-wasm/src/engine/guest_spans.rs
@@ -168,8 +168,9 @@ impl GuestSpanRegistry {
         );
         update_span_name(&span, name);
         apply_attributes(&span, &payload.attributes);
-        let (trace_id, span_id) = tracing_span_ids(&span);
         enter_thread_local_guest_span(&span);
+        let (trace_id, span_id) = tracing_span_ids(&span);
+        let attributes = manual_span_attributes(&self.context, id, &payload.attributes);
 
         self.spans.insert(
             id,
@@ -181,7 +182,7 @@ impl GuestSpanRegistry {
                 parent_context,
                 trace_id,
                 span_id,
-                attributes: allowed_attributes(&payload.attributes),
+                attributes,
                 events: Vec::new(),
             },
         );
@@ -382,6 +383,62 @@ fn allowed_attributes(attributes: &BTreeMap<String, Value>) -> BTreeMap<String, 
         .filter(|(key, _)| guest_span_attribute_allowed(key))
         .map(|(key, value)| (key.clone(), value.clone()))
         .collect()
+}
+
+fn manual_span_attributes(
+    context: &WasmInvocationContext,
+    span_id: i64,
+    attributes: &BTreeMap<String, Value>,
+) -> BTreeMap<String, Value> {
+    let mut manual = allowed_attributes(attributes);
+    manual.insert("tenant".to_string(), Value::String(context.tenant.clone()));
+    manual.insert(
+        "entity_type".to_string(),
+        Value::String(context.entity_type.clone()),
+    );
+    manual.insert(
+        "entity_id".to_string(),
+        Value::String(context.entity_id.clone()),
+    );
+    manual.insert(
+        "trigger_action".to_string(),
+        Value::String(context.trigger_action.clone()),
+    );
+    manual.insert(
+        "wasm_module".to_string(),
+        Value::String(context.wasm_module.clone().unwrap_or_default()),
+    );
+    manual.insert(
+        "agent_id".to_string(),
+        Value::String(context.agent_id.clone().unwrap_or_default()),
+    );
+    manual.insert(
+        "session_id".to_string(),
+        Value::String(context.session_id.clone().unwrap_or_default()),
+    );
+    manual.insert(
+        "workflow_root_entity_type".to_string(),
+        Value::String(
+            context
+                .workflow_root_entity_type
+                .clone()
+                .unwrap_or_default(),
+        ),
+    );
+    manual.insert(
+        "workflow_root_entity_id".to_string(),
+        Value::String(context.workflow_root_entity_id.clone().unwrap_or_default()),
+    );
+    manual.insert(
+        "workflow_run_id".to_string(),
+        Value::String(context.workflow_run_id.clone().unwrap_or_default()),
+    );
+    manual.insert(
+        "observability_event".to_string(),
+        Value::String("wasm_guest.span".to_string()),
+    );
+    manual.insert("wasm_guest_span_id".to_string(), Value::from(span_id));
+    manual
 }
 
 fn merge_allowed_attributes(
@@ -649,6 +706,39 @@ mod tests {
         assert!(!guest_span_attribute_allowed("_otel.parent_trace_id"));
         assert!(guest_span_attribute_allowed("tool.name"));
         assert!(guest_span_attribute_allowed("gen_ai.operation.name"));
+    }
+
+    #[test]
+    fn manual_span_snapshot_includes_invocation_correlation_attributes() {
+        let mut attributes = BTreeMap::new();
+        attributes.insert("tool.name".to_string(), Value::String("python".to_string()));
+        let snapshot = manual_span_attributes(&context(), 7, &attributes);
+
+        assert_eq!(
+            snapshot.get("tenant"),
+            Some(&Value::String("test".to_string()))
+        );
+        assert_eq!(
+            snapshot.get("entity_id"),
+            Some(&Value::String("s-1".to_string()))
+        );
+        assert_eq!(
+            snapshot.get("wasm_module"),
+            Some(&Value::String("test_guest".to_string()))
+        );
+        assert_eq!(
+            snapshot.get("workflow_run_id"),
+            Some(&Value::String("Session:s-1".to_string()))
+        );
+        assert_eq!(
+            snapshot.get("observability_event"),
+            Some(&Value::String("wasm_guest.span".to_string()))
+        );
+        assert_eq!(snapshot.get("wasm_guest_span_id"), Some(&Value::from(7)));
+        assert_eq!(
+            snapshot.get("tool.name"),
+            Some(&Value::String("python".to_string()))
+        );
     }
 
     #[test]

--- a/crates/temper-wasm/src/engine/guest_spans.rs
+++ b/crates/temper-wasm/src/engine/guest_spans.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::time::SystemTime;
 
@@ -46,6 +47,14 @@ struct GuestSpanEndPayload {
     attributes: BTreeMap<String, Value>,
 }
 
+thread_local! {
+    // `EnteredSpan` is intentionally !Send, while Wasmtime host state must be
+    // Send. Guest WASM execution is synchronous on one blocking thread, so keep
+    // the active enter guards thread-local and the registry itself portable.
+    static ENTERED_GUEST_SPANS: RefCell<Vec<tracing::span::EnteredSpan>> =
+        const { RefCell::new(Vec::new()) };
+}
+
 struct GuestSpanEntry {
     span: tracing::Span,
 }
@@ -61,6 +70,7 @@ pub(crate) struct GuestSpanRegistry {
 
 impl GuestSpanRegistry {
     pub(crate) fn new(context: WasmInvocationContext) -> Self {
+        clear_thread_local_guest_spans();
         Self {
             context,
             next_id: 1,
@@ -97,7 +107,6 @@ impl GuestSpanRegistry {
         self.next_id = self.next_id.saturating_add(1);
         self.total_started += 1;
         let kind = payload.kind.as_deref().unwrap_or("internal");
-        let parent_guard = self.enter_active();
         let span = tracing::info_span!(
             "wasm.guest",
             otel.name = %name,
@@ -129,9 +138,9 @@ impl GuestSpanRegistry {
             error.message = tracing::field::Empty,
             exception.message = tracing::field::Empty,
         );
-        drop(parent_guard);
         update_span_name(&span, name);
         apply_attributes(&span, &payload.attributes);
+        enter_thread_local_guest_span(&span);
 
         self.spans.insert(id, GuestSpanEntry { span });
         self.stack.push(id);
@@ -196,6 +205,7 @@ impl GuestSpanRegistry {
         self.stack.pop();
         apply_attributes(&entry.span, &payload.attributes);
         apply_end_status(&entry.span, &payload);
+        exit_thread_local_guest_span();
         end_otel_span(&entry.span);
         drop(entry);
         Ok(())
@@ -221,11 +231,13 @@ impl GuestSpanRegistry {
                     .context()
                     .span()
                     .set_status(Status::error("guest span left open"));
+                exit_thread_local_guest_span();
                 end_otel_span(&entry.span);
                 drop(entry);
             }
         }
         self.spans.clear();
+        clear_thread_local_guest_spans();
     }
 
     fn span(&self, span_id: i64) -> Result<&tracing::Span, String> {
@@ -260,6 +272,22 @@ pub(crate) fn guest_span_attribute_allowed(key: &str) -> bool {
 fn update_span_name(span: &tracing::Span, name: &str) {
     span.record("otel.name", name);
     span.context().span().update_name(name.to_string());
+}
+
+fn enter_thread_local_guest_span(span: &tracing::Span) {
+    ENTERED_GUEST_SPANS.with(|guards| {
+        guards.borrow_mut().push(span.clone().entered());
+    });
+}
+
+fn exit_thread_local_guest_span() {
+    ENTERED_GUEST_SPANS.with(|guards| {
+        let _ = guards.borrow_mut().pop();
+    });
+}
+
+fn clear_thread_local_guest_spans() {
+    ENTERED_GUEST_SPANS.with(|guards| guards.borrow_mut().clear());
 }
 
 fn apply_attributes(span: &tracing::Span, attributes: &BTreeMap<String, Value>) {

--- a/crates/temper-wasm/src/engine/guest_spans.rs
+++ b/crates/temper-wasm/src/engine/guest_spans.rs
@@ -3,7 +3,9 @@ use std::collections::BTreeMap;
 use std::time::SystemTime;
 
 use opentelemetry::KeyValue;
-use opentelemetry::trace::{Status, TraceContextExt as _};
+use opentelemetry::trace::{
+    Event, Span as OtelSpan, SpanId, SpanKind, Status, TraceContextExt as _, TraceId, Tracer,
+};
 use serde::Deserialize;
 use serde_json::Value;
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
@@ -57,10 +59,25 @@ thread_local! {
 
 struct GuestSpanEntry {
     span: tracing::Span,
+    name: String,
+    kind: String,
+    start_time: SystemTime,
+    parent_context: Option<opentelemetry::Context>,
+    trace_id: Option<TraceId>,
+    span_id: Option<SpanId>,
+    attributes: BTreeMap<String, Value>,
+    events: Vec<GuestSpanManualEvent>,
+}
+
+struct GuestSpanManualEvent {
+    name: String,
+    timestamp: SystemTime,
+    attributes: BTreeMap<String, Value>,
 }
 
 pub(crate) struct GuestSpanRegistry {
     context: WasmInvocationContext,
+    manual_export: bool,
     next_id: i64,
     total_started: usize,
     max_spans: usize,
@@ -69,10 +86,20 @@ pub(crate) struct GuestSpanRegistry {
 }
 
 impl GuestSpanRegistry {
+    #[cfg(test)]
     pub(crate) fn new(context: WasmInvocationContext) -> Self {
+        Self::with_manual_export(context, false)
+    }
+
+    pub(crate) fn for_invocation(context: WasmInvocationContext, needs_wasi: bool) -> Self {
+        Self::with_manual_export(context, needs_wasi)
+    }
+
+    fn with_manual_export(context: WasmInvocationContext, manual_export: bool) -> Self {
         clear_thread_local_guest_spans();
         Self {
             context,
+            manual_export,
             next_id: 1,
             total_started: 0,
             max_spans: DEFAULT_MAX_GUEST_SPANS,
@@ -107,6 +134,7 @@ impl GuestSpanRegistry {
         self.next_id = self.next_id.saturating_add(1);
         self.total_started += 1;
         let kind = payload.kind.as_deref().unwrap_or("internal");
+        let parent_context = manual_parent_context();
         let span = tracing::info_span!(
             "wasm.guest",
             otel.name = %name,
@@ -140,39 +168,67 @@ impl GuestSpanRegistry {
         );
         update_span_name(&span, name);
         apply_attributes(&span, &payload.attributes);
+        let (trace_id, span_id) = tracing_span_ids(&span);
         enter_thread_local_guest_span(&span);
 
-        self.spans.insert(id, GuestSpanEntry { span });
+        self.spans.insert(
+            id,
+            GuestSpanEntry {
+                span,
+                name: name.to_string(),
+                kind: kind.to_string(),
+                start_time: SystemTime::now(),
+                parent_context,
+                trace_id,
+                span_id,
+                attributes: allowed_attributes(&payload.attributes),
+                events: Vec::new(),
+            },
+        );
         self.stack.push(id);
         Ok(id)
     }
 
-    pub(crate) fn add_span_event(&self, span_id: i64, payload_json: &str) -> Result<(), String> {
+    pub(crate) fn add_span_event(
+        &mut self,
+        span_id: i64,
+        payload_json: &str,
+    ) -> Result<(), String> {
         let payload: GuestSpanEventPayload = serde_json::from_str(payload_json)
             .map_err(|e| format!("invalid guest span event payload: {e}"))?;
         let name = payload.name.trim();
         if name.is_empty() {
             return Err("guest span event name must not be empty".to_string());
         }
-        let span = self.span(span_id)?;
+        let entry = self.span_mut(span_id)?;
         let attrs = payload
             .attributes
             .iter()
             .filter_map(|(key, value)| key_value_from_json(key, value))
             .collect::<Vec<_>>();
-        span.context().span().add_event(name.to_string(), attrs);
+        entry
+            .span
+            .context()
+            .span()
+            .add_event(name.to_string(), attrs);
+        entry.events.push(GuestSpanManualEvent {
+            name: name.to_string(),
+            timestamp: SystemTime::now(),
+            attributes: allowed_attributes(&payload.attributes),
+        });
         Ok(())
     }
 
     pub(crate) fn set_span_attributes(
-        &self,
+        &mut self,
         span_id: i64,
         payload_json: &str,
     ) -> Result<(), String> {
         let payload: GuestSpanAttributesPayload = serde_json::from_str(payload_json)
             .map_err(|e| format!("invalid guest span attributes payload: {e}"))?;
-        let span = self.span(span_id)?;
-        apply_attributes(span, &payload.attributes);
+        let entry = self.span_mut(span_id)?;
+        apply_attributes(&entry.span, &payload.attributes);
+        merge_allowed_attributes(&mut entry.attributes, &payload.attributes);
         Ok(())
     }
 
@@ -203,10 +259,16 @@ impl GuestSpanRegistry {
             .remove(&span_id)
             .ok_or_else(|| format!("unknown guest span id: {span_id}"))?;
         self.stack.pop();
+        let mut entry = entry;
+        merge_allowed_attributes(&mut entry.attributes, &payload.attributes);
+        merge_end_status_attributes(&mut entry.attributes, &payload);
         apply_attributes(&entry.span, &payload.attributes);
         apply_end_status(&entry.span, &payload);
         exit_thread_local_guest_span();
         end_otel_span(&entry.span);
+        if self.manual_export {
+            export_manual_span(&entry, status_from_end_payload(&payload), SystemTime::now());
+        }
         drop(entry);
         Ok(())
     }
@@ -233,6 +295,13 @@ impl GuestSpanRegistry {
                     .set_status(Status::error("guest span left open"));
                 exit_thread_local_guest_span();
                 end_otel_span(&entry.span);
+                if self.manual_export {
+                    export_manual_span(
+                        &entry,
+                        Status::error("guest span left open"),
+                        SystemTime::now(),
+                    );
+                }
                 drop(entry);
             }
         }
@@ -240,10 +309,9 @@ impl GuestSpanRegistry {
         clear_thread_local_guest_spans();
     }
 
-    fn span(&self, span_id: i64) -> Result<&tracing::Span, String> {
+    fn span_mut(&mut self, span_id: i64) -> Result<&mut GuestSpanEntry, String> {
         self.spans
-            .get(&span_id)
-            .map(|entry| &entry.span)
+            .get_mut(&span_id)
             .ok_or_else(|| format!("unknown guest span id: {span_id}"))
     }
 }
@@ -288,6 +356,140 @@ fn exit_thread_local_guest_span() {
 
 fn clear_thread_local_guest_spans() {
     ENTERED_GUEST_SPANS.with(|guards| guards.borrow_mut().clear());
+}
+
+fn manual_parent_context() -> Option<opentelemetry::Context> {
+    let context = tracing::Span::current().context();
+    let span_context = context.span().span_context().clone();
+    span_context
+        .is_valid()
+        .then(|| opentelemetry::Context::new().with_remote_span_context(span_context))
+}
+
+fn tracing_span_ids(span: &tracing::Span) -> (Option<TraceId>, Option<SpanId>) {
+    let context = span.context();
+    let span_context = context.span().span_context().clone();
+    if span_context.is_valid() {
+        (Some(span_context.trace_id()), Some(span_context.span_id()))
+    } else {
+        (None, None)
+    }
+}
+
+fn allowed_attributes(attributes: &BTreeMap<String, Value>) -> BTreeMap<String, Value> {
+    attributes
+        .iter()
+        .filter(|(key, _)| guest_span_attribute_allowed(key))
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect()
+}
+
+fn merge_allowed_attributes(
+    target: &mut BTreeMap<String, Value>,
+    attributes: &BTreeMap<String, Value>,
+) {
+    for (key, value) in attributes {
+        if guest_span_attribute_allowed(key) {
+            target.insert(key.clone(), value.clone());
+        }
+    }
+}
+
+fn merge_end_status_attributes(
+    target: &mut BTreeMap<String, Value>,
+    payload: &GuestSpanEndPayload,
+) {
+    let status = payload.status.as_deref().unwrap_or("ok");
+    if !status.eq_ignore_ascii_case("error") {
+        return;
+    }
+    let error_message = payload
+        .error_message
+        .as_deref()
+        .filter(|value| !value.is_empty())
+        .unwrap_or("guest span failed");
+    let error_type = payload
+        .error_type
+        .as_deref()
+        .filter(|value| !value.is_empty())
+        .unwrap_or("guest_span_error");
+    target.insert(
+        "error.type".to_string(),
+        Value::String(error_type.to_string()),
+    );
+    target.insert(
+        "error.message".to_string(),
+        Value::String(error_message.to_string()),
+    );
+    target.insert(
+        "exception.message".to_string(),
+        Value::String(error_message.to_string()),
+    );
+}
+
+fn status_from_end_payload(payload: &GuestSpanEndPayload) -> Status {
+    let status = payload.status.as_deref().unwrap_or("ok");
+    if status.eq_ignore_ascii_case("error") {
+        let error_message = payload
+            .error_message
+            .as_deref()
+            .filter(|value| !value.is_empty())
+            .unwrap_or("guest span failed");
+        Status::error(error_message.to_string())
+    } else {
+        Status::Ok
+    }
+}
+
+fn export_manual_span(entry: &GuestSpanEntry, status: Status, end_time: SystemTime) {
+    let (Some(trace_id), Some(span_id), Some(parent_context)) =
+        (entry.trace_id, entry.span_id, entry.parent_context.clone())
+    else {
+        return;
+    };
+
+    let tracer = opentelemetry::global::tracer("temper-wasm-guest");
+    let attrs = entry
+        .attributes
+        .iter()
+        .filter_map(|(key, value)| key_value_from_json(key, value))
+        .collect::<Vec<_>>();
+    let events = entry
+        .events
+        .iter()
+        .map(|event| {
+            let attrs = event
+                .attributes
+                .iter()
+                .filter_map(|(key, value)| key_value_from_json(key, value))
+                .collect::<Vec<_>>();
+            Event::new(event.name.clone(), event.timestamp, attrs, 0)
+        })
+        .collect::<Vec<_>>();
+    let mut span = tracer.build_with_context(
+        tracer
+            .span_builder(entry.name.clone())
+            .with_trace_id(trace_id)
+            .with_span_id(span_id)
+            .with_kind(span_kind(&entry.kind))
+            .with_start_time(entry.start_time)
+            .with_end_time(end_time)
+            .with_status(status)
+            .with_attributes(attrs)
+            .with_events(events),
+        &parent_context,
+    );
+    span.end_with_timestamp(end_time);
+}
+
+fn span_kind(kind: &str) -> SpanKind {
+    match kind.to_ascii_lowercase().as_str() {
+        "server" => SpanKind::Server,
+        "client" => SpanKind::Client,
+        "producer" => SpanKind::Producer,
+        "consumer" => SpanKind::Consumer,
+        _ => SpanKind::Internal,
+    }
 }
 
 fn apply_attributes(span: &tracing::Span, attributes: &BTreeMap<String, Value>) {

--- a/crates/temper-wasm/src/engine/guest_spans.rs
+++ b/crates/temper-wasm/src/engine/guest_spans.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::time::SystemTime;
 
 use opentelemetry::KeyValue;
 use opentelemetry::trace::{Status, TraceContextExt as _};
@@ -195,6 +196,7 @@ impl GuestSpanRegistry {
         self.stack.pop();
         apply_attributes(&entry.span, &payload.attributes);
         apply_end_status(&entry.span, &payload);
+        end_otel_span(&entry.span);
         drop(entry);
         Ok(())
     }
@@ -219,6 +221,7 @@ impl GuestSpanRegistry {
                     .context()
                     .span()
                     .set_status(Status::error("guest span left open"));
+                end_otel_span(&entry.span);
                 drop(entry);
             }
         }
@@ -293,6 +296,14 @@ fn apply_end_status(span: &tracing::Span, payload: &GuestSpanEndPayload) {
             .set_status(Status::error(error_message.to_string()));
     } else {
         span.context().span().set_status(Status::Ok);
+    }
+}
+
+fn end_otel_span(span: &tracing::Span) {
+    let context = span.context();
+    let otel_span = context.span();
+    if otel_span.span_context().is_valid() {
+        otel_span.end_with_timestamp(SystemTime::now());
     }
 }
 

--- a/crates/temper-wasm/src/engine/guest_spans.rs
+++ b/crates/temper-wasm/src/engine/guest_spans.rs
@@ -1,0 +1,423 @@
+use std::collections::BTreeMap;
+
+use opentelemetry::KeyValue;
+use opentelemetry::trace::{Status, TraceContextExt as _};
+use serde::Deserialize;
+use serde_json::Value;
+use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+use crate::host_trait::{datadog_visible_span_hint_field, truncate_for_span_attr};
+use crate::types::WasmInvocationContext;
+
+const DEFAULT_MAX_GUEST_SPANS: usize = 256;
+
+#[derive(Debug, Deserialize)]
+struct GuestSpanStartPayload {
+    name: String,
+    #[serde(default)]
+    kind: Option<String>,
+    #[serde(default)]
+    attributes: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GuestSpanEventPayload {
+    name: String,
+    #[serde(default)]
+    attributes: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GuestSpanAttributesPayload {
+    #[serde(default)]
+    attributes: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GuestSpanEndPayload {
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default, rename = "error.type")]
+    error_type: Option<String>,
+    #[serde(default, rename = "error.message")]
+    error_message: Option<String>,
+    #[serde(default)]
+    attributes: BTreeMap<String, Value>,
+}
+
+struct GuestSpanEntry {
+    span: tracing::Span,
+}
+
+pub(crate) struct GuestSpanRegistry {
+    context: WasmInvocationContext,
+    next_id: i64,
+    total_started: usize,
+    max_spans: usize,
+    spans: BTreeMap<i64, GuestSpanEntry>,
+    stack: Vec<i64>,
+}
+
+impl GuestSpanRegistry {
+    pub(crate) fn new(context: WasmInvocationContext) -> Self {
+        Self {
+            context,
+            next_id: 1,
+            total_started: 0,
+            max_spans: DEFAULT_MAX_GUEST_SPANS,
+            spans: BTreeMap::new(),
+            stack: Vec::new(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_max_spans(context: WasmInvocationContext, max_spans: usize) -> Self {
+        Self {
+            max_spans,
+            ..Self::new(context)
+        }
+    }
+
+    pub(crate) fn start_span(&mut self, payload_json: &str) -> Result<i64, String> {
+        let payload: GuestSpanStartPayload = serde_json::from_str(payload_json)
+            .map_err(|e| format!("invalid guest span start payload: {e}"))?;
+        let name = payload.name.trim();
+        if name.is_empty() {
+            return Err("guest span name must not be empty".to_string());
+        }
+        if self.spans.len() >= self.max_spans || self.total_started >= self.max_spans {
+            return Err(format!(
+                "guest span limit exceeded: max_spans={}",
+                self.max_spans
+            ));
+        }
+
+        let id = self.next_id;
+        self.next_id = self.next_id.saturating_add(1);
+        self.total_started += 1;
+        let kind = payload.kind.as_deref().unwrap_or("internal");
+        let parent_guard = self.enter_active();
+        let span = tracing::info_span!(
+            "wasm.guest",
+            otel.name = %name,
+            otel.kind = %kind,
+            tenant = %self.context.tenant,
+            entity_type = %self.context.entity_type,
+            entity_id = %self.context.entity_id,
+            trigger_action = %self.context.trigger_action,
+            wasm_module = self.context.wasm_module.as_deref().unwrap_or(""),
+            agent_id = self.context.agent_id.as_deref().unwrap_or(""),
+            session_id = self.context.session_id.as_deref().unwrap_or(""),
+            workflow_root_entity_type = self.context.workflow_root_entity_type.as_deref().unwrap_or(""),
+            workflow_root_entity_id = self.context.workflow_root_entity_id.as_deref().unwrap_or(""),
+            workflow_run_id = self.context.workflow_run_id.as_deref().unwrap_or(""),
+            observability_event = "wasm_guest.span",
+            wasm_guest_span_id = id,
+            action_name = tracing::field::Empty,
+            managed_session_id = tracing::field::Empty,
+            inner_session_id = tracing::field::Empty,
+            parent_session_id = tracing::field::Empty,
+            environment_id = tracing::field::Empty,
+            workflow_step = tracing::field::Empty,
+            tool.name = tracing::field::Empty,
+            tool.call_id = tracing::field::Empty,
+            gen_ai.operation.name = tracing::field::Empty,
+            gen_ai.provider.name = tracing::field::Empty,
+            gen_ai.request.model = tracing::field::Empty,
+            error.type = tracing::field::Empty,
+            error.message = tracing::field::Empty,
+            exception.message = tracing::field::Empty,
+        );
+        drop(parent_guard);
+        update_span_name(&span, name);
+        apply_attributes(&span, &payload.attributes);
+
+        self.spans.insert(id, GuestSpanEntry { span });
+        self.stack.push(id);
+        Ok(id)
+    }
+
+    pub(crate) fn add_span_event(&self, span_id: i64, payload_json: &str) -> Result<(), String> {
+        let payload: GuestSpanEventPayload = serde_json::from_str(payload_json)
+            .map_err(|e| format!("invalid guest span event payload: {e}"))?;
+        let name = payload.name.trim();
+        if name.is_empty() {
+            return Err("guest span event name must not be empty".to_string());
+        }
+        let span = self.span(span_id)?;
+        let attrs = payload
+            .attributes
+            .iter()
+            .filter_map(|(key, value)| key_value_from_json(key, value))
+            .collect::<Vec<_>>();
+        span.context().span().add_event(name.to_string(), attrs);
+        Ok(())
+    }
+
+    pub(crate) fn set_span_attributes(
+        &self,
+        span_id: i64,
+        payload_json: &str,
+    ) -> Result<(), String> {
+        let payload: GuestSpanAttributesPayload = serde_json::from_str(payload_json)
+            .map_err(|e| format!("invalid guest span attributes payload: {e}"))?;
+        let span = self.span(span_id)?;
+        apply_attributes(span, &payload.attributes);
+        Ok(())
+    }
+
+    pub(crate) fn end_span(&mut self, span_id: i64, payload_json: &str) -> Result<(), String> {
+        if self.stack.last().copied() != Some(span_id) {
+            if self.spans.contains_key(&span_id) {
+                return Err(format!(
+                    "guest span {span_id} cannot end before its active child"
+                ));
+            }
+            return Err(format!("unknown guest span id: {span_id}"));
+        }
+
+        let payload: GuestSpanEndPayload = if payload_json.trim().is_empty() {
+            GuestSpanEndPayload {
+                status: Some("ok".to_string()),
+                error_type: None,
+                error_message: None,
+                attributes: BTreeMap::new(),
+            }
+        } else {
+            serde_json::from_str(payload_json)
+                .map_err(|e| format!("invalid guest span end payload: {e}"))?
+        };
+
+        let entry = self
+            .spans
+            .remove(&span_id)
+            .ok_or_else(|| format!("unknown guest span id: {span_id}"))?;
+        self.stack.pop();
+        apply_attributes(&entry.span, &payload.attributes);
+        apply_end_status(&entry.span, &payload);
+        drop(entry);
+        Ok(())
+    }
+
+    pub(crate) fn enter_active(&self) -> Option<tracing::span::EnteredSpan> {
+        let span_id = self.stack.last()?;
+        self.spans
+            .get(span_id)
+            .map(|entry| entry.span.clone().entered())
+    }
+
+    pub(crate) fn cleanup_unclosed(&mut self) {
+        while let Some(span_id) = self.stack.pop() {
+            if let Some(entry) = self.spans.remove(&span_id) {
+                entry.span.record("error.type", "unclosed_guest_span");
+                entry.span.record("error.message", "guest span left open");
+                entry
+                    .span
+                    .record("exception.message", "guest span left open");
+                entry
+                    .span
+                    .context()
+                    .span()
+                    .set_status(Status::error("guest span left open"));
+                drop(entry);
+            }
+        }
+        self.spans.clear();
+    }
+
+    fn span(&self, span_id: i64) -> Result<&tracing::Span, String> {
+        self.spans
+            .get(&span_id)
+            .map(|entry| &entry.span)
+            .ok_or_else(|| format!("unknown guest span id: {span_id}"))
+    }
+}
+
+pub(crate) fn guest_span_attribute_allowed(key: &str) -> bool {
+    let key = key.trim();
+    if key.is_empty() {
+        return false;
+    }
+    !matches!(
+        key,
+        "otel.name"
+            | "otel.kind"
+            | "trace_id"
+            | "span_id"
+            | "parent_span_id"
+            | "dd.trace_id"
+            | "dd.span_id"
+            | "otel.trace_id"
+            | "otel.span_id"
+            | "_otel.parent_trace_id"
+            | "_otel.parent_span_id"
+    ) && !key.starts_with("_otel.")
+}
+
+fn update_span_name(span: &tracing::Span, name: &str) {
+    span.record("otel.name", name);
+    span.context().span().update_name(name.to_string());
+}
+
+fn apply_attributes(span: &tracing::Span, attributes: &BTreeMap<String, Value>) {
+    for (key, value) in attributes {
+        let Some(kv) = key_value_from_json(key, value) else {
+            continue;
+        };
+        if let Some(field_name) = datadog_visible_span_hint_field(key) {
+            let value = span_record_value(value);
+            span.record(field_name, value.as_str());
+        }
+        span.context().span().set_attribute(kv);
+    }
+}
+
+fn apply_end_status(span: &tracing::Span, payload: &GuestSpanEndPayload) {
+    let status = payload.status.as_deref().unwrap_or("ok");
+    if status.eq_ignore_ascii_case("error") {
+        let error_message = payload
+            .error_message
+            .as_deref()
+            .filter(|value| !value.is_empty())
+            .unwrap_or("guest span failed");
+        let error_type = payload
+            .error_type
+            .as_deref()
+            .filter(|value| !value.is_empty())
+            .unwrap_or("guest_span_error");
+        span.record("error.type", error_type);
+        span.record("error.message", error_message);
+        span.record("exception.message", error_message);
+        span.context()
+            .span()
+            .set_status(Status::error(error_message.to_string()));
+    } else {
+        span.context().span().set_status(Status::Ok);
+    }
+}
+
+fn key_value_from_json(key: &str, value: &Value) -> Option<KeyValue> {
+    if !guest_span_attribute_allowed(key) {
+        return None;
+    }
+    let key = key.to_string();
+    Some(match value {
+        Value::String(value) => KeyValue::new(key, truncate_for_span_attr(value)),
+        Value::Bool(value) => KeyValue::new(key, *value),
+        Value::Number(value) => {
+            if let Some(value) = value.as_i64() {
+                KeyValue::new(key, value)
+            } else if let Some(value) = value.as_u64().and_then(|value| i64::try_from(value).ok()) {
+                KeyValue::new(key, value)
+            } else if let Some(value) = value.as_f64() {
+                KeyValue::new(key, value)
+            } else {
+                KeyValue::new(key, truncate_for_span_attr(&value.to_string()))
+            }
+        }
+        Value::Null | Value::Array(_) | Value::Object(_) => {
+            KeyValue::new(key, truncate_for_span_attr(&value.to_string()))
+        }
+    })
+}
+
+fn span_record_value(value: &Value) -> String {
+    match value {
+        Value::String(value) => truncate_for_span_attr(value),
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::Array(_) | Value::Object(_) => {
+            truncate_for_span_attr(&value.to_string())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn context() -> WasmInvocationContext {
+        WasmInvocationContext {
+            tenant: "test".to_string(),
+            entity_type: "Session".to_string(),
+            entity_id: "s-1".to_string(),
+            trigger_action: "Run".to_string(),
+            wasm_module: Some("test_guest".to_string()),
+            trigger_params: Value::Null,
+            entity_state: Value::Null,
+            agent_id: Some("agent-1".to_string()),
+            session_id: Some("session-1".to_string()),
+            integration_config: BTreeMap::new(),
+            trace_id: "00000000000000000000000000000001".to_string(),
+            workflow_root_entity_type: Some("Session".to_string()),
+            workflow_root_entity_id: Some("s-1".to_string()),
+            workflow_run_id: Some("Session:s-1".to_string()),
+            http_request: None,
+        }
+    }
+
+    #[test]
+    fn rejects_malformed_and_empty_start_payloads() {
+        let mut registry = GuestSpanRegistry::new(context());
+        assert!(registry.start_span("{").is_err());
+        assert!(registry.start_span(r#"{"name":""}"#).is_err());
+    }
+
+    #[test]
+    fn enforces_nested_lifo_end_order() {
+        let mut registry = GuestSpanRegistry::new(context());
+        let root = registry
+            .start_span(r#"{"name":"guest.root"}"#)
+            .expect("root span should start");
+        let child = registry
+            .start_span(r#"{"name":"guest.child"}"#)
+            .expect("child span should start");
+
+        assert!(registry.end_span(root, r#"{"status":"ok"}"#).is_err());
+        registry
+            .end_span(child, r#"{"status":"ok"}"#)
+            .expect("child can end first");
+        registry
+            .end_span(root, r#"{"status":"ok"}"#)
+            .expect("root can end after child");
+    }
+
+    #[test]
+    fn rejects_unknown_span_ids() {
+        let mut registry = GuestSpanRegistry::new(context());
+        assert!(registry.add_span_event(99, r#"{"name":"event"}"#).is_err());
+        assert!(
+            registry
+                .set_span_attributes(99, r#"{"attributes":{}}"#)
+                .is_err()
+        );
+        assert!(registry.end_span(99, r#"{"status":"ok"}"#).is_err());
+    }
+
+    #[test]
+    fn enforces_per_invocation_span_limit() {
+        let mut registry = GuestSpanRegistry::with_max_spans(context(), 1);
+        registry
+            .start_span(r#"{"name":"guest.root"}"#)
+            .expect("first span should start");
+        assert!(registry.start_span(r#"{"name":"guest.child"}"#).is_err());
+    }
+
+    #[test]
+    fn protects_reserved_observability_fields() {
+        assert!(!guest_span_attribute_allowed("trace_id"));
+        assert!(!guest_span_attribute_allowed("dd.span_id"));
+        assert!(!guest_span_attribute_allowed("_otel.parent_trace_id"));
+        assert!(guest_span_attribute_allowed("tool.name"));
+        assert!(guest_span_attribute_allowed("gen_ai.operation.name"));
+    }
+
+    #[test]
+    fn cleanup_closes_unended_spans() {
+        let mut registry = GuestSpanRegistry::new(context());
+        registry
+            .start_span(r#"{"name":"guest.root"}"#)
+            .expect("span should start");
+        assert!(registry.enter_active().is_some());
+        registry.cleanup_unclosed();
+        assert!(registry.enter_active().is_none());
+    }
+}

--- a/crates/temper-wasm/src/engine/guest_spans.rs
+++ b/crates/temper-wasm/src/engine/guest_spans.rs
@@ -3,15 +3,23 @@ use std::collections::BTreeMap;
 use std::time::SystemTime;
 
 use opentelemetry::KeyValue;
-use opentelemetry::trace::{
-    Event, Span as OtelSpan, SpanId, SpanKind, Status, TraceContextExt as _, TraceId, Tracer,
-};
+use opentelemetry::trace::{SpanId, Status, TraceContextExt as _, TraceId};
 use serde::Deserialize;
 use serde_json::Value;
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
 use crate::host_trait::{datadog_visible_span_hint_field, truncate_for_span_attr};
 use crate::types::WasmInvocationContext;
+
+mod export;
+#[cfg(test)]
+#[path = "guest_spans_test.rs"]
+mod tests;
+
+use export::{
+    export_manual_span, manual_parent_context, manual_span_attributes, merge_end_status_attributes,
+    status_from_end_payload, tracing_span_ids,
+};
 
 const DEFAULT_MAX_GUEST_SPANS: usize = 256;
 
@@ -359,86 +367,12 @@ fn clear_thread_local_guest_spans() {
     ENTERED_GUEST_SPANS.with(|guards| guards.borrow_mut().clear());
 }
 
-fn manual_parent_context() -> Option<opentelemetry::Context> {
-    let context = tracing::Span::current().context();
-    let span_context = context.span().span_context().clone();
-    span_context
-        .is_valid()
-        .then(|| opentelemetry::Context::new().with_remote_span_context(span_context))
-}
-
-fn tracing_span_ids(span: &tracing::Span) -> (Option<TraceId>, Option<SpanId>) {
-    let context = span.context();
-    let span_context = context.span().span_context().clone();
-    if span_context.is_valid() {
-        (Some(span_context.trace_id()), Some(span_context.span_id()))
-    } else {
-        (None, None)
-    }
-}
-
 fn allowed_attributes(attributes: &BTreeMap<String, Value>) -> BTreeMap<String, Value> {
     attributes
         .iter()
         .filter(|(key, _)| guest_span_attribute_allowed(key))
         .map(|(key, value)| (key.clone(), value.clone()))
         .collect()
-}
-
-fn manual_span_attributes(
-    context: &WasmInvocationContext,
-    span_id: i64,
-    attributes: &BTreeMap<String, Value>,
-) -> BTreeMap<String, Value> {
-    let mut manual = allowed_attributes(attributes);
-    manual.insert("tenant".to_string(), Value::String(context.tenant.clone()));
-    manual.insert(
-        "entity_type".to_string(),
-        Value::String(context.entity_type.clone()),
-    );
-    manual.insert(
-        "entity_id".to_string(),
-        Value::String(context.entity_id.clone()),
-    );
-    manual.insert(
-        "trigger_action".to_string(),
-        Value::String(context.trigger_action.clone()),
-    );
-    manual.insert(
-        "wasm_module".to_string(),
-        Value::String(context.wasm_module.clone().unwrap_or_default()),
-    );
-    manual.insert(
-        "agent_id".to_string(),
-        Value::String(context.agent_id.clone().unwrap_or_default()),
-    );
-    manual.insert(
-        "session_id".to_string(),
-        Value::String(context.session_id.clone().unwrap_or_default()),
-    );
-    manual.insert(
-        "workflow_root_entity_type".to_string(),
-        Value::String(
-            context
-                .workflow_root_entity_type
-                .clone()
-                .unwrap_or_default(),
-        ),
-    );
-    manual.insert(
-        "workflow_root_entity_id".to_string(),
-        Value::String(context.workflow_root_entity_id.clone().unwrap_or_default()),
-    );
-    manual.insert(
-        "workflow_run_id".to_string(),
-        Value::String(context.workflow_run_id.clone().unwrap_or_default()),
-    );
-    manual.insert(
-        "observability_event".to_string(),
-        Value::String("wasm_guest.span".to_string()),
-    );
-    manual.insert("wasm_guest_span_id".to_string(), Value::from(span_id));
-    manual
 }
 
 fn merge_allowed_attributes(
@@ -449,103 +383,6 @@ fn merge_allowed_attributes(
         if guest_span_attribute_allowed(key) {
             target.insert(key.clone(), value.clone());
         }
-    }
-}
-
-fn merge_end_status_attributes(
-    target: &mut BTreeMap<String, Value>,
-    payload: &GuestSpanEndPayload,
-) {
-    let status = payload.status.as_deref().unwrap_or("ok");
-    if !status.eq_ignore_ascii_case("error") {
-        return;
-    }
-    let error_message = payload
-        .error_message
-        .as_deref()
-        .filter(|value| !value.is_empty())
-        .unwrap_or("guest span failed");
-    let error_type = payload
-        .error_type
-        .as_deref()
-        .filter(|value| !value.is_empty())
-        .unwrap_or("guest_span_error");
-    target.insert(
-        "error.type".to_string(),
-        Value::String(error_type.to_string()),
-    );
-    target.insert(
-        "error.message".to_string(),
-        Value::String(error_message.to_string()),
-    );
-    target.insert(
-        "exception.message".to_string(),
-        Value::String(error_message.to_string()),
-    );
-}
-
-fn status_from_end_payload(payload: &GuestSpanEndPayload) -> Status {
-    let status = payload.status.as_deref().unwrap_or("ok");
-    if status.eq_ignore_ascii_case("error") {
-        let error_message = payload
-            .error_message
-            .as_deref()
-            .filter(|value| !value.is_empty())
-            .unwrap_or("guest span failed");
-        Status::error(error_message.to_string())
-    } else {
-        Status::Ok
-    }
-}
-
-fn export_manual_span(entry: &GuestSpanEntry, status: Status, end_time: SystemTime) {
-    let (Some(trace_id), Some(span_id), Some(parent_context)) =
-        (entry.trace_id, entry.span_id, entry.parent_context.clone())
-    else {
-        return;
-    };
-
-    let tracer = opentelemetry::global::tracer("temper-wasm-guest");
-    let attrs = entry
-        .attributes
-        .iter()
-        .filter_map(|(key, value)| key_value_from_json(key, value))
-        .collect::<Vec<_>>();
-    let events = entry
-        .events
-        .iter()
-        .map(|event| {
-            let attrs = event
-                .attributes
-                .iter()
-                .filter_map(|(key, value)| key_value_from_json(key, value))
-                .collect::<Vec<_>>();
-            Event::new(event.name.clone(), event.timestamp, attrs, 0)
-        })
-        .collect::<Vec<_>>();
-    let mut span = tracer.build_with_context(
-        tracer
-            .span_builder(entry.name.clone())
-            .with_trace_id(trace_id)
-            .with_span_id(span_id)
-            .with_kind(span_kind(&entry.kind))
-            .with_start_time(entry.start_time)
-            .with_end_time(end_time)
-            .with_status(status)
-            .with_attributes(attrs)
-            .with_events(events),
-        &parent_context,
-    );
-    span.end_with_timestamp(end_time);
-}
-
-fn span_kind(kind: &str) -> SpanKind {
-    match kind.to_ascii_lowercase().as_str() {
-        "server" => SpanKind::Server,
-        "client" => SpanKind::Client,
-        "producer" => SpanKind::Producer,
-        "consumer" => SpanKind::Consumer,
-        _ => SpanKind::Internal,
     }
 }
 
@@ -625,130 +462,5 @@ fn span_record_value(value: &Value) -> String {
         Value::Null | Value::Bool(_) | Value::Number(_) | Value::Array(_) | Value::Object(_) => {
             truncate_for_span_attr(&value.to_string())
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn context() -> WasmInvocationContext {
-        WasmInvocationContext {
-            tenant: "test".to_string(),
-            entity_type: "Session".to_string(),
-            entity_id: "s-1".to_string(),
-            trigger_action: "Run".to_string(),
-            wasm_module: Some("test_guest".to_string()),
-            trigger_params: Value::Null,
-            entity_state: Value::Null,
-            agent_id: Some("agent-1".to_string()),
-            session_id: Some("session-1".to_string()),
-            integration_config: BTreeMap::new(),
-            trace_id: "00000000000000000000000000000001".to_string(),
-            workflow_root_entity_type: Some("Session".to_string()),
-            workflow_root_entity_id: Some("s-1".to_string()),
-            workflow_run_id: Some("Session:s-1".to_string()),
-            http_request: None,
-        }
-    }
-
-    #[test]
-    fn rejects_malformed_and_empty_start_payloads() {
-        let mut registry = GuestSpanRegistry::new(context());
-        assert!(registry.start_span("{").is_err());
-        assert!(registry.start_span(r#"{"name":""}"#).is_err());
-    }
-
-    #[test]
-    fn enforces_nested_lifo_end_order() {
-        let mut registry = GuestSpanRegistry::new(context());
-        let root = registry
-            .start_span(r#"{"name":"guest.root"}"#)
-            .expect("root span should start");
-        let child = registry
-            .start_span(r#"{"name":"guest.child"}"#)
-            .expect("child span should start");
-
-        assert!(registry.end_span(root, r#"{"status":"ok"}"#).is_err());
-        registry
-            .end_span(child, r#"{"status":"ok"}"#)
-            .expect("child can end first");
-        registry
-            .end_span(root, r#"{"status":"ok"}"#)
-            .expect("root can end after child");
-    }
-
-    #[test]
-    fn rejects_unknown_span_ids() {
-        let mut registry = GuestSpanRegistry::new(context());
-        assert!(registry.add_span_event(99, r#"{"name":"event"}"#).is_err());
-        assert!(
-            registry
-                .set_span_attributes(99, r#"{"attributes":{}}"#)
-                .is_err()
-        );
-        assert!(registry.end_span(99, r#"{"status":"ok"}"#).is_err());
-    }
-
-    #[test]
-    fn enforces_per_invocation_span_limit() {
-        let mut registry = GuestSpanRegistry::with_max_spans(context(), 1);
-        registry
-            .start_span(r#"{"name":"guest.root"}"#)
-            .expect("first span should start");
-        assert!(registry.start_span(r#"{"name":"guest.child"}"#).is_err());
-    }
-
-    #[test]
-    fn protects_reserved_observability_fields() {
-        assert!(!guest_span_attribute_allowed("trace_id"));
-        assert!(!guest_span_attribute_allowed("dd.span_id"));
-        assert!(!guest_span_attribute_allowed("_otel.parent_trace_id"));
-        assert!(guest_span_attribute_allowed("tool.name"));
-        assert!(guest_span_attribute_allowed("gen_ai.operation.name"));
-    }
-
-    #[test]
-    fn manual_span_snapshot_includes_invocation_correlation_attributes() {
-        let mut attributes = BTreeMap::new();
-        attributes.insert("tool.name".to_string(), Value::String("python".to_string()));
-        let snapshot = manual_span_attributes(&context(), 7, &attributes);
-
-        assert_eq!(
-            snapshot.get("tenant"),
-            Some(&Value::String("test".to_string()))
-        );
-        assert_eq!(
-            snapshot.get("entity_id"),
-            Some(&Value::String("s-1".to_string()))
-        );
-        assert_eq!(
-            snapshot.get("wasm_module"),
-            Some(&Value::String("test_guest".to_string()))
-        );
-        assert_eq!(
-            snapshot.get("workflow_run_id"),
-            Some(&Value::String("Session:s-1".to_string()))
-        );
-        assert_eq!(
-            snapshot.get("observability_event"),
-            Some(&Value::String("wasm_guest.span".to_string()))
-        );
-        assert_eq!(snapshot.get("wasm_guest_span_id"), Some(&Value::from(7)));
-        assert_eq!(
-            snapshot.get("tool.name"),
-            Some(&Value::String("python".to_string()))
-        );
-    }
-
-    #[test]
-    fn cleanup_closes_unended_spans() {
-        let mut registry = GuestSpanRegistry::new(context());
-        registry
-            .start_span(r#"{"name":"guest.root"}"#)
-            .expect("span should start");
-        assert!(registry.enter_active().is_some());
-        registry.cleanup_unclosed();
-        assert!(registry.enter_active().is_none());
     }
 }

--- a/crates/temper-wasm/src/engine/guest_spans/export.rs
+++ b/crates/temper-wasm/src/engine/guest_spans/export.rs
@@ -1,0 +1,183 @@
+use std::collections::BTreeMap;
+use std::time::SystemTime;
+
+use opentelemetry::trace::{
+    Event, Span as OtelSpan, SpanId, SpanKind, Status, TraceContextExt as _, TraceId, Tracer,
+};
+use serde_json::Value;
+use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+use crate::types::WasmInvocationContext;
+
+use super::{GuestSpanEndPayload, GuestSpanEntry, allowed_attributes, key_value_from_json};
+
+pub(super) fn manual_parent_context() -> Option<opentelemetry::Context> {
+    let context = tracing::Span::current().context();
+    let span_context = context.span().span_context().clone();
+    span_context
+        .is_valid()
+        .then(|| opentelemetry::Context::new().with_remote_span_context(span_context))
+}
+
+pub(super) fn tracing_span_ids(span: &tracing::Span) -> (Option<TraceId>, Option<SpanId>) {
+    let context = span.context();
+    let span_context = context.span().span_context().clone();
+    if span_context.is_valid() {
+        (Some(span_context.trace_id()), Some(span_context.span_id()))
+    } else {
+        (None, None)
+    }
+}
+
+pub(super) fn manual_span_attributes(
+    context: &WasmInvocationContext,
+    span_id: i64,
+    attributes: &BTreeMap<String, Value>,
+) -> BTreeMap<String, Value> {
+    let mut manual = allowed_attributes(attributes);
+    manual.insert("tenant".to_string(), Value::String(context.tenant.clone()));
+    manual.insert(
+        "entity_type".to_string(),
+        Value::String(context.entity_type.clone()),
+    );
+    manual.insert(
+        "entity_id".to_string(),
+        Value::String(context.entity_id.clone()),
+    );
+    manual.insert(
+        "trigger_action".to_string(),
+        Value::String(context.trigger_action.clone()),
+    );
+    manual.insert(
+        "wasm_module".to_string(),
+        Value::String(context.wasm_module.clone().unwrap_or_default()),
+    );
+    manual.insert(
+        "agent_id".to_string(),
+        Value::String(context.agent_id.clone().unwrap_or_default()),
+    );
+    manual.insert(
+        "session_id".to_string(),
+        Value::String(context.session_id.clone().unwrap_or_default()),
+    );
+    manual.insert(
+        "workflow_root_entity_type".to_string(),
+        Value::String(
+            context
+                .workflow_root_entity_type
+                .clone()
+                .unwrap_or_default(),
+        ),
+    );
+    manual.insert(
+        "workflow_root_entity_id".to_string(),
+        Value::String(context.workflow_root_entity_id.clone().unwrap_or_default()),
+    );
+    manual.insert(
+        "workflow_run_id".to_string(),
+        Value::String(context.workflow_run_id.clone().unwrap_or_default()),
+    );
+    manual.insert(
+        "observability_event".to_string(),
+        Value::String("wasm_guest.span".to_string()),
+    );
+    manual.insert("wasm_guest_span_id".to_string(), Value::from(span_id));
+    manual
+}
+
+pub(super) fn merge_end_status_attributes(
+    target: &mut BTreeMap<String, Value>,
+    payload: &GuestSpanEndPayload,
+) {
+    let status = payload.status.as_deref().unwrap_or("ok");
+    if !status.eq_ignore_ascii_case("error") {
+        return;
+    }
+    let error_message = payload
+        .error_message
+        .as_deref()
+        .filter(|value| !value.is_empty())
+        .unwrap_or("guest span failed");
+    let error_type = payload
+        .error_type
+        .as_deref()
+        .filter(|value| !value.is_empty())
+        .unwrap_or("guest_span_error");
+    target.insert(
+        "error.type".to_string(),
+        Value::String(error_type.to_string()),
+    );
+    target.insert(
+        "error.message".to_string(),
+        Value::String(error_message.to_string()),
+    );
+    target.insert(
+        "exception.message".to_string(),
+        Value::String(error_message.to_string()),
+    );
+}
+
+pub(super) fn status_from_end_payload(payload: &GuestSpanEndPayload) -> Status {
+    let status = payload.status.as_deref().unwrap_or("ok");
+    if status.eq_ignore_ascii_case("error") {
+        let error_message = payload
+            .error_message
+            .as_deref()
+            .filter(|value| !value.is_empty())
+            .unwrap_or("guest span failed");
+        Status::error(error_message.to_string())
+    } else {
+        Status::Ok
+    }
+}
+
+pub(super) fn export_manual_span(entry: &GuestSpanEntry, status: Status, end_time: SystemTime) {
+    let (Some(trace_id), Some(span_id), Some(parent_context)) =
+        (entry.trace_id, entry.span_id, entry.parent_context.clone())
+    else {
+        return;
+    };
+
+    let tracer = opentelemetry::global::tracer("temper-wasm-guest");
+    let attrs = entry
+        .attributes
+        .iter()
+        .filter_map(|(key, value)| key_value_from_json(key, value))
+        .collect::<Vec<_>>();
+    let events = entry
+        .events
+        .iter()
+        .map(|event| {
+            let attrs = event
+                .attributes
+                .iter()
+                .filter_map(|(key, value)| key_value_from_json(key, value))
+                .collect::<Vec<_>>();
+            Event::new(event.name.clone(), event.timestamp, attrs, 0)
+        })
+        .collect::<Vec<_>>();
+    let mut span = tracer.build_with_context(
+        tracer
+            .span_builder(entry.name.clone())
+            .with_trace_id(trace_id)
+            .with_span_id(span_id)
+            .with_kind(span_kind(&entry.kind))
+            .with_start_time(entry.start_time)
+            .with_end_time(end_time)
+            .with_status(status)
+            .with_attributes(attrs)
+            .with_events(events),
+        &parent_context,
+    );
+    span.end_with_timestamp(end_time);
+}
+
+fn span_kind(kind: &str) -> SpanKind {
+    match kind.to_ascii_lowercase().as_str() {
+        "server" => SpanKind::Server,
+        "client" => SpanKind::Client,
+        "producer" => SpanKind::Producer,
+        "consumer" => SpanKind::Consumer,
+        _ => SpanKind::Internal,
+    }
+}

--- a/crates/temper-wasm/src/engine/guest_spans_test.rs
+++ b/crates/temper-wasm/src/engine/guest_spans_test.rs
@@ -1,0 +1,127 @@
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+use crate::types::WasmInvocationContext;
+
+use super::*;
+
+fn context() -> WasmInvocationContext {
+    WasmInvocationContext {
+        tenant: "test".to_string(),
+        entity_type: "Session".to_string(),
+        entity_id: "s-1".to_string(),
+        trigger_action: "Run".to_string(),
+        wasm_module: Some("test_guest".to_string()),
+        trigger_params: Value::Null,
+        entity_state: Value::Null,
+        agent_id: Some("agent-1".to_string()),
+        session_id: Some("session-1".to_string()),
+        integration_config: BTreeMap::new(),
+        trace_id: "00000000000000000000000000000001".to_string(),
+        workflow_root_entity_type: Some("Session".to_string()),
+        workflow_root_entity_id: Some("s-1".to_string()),
+        workflow_run_id: Some("Session:s-1".to_string()),
+        http_request: None,
+    }
+}
+
+#[test]
+fn rejects_malformed_and_empty_start_payloads() {
+    let mut registry = GuestSpanRegistry::new(context());
+    assert!(registry.start_span("{").is_err());
+    assert!(registry.start_span(r#"{"name":""}"#).is_err());
+}
+
+#[test]
+fn enforces_nested_lifo_end_order() {
+    let mut registry = GuestSpanRegistry::new(context());
+    let root = registry
+        .start_span(r#"{"name":"guest.root"}"#)
+        .expect("root span should start");
+    let child = registry
+        .start_span(r#"{"name":"guest.child"}"#)
+        .expect("child span should start");
+
+    assert!(registry.end_span(root, r#"{"status":"ok"}"#).is_err());
+    registry
+        .end_span(child, r#"{"status":"ok"}"#)
+        .expect("child can end first");
+    registry
+        .end_span(root, r#"{"status":"ok"}"#)
+        .expect("root can end after child");
+}
+
+#[test]
+fn rejects_unknown_span_ids() {
+    let mut registry = GuestSpanRegistry::new(context());
+    assert!(registry.add_span_event(99, r#"{"name":"event"}"#).is_err());
+    assert!(
+        registry
+            .set_span_attributes(99, r#"{"attributes":{}}"#)
+            .is_err()
+    );
+    assert!(registry.end_span(99, r#"{"status":"ok"}"#).is_err());
+}
+
+#[test]
+fn enforces_per_invocation_span_limit() {
+    let mut registry = GuestSpanRegistry::with_max_spans(context(), 1);
+    registry
+        .start_span(r#"{"name":"guest.root"}"#)
+        .expect("first span should start");
+    assert!(registry.start_span(r#"{"name":"guest.child"}"#).is_err());
+}
+
+#[test]
+fn protects_reserved_observability_fields() {
+    assert!(!guest_span_attribute_allowed("trace_id"));
+    assert!(!guest_span_attribute_allowed("dd.span_id"));
+    assert!(!guest_span_attribute_allowed("_otel.parent_trace_id"));
+    assert!(guest_span_attribute_allowed("tool.name"));
+    assert!(guest_span_attribute_allowed("gen_ai.operation.name"));
+}
+
+#[test]
+fn manual_span_snapshot_includes_invocation_correlation_attributes() {
+    let mut attributes = BTreeMap::new();
+    attributes.insert("tool.name".to_string(), Value::String("python".to_string()));
+    let snapshot = manual_span_attributes(&context(), 7, &attributes);
+
+    assert_eq!(
+        snapshot.get("tenant"),
+        Some(&Value::String("test".to_string()))
+    );
+    assert_eq!(
+        snapshot.get("entity_id"),
+        Some(&Value::String("s-1".to_string()))
+    );
+    assert_eq!(
+        snapshot.get("wasm_module"),
+        Some(&Value::String("test_guest".to_string()))
+    );
+    assert_eq!(
+        snapshot.get("workflow_run_id"),
+        Some(&Value::String("Session:s-1".to_string()))
+    );
+    assert_eq!(
+        snapshot.get("observability_event"),
+        Some(&Value::String("wasm_guest.span".to_string()))
+    );
+    assert_eq!(snapshot.get("wasm_guest_span_id"), Some(&Value::from(7)));
+    assert_eq!(
+        snapshot.get("tool.name"),
+        Some(&Value::String("python".to_string()))
+    );
+}
+
+#[test]
+fn cleanup_closes_unended_spans() {
+    let mut registry = GuestSpanRegistry::new(context());
+    registry
+        .start_span(r#"{"name":"guest.root"}"#)
+        .expect("span should start");
+    assert!(registry.enter_active().is_some());
+    registry.cleanup_unclosed();
+    assert!(registry.enter_active().is_none());
+}

--- a/crates/temper-wasm/src/engine/host_functions.rs
+++ b/crates/temper-wasm/src/engine/host_functions.rs
@@ -88,6 +88,21 @@ pub(crate) enum FieldResolution {
     HostError,
 }
 
+fn read_guest_string(caller: &mut Caller<'_, HostState>, ptr: i32, len: i32) -> Result<String, ()> {
+    if ptr < 0 || len < 0 {
+        return Err(());
+    }
+    let memory = caller.get_export("memory").and_then(|e| e.into_memory());
+    let Some(memory) = memory else {
+        return Err(());
+    };
+    let mut buf = vec![0u8; len as usize];
+    memory
+        .read(caller, ptr as usize, &mut buf)
+        .map_err(|_| ())?;
+    String::from_utf8(buf).map_err(|_| ())
+}
+
 #[derive(Debug, serde::Deserialize)]
 struct HostHttpBatchRequest {
     method: String,
@@ -226,6 +241,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                     let _ = memory.read(&caller, msg_ptr as usize, &mut msg_buf);
                     let level = String::from_utf8_lossy(&level_buf);
                     let msg = String::from_utf8_lossy(&msg_buf);
+                    let _guest_span = caller.data().guest_spans.enter_active();
                     caller.data().host.log(&level, &msg);
                 }
             },
@@ -287,6 +303,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 let Ok(payload) = String::from_utf8(buf) else {
                     return -1;
                 };
+                let _guest_span = caller.data().guest_spans.enter_active();
                 match caller.data().host.emit_progress(&payload) {
                     Ok(()) => 0,
                     Err(_) => -1,
@@ -312,6 +329,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 let Ok(payload) = String::from_utf8(buf) else {
                     return -1;
                 };
+                let _guest_span = caller.data().guest_spans.enter_active();
                 match caller.data().host.emit_wide_event(&payload) {
                     Ok(()) => 0,
                     Err(_) => -1,
@@ -337,6 +355,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 let Ok(payload) = String::from_utf8(buf) else {
                     return -1;
                 };
+                let _guest_span = caller.data().guest_spans.enter_active();
                 match caller.data().host.log_structured(&payload) {
                     Ok(()) => 0,
                     Err(_) => -1,
@@ -362,6 +381,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 let Ok(payload) = String::from_utf8(buf) else {
                     return -1;
                 };
+                let _guest_span = caller.data().guest_spans.enter_active();
                 match caller.data().host.emit_metric(&payload) {
                     Ok(()) => 0,
                     Err(_) => -1,
@@ -369,6 +389,96 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
             },
         )
         .map_err(|e| WasmError::Compilation(format!("failed to link host_emit_metric: {e}")))?;
+
+    // host_start_span(ptr, len) -> i64
+    linker
+        .func_wrap(
+            "env",
+            "host_start_span",
+            |mut caller: Caller<'_, HostState>, ptr: i32, len: i32| -> i64 {
+                let Ok(payload) = read_guest_string(&mut caller, ptr, len) else {
+                    return -1;
+                };
+                match caller.data_mut().guest_spans.start_span(&payload) {
+                    Ok(span_id) => span_id,
+                    Err(error) => {
+                        tracing::warn!(error = %error, "host_start_span failed");
+                        -1
+                    }
+                }
+            },
+        )
+        .map_err(|e| WasmError::Compilation(format!("failed to link host_start_span: {e}")))?;
+
+    // host_add_span_event(span_id, ptr, len) -> i32
+    linker
+        .func_wrap(
+            "env",
+            "host_add_span_event",
+            |mut caller: Caller<'_, HostState>, span_id: i64, ptr: i32, len: i32| -> i32 {
+                let Ok(payload) = read_guest_string(&mut caller, ptr, len) else {
+                    return -1;
+                };
+                match caller.data().guest_spans.add_span_event(span_id, &payload) {
+                    Ok(()) => 0,
+                    Err(error) => {
+                        tracing::warn!(span_id, error = %error, "host_add_span_event failed");
+                        -1
+                    }
+                }
+            },
+        )
+        .map_err(|e| WasmError::Compilation(format!("failed to link host_add_span_event: {e}")))?;
+
+    // host_set_span_attributes(span_id, ptr, len) -> i32
+    linker
+        .func_wrap(
+            "env",
+            "host_set_span_attributes",
+            |mut caller: Caller<'_, HostState>, span_id: i64, ptr: i32, len: i32| -> i32 {
+                let Ok(payload) = read_guest_string(&mut caller, ptr, len) else {
+                    return -1;
+                };
+                match caller
+                    .data()
+                    .guest_spans
+                    .set_span_attributes(span_id, &payload)
+                {
+                    Ok(()) => 0,
+                    Err(error) => {
+                        tracing::warn!(
+                            span_id,
+                            error = %error,
+                            "host_set_span_attributes failed"
+                        );
+                        -1
+                    }
+                }
+            },
+        )
+        .map_err(|e| {
+            WasmError::Compilation(format!("failed to link host_set_span_attributes: {e}"))
+        })?;
+
+    // host_end_span(span_id, ptr, len) -> i32
+    linker
+        .func_wrap(
+            "env",
+            "host_end_span",
+            |mut caller: Caller<'_, HostState>, span_id: i64, ptr: i32, len: i32| -> i32 {
+                let Ok(payload) = read_guest_string(&mut caller, ptr, len) else {
+                    return -1;
+                };
+                match caller.data_mut().guest_spans.end_span(span_id, &payload) {
+                    Ok(()) => 0,
+                    Err(error) => {
+                        tracing::warn!(span_id, error = %error, "host_end_span failed");
+                        -1
+                    }
+                }
+            },
+        )
+        .map_err(|e| WasmError::Compilation(format!("failed to link host_end_span: {e}")))?;
 
     // host_get_secret(key_ptr, key_len, buf_ptr, buf_len) -> actual_len (-1 on error)
     linker
@@ -388,6 +498,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 let _ = memory.read(&caller, key_ptr as usize, &mut key_buf);
                 let key = String::from_utf8_lossy(&key_buf);
 
+                let _guest_span = caller.data().guest_spans.enter_active();
                 match caller.data().host.get_secret(&key) {
                     Ok(secret) => {
                         let secret_bytes = secret.as_bytes();
@@ -458,6 +569,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
 
                 // Bridge async -> sync with an outer deadline so a hanging
                 // host call can never pin the actor indefinitely.
+                let _guest_span = caller.data().guest_spans.enter_active();
                 let host = caller.data().host.clone();
                 let Ok(result) = run_host_call_with_timeout("host_http_call", async move {
                     host.http_call(&method, &url, &headers, &body).await
@@ -510,6 +622,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                     Vec::new()
                 };
 
+                let _guest_span = caller.data().guest_spans.enter_active();
                 let host = caller.data().host.clone();
                 let result = tokio::task::block_in_place(|| {
                     tokio::runtime::Handle::current().block_on(
@@ -601,6 +714,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
 
                 // Bridge async -> sync with an outer deadline so a hanging
                 // host call can never pin the actor indefinitely.
+                let _guest_span = caller.data().guest_spans.enter_active();
                 let host = caller.data().host.clone();
                 let Ok(result) = run_host_call_with_timeout("host_connect_call", async move {
                     host.connect_call(&url, &headers, &body).await
@@ -702,6 +816,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
 
                 // Bridge async -> sync with an outer deadline so a hanging
                 // host call can never pin the actor indefinitely.
+                let _guest_span = caller.data().guest_spans.enter_active();
                 let host = caller.data().host.clone();
                 let Ok(result) = run_host_call_with_timeout("host_http_call_stream", async move {
                     host.http_call_binary(&method, &url, &headers, &body_bytes)
@@ -747,6 +862,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 let _ = memory.read(&caller, key_ptr as usize, &mut key_buf);
                 let key = String::from_utf8_lossy(&key_buf);
                 let started = Instant::now();
+                let _guest_span = caller.data().guest_spans.enter_active();
                 let span = tracing::info_span!(
                     "wasm.host.cache_contains",
                     otel.name = "wasm.host.cache_contains",
@@ -804,6 +920,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 let _ = memory.read(&caller, stream_id_ptr as usize, &mut id_buf);
                 let stream_id = String::from_utf8_lossy(&id_buf).to_string();
                 let started = Instant::now();
+                let _guest_span = caller.data().guest_spans.enter_active();
                 let span = tracing::info_span!(
                     "wasm.host.cache_to_stream",
                     otel.name = "wasm.host.cache_to_stream",
@@ -893,6 +1010,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 }
                 let field_name = String::from_utf8_lossy(&name_buf).to_string();
                 let started = Instant::now();
+                let _guest_span = caller.data().guest_spans.enter_active();
                 let span = tracing::info_span!(
                     "wasm.host.read_field",
                     otel.name = "wasm.host.read_field",
@@ -996,6 +1114,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 let _ = memory.read(&caller, stream_id_ptr as usize, &mut id_buf);
                 let stream_id = String::from_utf8_lossy(&id_buf).to_string();
                 let started = Instant::now();
+                let _guest_span = caller.data().guest_spans.enter_active();
                 let span = tracing::info_span!(
                     "wasm.host.cache_from_stream",
                     otel.name = "wasm.host.cache_from_stream",
@@ -1084,6 +1203,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 let _ = memory.read(&caller, algorithm_ptr as usize, &mut algo_buf);
                 let algorithm = String::from_utf8_lossy(&algo_buf).to_string();
                 let started = Instant::now();
+                let _guest_span = caller.data().guest_spans.enter_active();
                 let span = tracing::info_span!(
                     "wasm.host.hash_stream",
                     otel.name = "wasm.host.hash_stream",
@@ -1258,6 +1378,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 };
 
                 // Call host evaluate_spec (synchronous — no async bridge needed)
+                let _guest_span = caller.data().guest_spans.enter_active();
                 let result_json = match caller.data().host.evaluate_spec(
                     &ioa_source,
                     &current_state,
@@ -1339,6 +1460,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                     Vec::new()
                 };
 
+                let _guest_span = caller.data().guest_spans.enter_active();
                 let host = caller.data().host.clone();
                 let head = crate::http_stream::HttpRequestHead {
                     method,
@@ -1391,6 +1513,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                     return -4;
                 }
 
+                let _guest_span = caller.data().guest_spans.enter_active();
                 let host = caller.data().host.clone();
                 let sh = crate::http_stream::StreamHandle(handle as u32);
                 let result = tokio::task::block_in_place(|| {
@@ -1431,6 +1554,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 let mut buf = vec![0u8; data_len as usize];
                 let _ = memory.read(&caller, data_ptr as usize, &mut buf);
 
+                let _guest_span = caller.data().guest_spans.enter_active();
                 let host = caller.data().host.clone();
                 let sh = crate::http_stream::StreamHandle(handle as u32);
                 let result = tokio::task::block_in_place(|| {
@@ -1455,6 +1579,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
             "env",
             "host_http_stream_close",
             |caller: Caller<'_, HostState>, handle: i32| -> i32 {
+                let _guest_span = caller.data().guest_spans.enter_active();
                 let host = caller.data().host.clone();
                 let sh = crate::http_stream::StreamHandle(handle as u32);
                 let result = tokio::task::block_in_place(|| {
@@ -1488,6 +1613,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 let memory = caller.get_export("memory").and_then(|e| e.into_memory());
                 let Some(memory) = memory else { return -4 };
 
+                let _guest_span = caller.data().guest_spans.enter_active();
                 let host = caller.data().host.clone();
                 let sh = crate::http_stream::StreamHandle(resp_handle as u32);
                 let result = tokio::task::block_in_place(|| {
@@ -1555,6 +1681,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                     status: raw.status,
                     headers: raw.headers,
                 };
+                let _guest_span = caller.data().guest_spans.enter_active();
                 let host = caller.data().host.clone();
                 let sh = crate::http_stream::StreamHandle(resp_handle as u32);
                 let result = tokio::task::block_in_place(|| {

--- a/crates/temper-wasm/src/engine/host_functions.rs
+++ b/crates/temper-wasm/src/engine/host_functions.rs
@@ -419,7 +419,11 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 let Ok(payload) = read_guest_string(&mut caller, ptr, len) else {
                     return -1;
                 };
-                match caller.data().guest_spans.add_span_event(span_id, &payload) {
+                match caller
+                    .data_mut()
+                    .guest_spans
+                    .add_span_event(span_id, &payload)
+                {
                     Ok(()) => 0,
                     Err(error) => {
                         tracing::warn!(span_id, error = %error, "host_add_span_event failed");
@@ -440,7 +444,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                     return -1;
                 };
                 match caller
-                    .data()
+                    .data_mut()
                     .guest_spans
                     .set_span_attributes(span_id, &payload)
                 {

--- a/crates/temper-wasm/src/engine/mod.rs
+++ b/crates/temper-wasm/src/engine/mod.rs
@@ -3,6 +3,7 @@
 //! Modules are compiled once and cached by SHA-256 hash. Each invocation
 //! gets a fresh `Store` with fuel + memory limits (TigerStyle budgets).
 
+mod guest_spans;
 mod host_functions;
 mod telemetry;
 #[cfg(test)]
@@ -24,6 +25,8 @@ use crate::stream::StreamRegistry;
 use crate::types::{
     MAX_MODULE_SIZE, WasmInvocationContext, WasmInvocationResult, WasmResourceLimits,
 };
+
+pub(crate) use guest_spans::GuestSpanRegistry;
 
 const WASM_EPOCH_TICK_INTERVAL: Duration = Duration::from_millis(10);
 
@@ -183,6 +186,8 @@ pub(crate) struct HostState {
     /// blob refs synchronously. Keyed by blob key (e.g.
     /// `field-overflow/sha256/<hex>.json`). See ADR-0046.
     pub(crate) blob_cache: BTreeMap<String, Vec<u8>>,
+    /// Guest-created observability spans scoped to this invocation.
+    pub(crate) guest_spans: GuestSpanRegistry,
 }
 
 /// WASM engine: compile, cache, invoke modules.
@@ -433,6 +438,7 @@ impl WasmEngine {
             streams,
             wasi_ctx,
             blob_cache,
+            guest_spans: GuestSpanRegistry::new(context.clone()),
         };
         let mut store = Store::new(&engine, host_state);
         store
@@ -481,11 +487,20 @@ impl WasmEngine {
             WasmError::Invocation(format!("failed to write context to memory: {e}"))
         })?;
 
-        let result_ptr = run_fn
-            .call(&mut store, (ctx_ptr as i32, ctx_bytes.len() as i32))
-            .map_err(|e| {
-                telemetry::map_invoke_error(e, &context, needs_wasi, limits.max_duration, start)
-            })?;
+        let result_ptr = match run_fn.call(&mut store, (ctx_ptr as i32, ctx_bytes.len() as i32)) {
+            Ok(result_ptr) => result_ptr,
+            Err(e) => {
+                let err = telemetry::map_invoke_error(
+                    e,
+                    &context,
+                    needs_wasi,
+                    limits.max_duration,
+                    start,
+                );
+                store.data_mut().guest_spans.cleanup_unclosed();
+                return Err(err);
+            }
+        };
 
         let duration_ms = start.elapsed().as_millis() as u64;
         tracing::Span::current().record("duration_ms", duration_ms);
@@ -494,18 +509,29 @@ impl WasmEngine {
             host_result.clone()
         } else if result_ptr > 0 {
             let mut len_bytes = [0u8; 4];
-            memory
-                .read(&store, (result_ptr - 4) as usize, &mut len_bytes)
-                .map_err(|e| WasmError::Invocation(format!("failed to read result length: {e}")))?;
+            if let Err(e) = memory.read(&store, (result_ptr - 4) as usize, &mut len_bytes) {
+                store.data_mut().guest_spans.cleanup_unclosed();
+                return Err(WasmError::Invocation(format!(
+                    "failed to read result length: {e}"
+                )));
+            }
             let result_len = u32::from_le_bytes(len_bytes) as usize;
 
             let mut result_bytes = vec![0u8; result_len];
-            memory
-                .read(&store, result_ptr as usize, &mut result_bytes)
-                .map_err(|e| WasmError::Invocation(format!("failed to read result: {e}")))?;
+            if let Err(e) = memory.read(&store, result_ptr as usize, &mut result_bytes) {
+                store.data_mut().guest_spans.cleanup_unclosed();
+                return Err(WasmError::Invocation(format!("failed to read result: {e}")));
+            }
 
-            String::from_utf8(result_bytes)
-                .map_err(|e| WasmError::Invocation(format!("result is not valid UTF-8: {e}")))?
+            match String::from_utf8(result_bytes) {
+                Ok(result) => result,
+                Err(e) => {
+                    store.data_mut().guest_spans.cleanup_unclosed();
+                    return Err(WasmError::Invocation(format!(
+                        "result is not valid UTF-8: {e}"
+                    )));
+                }
+            }
         } else {
             String::new()
         };
@@ -524,18 +550,23 @@ impl WasmEngine {
                     );
                 }
             }
-            return Ok(telemetry::empty_result(&context, needs_wasi, duration_ms));
+            let result = telemetry::empty_result(&context, needs_wasi, duration_ms);
+            store.data_mut().guest_spans.cleanup_unclosed();
+            return Ok(result);
         }
 
-        let parsed = telemetry::parse_result_json(&result_json, &context, needs_wasi, duration_ms)?;
+        let parsed =
+            match telemetry::parse_result_json(&result_json, &context, needs_wasi, duration_ms) {
+                Ok(parsed) => parsed,
+                Err(err) => {
+                    store.data_mut().guest_spans.cleanup_unclosed();
+                    return Err(err);
+                }
+            };
 
-        Ok(telemetry::finalize_result(
-            &store,
-            parsed,
-            &context,
-            needs_wasi,
-            duration_ms,
-        ))
+        let result = telemetry::finalize_result(&store, parsed, &context, needs_wasi, duration_ms);
+        store.data_mut().guest_spans.cleanup_unclosed();
+        Ok(result)
     }
 
     /// Remove a module from the cache.

--- a/crates/temper-wasm/src/engine/mod.rs
+++ b/crates/temper-wasm/src/engine/mod.rs
@@ -438,7 +438,7 @@ impl WasmEngine {
             streams,
             wasi_ctx,
             blob_cache,
-            guest_spans: GuestSpanRegistry::new(context.clone()),
+            guest_spans: GuestSpanRegistry::for_invocation(context.clone(), needs_wasi),
         };
         let mut store = Store::new(&engine, host_state);
         store

--- a/crates/temper-wasm/src/engine/tests.rs
+++ b/crates/temper-wasm/src/engine/tests.rs
@@ -80,6 +80,64 @@ const WAT_HOST_CALL_THEN_RETURN: &str = r#"
     )
 "#;
 
+const WAT_GUEST_SPAN_LIFECYCLE: &str = r#"
+    (module
+      (import "env" "host_start_span" (func $host_start_span
+        (param i32 i32) (result i64)))
+      (import "env" "host_add_span_event" (func $host_add_span_event
+        (param i64 i32 i32) (result i32)))
+      (import "env" "host_set_span_attributes" (func $host_set_span_attributes
+        (param i64 i32 i32) (result i32)))
+      (import "env" "host_end_span" (func $host_end_span
+        (param i64 i32 i32) (result i32)))
+      (memory (export "memory") 1)
+      (data (i32.const 2048) "{\"name\":\"guest.root\",\"attributes\":{\"tool.name\":\"proof\",\"custom\":\"value\"}}")
+      (data (i32.const 2176) "{\"name\":\"guest.event\",\"attributes\":{\"phase\":\"inside\"}}")
+      (data (i32.const 2304) "{\"attributes\":{\"gen_ai.operation.name\":\"execute_tool\",\"tool.call_id\":\"call-1\"}}")
+      (data (i32.const 2432) "{\"status\":\"ok\",\"attributes\":{\"result\":\"done\"}}")
+      (func (export "run") (param i32 i32) (result i32)
+        (local $span i64)
+        i32.const 2048
+        i32.const 73
+        call $host_start_span
+        local.set $span
+
+        local.get $span
+        i64.const 0
+        i64.le_s
+        if
+          unreachable
+        end
+
+        local.get $span
+        i32.const 2176
+        i32.const 54
+        call $host_add_span_event
+        if
+          unreachable
+        end
+
+        local.get $span
+        i32.const 2304
+        i32.const 79
+        call $host_set_span_attributes
+        if
+          unreachable
+        end
+
+        local.get $span
+        i32.const 2432
+        i32.const 46
+        call $host_end_span
+        if
+          unreachable
+        end
+
+        i32.const 0
+      )
+    )
+"#;
+
 struct SlowHttpHost {
     delay: Duration,
 }
@@ -173,6 +231,29 @@ fn resource_limits_default() {
     // ADR-0045: raised from 30s to cover HTTP-fronted integrations under load.
     assert_eq!(limits.max_duration, std::time::Duration::from_secs(120));
     assert_eq!(limits.max_response_bytes, 1024 * 1024);
+}
+
+#[tokio::test]
+async fn wasm_guest_can_drive_structured_observability_span_lifecycle() {
+    let engine = WasmEngine::new().unwrap();
+    let hash = engine
+        .compile_and_cache(WAT_GUEST_SPAN_LIFECYCLE.as_bytes())
+        .unwrap();
+
+    let result = engine
+        .invoke(
+            &hash,
+            &make_context(),
+            make_host(),
+            &WasmResourceLimits::default(),
+            make_streams(),
+        )
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "guest span host functions should link and complete: {result:?}"
+    );
 }
 
 #[test]

--- a/crates/temper-wasm/src/host_trait.rs
+++ b/crates/temper-wasm/src/host_trait.rs
@@ -381,6 +381,27 @@ fn guest_metric_is_counter_kind(kind: Option<&str>) -> bool {
     matches!(kind, Some("count" | "counter"))
 }
 
+fn guest_metric_tag_allowed(key: &str) -> bool {
+    let key = key.trim();
+    if key.is_empty() {
+        return false;
+    }
+    !matches!(
+        key,
+        "trace_id"
+            | "span_id"
+            | "dd.trace_id"
+            | "dd.span_id"
+            | "otel.trace_id"
+            | "otel.span_id"
+            | "session_id"
+            | "entity_id"
+            | "workflow_run_id"
+            | "tool.call_id"
+            | "request.id"
+    ) && !key.ends_with("_id")
+}
+
 const DEFAULT_BLOB_TRANSPORT_MAX_CONCURRENCY: usize = 32;
 
 fn blob_transport_max_concurrency() -> usize {
@@ -1457,11 +1478,13 @@ impl WasmHost for ProductionWasmHost {
     fn emit_metric(&self, metric_json: &str) -> Result<(), String> {
         let payload: GuestMetricInput = serde_json::from_str(metric_json)
             .map_err(|e| format!("invalid guest metric payload: {e}"))?;
+        record_guest_metric_span_event(&payload, self.invocation_context.as_ref());
         let meter = opentelemetry::global::meter("temper");
         let mut attrs: Vec<opentelemetry::KeyValue> = payload
             .tags
-            .into_iter()
-            .map(|(key, value)| opentelemetry::KeyValue::new(key, value))
+            .iter()
+            .filter(|(key, _)| guest_metric_tag_allowed(key))
+            .map(|(key, value)| opentelemetry::KeyValue::new(key.clone(), value.clone()))
             .collect();
         if let Some(ctx) = &self.invocation_context {
             attrs.push(opentelemetry::KeyValue::new("tenant", ctx.tenant.clone()));
@@ -1469,14 +1492,12 @@ impl WasmHost for ProductionWasmHost {
                 "entity_type",
                 ctx.entity_type.clone(),
             ));
+            attrs.push(opentelemetry::KeyValue::new(
+                "trigger_action",
+                ctx.trigger_action.clone(),
+            ));
             if let Some(module) = &ctx.wasm_module {
                 attrs.push(opentelemetry::KeyValue::new("wasm_module", module.clone()));
-            }
-            if let Some(session_id) = context_session_id(ctx) {
-                attrs.push(opentelemetry::KeyValue::new(
-                    "session_id",
-                    session_id.to_string(),
-                ));
             }
         }
 
@@ -1806,6 +1827,62 @@ fn record_guest_log_span_event(
     let otel_span = cx.span();
     if otel_span.span_context().is_valid() {
         otel_span.add_event("wasm_guest.log", attrs);
+    }
+}
+
+fn record_guest_metric_span_event(
+    payload: &GuestMetricInput,
+    context: Option<&WasmInvocationContext>,
+) {
+    use opentelemetry::KeyValue;
+    use opentelemetry::trace::TraceContextExt as _;
+    use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+    let mut attrs = vec![
+        KeyValue::new("metric.name", truncate_for_span_attr(&payload.name)),
+        KeyValue::new("metric.value", payload.value),
+    ];
+    if let Some(kind) = payload.kind.as_deref().filter(|value| !value.is_empty()) {
+        attrs.push(KeyValue::new("metric.kind", truncate_for_span_attr(kind)));
+    }
+    if let Some(context) = context {
+        attrs.push(KeyValue::new("tenant", context.tenant.clone()));
+        attrs.push(KeyValue::new("entity_type", context.entity_type.clone()));
+        attrs.push(KeyValue::new("entity_id", context.entity_id.clone()));
+        attrs.push(KeyValue::new(
+            "trigger_action",
+            context.trigger_action.clone(),
+        ));
+        if let Some(module) = context
+            .wasm_module
+            .as_deref()
+            .filter(|value| !value.is_empty())
+        {
+            attrs.push(KeyValue::new("wasm_module", module.to_string()));
+        }
+        if let Some(session_id) = context_session_id(context) {
+            attrs.push(KeyValue::new("session_id", session_id.to_string()));
+        }
+        if let Some(run_id) = context
+            .workflow_run_id
+            .as_deref()
+            .filter(|value| !value.is_empty())
+        {
+            attrs.push(KeyValue::new("workflow_run_id", run_id.to_string()));
+        }
+    }
+    for (key, value) in &payload.tags {
+        attrs.push(KeyValue::new(
+            format!("metric.tag.{key}"),
+            truncate_for_span_attr(value),
+        ));
+    }
+
+    let span = tracing::Span::current();
+    let cx = span.context();
+    let otel_span = cx.span();
+    if otel_span.span_context().is_valid() {
+        otel_span.add_event("wasm_guest.metric", attrs);
     }
 }
 

--- a/crates/temper-wasm/src/host_trait/tests.rs
+++ b/crates/temper-wasm/src/host_trait/tests.rs
@@ -15,6 +15,17 @@ fn guest_metric_count_kind_is_counter() {
     assert!(!guest_metric_is_counter_kind(None));
 }
 
+#[test]
+fn guest_metric_tags_reject_high_cardinality_correlation_ids() {
+    assert!(guest_metric_tag_allowed("provider"));
+    assert!(guest_metric_tag_allowed("model"));
+    assert!(!guest_metric_tag_allowed("trace_id"));
+    assert!(!guest_metric_tag_allowed("dd.span_id"));
+    assert!(!guest_metric_tag_allowed("session_id"));
+    assert!(!guest_metric_tag_allowed("workflow_run_id"));
+    assert!(!guest_metric_tag_allowed("tool.call_id"));
+}
+
 /// Build a Connect frame: [flags(1)][length(4 big-endian)][payload].
 fn make_frame(flags: u8, payload: &[u8]) -> Vec<u8> {
     let mut frame = Vec::with_capacity(5 + payload.len());

--- a/docs/adrs/0087-wasm-guest-observability-host-api.md
+++ b/docs/adrs/0087-wasm-guest-observability-host-api.md
@@ -34,6 +34,11 @@ Guest metrics remain low-cardinality OTEL metrics. The host also emits a
 `wasm_guest.metric` event on the active guest span so operators can pivot from
 the trace to the metric without adding trace ids as metric tags.
 
+Temper closes the OpenTelemetry span attached to the tracing span when the
+guest ends or when invocation cleanup closes an unended span. That keeps the
+same span id usable for APM and log correlation even for WASI guests that do
+most work between host function calls.
+
 ## Consequences
 
 - WASM modules can create Datadog-visible child spans for useful pure guest

--- a/docs/adrs/0087-wasm-guest-observability-host-api.md
+++ b/docs/adrs/0087-wasm-guest-observability-host-api.md
@@ -48,6 +48,11 @@ host calls; the direct export uses those same ids and the captured parent
 context so Datadog receives the guest span even when the tracing subscriber's
 entered-guard path is not sufficient to emit it from WASI execution.
 
+Temper must not reduce-sample key guest execution boundaries such as
+`wasm:monty_repl`. Guest spans inherit parent sampling decisions; dropping the
+module boundary also drops the nested `tool.*` spans that make the WASM work
+observable.
+
 ## Consequences
 
 - WASM modules can create Datadog-visible child spans for useful pure guest

--- a/docs/adrs/0087-wasm-guest-observability-host-api.md
+++ b/docs/adrs/0087-wasm-guest-observability-host-api.md
@@ -1,0 +1,45 @@
+# ADR-0087: WASM Guest Observability Host API
+
+- Status: Accepted
+- Date: 2026-05-14
+
+## Context
+
+ADR-0086 made the WASM host boundary visible in Datadog with host-call spans,
+guest progress correlation, structured guest logs, metrics, and span-hint
+headers for outbound HTTP. That is enough to see when a guest crosses a host
+function, but it is not enough for pure in-guest work: a module cannot create
+its own nested spans, add span events, or mark a guest span as failed without
+going through an unrelated host boundary.
+
+TemperPaw now needs provider/tool execution spans that continue the same trace
+inside WASM and correlate logs, metrics, host calls, and Datadog APM views.
+
+## Decision
+
+Temper exposes a structured guest observability ABI:
+
+- `host_start_span(payload_ptr, payload_len) -> i64`
+- `host_add_span_event(span_id, payload_ptr, payload_len) -> i32`
+- `host_set_span_attributes(span_id, payload_ptr, payload_len) -> i32`
+- `host_end_span(span_id, payload_ptr, payload_len) -> i32`
+
+Payloads are JSON. `host_start_span` requires `name` and accepts optional
+`kind` and `attributes`. Span ids are opaque positive integers scoped to one
+WASM invocation. Guest spans nest by start/end order; the active guest span is
+entered around existing telemetry host functions so logs, metrics, progress,
+wide events, and host-boundary spans remain correlated.
+
+Guest metrics remain low-cardinality OTEL metrics. The host also emits a
+`wasm_guest.metric` event on the active guest span so operators can pivot from
+the trace to the metric without adding trace ids as metric tags.
+
+## Consequences
+
+- WASM modules can create Datadog-visible child spans for useful pure guest
+  work instead of abusing outbound HTTP span hints.
+- Existing `X-Temper-Span-*` hints remain supported for old modules.
+- The host owns span ids, limits, cleanup of unclosed spans, reserved
+  observability fields, and attribute truncation.
+- Guests do not receive raw OpenTelemetry objects or trace ids as control
+  handles.

--- a/docs/adrs/0087-wasm-guest-observability-host-api.md
+++ b/docs/adrs/0087-wasm-guest-observability-host-api.md
@@ -41,6 +41,13 @@ guest ends or when invocation cleanup closes an unended span. That keeps the
 same span id usable for APM and log correlation even for WASI guests that do
 most work between host function calls.
 
+For WASI guest invocations, Temper also keeps a minimal host-owned lifecycle
+snapshot and exports the guest span directly with the OpenTelemetry tracer on
+close. The tracing span still provides the trace/span ids used by logs and
+host calls; the direct export uses those same ids and the captured parent
+context so Datadog receives the guest span even when the tracing subscriber's
+entered-guard path is not sufficient to emit it from WASI execution.
+
 ## Consequences
 
 - WASM modules can create Datadog-visible child spans for useful pure guest

--- a/docs/adrs/0087-wasm-guest-observability-host-api.md
+++ b/docs/adrs/0087-wasm-guest-observability-host-api.md
@@ -26,9 +26,11 @@ Temper exposes a structured guest observability ABI:
 
 Payloads are JSON. `host_start_span` requires `name` and accepts optional
 `kind` and `attributes`. Span ids are opaque positive integers scoped to one
-WASM invocation. Guest spans nest by start/end order; the active guest span is
-entered around existing telemetry host functions so logs, metrics, progress,
-wide events, and host-boundary spans remain correlated.
+WASM invocation. Guest spans nest by start/end order. Temper keeps the guest
+span stack entered on the synchronous WASM execution thread, and also enters
+the active guest span around existing telemetry host functions, so pure guest
+work, logs, metrics, progress, wide events, and host-boundary spans remain
+correlated.
 
 Guest metrics remain low-cardinality OTEL metrics. The host also emits a
 `wasm_guest.metric` event on the active guest span so operators can pivot from


### PR DESCRIPTION
## Summary
- add structured WASM guest span host functions and per-invocation registry
- add temper-wasm-sdk span lifecycle wrappers with safe drop cleanup
- keep legacy span hints while correlating logs, metrics, progress, and host-boundary work with active guest spans
- add ADR-0087 and tests for malformed payloads, nesting, cleanup, limits, SDK payloads, and WASI/manual export correlation

## Verification
- cargo test -p temper-wasm
- cargo test -p temper-observe
- full pre-push verification pipeline: fmt, clippy, readability ratchet, full workspace test suite
