### PR TITLE
Index Cedar authz candidate selection

### DIFF
--- a/crates/temper-authz/src/engine/candidates.rs
+++ b/crates/temper-authz/src/engine/candidates.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use cedar_policy::{
     ActionConstraint, EntityTypeName, EntityUid, Policy, PolicySet, PrincipalConstraint,
     ResourceConstraint,
@@ -33,6 +35,127 @@ pub(super) struct CandidatePolicySelection {
     pub(super) counts: CandidatePolicyCounts,
 }
 
+#[derive(Debug, Clone)]
+pub(super) struct CandidatePolicyIndex {
+    full_count: usize,
+    policies: Vec<Policy>,
+    state: CandidatePolicyIndexState,
+}
+
+#[derive(Debug, Clone)]
+enum CandidatePolicyIndexState {
+    Indexed(CandidatePolicyBuckets),
+    Fallback,
+}
+
+#[derive(Debug, Clone, Default)]
+struct CandidatePolicyBuckets {
+    principal_any: Vec<usize>,
+    principal_by_type: BTreeMap<String, Vec<usize>>,
+    principal_by_uid: BTreeMap<String, Vec<usize>>,
+    action_any: Vec<usize>,
+    action_by_uid: BTreeMap<String, Vec<usize>>,
+    resource_any: Vec<usize>,
+    resource_by_type: BTreeMap<String, Vec<usize>>,
+    resource_by_uid: BTreeMap<String, Vec<usize>>,
+}
+
+impl CandidatePolicyIndex {
+    pub(super) fn new(policy_set: &PolicySet) -> Self {
+        let mut policies = Vec::new();
+        let mut buckets = CandidatePolicyBuckets::default();
+        let mut fallback = false;
+
+        for (idx, policy) in policy_set.policies().enumerate() {
+            policies.push(policy.clone());
+
+            if !policy.is_static() {
+                fallback = true;
+                continue;
+            }
+
+            index_principal_constraint(&mut buckets, idx, policy.principal_constraint());
+            index_action_constraint(&mut buckets, idx, policy.action_constraint());
+            index_resource_constraint(&mut buckets, idx, policy.resource_constraint());
+        }
+
+        let state = if fallback {
+            CandidatePolicyIndexState::Fallback
+        } else {
+            CandidatePolicyIndexState::Indexed(buckets)
+        };
+        Self {
+            full_count: policies.len(),
+            policies,
+            state,
+        }
+    }
+
+    pub(super) fn select(
+        &self,
+        principal_uid: &EntityUid,
+        action_uid: &EntityUid,
+        resource_uid: &EntityUid,
+    ) -> CandidatePolicySelection {
+        if self.full_count == 0 {
+            return use_full_policy_set(self.full_count);
+        }
+
+        let CandidatePolicyIndexState::Indexed(buckets) = &self.state else {
+            return fallback_policy_set(self.full_count, self.full_count);
+        };
+
+        let principal_candidates = union_sorted_buckets([
+            Some(&buckets.principal_any),
+            buckets
+                .principal_by_type
+                .get(&entity_type_key(principal_uid.type_name())),
+            buckets.principal_by_uid.get(&entity_uid_key(principal_uid)),
+        ]);
+        let action_candidates = union_sorted_buckets([
+            Some(&buckets.action_any),
+            buckets.action_by_uid.get(&entity_uid_key(action_uid)),
+            None,
+        ]);
+        let resource_candidates = union_sorted_buckets([
+            Some(&buckets.resource_any),
+            buckets
+                .resource_by_type
+                .get(&entity_type_key(resource_uid.type_name())),
+            buckets.resource_by_uid.get(&entity_uid_key(resource_uid)),
+        ]);
+
+        let candidate_indices = intersect_dimensions(vec![
+            principal_candidates,
+            action_candidates,
+            resource_candidates,
+        ]);
+        let candidate_count = candidate_indices.len();
+
+        if candidate_count == self.full_count {
+            return use_full_policy_set(self.full_count);
+        }
+
+        let candidates: Vec<Policy> = candidate_indices
+            .iter()
+            .map(|idx| self.policies[*idx].clone())
+            .collect();
+
+        match PolicySet::from_policies(candidates) {
+            Ok(filtered) => CandidatePolicySelection {
+                policy_set: Some(filtered),
+                counts: CandidatePolicyCounts {
+                    full: self.full_count,
+                    candidate: candidate_count,
+                    outcome: CandidateSelectionOutcome::Filtered,
+                },
+            },
+            Err(_) => fallback_policy_set(self.full_count, candidate_count),
+        }
+    }
+}
+
+#[cfg(test)]
 pub(super) fn select_candidate_policy_set(
     policy_set: &PolicySet,
     principal_uid: &EntityUid,
@@ -97,6 +220,7 @@ fn fallback_policy_set(full_count: usize, candidate_count: usize) -> CandidatePo
     }
 }
 
