### PR TITLE
[codex] Optimize projection field-index upserts

### DIFF
--- a/crates/temper-store-postgres/src/platform.rs
+++ b/crates/temper-store-postgres/src/platform.rs
@@ -26,6 +26,9 @@ const MAX_INDEXABLE_FIELD_VALUE_BYTES: usize = 2000;
 const QUERY_PROJECTION_UPSERT_OPERATION: &str = "query_projection_upsert";
 const QUERY_PROJECTION_REMOVE_OPERATION: &str = "query_projection_remove";
 
+type ScalarFieldIndex = BTreeMap<String, String>;
+type ExistingFieldIndex = BTreeMap<String, (Option<String>, Option<String>)>;
+
 #[derive(Clone, Copy, Debug)]
 pub struct PostgresSpecVerificationUpdate<'a> {
     pub status: &'a str,
@@ -423,6 +426,9 @@ impl PostgresEventStore {
                 return Err(storage_error(e));
             }
         };
+        // The catalog row is the per-entity projection serialization point. Doing
+        // this before diffing field-index rows also serializes first writers when
+        // no catalog row existed at transaction start.
         crate::dbm::postgres_query!(
             "INSERT INTO entity_catalog \
              (tenant, entity_type, entity_id, status, fields, sequence_nr, projection_version, projection_hash, updated_at) \
@@ -442,54 +448,71 @@ impl PostgresEventStore {
         .await
         .map_err(storage_error)?;
 
-        crate::dbm::postgres_query!("DELETE FROM entity_field_index WHERE tenant = $1 AND entity_type = $2 AND entity_id = $3")
+        let existing_index_rows: Vec<(String, Option<String>, Option<String>)> =
+            crate::dbm::postgres_query_as!(
+                "SELECT field_name, field_value, status \
+                 FROM entity_field_index \
+                 WHERE tenant = $1 AND entity_type = $2 AND entity_id = $3 \
+                 FOR UPDATE",
+            )
             .bind(tenant)
             .bind(entity_type)
             .bind(entity_id)
-            .execute(&mut *tx)
+            .fetch_all(&mut *tx)
             .await
             .map_err(storage_error)?;
+        let existing_index = existing_index_rows
+            .into_iter()
+            .map(|(field_name, field_value, field_status)| {
+                (field_name, (field_value, field_status))
+            })
+            .collect::<ExistingFieldIndex>();
 
-        let mut indexed_fields = 0_u64;
-        let mut skipped_fields = 0_u64;
-        if let Some(object) = fields.as_object() {
-            for (field_name, value) in object {
-                if let Some(field_value) = scalar_field_value(value) {
-                    // Postgres btree caps an indexed key at ~2704 bytes (compressed).
-                    // Inserting a longer value into entity_field_index errors out and
-                    // poisons the whole transaction, which then rolls back the
-                    // entity_catalog upsert above too — silently dropping the entire
-                    // row from both projections. Long fields can't be btree-indexed
-                    // by Postgres in any case, so they're meaningless to $filter
-                    // pushdown; the full value is still in entity_catalog.fields
-                    // (jsonb) for read-by-id and catalog-fast-read. Skipping them
-                    // here keeps the projection consistent.
-                    // Skip silently — this is normal for any field whose
-                    // serialized scalar exceeds Postgres' btree key cap.
-                    // The full value is preserved in entity_catalog.fields
-                    // jsonb, which is what reads return.
-                    if field_value.len() > MAX_INDEXABLE_FIELD_VALUE_BYTES {
-                        skipped_fields += 1;
-                        continue;
-                    }
-                    indexed_fields += 1;
-                    crate::dbm::postgres_query!(
-                        "INSERT INTO entity_field_index \
-                         (tenant, entity_type, entity_id, field_name, field_value, status) \
-                         VALUES ($1, $2, $3, $4, $5, $6) \
-                         ON CONFLICT (tenant, entity_type, entity_id, field_name) DO UPDATE SET \
-                             field_value = EXCLUDED.field_value, status = EXCLUDED.status",
-                    )
-                    .bind(tenant)
-                    .bind(entity_type)
-                    .bind(entity_id)
-                    .bind(field_name)
-                    .bind(field_value)
-                    .bind(status)
-                    .execute(&mut *tx)
-                    .await
-                    .map_err(storage_error)?;
-                }
+        let (new_index, indexed_fields, skipped_fields) = scalar_index_fields(fields);
+
+        for (field_name, (old_value, _old_status)) in &existing_index {
+            let should_delete = match (old_value.as_ref(), new_index.get(field_name)) {
+                (Some(old), Some(new)) => old != new,
+                _ => true,
+            };
+            if should_delete {
+                crate::dbm::postgres_query!(
+                    "DELETE FROM entity_field_index \
+                     WHERE tenant = $1 AND entity_type = $2 AND entity_id = $3 AND field_name = $4",
+                )
+                .bind(tenant)
+                .bind(entity_type)
+                .bind(entity_id)
+                .bind(field_name)
+                .execute(&mut *tx)
+                .await
+                .map_err(storage_error)?;
+            }
+        }
+
+        for (field_name, field_value) in &new_index {
+            let should_upsert = !matches!(
+                existing_index.get(field_name),
+                Some((Some(old_value), Some(old_status)))
+                    if old_value == field_value && old_status.as_str() == status
+            );
+            if should_upsert {
+                crate::dbm::postgres_query!(
+                    "INSERT INTO entity_field_index \
+                     (tenant, entity_type, entity_id, field_name, field_value, status) \
+                     VALUES ($1, $2, $3, $4, $5, $6) \
+                     ON CONFLICT (tenant, entity_type, entity_id, field_name) DO UPDATE SET \
+                         field_value = EXCLUDED.field_value, status = EXCLUDED.status",
+                )
+                .bind(tenant)
+                .bind(entity_type)
+                .bind(entity_id)
+                .bind(field_name)
+                .bind(field_value)
+                .bind(status)
+                .execute(&mut *tx)
+                .await
+                .map_err(storage_error)?;
             }
         }
 
@@ -2163,6 +2186,29 @@ fn scalar_field_value(value: &serde_json::Value) -> Option<String> {
         serde_json::Value::String(v) => Some(v.clone()),
         serde_json::Value::Array(_) | serde_json::Value::Object(_) => None,
     }
+}
+
+fn scalar_index_fields(fields: &serde_json::Value) -> (ScalarFieldIndex, u64, u64) {
+    let mut indexed = ScalarFieldIndex::new();
+    let mut skipped_fields = 0_u64;
+
+    if let Some(object) = fields.as_object() {
+        for (field_name, value) in object {
+            let Some(field_value) = scalar_field_value(value) else {
+                continue;
+            };
+            // Postgres btree caps an indexed key at roughly one third of an
+            // 8KB page. Long fields remain fully preserved in entity_catalog.
+            if field_value.len() > MAX_INDEXABLE_FIELD_VALUE_BYTES {
+                skipped_fields += 1;
+                continue;
+            }
+            indexed.insert(field_name.clone(), field_value);
+        }
+    }
+
+    let indexed_fields = indexed.len() as u64;
+    (indexed, indexed_fields, skipped_fields)
 }
 
 fn postgres_placeholders(sql: &str, max_index: usize) -> String {

--- a/crates/temper-store-postgres/src/store.rs
+++ b/crates/temper-store-postgres/src/store.rs
@@ -326,6 +326,10 @@ impl EventStore for PostgresEventStore {
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
+#[path = "store_projection_test.rs"]
+mod projection_tests;
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::migration::run_migrations;

--- a/crates/temper-store-postgres/src/store_projection_test.rs
+++ b/crates/temper-store-postgres/src/store_projection_test.rs
@@ -1,0 +1,262 @@
+use super::*;
+use crate::migration::run_migrations;
+use sqlx::PgPool;
+
+#[test]
+fn upsert_query_projection_diffs_field_index_rows() {
+    let database_url = match std::env::var("DATABASE_URL") {
+        Ok(url) => url,
+        Err(_) => return,
+    };
+
+    sqlx::test_block_on(async {
+        let pool = PgPool::connect(&database_url).await.unwrap();
+        run_migrations(&pool).await.unwrap();
+        let store = PostgresEventStore::new(pool.clone());
+        let tenant = format!("tenant-projection-diff-{}", uuid::Uuid::new_v4());
+        let entity_type = "File";
+        let entity_id = "file-diff";
+
+        store
+            .upsert_query_projection(
+                &tenant,
+                entity_type,
+                entity_id,
+                "Ready",
+                &serde_json::json!({
+                    "content_hash": "sha256:old",
+                    "mime_type": "text/plain",
+                    "owner": "alice",
+                }),
+                1,
+            )
+            .await
+            .unwrap();
+
+        let owner_xmin_before: String = crate::dbm::postgres_query_scalar!(
+            "SELECT xmin::text FROM entity_field_index \
+             WHERE tenant = $1 AND entity_type = $2 AND entity_id = $3 AND field_name = $4",
+        )
+        .bind(&tenant)
+        .bind(entity_type)
+        .bind(entity_id)
+        .bind("owner")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let hash_xmin_before: String = crate::dbm::postgres_query_scalar!(
+            "SELECT xmin::text FROM entity_field_index \
+             WHERE tenant = $1 AND entity_type = $2 AND entity_id = $3 AND field_name = $4",
+        )
+        .bind(&tenant)
+        .bind(entity_type)
+        .bind(entity_id)
+        .bind("content_hash")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        store
+            .upsert_query_projection(
+                &tenant,
+                entity_type,
+                entity_id,
+                "Ready",
+                &serde_json::json!({
+                    "content_hash": "sha256:new",
+                    "owner": "alice",
+                    "size_bytes": 128,
+                }),
+                2,
+            )
+            .await
+            .unwrap();
+
+        let owner_xmin_after: String = crate::dbm::postgres_query_scalar!(
+            "SELECT xmin::text FROM entity_field_index \
+             WHERE tenant = $1 AND entity_type = $2 AND entity_id = $3 AND field_name = $4",
+        )
+        .bind(&tenant)
+        .bind(entity_type)
+        .bind(entity_id)
+        .bind("owner")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let hash_xmin_after: String = crate::dbm::postgres_query_scalar!(
+            "SELECT xmin::text FROM entity_field_index \
+             WHERE tenant = $1 AND entity_type = $2 AND entity_id = $3 AND field_name = $4",
+        )
+        .bind(&tenant)
+        .bind(entity_type)
+        .bind(entity_id)
+        .bind("content_hash")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            owner_xmin_before, owner_xmin_after,
+            "unchanged field index rows should not be rewritten"
+        );
+        assert_ne!(
+            hash_xmin_before, hash_xmin_after,
+            "changed field index rows should be rewritten"
+        );
+
+        let field_rows: Vec<(String, Option<String>, Option<String>)> =
+            crate::dbm::postgres_query_as!(
+                "SELECT field_name, field_value, status FROM entity_field_index \
+                 WHERE tenant = $1 AND entity_type = $2 AND entity_id = $3 \
+                 ORDER BY field_name",
+            )
+            .bind(&tenant)
+            .bind(entity_type)
+            .bind(entity_id)
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            field_rows,
+            vec![
+                (
+                    "content_hash".to_string(),
+                    Some("sha256:new".to_string()),
+                    Some("Ready".to_string())
+                ),
+                (
+                    "owner".to_string(),
+                    Some("alice".to_string()),
+                    Some("Ready".to_string())
+                ),
+                (
+                    "size_bytes".to_string(),
+                    Some("128".to_string()),
+                    Some("Ready".to_string())
+                ),
+            ]
+        );
+
+        let catalog_row: (String, serde_json::Value, i64) = crate::dbm::postgres_query_as!(
+            "SELECT status, fields, sequence_nr FROM entity_catalog \
+             WHERE tenant = $1 AND entity_type = $2 AND entity_id = $3",
+        )
+        .bind(&tenant)
+        .bind(entity_type)
+        .bind(entity_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(catalog_row.0, "Ready");
+        assert_eq!(catalog_row.1["content_hash"], "sha256:new");
+        assert_eq!(catalog_row.1["owner"], "alice");
+        assert_eq!(catalog_row.1["size_bytes"], 128);
+        assert_eq!(catalog_row.2, 2);
+
+        crate::dbm::postgres_query!("DELETE FROM entity_field_index WHERE tenant = $1")
+            .bind(&tenant)
+            .execute(&pool)
+            .await
+            .unwrap();
+        crate::dbm::postgres_query!("DELETE FROM entity_catalog WHERE tenant = $1")
+            .bind(&tenant)
+            .execute(&pool)
+            .await
+            .unwrap();
+    });
+}
+
+#[test]
+fn upsert_query_projection_removes_index_row_when_value_becomes_too_long() {
+    let database_url = match std::env::var("DATABASE_URL") {
+        Ok(url) => url,
+        Err(_) => return,
+    };
+
+    sqlx::test_block_on(async {
+        let pool = PgPool::connect(&database_url).await.unwrap();
+        run_migrations(&pool).await.unwrap();
+        let store = PostgresEventStore::new(pool.clone());
+        let tenant = format!("tenant-projection-long-field-{}", uuid::Uuid::new_v4());
+        let entity_type = "File";
+        let entity_id = "file-long-field";
+
+        store
+            .upsert_query_projection(
+                &tenant,
+                entity_type,
+                entity_id,
+                "Ready",
+                &serde_json::json!({"description": "short"}),
+                1,
+            )
+            .await
+            .unwrap();
+
+        let indexed_before: i64 = crate::dbm::postgres_query_scalar!(
+            "SELECT COUNT(*)::bigint FROM entity_field_index \
+             WHERE tenant = $1 AND entity_type = $2 AND entity_id = $3 AND field_name = $4",
+        )
+        .bind(&tenant)
+        .bind(entity_type)
+        .bind(entity_id)
+        .bind("description")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(indexed_before, 1);
+
+        let long_description = "x".repeat(2500);
+        store
+            .upsert_query_projection(
+                &tenant,
+                entity_type,
+                entity_id,
+                "Ready",
+                &serde_json::json!({"description": long_description}),
+                2,
+            )
+            .await
+            .unwrap();
+
+        let indexed_after: i64 = crate::dbm::postgres_query_scalar!(
+            "SELECT COUNT(*)::bigint FROM entity_field_index \
+             WHERE tenant = $1 AND entity_type = $2 AND entity_id = $3 AND field_name = $4",
+        )
+        .bind(&tenant)
+        .bind(entity_type)
+        .bind(entity_id)
+        .bind("description")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(indexed_after, 0);
+
+        let catalog_description: Option<String> = crate::dbm::postgres_query_scalar!(
+            "SELECT fields ->> 'description' FROM entity_catalog \
+             WHERE tenant = $1 AND entity_type = $2 AND entity_id = $3",
+        )
+        .bind(&tenant)
+        .bind(entity_type)
+        .bind(entity_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let expected_description = "x".repeat(2500);
+        assert_eq!(
+            catalog_description.as_deref(),
+            Some(expected_description.as_str())
+        );
+
+        crate::dbm::postgres_query!("DELETE FROM entity_field_index WHERE tenant = $1")
+            .bind(&tenant)
+            .execute(&pool)
+            .await
+            .unwrap();
+        crate::dbm::postgres_query!("DELETE FROM entity_catalog WHERE tenant = $1")
+            .bind(&tenant)
+            .execute(&pool)
+            .await
+            .unwrap();
+    });
+}

--- a/docs/adrs/0091-query-projection-diff-index-upserts.md
+++ b/docs/adrs/0091-query-projection-diff-index-upserts.md
@@ -1,0 +1,143 @@
+# ADR-0091: Query Projection Diff Index Upserts
+
+- Status: Proposed
+- Date: 2026-05-16
+- Deciders: Temper core maintainers
+- Related:
+  - ADR-0082: Projection Correctness Observability
+  - ADR-0083: Trace Budget and Fanout Summarization
+  - ADR-0088: Native File Value Write Fast Path
+  - ADR-0090: AuthZ Candidate Selection Index
+  - `crates/temper-store-postgres/src/platform.rs`
+  - `crates/temper-server/src/state/dispatch/effects.rs`
+  - `crates/temper-server/src/query_projection_metrics.rs`
+
+## Context
+
+The latency program has moved the top measured bottleneck away from Cedar candidate scanning and toward projection/write fanout.
+The latest production proof for PERF-001B (`authz-index-live-proof-20260516164954`) showed the exact File create trace at roughly 62.5 ms p50 / 65.0 ms p95, with `dispatch.phase.query_projection` around 20.8 ms p50 / 25.4 ms p95 and `entity.get_or_spawn_tenant_actor_with_fields` p95 around 41.9 ms.
+Datadog also shows the File `$value` path still has meaningful PUT/read latency after the native fast path.
+
+The current Postgres query projection write is intentionally simple:
+
+1. Upsert the full `entity_catalog` row.
+2. Delete every `entity_field_index` row for `(tenant, entity_type, entity_id)`.
+3. Reinsert every scalar indexed field, one SQL statement per field.
+
+That guarantees stale EAV rows do not survive, but it turns small updates into many tiny SQL writes. On live File proof traces this appears as repeated `entity_field_index` inserts, repeated delete/index update work, and `dispatch.phase.query_projection` spans that now dominate the in-process write path more than AuthZ candidate selection.
+
+The query projection is a derived read model, so correctness is more important than raw write speed. Any optimization must keep:
+
+- `entity_catalog.fields` as the complete projected JSON object for read-by-id and catalog-fast reads.
+- `entity_field_index` as a scalar `$filter` pushdown index with no stale rows.
+- tenant isolation and RLS behavior unchanged.
+- replay parity, sampled shadow checks, and applied-sequence metrics meaningful.
+
+## Decision
+
+Use diffed `entity_field_index` maintenance for Postgres query projection upserts.
+The write will still update `entity_catalog` on every accepted projection update, but it will stop deleting and reinserting unchanged field-index rows.
+
+### Serialize Through the Catalog Row
+
+Inside the existing transaction, upsert the new `entity_catalog` row first.
+The catalog row is the per-entity projection serialization point: existing rows are locked by the `ON CONFLICT DO UPDATE`, and the first writer creates the row so concurrent first-writer transactions wait on the same primary key conflict before they inspect the field index.
+
+**Why this approach**: Loading the catalog row with `FOR UPDATE` is not enough when the row does not exist yet. Upserting the catalog before diffing makes new and existing entity updates use one serialization point without adding a new lock table, cache, or advisory-lock protocol.
+
+### Keep Catalog Writes Loud and Complete
+
+Always write the new `entity_catalog` state before committing, including `fields`, `status`, `sequence_nr`, `projection_hash`, and `updated_at`.
+Do not use this ADR to introduce projection decision caches or to skip catalog updates solely because projected fields are unchanged.
+
+**Why this approach**: The catalog row carries authoritative projection fields and sequence metadata. Even when indexed fields are unchanged, the latest sequence number is correctness evidence for replay parity and shadow checks.
+
+### Diff Scalar Index Rows
+
+Load the actual `entity_field_index` rows for the entity with `FOR UPDATE` after the catalog upsert has serialized the transaction.
+Convert the new projected JSON object into a bounded scalar index map using the same scalar extraction and max indexed-value-byte rule already used today.
+
+Then apply:
+
+- delete existing rows whose fields are absent from the new scalar map or no longer indexable;
+- delete existing rows whose scalar indexed value changed;
+- upsert rows that are new, changed, or whose denormalized status changed;
+- preserve rows whose field value and status already match the new projection.
+
+**Why this approach**: This preserves the no-stale-index-row invariant while turning common small updates into O(changed fields) writes instead of O(all indexed fields) writes.
+
+### Preserve Fallback Simplicity
+
+The first implementation should be Postgres-only and should not change Turso behavior.
+Turso remains a separate storage surface with its own correctness tests.
+The Postgres path can fall back to the current delete-all/reinsert-all algorithm when it cannot safely compute a diff.
+
+**Why this approach**: Production uses Postgres for this measured bottleneck, and narrowing the first change reduces correctness risk.
+
+### Measure Row Operations
+
+Continue emitting the existing projection indexed/skipped field metrics.
+At minimum, local tests must prove unchanged field-index rows are not rewritten while changed, removed, and unindexable fields are reconciled correctly.
+
+**Why this approach**: This optimization is only valuable if it reduces actual write amplification. The observability program should be able to prove the row-operation reduction live, not infer it from code shape.
+
+## Rollout Plan
+
+1. **Phase 0 (Immediate)** — Implement Postgres diffed `entity_field_index` maintenance behind the existing projection upsert API. Add focused Postgres tests for unchanged fields, changed fields, removed fields, long-value skips, and catalog preservation.
+2. **Phase 1 (Production proof)** — Roll into TemperPaw, deploy, rerun the File/OData proof, and compare Datadog `dispatch.phase.query_projection`, field-index SQL counts, projection update duration, and replay/shadow correctness.
+3. **Phase 2 (Follow-up)** — If the diffed path helps but SQL count is still high, consider set-based `UNNEST` upserts/deletes and event-level coalescing for background projection work.
+
+## Readiness Gates
+
+- `cargo test -p temper-store-postgres` focused projection tests pass.
+- `cargo check -p temper-store-postgres` passes.
+- `cargo clippy -p temper-store-postgres --all-targets -- -D warnings` passes.
+- `cargo test -p temper-server --test query_projection_backfill` passes replay/backfill coverage when server projection behavior changes.
+- `cargo check -p temper-server` passes when server projection behavior changes.
+- DST review is run for simulation-visible server changes if the implementation touches `temper-server`.
+- Live proof preserves read-after-write correctness and Datadog shows no replay/shadow drift increase.
+
+## Consequences
+
+### Positive
+
+- Small updates stop rewriting every indexed field.
+- Projection spans should shrink on entity updates and File version-recording paths.
+- The read model remains fully durable and queryable; no cache invalidation problem is introduced.
+
+### Negative
+
+- The Postgres projection path becomes more complex.
+- Each upsert now reads the current field-index rows after writing the catalog row, so no-change or small-change updates improve while cold creates still pay the full insert cost.
+- Status changes require care because `status` is denormalized into every EAV field row.
+
+### Risks
+
+- A diff bug could leave stale field-index rows. Mitigation: delete changed/removed rows before upserting replacements, test replay parity, and keep fallback full rebuild available.
+- Serializing through the catalog upsert could add contention under concurrent updates to the same entity. Mitigation: the row is already the projection serialization point; measure transaction duration and wait evidence before expanding scope.
+- A long field that crosses the indexable-size boundary could be mishandled. Mitigation: reuse the current scalar extraction and max-byte rule for both old and new maps.
+
+### DST Compliance
+
+- The primary change is in `temper-store-postgres`, outside simulation-visible crates.
+- If `temper-server` metrics or dispatch tests are touched, do not introduce wall-clock or random behavior into simulation-visible logic. Existing production-only metrics using `Instant` must keep `// determinism-ok` annotations.
+
+## Non-Goals
+
+- No change to Cedar authorization or governance semantics.
+- No decision cache, projection cache, or out-of-process read-model service.
+- No Turso rewrite in the first PR.
+- No presigned/direct blob upload architecture in this ADR.
+- No change to OData `$filter` semantics.
+
+## Alternatives Considered
+
+1. **Keep full delete/reinsert** — Correct and simple, but live evidence shows it is now a real latency source.
+2. **Move all filters to JSONB GIN and delete `entity_field_index`** — Potentially cleaner long-term, but it would require a broader OData SQL translator migration and new query-plan proof.
+3. **Cache projected fields in memory** — Faster for repeated updates, but invalidation and multi-instance correctness would be harder than the current durable source-of-truth comparison.
+4. **Batch with `UNNEST` only** — Reduces round trips but still rewrites unchanged fields. This remains a possible Phase 2 after diffing.
+
+## Rollback Policy
+
+Revert to the current full rebuild algorithm for Postgres projection upserts.
+Because `entity_catalog.fields` remains the complete source of truth, a rollback can repair any suspected stale field index by running the existing projection backfill/replay path.


### PR DESCRIPTION
## What changed

- Adds ADR-0091 for diffed Postgres query projection field-index upserts.
- Changes `upsert_query_projection` to serialize each entity through the `entity_catalog` row, then diff the actual `entity_field_index` rows instead of deleting and reinserting every scalar field.
- Deletes stale or no-longer-indexable field rows, upserts only changed rows, and preserves unchanged index rows so unrelated field updates do less database work.
- Adds projection store tests for unchanged-row preservation, stale-row deletion, changed/new field handling, and removal when a field value becomes too large to index.

## Why

TemperPaw and production chat read paths depend heavily on Temper's query projection plane. The previous write path rewrote every indexed field for an entity even when only one field changed, which increases write amplification, index churn, WAL pressure, and lock time. This is a direct latency improvement slice under the latency/observability program, while preserving projection correctness.

## Correctness notes

During review I found a first-writer race in the initial implementation. The final version upserts `entity_catalog` before locking field-index rows, so concurrent first projections for the same entity serialize through the catalog primary key before computing the field-index diff.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p temper-store-postgres`
- `cargo clippy -p temper-store-postgres --all-targets -- -D warnings`
- `cargo test -p temper-store-postgres -- --nocapture`
- `bash scripts/readability-ratchet.sh check .ci/readability-baseline.env`
- Full pre-push gate: rustfmt, clippy, readability ratchet, and `cargo test --workspace`

Note: local `DATABASE_URL` was not set, so Postgres-backed integration tests compiled and skipped locally. The branch still passed the full repository pre-push gate. Live DB proof is planned in the follow-on TemperPaw/deployment verification step.