### PR TITLE
[codex] Move File reactions off upload response path

### DIFF
--- a/crates/temper-platform/src/os_apps/agent_bootstrap.rs
+++ b/crates/temper-platform/src/os_apps/agent_bootstrap.rs
@@ -261,6 +261,7 @@ pub(super) async fn bootstrap_agents(
                         }),
                         agent_ctx: &agent_ctx,
                         await_integration: false,
+                        await_reactions: true,
                     })
                     .await
                 {
@@ -282,6 +283,7 @@ pub(super) async fn bootstrap_agents(
                         params: json!({}),
                         agent_ctx: &agent_ctx,
                         await_integration: false,
+                        await_reactions: true,
                     })
                     .await;
 
@@ -347,6 +349,7 @@ async fn set_agent_source_app(
                     }),
                     agent_ctx,
                     await_integration: false,
+                    await_reactions: true,
                 })
                 .await
             {
@@ -396,6 +399,7 @@ async fn ensure_inline_file_uploaded(
                 }),
                 agent_ctx,
                 await_integration: false,
+                await_reactions: true,
             })
             .await
             .map_err(|e| format!("failed to initialize File('{file_id}'): {e}"))?;

--- a/crates/temper-platform/src/os_apps/mod.rs
+++ b/crates/temper-platform/src/os_apps/mod.rs
@@ -1599,6 +1599,7 @@ async fn bootstrap_app_entity(
                 }),
                 agent_ctx: &agent_ctx,
                 await_integration: false,
+                await_reactions: true,
             })
             .await;
         tracing::info!(tenant, app = %app_name, id = %id, "App entity updated");
@@ -1630,6 +1631,7 @@ async fn bootstrap_app_entity(
                     }),
                     agent_ctx: &agent_ctx,
                     await_integration: false,
+                    await_reactions: true,
                 })
                 .await
             {
@@ -2101,6 +2103,7 @@ pub(super) async fn ensure_app_docs_workspace(
                 }),
                 agent_ctx,
                 await_integration: false,
+                await_reactions: true,
             })
             .await
             .map_err(|e| format!("failed to initialize app docs workspace: {e}"))?;
@@ -2173,6 +2176,7 @@ pub(super) async fn ensure_directory(
             }),
             agent_ctx,
             await_integration: false,
+            await_reactions: true,
         })
         .await
         .map_err(|e| {
@@ -2193,6 +2197,7 @@ pub(super) async fn ensure_directory(
                 params: serde_json::json!({}),
                 agent_ctx,
                 await_integration: false,
+                await_reactions: true,
             })
             .await
             .map_err(|e| {
@@ -2247,6 +2252,7 @@ pub(super) async fn ensure_markdown_file(
                 }),
                 agent_ctx,
                 await_integration: false,
+                await_reactions: true,
             })
             .await
             .map_err(|e| format!("failed to initialize File('{}'): {e}", target.file_id))?;
@@ -2260,6 +2266,7 @@ pub(super) async fn ensure_markdown_file(
                 params: serde_json::json!({}),
                 agent_ctx,
                 await_integration: false,
+                await_reactions: true,
             })
             .await
             .map_err(|e| {
@@ -2278,6 +2285,7 @@ pub(super) async fn ensure_markdown_file(
                 params: serde_json::json!({}),
                 agent_ctx,
                 await_integration: false,
+                await_reactions: true,
             })
             .await
             .map_err(|e| {
@@ -2454,6 +2462,7 @@ async fn bootstrap_seed_data(
                             params,
                             agent_ctx: &agent_ctx,
                             await_integration: false,
+                            await_reactions: true,
                         })
                         .await
                     {

--- a/crates/temper-platform/src/os_apps/mod_test.rs
+++ b/crates/temper-platform/src/os_apps/mod_test.rs
@@ -2215,6 +2215,7 @@ async fn test_local_stream_uploads_create_real_file_version_lineage() {
             }),
             agent_ctx: &agent_ctx,
             await_integration: false,
+            await_reactions: true,
         })
         .await
         .expect("initialize file");

