### PR TITLE
Remove duplicate uncorrelated WASM guest logs

### DIFF
--- a/crates/temper-wasm/src/host_trait.rs
+++ b/crates/temper-wasm/src/host_trait.rs
@@ -1286,12 +1286,6 @@ impl WasmHost for ProductionWasmHost {
 
     fn log(&self, level: &str, message: &str) {
         record_guest_log_span_event(level, message, self.invocation_context.as_ref(), None);
-        match level {
-            "error" => tracing::error!(target: "wasm_guest", "{}", message),
-            "warn" => tracing::warn!(target: "wasm_guest", "{}", message),
-            "info" => tracing::info!(target: "wasm_guest", "{}", message),
-            _ => tracing::debug!(target: "wasm_guest", "{}", message),
-        }
     }
 
     fn evaluate_spec(

--- a/crates/temper-wasm/src/host_trait/tests/log_correlation.rs
+++ b/crates/temper-wasm/src/host_trait/tests/log_correlation.rs
@@ -123,9 +123,12 @@ fn guest_log_named_event_carries_datadog_trace_and_span_correlation() {
 
 #[test]
 fn production_guest_log_does_not_emit_duplicate_uncorrelated_wasm_event() {
+    type CapturedEvent = (String, BTreeMap<String, String>);
+    type CapturedEvents = Arc<Mutex<Vec<CapturedEvent>>>;
+
     #[derive(Clone)]
     struct EventCapture {
-        events: Arc<Mutex<Vec<(String, BTreeMap<String, String>)>>>,
+        events: CapturedEvents,
     }
 
     #[derive(Default)]

--- a/crates/temper-wasm/src/host_trait/tests/log_correlation.rs
+++ b/crates/temper-wasm/src/host_trait/tests/log_correlation.rs
@@ -120,3 +120,115 @@ fn guest_log_named_event_carries_datadog_trace_and_span_correlation() {
     assert_eq!(event["dd.trace_id"], expected_dd_trace_id);
     assert_eq!(event["dd.span_id"], expected_dd_span_id);
 }
+
+#[test]
+fn production_guest_log_does_not_emit_duplicate_uncorrelated_wasm_event() {
+    #[derive(Clone)]
+    struct EventCapture {
+        events: Arc<Mutex<Vec<(String, BTreeMap<String, String>)>>>,
+    }
+
+    #[derive(Default)]
+    struct FieldVisitor {
+        fields: BTreeMap<String, String>,
+    }
+
+    impl Visit for FieldVisitor {
+        fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+            self.fields
+                .insert(field.name().to_string(), format!("{value:?}"));
+        }
+
+        fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+    }
+
+    impl<S> tracing_subscriber::Layer<S> for EventCapture
+    where
+        S: tracing::Subscriber,
+    {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            if event.metadata().target() != "wasm_guest" {
+                return;
+            }
+            let mut visitor = FieldVisitor::default();
+            event.record(&mut visitor);
+            self.events
+                .lock()
+                .expect("event capture lock poisoned")
+                .push((event.metadata().name().to_string(), visitor.fields));
+        }
+    }
+
+    let tracer_provider = SdkTracerProvider::builder().build();
+    let captured_events = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::registry()
+        .with(
+            tracing_opentelemetry::layer().with_tracer(tracer_provider.tracer("temper-wasm-test")),
+        )
+        .with(EventCapture {
+            events: captured_events.clone(),
+        });
+    let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+
+    let context = WasmInvocationContext {
+        tenant: "tenant-a".to_string(),
+        entity_type: "Session".to_string(),
+        entity_id: "ss-1".to_string(),
+        trigger_action: "FinalizeResult".to_string(),
+        wasm_module: Some("emit_ots_trajectory".to_string()),
+        trigger_params: serde_json::Value::Null,
+        entity_state: serde_json::Value::Null,
+        agent_id: Some("service:wasm-runtime".to_string()),
+        session_id: None,
+        integration_config: BTreeMap::new(),
+        trace_id: "0123456789abcdef0123456789abcdef".to_string(),
+        workflow_root_entity_type: Some("Channel".to_string()),
+        workflow_root_entity_id: Some("en-1".to_string()),
+        workflow_run_id: Some("Channel:en-1".to_string()),
+        http_request: None,
+    };
+    let host = ProductionWasmHost::new(BTreeMap::new()).with_invocation_context(context);
+
+    let span = tracing::info_span!("wasm.invoke");
+    span.in_scope(|| {
+        host.log(
+            "info",
+            "emit_ots_trajectory: emitted trajectory trj-1 for session ss-1",
+        );
+    });
+
+    let events = captured_events.lock().expect("event capture lock poisoned");
+    assert_eq!(
+        events.len(),
+        1,
+        "ctx.log must not emit a second bare wasm_guest log without Datadog correlation fields: {events:?}"
+    );
+    let (event_name, fields) = events.first().expect("expected one wasm_guest log event");
+    assert_eq!(event_name, "wasm_guest.log");
+    for required in [
+        "tenant",
+        "entity_type",
+        "entity_id",
+        "session_id",
+        "wasm_module",
+        "workflow_run_id",
+        "trace_id",
+        "span_id",
+        "otel.trace_id",
+        "otel.span_id",
+        "dd.trace_id",
+        "dd.span_id",
+    ] {
+        assert!(
+            fields.get(required).is_some_and(|value| !value.is_empty()),
+            "correlated wasm_guest.log event must include non-empty {required}: {fields:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- emit WASM guest logs only through the enriched `wasm_guest.log` event path
- remove the second plain `wasm_guest` tracing event that Datadog ingested without trace/span correlation
- add a regression test proving `ProductionWasmHost::log` produces exactly one correlated guest log event

## Why

TemperPaw live Datadog proof showed paired WASM guest logs: one enriched/correlated copy and one bare uncorrelated copy. The root cause was in Temper’s host boundary, so the fix belongs in `temper-wasm` rather than in TemperPaw filters.

## Validation

- `cargo test -p temper-wasm production_guest_log_does_not_emit_duplicate_uncorrelated_wasm_event -- --nocapture`
- `cargo test -p temper-wasm guest_log_named_event_carries_datadog_trace_and_span_correlation -- --nocapture`
- `cargo test -p temper-wasm log_correlation -- --nocapture`
- `cargo fmt --all`
- `git diff --check`
- pre-push hook: rustfmt, clippy, readability ratchet, full `cargo test --workspace`, doctests: ALL GATES PASSED