### PR TITLE
[codex] Instrument native blob transport latency

### DIFF
--- a/crates/temper-server/src/blob_store.rs
+++ b/crates/temper-server/src/blob_store.rs
@@ -13,7 +13,11 @@ use reqwest::{Method, StatusCode};
 use sha2::{Digest, Sha256};
 use temper_runtime::tenant::TenantId;
 use tokio::sync::Semaphore;
+use tracing::Instrument;
 
+use crate::blob_transport_observability::{
+    BlobTransportError, BlobTransportFinish, blob_transport_span, finish_blob_transport,
+};
 use crate::state::ServerState;
 
 type HmacSha256 = Hmac<Sha256>;
@@ -107,7 +111,9 @@ impl BlobStore {
         }
 
         match &self.backend {
-            BlobStoreBackend::LocalFs { root } => put_local_blob(root, key, body).await,
+            BlobStoreBackend::LocalFs { root } => {
+                put_local_blob_observed(root, key, body, "put").await
+            }
             BlobStoreBackend::S3(store) => store.put_if_absent(key, body).await,
         }
     }
@@ -142,8 +148,10 @@ impl BlobStore {
         }
 
         match &self.backend {
-            BlobStoreBackend::LocalFs { root } => put_local_blob(root, key, body).await,
-            BlobStoreBackend::S3(store) => store.put(key, body).await,
+            BlobStoreBackend::LocalFs { root } => {
+                put_local_blob_observed(root, key, body, "put_content").await
+            }
+            BlobStoreBackend::S3(store) => store.put_with_operation("put_content", key, body).await,
         }
     }
 
@@ -160,7 +168,7 @@ impl BlobStore {
         }
 
         match &self.backend {
-            BlobStoreBackend::LocalFs { root } => get_local_blob(root, key).await,
+            BlobStoreBackend::LocalFs { root } => get_local_blob_observed(root, key).await,
             BlobStoreBackend::S3(store) => store.get(key).await,
         }
     }
@@ -262,76 +270,198 @@ impl S3BlobStore {
             return Ok(());
         }
 
-        self.put(key, body).await
+        self.put_with_operation("put", key, body).await
     }
 