--- a/crates/temper-server/src/observe/evolution/operations/support.rs
+++ b/crates/temper-server/src/observe/evolution/operations/support.rs
@@ -267,6 +267,7 @@ pub(super) async fn spawn_intent_discovery(
             DispatchExtOptions {
                 agent_ctx,
                 await_integration,
+                await_reactions: true,
             },
         )
         .await?;

--- a/crates/temper-server/src/odata/bindings.rs
+++ b/crates/temper-server/src/odata/bindings.rs
@@ -231,6 +231,7 @@ pub(super) async fn dispatch_bound_action(
             DispatchExtOptions {
                 agent_ctx: &dispatch_agent_ctx,
                 await_integration,
+                await_reactions: true,
             },
         )
         .await;

--- a/crates/temper-server/src/state/dispatch/actions.rs
+++ b/crates/temper-server/src/state/dispatch/actions.rs
@@ -1,4 +1,7 @@
-use tracing::instrument;
+use std::sync::{Arc, OnceLock};
+
+use tokio::sync::Semaphore;
+use tracing::{Instrument, instrument};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::entity_actor::{EntityMsg, EntityResponse};
@@ -11,6 +14,27 @@ use super::effects::PostDispatchContext;
 use super::retry;
 use super::{DispatchCommand, DispatchError, DispatchExtOptions, record_workflow_span_attrs};
 use crate::state::admission::AdmissionOutcome;
+
+const DEFAULT_BACKGROUND_REACTION_MAX_CONCURRENCY: usize = 64;
+
+struct BackgroundReactionDispatch {
+    dispatcher: Arc<crate::trigger::ReactionDispatcher>,
+    tenant: TenantId,
+    entity_type: String,
+    entity_id: String,
+    action: String,
+    to_state: String,
+    fields: serde_json::Value,
+    agent_ctx: AgentContext,
+}
+
+fn background_reaction_semaphore() -> Arc<Semaphore> {
+    static SEMAPHORE: OnceLock<Arc<Semaphore>> = OnceLock::new();
+    Arc::clone(
+        SEMAPHORE
+            .get_or_init(|| Arc::new(Semaphore::new(DEFAULT_BACKGROUND_REACTION_MAX_CONCURRENCY))),
+    )
+}
 
 impl crate::state::ServerState {
     /// Dispatch an action using the unified command object.
@@ -72,6 +96,7 @@ impl crate::state::ServerState {
             params,
             agent_ctx,
             await_integration: false,
+            await_reactions: true,
         })
         .await
     }
@@ -118,6 +143,7 @@ impl crate::state::ServerState {
             params,
             agent_ctx: options.agent_ctx,
             await_integration: options.await_integration,
+            await_reactions: options.await_reactions,
         })
         .await
     }
@@ -134,6 +160,7 @@ impl crate::state::ServerState {
             params,
             agent_ctx,
             await_integration,
+            await_reactions,
         } = cmd;
 
         let response = self
@@ -156,30 +183,123 @@ impl crate::state::ServerState {
                 .ok()
                 .and_then(|slot| slot.clone());
             if let Some(dispatcher) = dispatcher {
+                let to_state = response.state.status.clone();
                 let fields = serde_json::to_value(&response.state.fields).unwrap_or_default();
-                dispatcher
-                    .dispatch_reactions(
-                        self,
-                        tenant,
+                if await_reactions {
+                    dispatcher
+                        .dispatch_reactions(
+                            self,
+                            tenant,
+                            entity_type,
+                            entity_id,
+                            action,
+                            &to_state,
+                            &fields,
+                            0,
+                            // ADR-0046: thread the invoking context through so
+                            // reactions without an explicit principal inherit
+                            // the invoking authority, and declared principals
+                            // can elevate deterministically.
+                            agent_ctx,
+                        )
+                        .await;
+                } else if let Some(background) =
+                    self.try_spawn_background_reactions(BackgroundReactionDispatch {
+                        dispatcher: Arc::clone(&dispatcher),
+                        tenant: tenant.clone(),
+                        entity_type: entity_type.to_string(),
+                        entity_id: entity_id.to_string(),
+                        action: action.to_string(),
+                        to_state,
+                        fields,
+                        agent_ctx: agent_ctx.clone(),
+                    })
+                {
+                    tracing::warn!(
+                        tenant = %tenant,
                         entity_type,
                         entity_id,
-                        action,
-                        &response.state.status,
-                        &fields,
-                        0,
-                        // ADR-0046: thread the invoking context through so
-                        // reactions without an explicit principal inherit
-                        // the invoking authority, and declared principals
-                        // can elevate deterministically.
-                        agent_ctx,
-                    )
-                    .await;
+                        action_name = action,
+                        "background reaction budget exhausted; awaiting reactions inline"
+                    );
+                    dispatcher
+                        .dispatch_reactions(
+                            self,
+                            tenant,
+                            entity_type,
+                            entity_id,
+                            action,
+                            &background.to_state,
+                            &background.fields,
+                            0,
+                            agent_ctx,
+                        )
+                        .await;
+                }
             }
         }
 
         // Scheduled actions are handled inside run_post_dispatch_effects
         // (called from dispatch_tenant_action_core).
         Ok(response)