+#[cfg(test)]
 fn policy_may_match_request(
     policy: &Policy,
     principal_uid: &EntityUid,
@@ -108,6 +232,7 @@ fn policy_may_match_request(
         && resource_constraint_may_match(policy.resource_constraint(), resource_uid)
 }
 
+#[cfg(test)]
 fn principal_constraint_may_match(
     constraint: PrincipalConstraint,
     principal_uid: &EntityUid,
@@ -125,6 +250,7 @@ fn principal_constraint_may_match(
     }
 }
 
+#[cfg(test)]
 fn action_constraint_may_match(constraint: ActionConstraint, action_uid: &EntityUid) -> bool {
     match constraint {
         ActionConstraint::Any => true,
@@ -133,6 +259,7 @@ fn action_constraint_may_match(constraint: ActionConstraint, action_uid: &Entity
     }
 }
 
+#[cfg(test)]
 fn resource_constraint_may_match(constraint: ResourceConstraint, resource_uid: &EntityUid) -> bool {
     match constraint {
         ResourceConstraint::Any => true,
@@ -145,216 +272,161 @@ fn resource_constraint_may_match(constraint: ResourceConstraint, resource_uid: &
     }
 }
 
+#[cfg(test)]
 fn entity_type_matches(expected_type: &EntityTypeName, uid: &EntityUid) -> bool {
     uid.type_name() == expected_type
 }
 
-#[cfg(test)]
-mod tests {
-    use std::collections::{HashMap, HashSet};
-    use std::str::FromStr;
-
-    use cedar_policy::{Authorizer, Context, Decision, Entities, Entity, Request};
-
-    use super::*;
-
-    fn uid(value: &str) -> EntityUid {
-        EntityUid::from_str(value).expect("test UID should parse")
-    }
-
-    fn policy_set(source: &str) -> PolicySet {
-        PolicySet::from_str(source).expect("test policy should parse")
-    }
-
-    fn decision_and_reasons(
-        policy_set: &PolicySet,
-        principal_uid: &EntityUid,
-        action_uid: &EntityUid,
-        resource_uid: &EntityUid,
-    ) -> (Decision, Vec<String>) {
-        let principal = Entity::new(principal_uid.clone(), HashMap::new(), HashSet::new())
-            .expect("principal entity should build");
-        let resource = Entity::new(resource_uid.clone(), HashMap::new(), HashSet::new())
-            .expect("resource entity should build");
-        let entities =
-            Entities::from_entities([principal, resource], None).expect("entities should build");
-        let request = Request::new(
-            principal_uid.clone(),
-            action_uid.clone(),
-            resource_uid.clone(),
-            Context::empty(),
-            None,
-        )
-        .expect("request should build");
-        let response = Authorizer::new().is_authorized(&request, policy_set, &entities);
-        let reasons = response
-            .diagnostics()
-            .reason()
-            .map(|id| id.to_string())
-            .collect();
-        (response.decision(), reasons)
-    }
-
-    fn filtered_policy_set(
-        policy_set: &PolicySet,
-        principal_uid: &EntityUid,
-        action_uid: &EntityUid,
-        resource_uid: &EntityUid,
-    ) -> (PolicySet, CandidatePolicyCounts) {
-        let selection =
-            select_candidate_policy_set(policy_set, principal_uid, action_uid, resource_uid);
-        (
-            selection.policy_set.unwrap_or_else(|| policy_set.clone()),
-            selection.counts,
-        )
-    }
-
-    #[test]
-    fn filters_impossible_scopes_without_changing_allow_diagnostics() {
-        let policies = policy_set(
-            r#"
-            @id("permit-doc-read")
-            permit(principal is Customer, action == Action::"read", resource is Doc);
-
-            @id("irrelevant-action")
-            permit(principal is Customer, action == Action::"write", resource is Doc);
-
-            @id("irrelevant-principal")
-            permit(principal is Agent, action == Action::"read", resource is Doc);
-
-            @id("irrelevant-resource")
-            permit(principal is Customer, action == Action::"read", resource is Issue);
-
-            @id("irrelevant-resource-id")
-            forbid(principal is Customer, action == Action::"read", resource == Doc::"blocked");
-            "#,
-        );
-        let principal = uid(r#"Customer::"alice""#);
-        let action = uid(r#"Action::"read""#);
-        let resource = uid(r#"Doc::"doc-1""#);
-
-        let (filtered, counts) = filtered_policy_set(&policies, &principal, &action, &resource);
-
-        assert_eq!(counts.full, 5);
-        assert_eq!(counts.candidate, 1);
-        assert_eq!(counts.outcome, CandidateSelectionOutcome::Filtered);
-        assert_eq!(
-            decision_and_reasons(&policies, &principal, &action, &resource),
-            decision_and_reasons(&filtered, &principal, &action, &resource)
-        );
-    }
-
-    #[test]
-    fn preserves_matching_forbid_deny_override() {
-        let policies = policy_set(
-            r#"
-            @id("permit-doc-read")
-            permit(principal is Customer, action == Action::"read", resource is Doc);
-
-            @id("forbid-blocked-doc")
-            forbid(principal is Customer, action == Action::"read", resource == Doc::"blocked");
-
-            @id("irrelevant-resource")
-            permit(principal is Customer, action == Action::"read", resource is Issue);
-            "#,
-        );
-        let principal = uid(r#"Customer::"alice""#);
-        let action = uid(r#"Action::"read""#);
-        let resource = uid(r#"Doc::"blocked""#);
-
-        let (filtered, counts) = filtered_policy_set(&policies, &principal, &action, &resource);
-        let full_result = decision_and_reasons(&policies, &principal, &action, &resource);
-        let filtered_result = decision_and_reasons(&filtered, &principal, &action, &resource);
-
-        assert_eq!(counts.full, 3);
-        assert_eq!(counts.candidate, 2);
-        assert_eq!(full_result, filtered_result);
-        assert_eq!(filtered_result.0, Decision::Deny);
-        assert!(!filtered_result.1.is_empty());
-    }
-
-    #[test]
-    fn empty_candidate_set_still_denies_without_reasons() {
-        let policies = policy_set(
-            r#"
-            @id("irrelevant-action")
-            permit(principal is Customer, action == Action::"write", resource is Doc);
-
-            @id("irrelevant-resource")
-            permit(principal is Customer, action == Action::"read", resource is Issue);
-            "#,
-        );
-        let principal = uid(r#"Customer::"alice""#);
-        let action = uid(r#"Action::"read""#);
-        let resource = uid(r#"Doc::"doc-1""#);
-
-        let (filtered, counts) = filtered_policy_set(&policies, &principal, &action, &resource);
-
-        assert_eq!(counts.full, 2);
-        assert_eq!(counts.candidate, 0);
-        assert_eq!(
-            decision_and_reasons(&policies, &principal, &action, &resource),
-            decision_and_reasons(&filtered, &principal, &action, &resource)
-        );
-        assert_eq!(
-            decision_and_reasons(&filtered, &principal, &action, &resource),
-            (Decision::Deny, Vec::new())
-        );
-    }
-
-    #[test]
-    fn broad_forbids_remain_candidates() {
-        let policies = policy_set(
-            r#"
-            @id("permit-doc-read")
-            permit(principal is Customer, action == Action::"read", resource is Doc);
-
-            @id("broad-forbid")
-            forbid(principal, action, resource);
-
-            @id("irrelevant-action")
-            permit(principal is Customer, action == Action::"write", resource is Doc);
-            "#,
-        );
-        let principal = uid(r#"Customer::"alice""#);
-        let action = uid(r#"Action::"read""#);
-        let resource = uid(r#"Doc::"doc-1""#);
-
-        let (filtered, counts) = filtered_policy_set(&policies, &principal, &action, &resource);
-        let filtered_result = decision_and_reasons(&filtered, &principal, &action, &resource);
-
-        assert_eq!(counts.full, 3);
-        assert_eq!(counts.candidate, 2);
-        assert_eq!(
-            decision_and_reasons(&policies, &principal, &action, &resource),
-            filtered_result
-        );
-        assert_eq!(filtered_result.0, Decision::Deny);
-        assert!(!filtered_result.1.is_empty());
-    }
-
-    #[test]
-    fn hierarchy_constraints_are_included_conservatively() {
-        let policies = policy_set(
-            r#"
-            @id("principal-hierarchy")
-            permit(principal in Group::"operators", action == Action::"read", resource is Doc);
-
-            @id("resource-hierarchy")
-            permit(principal is Customer, action == Action::"read", resource in Folder::"root");
-
-            @id("irrelevant-resource")
-            permit(principal is Customer, action == Action::"read", resource is Issue);
-            "#,
-        );
-        let principal = uid(r#"Customer::"alice""#);
-        let action = uid(r#"Action::"read""#);
-        let resource = uid(r#"Doc::"doc-1""#);
-
-        let (_, counts) = filtered_policy_set(&policies, &principal, &action, &resource);
-
-        assert_eq!(counts.full, 3);
-        assert_eq!(counts.candidate, 2);
-        assert_eq!(counts.outcome, CandidateSelectionOutcome::Filtered);
+fn index_principal_constraint(
+    buckets: &mut CandidatePolicyBuckets,
+    idx: usize,
+    constraint: PrincipalConstraint,
+) {
+    match constraint {
+        PrincipalConstraint::Any | PrincipalConstraint::In(_) => {
+            push_index(&mut buckets.principal_any, idx);
+        }
+        PrincipalConstraint::Eq(expected) => {
+            push_index(
+                buckets
+                    .principal_by_uid
+                    .entry(entity_uid_key(&expected))
+                    .or_default(),
+                idx,
+            );
+        }
+        PrincipalConstraint::Is(expected_type) | PrincipalConstraint::IsIn(expected_type, _) => {
+            push_index(
+                buckets
+                    .principal_by_type
+                    .entry(entity_type_key(&expected_type))
+                    .or_default(),
+                idx,
+            );
+        }
     }
 }
+
+fn index_action_constraint(
+    buckets: &mut CandidatePolicyBuckets,
+    idx: usize,
+    constraint: ActionConstraint,
+) {
+    match constraint {
+        ActionConstraint::Any => push_index(&mut buckets.action_any, idx),
+        ActionConstraint::Eq(expected) => {
+            push_index(
+                buckets
+                    .action_by_uid
+                    .entry(entity_uid_key(&expected))
+                    .or_default(),
+                idx,
+            );
+        }
+        ActionConstraint::In(expected) => {
+            for action_uid in expected {
+                push_index(
+                    buckets
+                        .action_by_uid
+                        .entry(entity_uid_key(&action_uid))
+                        .or_default(),
+                    idx,
+                );
+            }
+        }
+    }
+}
+
+fn index_resource_constraint(
+    buckets: &mut CandidatePolicyBuckets,
+    idx: usize,
+    constraint: ResourceConstraint,
+) {
+    match constraint {
+        ResourceConstraint::Any | ResourceConstraint::In(_) => {
+            push_index(&mut buckets.resource_any, idx);
+        }
+        ResourceConstraint::Eq(expected) => {
+            push_index(
+                buckets
+                    .resource_by_uid
+                    .entry(entity_uid_key(&expected))
+                    .or_default(),
+                idx,
+            );
+        }
+        ResourceConstraint::Is(expected_type) | ResourceConstraint::IsIn(expected_type, _) => {
+            push_index(
+                buckets
+                    .resource_by_type
+                    .entry(entity_type_key(&expected_type))
+                    .or_default(),
+                idx,
+            );
+        }
+    }
+}
+
+fn push_index(bucket: &mut Vec<usize>, idx: usize) {
+    if bucket.last().copied() != Some(idx) {
+        bucket.push(idx);
+    }
+}
+
+fn entity_uid_key(uid: &EntityUid) -> String {
+    uid.to_string()
+}
+
+fn entity_type_key(entity_type: &EntityTypeName) -> String {
+    entity_type.to_string()
+}
+
+fn union_sorted_buckets<const N: usize>(buckets: [Option<&Vec<usize>>; N]) -> Vec<usize> {
+    let mut result = Vec::new();
+    for bucket in buckets.into_iter().flatten() {
+        result.extend_from_slice(bucket);
+    }
+    result.sort_unstable();
+    result.dedup();
+    result
+}
+
+fn intersect_dimensions(mut dimensions: Vec<Vec<usize>>) -> Vec<usize> {
+    if dimensions.iter().any(Vec::is_empty) {
+        return Vec::new();
+    }
+
+    dimensions.sort_by_key(Vec::len);
+    let mut result = dimensions.remove(0);
+    for dimension in dimensions {
+        result = intersect_sorted(&result, &dimension);
+        if result.is_empty() {
+            break;
+        }
+    }
+    result
+}
+
+fn intersect_sorted(left: &[usize], right: &[usize]) -> Vec<usize> {
+    let mut result = Vec::new();
+    let mut left_idx = 0usize;
+    let mut right_idx = 0usize;
+
+    while left_idx < left.len() && right_idx < right.len() {
+        match left[left_idx].cmp(&right[right_idx]) {
+            std::cmp::Ordering::Less => left_idx += 1,
+            std::cmp::Ordering::Greater => right_idx += 1,
+            std::cmp::Ordering::Equal => {
+                result.push(left[left_idx]);
+                left_idx += 1;
+                right_idx += 1;
+            }
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+#[path = "candidates_tests.rs"]
+mod tests;

--- a/crates/temper-authz/src/engine/candidates_tests.rs
+++ b/crates/temper-authz/src/engine/candidates_tests.rs
@@ -1,0 +1,308 @@
+use std::collections::{HashMap, HashSet};
+use std::str::FromStr;
+
+use cedar_policy::{
+    Authorizer, Context, Decision, Entities, Entity, EntityUid, PolicySet, Request,
+};
+
+use super::*;
+
+fn uid(value: &str) -> EntityUid {
+    EntityUid::from_str(value).expect("test UID should parse")
+}
+
+fn policy_set(source: &str) -> PolicySet {
+    PolicySet::from_str(source).expect("test policy should parse")
+}
+
+fn decision_and_reasons(
+    policy_set: &PolicySet,
+    principal_uid: &EntityUid,
+    action_uid: &EntityUid,
+    resource_uid: &EntityUid,
+) -> (Decision, Vec<String>) {
+    let principal = Entity::new(principal_uid.clone(), HashMap::new(), HashSet::new())
+        .expect("principal entity should build");
+    let resource = Entity::new(resource_uid.clone(), HashMap::new(), HashSet::new())
+        .expect("resource entity should build");
+    let entities =
+        Entities::from_entities([principal, resource], None).expect("entities should build");
+    let request = Request::new(
+        principal_uid.clone(),
+        action_uid.clone(),
+        resource_uid.clone(),
+        Context::empty(),
+        None,
+    )
+    .expect("request should build");
+    let response = Authorizer::new().is_authorized(&request, policy_set, &entities);
+    let reasons = response
+        .diagnostics()
+        .reason()
+        .map(|id| id.to_string())
+        .collect();
+    (response.decision(), reasons)
+}
+
+fn filtered_policy_set(
+    policy_set: &PolicySet,
+    principal_uid: &EntityUid,
+    action_uid: &EntityUid,
+    resource_uid: &EntityUid,
+) -> (PolicySet, CandidatePolicyCounts) {
+    let selection =
+        select_candidate_policy_set(policy_set, principal_uid, action_uid, resource_uid);
+    (
+        selection.policy_set.unwrap_or_else(|| policy_set.clone()),
+        selection.counts,
+    )
+}
+
+fn indexed_policy_set(
+    policy_set: &PolicySet,
+    principal_uid: &EntityUid,
+    action_uid: &EntityUid,
+    resource_uid: &EntityUid,
+) -> (PolicySet, CandidatePolicyCounts) {
+    let index = CandidatePolicyIndex::new(policy_set);
+    let selection = index.select(principal_uid, action_uid, resource_uid);
+    (
+        selection.policy_set.unwrap_or_else(|| policy_set.clone()),
+        selection.counts,
+    )
+}
+
+#[test]
+fn filters_impossible_scopes_without_changing_allow_diagnostics() {
+    let policies = policy_set(
+        r#"
+        @id("permit-doc-read")
+        permit(principal is Customer, action == Action::"read", resource is Doc);
+
+        @id("irrelevant-action")
+        permit(principal is Customer, action == Action::"write", resource is Doc);
+
+        @id("irrelevant-principal")
+        permit(principal is Agent, action == Action::"read", resource is Doc);
+
+        @id("irrelevant-resource")
+        permit(principal is Customer, action == Action::"read", resource is Issue);
+
+        @id("irrelevant-resource-id")
+        forbid(principal is Customer, action == Action::"read", resource == Doc::"blocked");
+        "#,
+    );
+    let principal = uid(r#"Customer::"alice""#);
+    let action = uid(r#"Action::"read""#);
+    let resource = uid(r#"Doc::"doc-1""#);
+
+    let (filtered, counts) = filtered_policy_set(&policies, &principal, &action, &resource);
+
+    assert_eq!(counts.full, 5);
+    assert_eq!(counts.candidate, 1);
+    assert_eq!(counts.outcome, CandidateSelectionOutcome::Filtered);
+    assert_eq!(
+        decision_and_reasons(&policies, &principal, &action, &resource),
+        decision_and_reasons(&filtered, &principal, &action, &resource)
+    );
+}
+
+#[test]
+fn indexed_selection_matches_scan_selection_and_diagnostics() {
+    let policies = policy_set(
+        r#"
+        @id("permit-doc-read")
+        permit(principal is Customer, action == Action::"read", resource is Doc);
+
+        @id("permit-doc-read-by-id")
+        permit(principal == Customer::"alice", action in [Action::"read", Action::"list"], resource == Doc::"doc-1");
+
+        @id("forbid-doc-1")
+        forbid(principal is Customer, action == Action::"read", resource == Doc::"doc-1");
+
+        @id("broad-resource-tree")
+        permit(principal in Group::"customers", action == Action::"read", resource in Folder::"docs");
+
+        @id("irrelevant-principal")
+        permit(principal is Agent, action == Action::"read", resource is Doc);
+
+        @id("irrelevant-action")
+        permit(principal is Customer, action == Action::"write", resource is Doc);
+
+        @id("irrelevant-resource")
+        permit(principal is Customer, action == Action::"read", resource is Issue);
+        "#,
+    );
+    let principal = uid(r#"Customer::"alice""#);
+    let action = uid(r#"Action::"read""#);
+    let resource = uid(r#"Doc::"doc-1""#);
+
+    let (scan_filtered, scan_counts) =
+        filtered_policy_set(&policies, &principal, &action, &resource);
+    let (indexed_filtered, indexed_counts) =
+        indexed_policy_set(&policies, &principal, &action, &resource);
+
+    assert_eq!(scan_counts, indexed_counts);
+    assert_eq!(
+        decision_and_reasons(&scan_filtered, &principal, &action, &resource),
+        decision_and_reasons(&indexed_filtered, &principal, &action, &resource)
+    );
+    assert_eq!(
+        decision_and_reasons(&policies, &principal, &action, &resource),
+        decision_and_reasons(&indexed_filtered, &principal, &action, &resource)
+    );
+}
+
+#[test]
+fn indexed_selection_matches_scan_for_large_policy_sets() {
+    let mut source = String::new();
+    for idx in 0..1_000 {
+        source.push_str(&format!(
+            r#"
+            @id("irrelevant-{idx}")
+            permit(principal is Agent, action == Action::"noop-{idx}", resource is Issue);
+            "#
+        ));
+    }
+    source.push_str(
+        r#"
+        @id("permit-doc-read")
+        permit(principal is Customer, action == Action::"read", resource is Doc);
+
+        @id("forbid-doc-1")
+        forbid(principal is Customer, action == Action::"read", resource == Doc::"doc-1");
+        "#,
+    );
+
+    let policies = policy_set(&source);
+    let principal = uid(r#"Customer::"alice""#);
+    let action = uid(r#"Action::"read""#);
+    let resource = uid(r#"Doc::"doc-1""#);
+
+    let (scan_filtered, scan_counts) =
+        filtered_policy_set(&policies, &principal, &action, &resource);
+    let (indexed_filtered, indexed_counts) =
+        indexed_policy_set(&policies, &principal, &action, &resource);
+
+    assert_eq!(scan_counts.full, 1_002);
+    assert_eq!(scan_counts.candidate, 2);
+    assert_eq!(scan_counts, indexed_counts);
+    assert_eq!(
+        decision_and_reasons(&scan_filtered, &principal, &action, &resource),
+        decision_and_reasons(&indexed_filtered, &principal, &action, &resource)
+    );
+}
+
+#[test]
+fn preserves_matching_forbid_deny_override() {
+    let policies = policy_set(
+        r#"
+        @id("permit-doc-read")
+        permit(principal is Customer, action == Action::"read", resource is Doc);
+
+        @id("forbid-blocked-doc")
+        forbid(principal is Customer, action == Action::"read", resource == Doc::"blocked");
+
+        @id("irrelevant-resource")
+        permit(principal is Customer, action == Action::"read", resource is Issue);
+        "#,
+    );
+    let principal = uid(r#"Customer::"alice""#);
+    let action = uid(r#"Action::"read""#);
+    let resource = uid(r#"Doc::"blocked""#);
+
+    let (filtered, counts) = filtered_policy_set(&policies, &principal, &action, &resource);
+    let full_result = decision_and_reasons(&policies, &principal, &action, &resource);
+    let filtered_result = decision_and_reasons(&filtered, &principal, &action, &resource);
+
+    assert_eq!(counts.full, 3);
+    assert_eq!(counts.candidate, 2);
+    assert_eq!(full_result, filtered_result);
+    assert_eq!(filtered_result.0, Decision::Deny);
+    assert!(!filtered_result.1.is_empty());
+}
+
+#[test]
+fn empty_candidate_set_still_denies_without_reasons() {
+    let policies = policy_set(
+        r#"
+        @id("irrelevant-action")
+        permit(principal is Customer, action == Action::"write", resource is Doc);
+
+        @id("irrelevant-resource")
+        permit(principal is Customer, action == Action::"read", resource is Issue);
+        "#,
+    );
+    let principal = uid(r#"Customer::"alice""#);
+    let action = uid(r#"Action::"read""#);
+    let resource = uid(r#"Doc::"doc-1""#);
+
+    let (filtered, counts) = filtered_policy_set(&policies, &principal, &action, &resource);
+
+    assert_eq!(counts.full, 2);
+    assert_eq!(counts.candidate, 0);
+    assert_eq!(
+        decision_and_reasons(&policies, &principal, &action, &resource),
+        decision_and_reasons(&filtered, &principal, &action, &resource)
+    );
+    assert_eq!(
+        decision_and_reasons(&filtered, &principal, &action, &resource),
+        (Decision::Deny, Vec::new())
+    );
+}
+
+#[test]
+fn broad_forbids_remain_candidates() {
+    let policies = policy_set(
+        r#"
+        @id("permit-doc-read")
+        permit(principal is Customer, action == Action::"read", resource is Doc);
+
+        @id("broad-forbid")
+        forbid(principal, action, resource);
+
+        @id("irrelevant-action")
+        permit(principal is Customer, action == Action::"write", resource is Doc);
+        "#,
+    );
+    let principal = uid(r#"Customer::"alice""#);
+    let action = uid(r#"Action::"read""#);
+    let resource = uid(r#"Doc::"doc-1""#);
+
+    let (filtered, counts) = filtered_policy_set(&policies, &principal, &action, &resource);
+    let filtered_result = decision_and_reasons(&filtered, &principal, &action, &resource);
+
+    assert_eq!(counts.full, 3);
+    assert_eq!(counts.candidate, 2);
+    assert_eq!(
+        decision_and_reasons(&policies, &principal, &action, &resource),
+        filtered_result
+    );
+    assert_eq!(filtered_result.0, Decision::Deny);
+    assert!(!filtered_result.1.is_empty());
+}
+
+#[test]
+fn hierarchy_constraints_are_included_conservatively() {
+    let policies = policy_set(
+        r#"
+        @id("principal-hierarchy")
+        permit(principal in Group::"operators", action == Action::"read", resource is Doc);
+
+        @id("resource-hierarchy")
+        permit(principal is Customer, action == Action::"read", resource in Folder::"root");
+
+        @id("irrelevant-resource")
+        permit(principal is Customer, action == Action::"read", resource is Issue);
+        "#,
+    );
+    let principal = uid(r#"Customer::"alice""#);
+    let action = uid(r#"Action::"read""#);
+    let resource = uid(r#"Doc::"doc-1""#);
+
+    let (_, counts) = filtered_policy_set(&policies, &principal, &action, &resource);
+
+    assert_eq!(counts.full, 3);
+    assert_eq!(counts.candidate, 2);
+    assert_eq!(counts.outcome, CandidateSelectionOutcome::Filtered);
+}

--- a/crates/temper-authz/src/engine/mod.rs
+++ b/crates/temper-authz/src/engine/mod.rs
@@ -55,9 +55,25 @@ impl AuthzDecision {
     }
 }
 
-/// Per-tenant policy data: the compiled `PolicySet` and the source text.
-struct TenantPolicies {
+/// Compiled policy data used by Cedar and the request-time candidate selector.
+struct CompiledPolicies {
     policy_set: PolicySet,
+    candidate_index: candidates::CandidatePolicyIndex,
+}
+
+impl CompiledPolicies {
+    fn new(policy_set: PolicySet) -> Self {
+        let candidate_index = candidates::CandidatePolicyIndex::new(&policy_set);
+        Self {
+            policy_set,
+            candidate_index,
+        }
+    }
+}
+
+/// Per-tenant policy data: the compiled policies and the source text.
+struct TenantPolicies {
+    policies: CompiledPolicies,
     source_text: String,
 }
 
@@ -71,7 +87,7 @@ pub struct AuthzEngine {
     tenant_policies: RwLock<BTreeMap<String, TenantPolicies>>,
     /// Fallback global policy set for callers that don't specify a tenant.
     /// Deprecated: callers should migrate to `authorize_for_tenant`.
-    fallback_policy_set: RwLock<PolicySet>,
+    fallback_policy_set: RwLock<CompiledPolicies>,
     authorizer: Authorizer,
 }
 
@@ -89,7 +105,7 @@ impl AuthzEngine {
 
         Ok(Self {
             tenant_policies: RwLock::new(BTreeMap::new()),
-            fallback_policy_set: RwLock::new(policy_set),
+            fallback_policy_set: RwLock::new(CompiledPolicies::new(policy_set)),
             authorizer: Authorizer::new(),
         })
     }
@@ -106,7 +122,7 @@ impl AuthzEngine {
         merge_system_platform_policy(&mut policy_set);
         Self {
             tenant_policies: RwLock::new(BTreeMap::new()),
-            fallback_policy_set: RwLock::new(policy_set),
+            fallback_policy_set: RwLock::new(CompiledPolicies::new(policy_set)),
             authorizer: Authorizer::new(),
         }
     }
@@ -121,7 +137,7 @@ impl AuthzEngine {
             PolicySet::from_str("permit(principal, action, resource);").unwrap_or_default();
         Self {
             tenant_policies: RwLock::new(BTreeMap::new()),
-            fallback_policy_set: RwLock::new(policy_set),
+            fallback_policy_set: RwLock::new(CompiledPolicies::new(policy_set)),
             authorizer: Authorizer::new(),
         }
     }
@@ -146,7 +162,7 @@ impl AuthzEngine {
         tenants.insert(
             tenant.to_string(),
             TenantPolicies {
-                policy_set: new_policy_set,
+                policies: CompiledPolicies::new(new_policy_set),
                 source_text: policy_text.to_string(),
             },
         );
@@ -210,7 +226,7 @@ impl AuthzEngine {
         tenants.insert(
             tenant.to_string(),
             TenantPolicies {
-                policy_set: combined_set,
+                policies: CompiledPolicies::new(combined_set),
                 source_text: combined_text,
             },
         );
@@ -246,7 +262,7 @@ impl AuthzEngine {
             .fallback_policy_set
             .write()
             .map_err(|e| AuthzError::Engine(format!("policy lock poisoned: {e}")))?;
-        *current = new_policy_set;
+        *current = CompiledPolicies::new(new_policy_set);
         Ok(())
     }
 
@@ -257,14 +273,14 @@ impl AuthzEngine {
             .read()
             .map(|t| {
                 t.values()
-                    .map(|tp| count_user_policies(&tp.policy_set))
+                    .map(|tp| count_user_policies(&tp.policies.policy_set))
                     .sum()
             })
             .unwrap_or(0);
         let fallback_count = self
             .fallback_policy_set
             .read()
-            .map_or(0, |ps| count_user_policies(&ps));
+            .map_or(0, |ps| count_user_policies(&ps.policy_set));
         tenant_count + fallback_count
     }
 
@@ -323,7 +339,7 @@ impl AuthzEngine {
                 action,
                 resource_type,
                 resource_attrs,
-                &tp.policy_set,
+                &tp.policies,
             )
         } else {
             // No per-tenant policies loaded — fall back to global.
@@ -340,7 +356,7 @@ impl AuthzEngine {
         action: &str,
         resource_type: &str,
         resource_attrs: &HashMap<String, serde_json::Value>,
-        policy_set: &PolicySet,
+        policies: &CompiledPolicies,
     ) -> AuthzDecision {
         let mut recorder = CedarEvaluationRecorder::start();
 
@@ -550,12 +566,10 @@ impl AuthzEngine {
         };
         recorder.finish_phase("request");
 
-        let candidate_selection = candidates::select_candidate_policy_set(
-            policy_set,
-            &principal_uid,
-            &action_uid,
-            &resource_uid,
-        );
+        let candidate_selection =
+            policies
+                .candidate_index
+                .select(&principal_uid, &action_uid, &resource_uid);
         crate::metrics::record_cedar_policy_candidate_counts(
             candidate_selection.counts.full,
             candidate_selection.counts.candidate,
@@ -566,7 +580,7 @@ impl AuthzEngine {
         let effective_policy_set = candidate_selection
             .policy_set
             .as_ref()
-            .unwrap_or(policy_set);
+            .unwrap_or(&policies.policy_set);
         let response: CedarResponse =
             self.authorizer
                 .is_authorized(&request, effective_policy_set, &entities);

--- a/docs/adrs/0090-authz-candidate-selection-index.md
+++ b/docs/adrs/0090-authz-candidate-selection-index.md
@@ -1,0 +1,111 @@
+# ADR-0090: AuthZ Candidate Selection Index
+
+- Status: Proposed
+- Date: 2026-05-16
+- Deciders: Temper core maintainers
+- Related:
+  - ADR-0084: AuthZ latency phase instrumentation
+  - ADR-0089: AuthZ policy candidate index
+  - `crates/temper-authz/src/engine/candidates.rs`
+  - `crates/temper-authz/src/engine/mod.rs`
+
+## Context
+
+ADR-0089 made Cedar authorization safer to optimize by filtering each request's `PolicySet` to only policies whose static principal/action/resource constraints could still match the request. That rollout is live in TemperPaw production as `7726e4dfba5453c337dafb7411f88c239f3d5bd5`.
+
+The production proof on 2026-05-16 shows the first filter is semantically useful but not fast enough:
+
+- `temper_cedar_policy_candidate_count` reduced the sampled policy volume from 16,497 full policies to 48 candidate policies per evaluation.
+- `temper_cedar_evaluation_phase_duration_ms{phase:authorizer}` dropped to about 0.23 ms p95 in the corrected proof bucket.
+- `temper_cedar_evaluation_phase_duration_ms{phase:policy_candidates}` remained about 13.4 ms p95, and sampled AuthZ spans still spent 19.6-26.1 ms around full authorization calls.
+
+The cause is visible in the implementation: every authorization call scans `policy_set.policies()`, checks constraints one policy at a time, clones the matching policies, and builds a fresh `PolicySet`. That preserves correctness, but it keeps per-request CPU proportional to total policy count. With thousands of generated policies, that is exactly the wrong hot-path shape.
+
+## Decision
+
+Precompute a per-policy-set candidate selection index at policy load time, then use it for request-time selection.
+
+### Sub-Decision 1: Index Static Constraint Buckets
+
+For each static Cedar policy, index the policy ordinal into principal, action, and resource buckets:
+
+- Principal buckets: always-match, principal type, exact principal UID.
+- Action buckets: always-match, exact action UID.
+- Resource buckets: always-match, resource type, exact resource UID.
+
+Request-time selection computes the union of matching buckets for each dimension, intersects the three sorted ordinal lists, and builds the candidate `PolicySet` from that small result.
+
+**Why this approach**: ADR-0089 already defined the conservative scope rules. Indexing those rules avoids total policy scans while preserving the same "drop only impossible static mismatches" semantics.
+
+### Sub-Decision 2: Keep Decision Caching Out Of Scope
+
+This change does not cache allow/deny decisions. It may reuse the static candidate index for a policy set, but every request still builds Cedar entities/context and calls Cedar's authorizer.
+
+**Why this approach**: Authorization decisions depend on context, principal attributes, resource attributes, forbids, and future policy changes. Decision caching needs a separate invalidation design. The current bottleneck is candidate selection, so the smaller fix is safer.
+
+### Sub-Decision 3: Fail Closed To Full Policy Set
+
+If a policy is non-static, template-linked, or cannot be indexed safely, the index marks the policy set as fallback. Runtime selection then uses the full policy set and records fallback candidate counts.
+
+**Why this approach**: A missed forbid or missed broad permit would be worse than a slow request. Fallback preserves Cedar's original semantics when the optimizer cannot prove a policy's static scope.
+
+### Sub-Decision 4: Rebuild On Policy Reload
+
+Tenant policy reloads and fallback policy reloads rebuild the index atomically with the `PolicySet`.
+
+**Why this approach**: Policy reload is already the trust boundary for replacing compiled Cedar policy text. Keeping the index inside the compiled policy bundle gives simple invalidation with no cross-request cache lifecycle.
+
+## Rollout Plan
+
+1. **Phase 0 (Immediate)** - Add the indexed selector and wire `AuthzEngine` to store a compiled policy bundle containing both the `PolicySet` and the candidate index.
+2. **Phase 1 (Verification)** - Add semantic equivalence tests for permits, forbids, empty candidate sets, exact UID constraints, broad hierarchy constraints, tenant reloads, and named policy diagnostics.
+3. **Phase 2 (Production Proof)** - Roll through Temper and TemperPaw, then rerun the File/OData proof and verify that `phase:policy_candidates` p95 falls below 2 ms while candidate counts and authorization decisions remain correct.
+
+## Readiness Gates
+
+- `cargo test -p temper-authz` passes.
+- Focused tests prove indexed and scan-based selection produce equivalent Cedar decisions and diagnostics.
+- `cargo check -p temper-server` passes because Temper server depends on the changed authz engine surface.
+- Datadog shows live `temper_cedar_policy_candidate_count` and reduced `phase:policy_candidates` after deployment.
+- Live OData read-after-write proof still reaches `Ready` and returns matching bytes.
+
+## Consequences
+
+### Positive
+
+- Request-time candidate selection becomes proportional to matching bucket sizes instead of total policy count.
+- Cedar evaluator work remains small without relying on authorization decision caching.
+- Tenant policy reload naturally invalidates the index.
+
+### Negative
+
+- `temper-authz` owns more in-memory policy metadata.
+- Candidate selection code becomes more complex than a linear scan.
+- Broad policies still appear in every request's bucket; those must be optimized by policy design or a later semantic index.
+
+### Risks
+
+- A bucket classification bug could omit a policy. Mitigation: keep rules identical to ADR-0089, test forbids and exact UID policies, and fallback to full policy set on unsupported shapes.
+- `PolicySet::from_policies` may still be measurable if candidate sets are large. Mitigation: measure after index rollout before adding a reusable candidate `PolicySet` cache.
+
+### DST Compliance
+
+This change is confined to `temper-authz`, not the simulation-visible crates listed in the project guide. The implementation still prefers deterministic `BTreeMap` ordering for stable tests and reproducible behavior.
+
+## Non-Goals
+
+- No allow/deny decision cache.
+- No Cedar bypass.
+- No changes to Cedar policy language or generated app policy shape.
+- No weakening of default deny, forbid override, tenant isolation, or named policy diagnostics.
+
+## Alternatives Considered
+
+1. **Keep the ADR-0089 linear scan** - Rejected because production Datadog shows the candidate-selection phase is now the AuthZ bottleneck.
+2. **Cache final authorization decisions** - Rejected for this slice because invalidation across context/resource/principal/policy changes is a separate correctness problem.
+3. **Prebuild every possible candidate `PolicySet`** - Rejected because exact principal/resource UID combinations can be high-cardinality and unbounded.
+4. **Skip broad hierarchy policies aggressively** - Rejected because Cedar entity hierarchy semantics need explicit entity data; conservative inclusion is safer.
+
+## Rollback Policy
+
+If the index causes incorrect decisions or measurable regressions, revert the engine to ADR-0089's linear `select_candidate_policy_set` call. The metrics and tests added for this change remain useful because they identify the candidate-selection phase independently from Cedar authorizer time.


### PR DESCRIPTION
## Summary
- add ADR-0090 for a precomputed Cedar authorization candidate-selection index
- build a per-policy-set principal/action/resource bucket index at policy load/reload time
- keep the safety model conservative: no decision cache, no Cedar bypass, fallback to the full policy set on unsafe/non-static policy sets
- split candidate selector tests and add a 1,002-policy equivalence case that matches the production shape behind the policy_candidates bottleneck

## Verification
- cargo test -p temper-authz
- cargo check -p temper-server
- cargo clippy -p temper-authz -p temper-server --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- pre-push gate: rustfmt, workspace clippy, readability ratchet, full cargo test --workspace and doctests passed on retry

Note: the first pre-push run hit a single unrelated temper-store-turso concurrency test failure; the exact test passed on immediate rerun, and the second full pre-push run passed all gates.

## Rollout Proof Needed
- merge after GitHub CI
- bump Temper in TemperPaw
- deploy through Docker/Railway
- rerun live File/OData proof
- confirm in Datadog that phase:policy_candidates p95 drops below 2 ms while candidate counts and decisions stay correct