-    async fn put(&self, key: &str, body: &[u8]) -> Result<(), String> {
-        let url = self.object_url(key);
-        let mut request = self.client.put(&url).body(body.to_vec());
-        let headers = self.signed_headers(Method::PUT, &url)?;
-        for (header_name, header_value) in &headers {
-            request = request.header(header_name, header_value);
-        }
+    async fn put_with_operation(
+        &self,
+        operation: &'static str,
+        key: &str,
+        body: &[u8],
+    ) -> Result<(), String> {
+        let request_bytes = body.len() as u64;
+        let started_at = Instant::now(); // determinism-ok: production blob transport metric only
+        let span = blob_transport_span(operation, "s3", request_bytes);
+        let result = async {
+            let url = self.object_url(key);
+            let mut request = self.client.put(&url).body(body.to_vec());
+            let headers = self
+                .signed_headers(Method::PUT, &url)
+                .map_err(BlobTransportError::message)?;
+            for (header_name, header_value) in &headers {
+                request = request.header(header_name, header_value);
+            }
 
-        let response = request
-            .send()
-            .await
-            .map_err(|e| format!("blob PUT request failed for '{key}': {e}"))?;
-        if response.status().is_success() {
-            return Ok(());
+            let response = request.send().await.map_err(|e| {
+                BlobTransportError::message(format!("blob PUT request failed for '{key}': {e}"))
+            })?;
+            let status = response.status();
+            if status.is_success() {
+                return Ok(status);
+            }
+            Err(BlobTransportError::status(
+                format!("blob PUT failed for '{key}' with HTTP {status}"),
+                status,
+            ))
         }
-        Err(format!(
-            "blob PUT failed for '{key}' with HTTP {}",
-            response.status()
-        ))
+        .instrument(span.clone())
+        .await;
+
+        match result {
+            Ok(status) => {
+                finish_blob_transport(BlobTransportFinish {
+                    started_at,
+                    span: &span,
+                    operation,
+                    backend: "s3",
+                    outcome: "ok",
+                    status: Some(status),
+                    request_bytes,
+                    response_bytes: 0,
+                });
+                Ok(())
+            }
+            Err(error) => {
+                finish_blob_transport(BlobTransportFinish {
+                    started_at,
+                    span: &span,
+                    operation,
+                    backend: "s3",
+                    outcome: "error",
+                    status: error.status,
+                    request_bytes,
+                    response_bytes: 0,
+                });
+                Err(error.message)
+            }
+        }
     }
 
     async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, String> {
-        let url = self.object_url(key);
-        let mut request = self.client.get(&url);
-        let headers = self.signed_headers(Method::GET, &url)?;
-        for (header_name, header_value) in &headers {
-            request = request.header(header_name, header_value);
-        }
+        let started_at = Instant::now(); // determinism-ok: production blob transport metric only
+        let span = blob_transport_span("get", "s3", 0);
+        let result = async {
+            let url = self.object_url(key);
+            let mut request = self.client.get(&url);
+            let headers = self
+                .signed_headers(Method::GET, &url)
+                .map_err(BlobTransportError::message)?;
+            for (header_name, header_value) in &headers {
+                request = request.header(header_name, header_value);
+            }
 
-        let response = request
-            .send()
-            .await
-            .map_err(|e| format!("blob GET request failed for '{key}': {e}"))?;
-        if response.status() == StatusCode::NOT_FOUND {
-            return Ok(None);
-        }
-        if !response.status().is_success() {
-            return Err(format!(
-                "blob GET failed for '{key}' with HTTP {}",
-                response.status()
-            ));
-        }
+            let response = request.send().await.map_err(|e| {
+                BlobTransportError::message(format!("blob GET request failed for '{key}': {e}"))
+            })?;
+            let status = response.status();
+            if status == StatusCode::NOT_FOUND {
+                return Ok((status, None));
+            }
+            if !status.is_success() {
+                return Err(BlobTransportError::status(
+                    format!("blob GET failed for '{key}' with HTTP {status}"),
+                    status,
+                ));
+            }
 
-        let bytes = response
-            .bytes()
-            .await
-            .map_err(|e| format!("blob GET body read failed for '{key}': {e}"))?;
-        Ok(Some(bytes.to_vec()))
+            let bytes = response.bytes().await.map_err(|e| {
+                BlobTransportError::message(format!("blob GET body read failed for '{key}': {e}"))
+            })?;
+            Ok((status, Some(bytes.to_vec())))
+        }
+        .instrument(span.clone())
+        .await;
+
+        match result {
+            Ok((status, bytes)) => {
+                let response_bytes = bytes.as_ref().map_or(0, |bytes| bytes.len() as u64);
+                let outcome = if bytes.is_some() { "ok" } else { "not_found" };
+                finish_blob_transport(BlobTransportFinish {
+                    started_at,
+                    span: &span,
+                    operation: "get",
+                    backend: "s3",
+                    outcome,
+                    status: Some(status),
+                    request_bytes: 0,
+                    response_bytes,
+                });
+                Ok(bytes)
+            }
+            Err(error) => {
+                finish_blob_transport(BlobTransportFinish {
+                    started_at,
+                    span: &span,
+                    operation: "get",
+                    backend: "s3",
+                    outcome: "error",
+                    status: error.status,
+                    request_bytes: 0,
+                    response_bytes: 0,
+                });
+                Err(error.message)
+            }
+        }
     }
 
     async fn exists(&self, key: &str) -> Result<bool, String> {
-        let url = self.object_url(key);
-        let mut request = self.client.head(&url);
-        let headers = self.signed_headers(Method::HEAD, &url)?;
-        for (header_name, header_value) in &headers {
-            request = request.header(header_name, header_value);
-        }
+        let started_at = Instant::now(); // determinism-ok: production blob transport metric only
+        let span = blob_transport_span("head", "s3", 0);
+        let result = async {
+            let url = self.object_url(key);
+            let mut request = self.client.head(&url);
+            let headers = self
+                .signed_headers(Method::HEAD, &url)
+                .map_err(BlobTransportError::message)?;
+            for (header_name, header_value) in &headers {
+                request = request.header(header_name, header_value);
+            }
 
-        let response = request
-            .send()
-            .await
-            .map_err(|e| format!("blob HEAD request failed for '{key}': {e}"))?;
-        match response.status() {
-            StatusCode::OK | StatusCode::NO_CONTENT => Ok(true),
-            StatusCode::NOT_FOUND => Ok(false),
-            status if status.is_success() => Ok(true),
-            status => Err(format!("blob HEAD failed for '{key}' with HTTP {status}")),
+            let response = request.send().await.map_err(|e| {
+                BlobTransportError::message(format!("blob HEAD request failed for '{key}': {e}"))
+            })?;
+            let status = response.status();
+            match status {
+                StatusCode::OK | StatusCode::NO_CONTENT => Ok((status, true)),
+                StatusCode::NOT_FOUND => Ok((status, false)),
+                status if status.is_success() => Ok((status, true)),
+                status => Err(BlobTransportError::status(
+                    format!("blob HEAD failed for '{key}' with HTTP {status}"),
+                    status,
+                )),
+            }
+        }
+        .instrument(span.clone())
+        .await;
+
+        match result {
+            Ok((status, exists)) => {
+                let outcome = if exists { "ok" } else { "not_found" };
+                finish_blob_transport(BlobTransportFinish {
+                    started_at,
+                    span: &span,
+                    operation: "head",
+                    backend: "s3",
+                    outcome,
+                    status: Some(status),
+                    request_bytes: 0,
+                    response_bytes: 0,
+                });
+                Ok(exists)
+            }
+            Err(error) => {
+                finish_blob_transport(BlobTransportFinish {
+                    started_at,
+                    span: &span,
+                    operation: "head",
+                    backend: "s3",
+                    outcome: "error",
+                    status: error.status,
+                    request_bytes: 0,
+                    response_bytes: 0,
+                });
+                Err(error.message)
+            }
         }
     }
 
@@ -420,6 +550,32 @@ async fn put_local_blob(root: &Path, key: &str, body: &[u8]) -> Result<(), Strin
         .map_err(|e| format!("failed to write local blob '{}': {e}", path.display()))
 }
 
+async fn put_local_blob_observed(
+    root: &Path,
+    key: &str,
+    body: &[u8],
+    operation: &'static str,
+) -> Result<(), String> {
+    let request_bytes = body.len() as u64;
+    let started_at = Instant::now(); // determinism-ok: production blob transport metric only
+    let span = blob_transport_span(operation, "local_fs", request_bytes);
+    let result = put_local_blob(root, key, body)
+        .instrument(span.clone())
+        .await;
+    let outcome = if result.is_ok() { "ok" } else { "error" };
+    finish_blob_transport(BlobTransportFinish {
+        started_at,
+        span: &span,
+        operation,
+        backend: "local_fs",
+        outcome,
+        status: None,
+        request_bytes,
+        response_bytes: 0,
+    });
+    result
+}
+
 async fn get_local_blob(root: &Path, key: &str) -> Result<Option<Vec<u8>>, String> {
     let path = local_blob_path(root, key)?;
     if !tokio::fs::try_exists(&path)
@@ -432,6 +588,28 @@ async fn get_local_blob(root: &Path, key: &str) -> Result<Option<Vec<u8>>, Strin
         .await
         .map(Some)
         .map_err(|e| format!("failed to read local blob '{}': {e}", path.display()))
+}
+
+async fn get_local_blob_observed(root: &Path, key: &str) -> Result<Option<Vec<u8>>, String> {
+    let started_at = Instant::now(); // determinism-ok: production blob transport metric only
+    let span = blob_transport_span("get", "local_fs", 0);
+    let result = get_local_blob(root, key).instrument(span.clone()).await;
+    let (outcome, response_bytes) = match &result {
+        Ok(Some(bytes)) => ("ok", bytes.len() as u64),
+        Ok(None) => ("not_found", 0),
+        Err(_) => ("error", 0),
+    };
+    finish_blob_transport(BlobTransportFinish {
+        started_at,
+        span: &span,
+        operation: "get",
+        backend: "local_fs",
+        outcome,
+        status: None,
+        request_bytes: 0,
+        response_bytes,
+    });
+    result
 }
 
 fn local_blob_path(root: &Path, key: &str) -> Result<PathBuf, String> {

--- a/crates/temper-server/src/blob_transport_observability.rs
+++ b/crates/temper-server/src/blob_transport_observability.rs
@@ -1,0 +1,164 @@
+use std::time::Instant;
+
+use reqwest::StatusCode;
+
+#[derive(Debug)]
+pub(crate) struct BlobTransportError {
+    pub(crate) message: String,
+    pub(crate) status: Option<StatusCode>,
+}
+
+pub(crate) struct BlobTransportFinish<'a> {
+    pub(crate) started_at: Instant,
+    pub(crate) span: &'a tracing::Span,
+    pub(crate) operation: &'a str,
+    pub(crate) backend: &'a str,
+    pub(crate) outcome: &'a str,
+    pub(crate) status: Option<StatusCode>,
+    pub(crate) request_bytes: u64,
+    pub(crate) response_bytes: u64,
+}
+
+impl BlobTransportError {
+    pub(crate) fn message(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            status: None,
+        }
+    }
+
+    pub(crate) fn status(message: impl Into<String>, status: StatusCode) -> Self {
+        Self {
+            message: message.into(),
+            status: Some(status),
+        }
+    }
+}
+
+pub(crate) fn blob_transport_span(
+    operation: &'static str,
+    backend: &'static str,
+    request_bytes: u64,
+) -> tracing::Span {
+    match operation {
+        "put" => tracing::info_span!(
+            "blob.transport.put",
+            otel.name = "blob.transport.put",
+            blob.backend = backend,
+            blob.operation = operation,
+            request_bytes,
+            response_bytes = tracing::field::Empty,
+            outcome = tracing::field::Empty,
+            status_code_class = tracing::field::Empty,
+            http.status_code = tracing::field::Empty,
+            duration_ms = tracing::field::Empty,
+        ),
+        "put_content" => tracing::info_span!(
+            "blob.transport.put_content",
+            otel.name = "blob.transport.put_content",
+            blob.backend = backend,
+            blob.operation = operation,
+            request_bytes,
+            response_bytes = tracing::field::Empty,
+            outcome = tracing::field::Empty,
+            status_code_class = tracing::field::Empty,
+            http.status_code = tracing::field::Empty,
+            duration_ms = tracing::field::Empty,
+        ),
+        "get" => tracing::info_span!(
+            "blob.transport.get",
+            otel.name = "blob.transport.get",
+            blob.backend = backend,
+            blob.operation = operation,
+            request_bytes,
+            response_bytes = tracing::field::Empty,
+            outcome = tracing::field::Empty,
+            status_code_class = tracing::field::Empty,
+            http.status_code = tracing::field::Empty,
+            duration_ms = tracing::field::Empty,
+        ),
+        "head" => tracing::info_span!(
+            "blob.transport.head",
+            otel.name = "blob.transport.head",
+            blob.backend = backend,
+            blob.operation = operation,
+            request_bytes,
+            response_bytes = tracing::field::Empty,
+            outcome = tracing::field::Empty,
+            status_code_class = tracing::field::Empty,
+            http.status_code = tracing::field::Empty,
+            duration_ms = tracing::field::Empty,
+        ),
+        _ => tracing::info_span!(
+            "blob.transport",
+            otel.name = "blob.transport",
+            blob.backend = backend,
+            blob.operation = operation,
+            request_bytes,
+            response_bytes = tracing::field::Empty,
+            outcome = tracing::field::Empty,
+            status_code_class = tracing::field::Empty,
+            http.status_code = tracing::field::Empty,
+            duration_ms = tracing::field::Empty,
+        ),
+    }
+}
+
+pub(crate) fn finish_blob_transport(record: BlobTransportFinish<'_>) {
+    let duration = record.started_at.elapsed();
+    let status_code_class = blob_status_code_class(record.status, record.outcome);
+    record.span.record("response_bytes", record.response_bytes);
+    record.span.record("outcome", record.outcome);
+    record.span.record("status_code_class", status_code_class);
+    if let Some(status) = record.status {
+        record.span.record("http.status_code", status.as_u16());
+    }
+    record
+        .span
+        .record("duration_ms", duration.as_secs_f64() * 1000.0);
+    crate::runtime_metrics::blob_transport::record(
+        duration,
+        record.operation,
+        record.backend,
+        record.outcome,
+        status_code_class,
+        record.request_bytes,
+        record.response_bytes,
+    );
+}
+
+fn blob_status_code_class(status: Option<StatusCode>, outcome: &str) -> &'static str {
+    match status {
+        Some(status) if status.is_success() => "2xx",
+        Some(status) if status.is_client_error() => "4xx",
+        Some(status) if status.is_server_error() => "5xx",
+        Some(_) => "error",
+        None if outcome == "error" => "error",
+        None => "none",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blob_status_code_class_has_bounded_tags() {
+        assert_eq!(blob_status_code_class(Some(StatusCode::OK), "ok"), "2xx");
+        assert_eq!(
+            blob_status_code_class(Some(StatusCode::NOT_FOUND), "not_found"),
+            "4xx"
+        );
+        assert_eq!(
+            blob_status_code_class(Some(StatusCode::INTERNAL_SERVER_ERROR), "error"),
+            "5xx"
+        );
+        assert_eq!(blob_status_code_class(None, "ok"), "none");
+        assert_eq!(blob_status_code_class(None, "not_found"), "none");
+        assert_eq!(blob_status_code_class(None, "error"), "error");
+        assert_eq!(
+            blob_status_code_class(Some(StatusCode::TEMPORARY_REDIRECT), "error"),
+            "error"
+        );
+    }
+}

--- a/crates/temper-server/src/lib.rs
+++ b/crates/temper-server/src/lib.rs
@@ -11,6 +11,7 @@ mod api;
 pub mod authz;
 pub mod blob_store;
 pub mod blob_sweeper;
+mod blob_transport_observability;
 pub mod blobs;
 pub mod channels;
 pub mod entity_actor;

--- a/crates/temper-server/src/runtime_metrics.rs
+++ b/crates/temper-server/src/runtime_metrics.rs
@@ -13,6 +13,8 @@ use opentelemetry::{KeyValue, global};
 
 use crate::state::ServerState;
 
+pub(crate) mod blob_transport;
+
 struct RuntimeMetrics {
     process_resident_memory_bytes: Gauge<u64>,
     active_actors: Gauge<u64>,

--- a/crates/temper-server/src/runtime_metrics/blob_transport.rs
+++ b/crates/temper-server/src/runtime_metrics/blob_transport.rs
@@ -1,0 +1,65 @@
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use opentelemetry::metrics::{Counter, Histogram};
+use opentelemetry::{KeyValue, global};
+
+struct BlobTransportMetrics {
+    duration_ms: Histogram<f64>,
+    requests_total: Counter<u64>,
+    request_bytes: Histogram<u64>,
+    response_bytes: Histogram<u64>,
+}
+
+fn metrics() -> &'static BlobTransportMetrics {
+    static METRICS: OnceLock<BlobTransportMetrics> = OnceLock::new();
+    METRICS.get_or_init(|| {
+        let meter = global::meter("temper.runtime");
+        BlobTransportMetrics {
+            duration_ms: meter
+                .f64_histogram("temper_blob_native_transport_duration_ms")
+                .with_unit("ms")
+                .with_description("Duration of native Temper blob backend operations.")
+                .build(),
+            requests_total: meter
+                .u64_counter("temper_blob_native_transport_requests_total")
+                .with_description("Total number of native Temper blob backend operations.")
+                .build(),
+            request_bytes: meter
+                .u64_histogram("temper_blob_native_transport_request_bytes")
+                .with_unit("By")
+                .with_description("Request payload size for native Temper blob backend operations.")
+                .build(),
+            response_bytes: meter
+                .u64_histogram("temper_blob_native_transport_response_bytes")
+                .with_unit("By")
+                .with_description(
+                    "Response payload size for native Temper blob backend operations.",
+                )
+                .build(),
+        }
+    })
+}
+
+pub(crate) fn record(
+    duration: Duration,
+    operation: &str,
+    backend: &str,
+    outcome: &str,
+    status_code_class: &str,
+    request_bytes: u64,
+    response_bytes: u64,
+) {
+    let attrs = [
+        KeyValue::new("operation", operation.to_string()),
+        KeyValue::new("backend", backend.to_string()),
+        KeyValue::new("outcome", outcome.to_string()),
+        KeyValue::new("status_code_class", status_code_class.to_string()),
+    ];
+    metrics()
+        .duration_ms
+        .record(duration.as_secs_f64() * 1000.0, &attrs);
+    metrics().requests_total.add(1, &attrs);
+    metrics().request_bytes.record(request_bytes, &attrs);
+    metrics().response_bytes.record(response_bytes, &attrs);
+}

--- a/docs/adrs/0093-native-blob-transport-observability.md
+++ b/docs/adrs/0093-native-blob-transport-observability.md
@@ -1,0 +1,196 @@
+# ADR-0093: Native Blob Transport Observability
+
+- Status: Proposed
+- Date: 2026-05-16
+- Deciders: Temper core maintainers
+- Related:
+  - ADR-0081: Latency Observability Acceleration Program
+  - ADR-0083: Trace Budget and Fanout Summarization
+  - ADR-0088: Native File `$value` Write Fast Path
+  - ADR-0092: Bounded Background File Reactions
+  - `crates/temper-server/src/blob_store.rs`
+  - `crates/temper-server/src/runtime_metrics.rs`
+  - `crates/temper-wasm/src/metrics.rs`
+
+## Context
+
+PERF-005B moved the FileVersion/RecordVersion reaction cascade off the native
+File `$value` response path. Production proof
+`file-reaction-background-live-proof-20260516215205` showed that this worked:
+sampled `PUT $value` p95 fell to about 238.7 ms, `File.StreamUpdated` p95 fell
+to about 13.7 ms, and `reaction.dispatch.background` appears after the HTTP
+response boundary.
+
+The remaining user-visible File byte latency is now mostly inside
+`state.put_file_stream_content.native`. Datadog can show the whole native span,
+but it cannot currently explain the blob portion because the native
+`BlobStore` only records `temper_blob_io_wait_duration_ms`, which is semaphore
+queue wait. It does not record the actual local filesystem or S3/R2 transport
+duration, request outcome, HTTP status class, or payload size. The older
+`temper_blob_transport_*` metrics only cover WASM host HTTP blob requests, so
+the dashboard has a misleading gap exactly where the latest production proof
+needs evidence. Native metrics must use a distinct name family rather than
+reusing the WASM request counter with a different tag shape.
+
+Without native blob transport timing, the next optimization would be guesswork:
+we cannot tell whether to focus on R2 endpoint behavior, request/client setup,
+payload copying, File state loading, actor cold start, DB append shape, or a
+larger direct-upload data plane.
+
+## Decision
+
+Add native blob transport spans and metrics at the `temper-server` `BlobStore`
+boundary without changing File semantics.
+
+### Sub-Decision 1: Keep the Existing Queue-Wait Metric
+
+Continue to emit `temper_blob_io_wait_duration_ms` for time spent waiting on the
+shared blob I/O semaphore.
+
+**Why this approach**: Queue wait is still useful as a saturation signal. It
+answers "are we waiting for our own backpressure budget?" but should no longer
+be treated as total blob latency.
+
+### Sub-Decision 2: Add Native Transport Duration and Request Counters
+
+Emit a new histogram and counter from all native blob operations:
+
+- `temper_blob_native_transport_duration_ms`
+- `temper_blob_native_transport_requests_total`
+
+The tag set is intentionally bounded:
+
+- `operation`: `put`, `put_content`, `get`, or `head`
+- `backend`: `local_fs` or `s3`
+- `outcome`: `ok`, `not_found`, or `error`
+- `status_code_class`: `2xx`, `4xx`, `5xx`, `none`, or `error`
+
+**Why this approach**: These dimensions are enough to distinguish object-store
+transport from local filesystem work, separate reads from writes, and group
+errors without creating high-cardinality metric tags.
+
+### Sub-Decision 3: Add Payload Size Histograms
+
+Emit:
+
+- `temper_blob_native_transport_request_bytes`
+- `temper_blob_native_transport_response_bytes`
+
+with the same bounded operation/backend/outcome/status tags.
+
+**Why this approach**: File latency is byte-size sensitive. Size histograms let
+the dashboard correlate transport latency with payload size without tagging raw
+paths, hashes, or tenant IDs.
+
+### Sub-Decision 4: Add Trace Spans Around the Transport Boundary
+
+Create spans named:
+
+- `blob.transport.put`
+- `blob.transport.put_content`
+- `blob.transport.get`
+- `blob.transport.head`
+
+Span fields include backend, operation, request bytes, response bytes, outcome,
+status code, and duration. Blob keys should not be recorded as span fields.
+
+**Why this approach**: APM traces should make the native File byte path
+self-explaining while avoiding high-cardinality or sensitive object names.
+
+### Sub-Decision 5: Do Not Change File Acknowledgement Semantics
+
+The File `$value` response still waits for hash computation, durable blob write,
+and verified `File.StreamUpdated` commit. This ADR only adds measurement.
+
+**Why this approach**: The latency program is allowed to be bold, but
+correctness remains a hard boundary. Direct upload, async upload, or local
+write-through cache designs need separate ADRs after this measurement proves
+where the remaining time goes.
+
+## Rollout Plan
+
+1. **Phase 0 (Immediate)** - Add the metrics/spans in Temper, unit-test the
+   bounded metric labels, and validate `temper-server` locally.
+2. **Phase 1 (Rollout)** - Bump TemperPaw to the merged Temper revision,
+   update the Datadog metric contract/dashboard/monitors to include native blob
+   transport duration and request counters, then deploy.
+3. **Phase 2 (Production proof)** - Rerun the File `$value` proof and query
+   Datadog for `PUT $value`, `state.put_file_stream_content.native`,
+   `blob.transport.put_content`, `temper_blob_native_transport_duration_ms`,
+   queue wait, request bytes, and response bytes.
+4. **Phase 3 (Optimization decision)** - Decide whether the next slice is
+   object-store endpoint/client tuning, read/write-through cache, streaming
+   upload, presigned direct upload, or actor/DB work outside blob transport.
+
+## Readiness Gates
+
+- `cargo test -p temper-server` focused blob tests pass.
+- `cargo check -p temper-server` and `cargo fmt --all -- --check` pass.
+- New metrics use bounded tags and do not include tenants, blob keys, file
+  names, hashes, URLs, or auth material.
+- Production APM shows native `blob.transport.*` spans under File `$value`
+  traces after rollout.
+- Datadog can query p95/p99 for native blob transport duration by operation and
+  backend.
+
+## Consequences
+
+### Positive
+
+- The remaining native File byte-path latency becomes attributable.
+- Existing queue-wait metrics keep their meaning while no longer pretending to
+  cover remote object-store duration.
+- Future data-plane changes can be chosen from production evidence.
+- Payload-size correlation becomes possible without high-cardinality labels.
+
+### Negative
+
+- Adds a small amount of metric and span overhead on blob operations.
+- Datadog dashboards and monitors need another contract update in TemperPaw.
+- The first PR improves diagnosis, not user-visible latency by itself.
+
+### Risks
+
+- **Metric cardinality creep**: mitigated by a fixed tag set with no keys,
+  URLs, tenants, hashes, or file names.
+- **Trace volume**: mitigated by one span per native blob operation, aligned
+  with existing sampled APM behavior.
+- **Misreading local filesystem timings as production R2 timings**: mitigated
+  by the `backend` tag.
+
+### DST Compliance
+
+- The change touches `temper-server`, a simulation-visible crate.
+- Timing uses `std::time::Instant` only for production observability and must
+  carry `// determinism-ok` annotations where new wall-clock measurement is
+  introduced.
+- No simulation-visible state, ordering, IDs, or transition decisions depend on
+  wall-clock time or metric output.
+
+## Non-Goals
+
+- No direct browser-to-object-store upload.
+- No async acknowledgement before the blob is durable.
+- No object-store provider change.
+- No retry/backoff policy change.
+- No FileVersion or projection behavior change.
+- No path, tenant, hash, or URL tags in Datadog metrics.
+
+## Alternatives Considered
+
+1. **Use only existing `temper_blob_io_wait_duration_ms`** - Rejected because it
+   measures only semaphore wait and returned no useful samples for the current
+   production proof.
+2. **Instrument only APM spans** - Rejected because dashboards and monitors need
+   percentile metrics independent of trace sampling.
+3. **Instrument only metrics** - Rejected because trace shape is the fastest way
+   to explain a single File proof request end to end.
+4. **Start with direct upload architecture** - Rejected for this slice because
+   the measured residual has not yet been decomposed enough to justify a
+   correctness-affecting data-plane change.
+
+## Rollback Policy
+
+Remove the new metric fields, recording helper, and `blob.transport.*` spans.
+No data migration is required because File state, blob storage, and projection
+semantics are unchanged.


### PR DESCRIPTION
## Summary

Adds native BlobStore transport observability so the File `$value` residual latency can be separated into durable blob I/O, content hashing, queue wait, actor/event commit work, and HTTP framing.

This is the next measured slice after PERF-005B moved File projection reactions into bounded background dispatch. Datadog now shows the remaining live `$value` p95 sitting in native content write work, so this PR makes that path visible before changing transport architecture.

## What changed

- Adds ADR-0093 for native blob transport observability and the measurement-before-optimization plan.
- Instruments native `BlobStore` `put`, `put_content`, `get`, and `head` operations with bounded tracing spans.
- Adds a native metric family with bounded labels only:
  - `temper_blob_native_transport_duration_ms`
  - `temper_blob_native_transport_requests_total`
  - `temper_blob_native_transport_request_bytes`
  - `temper_blob_native_transport_response_bytes`
- Keeps the existing `temper_blob_io_wait_duration_ms` metric scoped to semaphore queue wait only.
- Avoids tenant IDs, blob keys, hashes, URLs, filenames, or auth material in metric labels and span fields.
- Splits the metric code into a runtime metrics submodule so the readability ratchet baseline does not grow.

## Correctness and safety

This PR does not alter File `$value` acknowledgement semantics. The response still waits for content hash computation, durable blob write, and the verified `File.StreamUpdated` event commit. It only adds timing and outcome observation around the native transport boundary.

## Validation

Local checks run before push:

- `cargo check -p temper-server`
- `cargo clippy -p temper-server --all-targets -- -D warnings`
- `cargo test -p temper-server blob`
- `cargo test -p temper-server --test file_value_fast_path`
- `cargo fmt --all -- --check`
- `git diff --check`
- `scripts/check-determinism.sh` (exit 0; pre-existing findings remain, new `Instant::now` usage is annotated `// determinism-ok`)
- `scripts/readability-ratchet.sh check .ci/readability-baseline.env`

Pre-push gate passed:

- rustfmt check
- workspace clippy
- readability ratchet
- full `cargo test --workspace`

## Follow-up after merge

- Roll this Temper revision into TemperPaw.
- Add/update Datadog dashboard contracts for the native blob metric family and `blob.transport.*` spans.
- Deploy to Railway production.
- Re-run live File `$value` proof and use Datadog to decide whether the next optimization is R2/S3 client tuning, read/write-through cache, direct upload, or a different residual hotspot.