+    }
+
+    fn try_spawn_background_reactions(
+        &self,
+        dispatch: BackgroundReactionDispatch,
+    ) -> Option<BackgroundReactionDispatch> {
+        let Ok(permit) = background_reaction_semaphore().try_acquire_owned() else {
+            return Some(dispatch);
+        };
+
+        let state = self.clone();
+        let BackgroundReactionDispatch {
+            dispatcher,
+            tenant,
+            entity_type,
+            entity_id,
+            action,
+            to_state,
+            fields,
+            agent_ctx,
+        } = dispatch;
+        let span = tracing::info_span!(
+            "reaction.dispatch.background",
+            tenant = %tenant,
+            entity_type = %entity_type,
+            entity_id = %entity_id,
+            action_name = %action,
+        );
+
+        tokio::spawn(
+            async move {
+                // determinism-ok: production-only post-commit reaction side effects
+                let _permit = permit;
+                let results = dispatcher
+                    .dispatch_reactions(
+                        &state,
+                        &tenant,
+                        &entity_type,
+                        &entity_id,
+                        &action,
+                        &to_state,
+                        &fields,
+                        0,
+                        &agent_ctx,
+                    )
+                    .await;
+                tracing::info!(
+                    tenant = %tenant,
+                    entity_type = %entity_type,
+                    entity_id = %entity_id,
+                    action_name = %action,
+                    reaction.result_count = results.len(),
+                    "background reactions completed"
+                );
+            }
+            .instrument(span),
+        );
+        None
     }
 
     /// Core dispatch without reaction cascade (used by ReactionDispatcher to

--- a/crates/temper-server/src/state/dispatch/mod.rs
+++ b/crates/temper-server/src/state/dispatch/mod.rs
@@ -193,6 +193,7 @@ impl From<String> for DispatchError {
 pub struct DispatchExtOptions<'a> {
     pub agent_ctx: &'a AgentContext,
     pub await_integration: bool,
+    pub await_reactions: bool,
 }
 
 /// Unified command object for entity action dispatch.
@@ -216,6 +217,8 @@ pub struct DispatchCommand<'a> {
     pub agent_ctx: &'a AgentContext,
     /// Whether to await WASM integration callbacks before returning.
     pub await_integration: bool,
+    /// Whether to await cross-entity reaction cascades before returning.
+    pub await_reactions: bool,
 }
 
 pub(super) fn record_workflow_span_attrs(

--- a/crates/temper-server/src/state/dispatch/state_timeouts.rs
+++ b/crates/temper-server/src/state/dispatch/state_timeouts.rs
@@ -722,6 +722,7 @@ queue_timeout_seconds = 10
                         crate::state::dispatch::DispatchExtOptions {
                             agent_ctx: &agent_ctx,
                             await_integration: false,
+                            await_reactions: true,
                         },
                     )
                     .await;
@@ -899,6 +900,7 @@ queue_timeout_seconds = 0
                         crate::state::dispatch::DispatchExtOptions {
                             agent_ctx: &agent_ctx,
                             await_integration: false,
+                            await_reactions: true,
                         },
                     )
                     .await;
@@ -1064,6 +1066,7 @@ queue_timeout_seconds = 30
                         crate::state::dispatch::DispatchExtOptions {
                             agent_ctx: &agent_ctx,
                             await_integration: false,
+                            await_reactions: true,
                         },
                     )
                     .await;
@@ -1182,6 +1185,7 @@ queue_timeout_seconds = 30
                 params: serde_json::json!({}),
                 agent_ctx: &agent_ctx,
                 await_integration: false,
+                await_reactions: true,
             })
             .await;
         if let Ok(r) = retry {

--- a/crates/temper-server/src/state/file_writes.rs
+++ b/crates/temper-server/src/state/file_writes.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, RwLock};
 use sha2::{Digest, Sha256};
 use temper_wasm::{StreamRegistry, WasmInvocationContext};
 
-use super::ServerState;
+use super::{DispatchExtOptions, ServerState};
 
 /// Error returned by the native/File `$value` content upload path.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -143,7 +143,7 @@ impl ServerState {
             .and_then(|value| value.as_str())
             .unwrap_or_default();
         let created_by = agent_ctx.agent_id.clone().unwrap_or_default();
-        self.dispatch_tenant_action(
+        self.dispatch_tenant_action_ext_typed(
             tenant,
             "File",
             file_id,
@@ -156,10 +156,14 @@ impl ServerState {
                 "previous_version_id": previous_version_id,
                 "created_by": created_by,
             }),
-            agent_ctx,
+            DispatchExtOptions {
+                agent_ctx,
+                await_integration: false,
+                await_reactions: false,
+            },
         )
         .await
-        .map_err(FileStreamContentError::ActionRejected)
+        .map_err(|error| FileStreamContentError::ActionRejected(error.to_string()))
     }
 
     #[tracing::instrument(skip_all, fields(

--- a/crates/temper-server/tests/adapter_dispatch.rs
+++ b/crates/temper-server/tests/adapter_dispatch.rs
@@ -108,6 +108,7 @@ method = "POST"
             DispatchExtOptions {
                 agent_ctx: &agent_ctx,
                 await_integration: true,
+                await_reactions: true,
             },
         )
         .await
@@ -181,6 +182,7 @@ method = "POST"
             DispatchExtOptions {
                 agent_ctx: &agent_ctx,
                 await_integration: true,
+                await_reactions: true,
             },
         )
         .await
@@ -269,6 +271,7 @@ method = "POST"
             DispatchExtOptions {
                 agent_ctx: &agent_ctx,
                 await_integration: true,
+                await_reactions: true,
             },
         )
         .await
@@ -285,6 +288,7 @@ method = "POST"
             DispatchExtOptions {
                 agent_ctx: &agent_ctx,
                 await_integration: true,
+                await_reactions: true,
             },
         )
         .await

--- a/crates/temper-server/tests/trigger_e2e_prod.rs
+++ b/crates/temper-server/tests/trigger_e2e_prod.rs
@@ -12,6 +12,7 @@ use temper_runtime::tenant::TenantId;
 use temper_server::ServerState;
 use temper_server::registry::SpecRegistry;
 use temper_server::request_context::AgentContext;
+use temper_server::state::DispatchExtOptions;
 use temper_spec::csdl::parse_csdl;
 
 const CSDL_XML: &str = r#"<?xml version="1.0" encoding="utf-8"?>
@@ -432,5 +433,77 @@ permit(
         workspace_after.state.fields["used_bytes"],
         serde_json::json!(42),
         "inline trigger should resolve workspace_id and increment workspace usage",
+    );
+}
+
+#[tokio::test]
+async fn inline_action_triggers_can_run_in_background_when_requested() {
+    let tenant = TenantId::new("trigger-e2e-bg");
+    let state = build_file_workspace_state(
+        "trigger-e2e-bg",
+        r#"
+permit(
+    principal is Agent,
+    action == Action::"IncrementUsage",
+    resource is Workspace
+) when {
+    principal.agent_type == "file-service"
+};
+"#,
+    );
+
+    let workspace_id = "ws-bg";
+    let file_id = "file-bg";
+    state
+        .get_or_create_tenant_entity(&tenant, "Workspace", workspace_id, serde_json::json!({}))
+        .await
+        .expect("workspace seed should succeed");
+    state
+        .get_or_create_tenant_entity(
+            &tenant,
+            "File",
+            file_id,
+            serde_json::json!({ "workspace_id": workspace_id }),
+        )
+        .await
+        .expect("file seed should succeed");
+
+    let agent_ctx = AgentContext::system();
+    let resp = state
+        .dispatch_tenant_action_ext_typed(
+            &tenant,
+            "File",
+            file_id,
+            "StreamUpdated",
+            serde_json::json!({ "size_bytes": 42 }),
+            DispatchExtOptions {
+                agent_ctx: &agent_ctx,
+                await_integration: false,
+                await_reactions: false,
+            },
+        )
+        .await
+        .expect("File.StreamUpdated should dispatch");
+
+    assert!(resp.success, "source File transition should commit");
+    assert_eq!(resp.state.status, "Ready");
+
+    let mut observed_usage = None;
+    for _ in 0..50 {
+        let workspace_after = state
+            .get_tenant_entity_state(&tenant, "Workspace", workspace_id)
+            .await
+            .expect("workspace should exist after trigger fired");
+        if workspace_after.state.fields["used_bytes"] == serde_json::json!(42) {
+            observed_usage = Some(workspace_after.state.fields["used_bytes"].clone());
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+
+    assert_eq!(
+        observed_usage,
+        Some(serde_json::json!(42)),
+        "background inline trigger should eventually increment workspace usage",
     );
 }

--- a/crates/temper-server/tests/wasm_dispatch.rs
+++ b/crates/temper-server/tests/wasm_dispatch.rs
@@ -546,6 +546,7 @@ async fn wasm_authz_denial_records_governance_artifacts_blocking_mode() {
             DispatchExtOptions {
                 agent_ctx: &agent_ctx,
                 await_integration: true,
+                await_reactions: true,
             },
         )
         .await

--- a/docs/adrs/0092-bounded-background-file-reactions.md
+++ b/docs/adrs/0092-bounded-background-file-reactions.md
@@ -1,0 +1,188 @@
+# ADR-0092: Bounded Background File Reactions
+
+- Status: Proposed
+- Date: 2026-05-16
+- Deciders: Temper core maintainers
+- Related:
+  - ADR-0081: Latency observability acceleration program
+  - ADR-0083: Trace Budget and Fanout Summarization
+  - ADR-0088: Native File `$value` Write Fast Path
+  - ADR-0091: Query Projection Diff Index Upserts
+  - `crates/temper-server/src/state/file_writes.rs`
+  - `crates/temper-server/src/state/dispatch/actions.rs`
+  - `crates/temper-server/src/trigger/dispatcher.rs`
+  - `os-apps/temper-fs/specs/file.ioa.toml`
+
+## Context
+
+PERF-002 moved File projection upserts into the measured 42-91 ms p95 range for
+the current production proof bucket. The remaining current-version Datadog
+tail after long-lived event streams is File byte transfer:
+
+- `PUT $value` internal p95 is about 611 ms and HTTP File `$value` p95 is about
+  490 ms in the last two-hour current-version window.
+- `GET $value` p95 is about 297 ms.
+- `File.StreamUpdated` p95 is about 248 ms.
+- `reaction.dispatch` p95 is about 220 ms.
+- Cedar candidate phases are now usually sub-millisecond to low-single-digit
+  milliseconds, and dispatch p95 is about 20-25 ms.
+
+ADR-0088 already removed the WASM blob adapter from the built-in File write
+path. The current native File write still waits for two kinds of work before
+returning the HTTP `204`:
+
+1. synchronous correctness work: hash bytes, durably write the blob, and commit
+   `File.StreamUpdated` through the verified transition table;
+2. cascade work: create the `FileVersion`, supersede the previous version, and
+   increment Workspace usage through inline `[[action.triggers]]`.
+
+The reaction dispatcher documentation already says reactions are
+fire-and-forget and that the source transition is committed regardless of
+reaction outcome. In practice, `dispatch_tenant_action` awaits the whole
+reaction cascade inline. That is safer for historical tests, but it makes the
+user-visible File upload wait on post-commit bookkeeping that can complete
+immediately after the response without weakening the File state machine.
+
+## Decision
+
+Introduce an explicit dispatch option for background reaction execution and use
+it only for the native File `$value` write path in the first PR.
+
+### Sub-Decision 1: Keep the File Commit Synchronous
+
+The File `$value` response may return only after all of the following are true:
+
+- the request body is hashed;
+- the content-addressed blob write succeeds;
+- `File.StreamUpdated` commits through the verified transition table;
+- the File entity state reflects `Ready`, `has_content`, `content_hash`,
+  `mime_type`, `size_bytes`, and version counters.
+
+**Why this approach**: These are the read-after-write and correctness boundaries
+the user observes directly. The optimization must not acknowledge bytes before
+Temper can read them back through the File entity.
+
+### Sub-Decision 2: Run File Reactions in a Bounded Background Lane
+
+For native File `$value` writes, run the post-commit inline trigger cascade in a
+background task guarded by a process-wide semaphore budget. If the background
+budget is saturated, fall back to the existing inline await path.
+
+**Why this approach**: This removes reaction fanout from the common File upload
+response path while preserving correctness under overload. The bounded fallback
+means the system slows down instead of dropping FileVersion or Workspace
+updates.
+
+### Sub-Decision 3: Preserve Default Inline Reactions Elsewhere
+
+Generic `dispatch_tenant_action` and all existing OData action dispatches will
+continue to await reactions unless a caller explicitly opts into background
+reactions.
+
+**Why this approach**: The first latency slice should target the measured File
+path without silently changing every generated app workflow. A broader reaction
+execution policy can follow after production proof.
+
+### Sub-Decision 4: Make the Choice Visible
+
+The background path must emit a span such as
+`reaction.dispatch.background` with the source entity/action and budget outcome.
+The fallback path should log when the background budget is exhausted and it has
+to await reactions inline.
+
+**Why this approach**: The latency program needs evidence that response latency
+fell because reaction work moved off the synchronous path, not because reaction
+work disappeared.
+
+## Rollout Plan
+
+1. **Phase 0 (Immediate)** - Add the dispatch option, bounded background
+   reaction helper, and native File `$value` opt-in. Update focused tests so the
+   File response is fast-path correct immediately and FileVersion/Workspace
+   effects are verified eventually.
+2. **Phase 1 (Production proof)** - Roll into TemperPaw, deploy, rerun the
+   File proof, and compare Datadog `PUT $value`, `File.StreamUpdated`,
+   `reaction.dispatch`, FileVersion creation, and DB projection metrics.
+3. **Phase 2 (Follow-up)** - If this is stable, consider making background
+   reactions a spec-level or action-level policy with stronger queue metrics and
+   replay repair.
+
+## Readiness Gates
+
+- Native File `$value` tests pass and still prove blob hash equality.
+- FileVersion and Workspace trigger effects are observed eventually in tests.
+- Background budget saturation falls back to inline execution rather than
+  dropping reactions.
+- No decision cache, Cedar bypass, direct projection write, or File state
+  mutation outside `StreamUpdated` is introduced.
+- Production proof shows File bytes read back immediately and FileVersion rows
+  appear after the background cascade.
+
+## Consequences
+
+### Positive
+
+- Removes measured reaction fanout from the common File upload response path.
+- Keeps the File entity's verified transition and read-after-write semantics
+  synchronous.
+- Gives the platform an explicit dispatch policy knob instead of relying on
+  misleading "fire-and-forget" comments.
+- Provides a bounded overload behavior: inline await instead of silent loss.
+
+### Negative
+
+- FileVersion and Workspace side effects become eventually consistent for this
+  HTTP response.
+- Tests that assume inline reaction completion for File upload must wait for the
+  side effect they care about.
+- The dispatch API gains one more option.
+
+### Risks
+
+- **Lost background reaction**: mitigated by acquiring a bounded permit before
+  spawning and falling back to inline reactions when saturated.
+- **Read-after-write misunderstanding**: mitigated by keeping File state and
+  blob content synchronous, and documenting that FileVersion is eventual on this
+  path.
+- **Process crash after File commit but before reaction completion**: this risk
+  already exists conceptually for fire-and-forget reactions, but the current
+  inline implementation reduces it. The first PR accepts this only for File
+  uploads; Phase 2 should add durable reaction outbox/replay if the broader
+  architecture moves this way.
+
+### DST Compliance
+
+- The change touches `temper-server`, a simulation-visible crate.
+- No simulation-visible state depends on wall-clock time or random order.
+- The background task is production-only post-commit side-effect execution and
+  must carry a `// determinism-ok` annotation.
+- The bounded semaphore is a production admission budget, not model state.
+
+## Non-Goals
+
+- No direct browser-to-object-store upload in this ADR.
+- No removal of FileVersion or Workspace triggers.
+- No change to generated app reaction semantics by default.
+- No durable reaction outbox in the first PR.
+- No projection cache or direct projection mutation.
+
+## Alternatives Considered
+
+1. **Keep awaiting reactions inline** - Safest, but leaves a measured 220-250 ms
+   post-commit cascade in the File upload response path.
+2. **Make all reactions background by default** - Architecturally coherent with
+   the comments, but too broad for a measured first slice.
+3. **Drop FileVersion creation from upload** - Rejected because version history
+   is part of TemperFS correctness and user trust.
+4. **Use unbounded `tokio::spawn` for reactions** - Rejected because the system
+   needs a budgeted overload path.
+5. **Build a durable reaction outbox first** - Stronger long-term architecture,
+   but larger than needed to prove this latency slice. It remains the Phase 2
+   path if background reactions become general.
+
+## Rollback Policy
+
+Set the native File `$value` dispatch call back to inline reaction execution.
+Because File state and blob writes still commit through `StreamUpdated`, rollback
+does not require data migration; it only changes whether future File upload
+responses wait for the reaction cascade before returning.


### PR DESCRIPTION
## Summary

- add ADR-0092 for bounded background File reactions
- add an explicit `await_reactions` dispatch option while preserving inline reaction behavior for existing/default call sites
- move native File `$value` post-commit FileVersion/Workspace reactions into a bounded background lane, with inline fallback when the budget is exhausted
- add a production-style trigger test proving the source File transition commits immediately while reaction effects arrive eventually

## Why

Current Datadog evidence after PERF-002 shows residual File `$value` latency is still paying for post-commit reaction fanout. The File byte/blob write and verified `StreamUpdated` transition must remain synchronous for read-after-write correctness, but FileVersion and Workspace bookkeeping can run after the upload response as bounded background work.

## Correctness Notes

- File body hash, blob write, and verified `File.StreamUpdated` commit remain synchronous before the HTTP upload path can return.
- Generic dispatch, OData action dispatch, adapter callbacks, WASM callbacks, platform bootstrap dispatches, and state-timeout dispatches continue to await reactions by default.
- Background reaction execution is bounded by a semaphore and falls back to inline reaction execution when saturated, so reaction work slows the caller instead of being dropped.

## Validation

- `cargo test -p temper-server --test trigger_e2e_prod inline_action_triggers_can_run_in_background_when_requested -- --nocapture`
- `cargo test -p temper-server --test file_value_fast_path -- --nocapture`
- `cargo test -p temper-server --test trigger_e2e_prod --test reaction_e2e_prod --test adapter_dispatch --test wasm_dispatch -- --nocapture`
- `cargo check -p temper-server -p temper-platform`
- `cargo clippy -p temper-server -p temper-platform --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- pre-push gate passed: rustfmt, workspace clippy, readability ratchet, full workspace tests, and doctests
