### PR TITLE
Shorten projection transaction fast path

### DIFF
--- a/crates/temper-store-postgres/src/metrics.rs
+++ b/crates/temper-store-postgres/src/metrics.rs
@@ -11,6 +11,7 @@ struct PostgresMetrics {
     transaction_duration_ms: Histogram<f64>,
     operation_outcomes_total: Counter<u64>,
     projection_index_fields: Histogram<u64>,
+    projection_index_reconciliations_total: Counter<u64>,
     projection_skipped_index_fields_total: Counter<u64>,
 }
 
@@ -51,6 +52,12 @@ fn metrics() -> &'static PostgresMetrics {
                 .u64_histogram("temper_postgres_projection_index_fields")
                 .with_description(
                     "Number of scalar fields indexed into entity_field_index per projection upsert.",
+                )
+                .build(),
+            projection_index_reconciliations_total: meter
+                .u64_counter("temper_postgres_projection_index_reconciliations_total")
+                .with_description(
+                    "Projection field-index reconciliation decisions by low-cardinality path.",
                 )
                 .build(),
             projection_skipped_index_fields_total: meter
@@ -123,6 +130,16 @@ pub(crate) fn record_postgres_projection_index_fields(indexed_fields: u64, skipp
     }
 }
 
+pub(crate) fn record_postgres_projection_index_reconciliation(path: &'static str) {
+    metrics().projection_index_reconciliations_total.add(
+        1,
+        &[
+            KeyValue::new("operation", "query_projection_upsert"),
+            KeyValue::new("path", path),
+        ],
+    );
+}
+
 pub(crate) struct PostgresTransactionTimer {
     operation: &'static str,
     started: Instant,
@@ -167,6 +184,7 @@ mod tests {
         record_postgres_transaction_begin_duration(Duration::from_millis(1), "event_append", "ok");
         record_postgres_transaction_commit_duration(Duration::from_millis(3), "event_append", "ok");
         record_postgres_projection_index_fields(4, 1);
+        record_postgres_projection_index_reconciliation("skipped_unchanged");
 
         let mut timer = PostgresTransactionTimer::start("event_append");
         timer.set_outcome("ok");

--- a/crates/temper-store-postgres/src/platform.rs
+++ b/crates/temper-store-postgres/src/platform.rs
@@ -4,14 +4,14 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::time::{Duration, Instant};
 
 use sha2::{Digest, Sha256};
-use sqlx::{Acquire, Row};
+use sqlx::{Acquire, Postgres, Row, Transaction};
 use temper_runtime::persistence::PersistenceError;
 
 use crate::PostgresEventStore;
 use crate::metrics::{
     PostgresTransactionTimer, record_postgres_pool_acquire_duration,
-    record_postgres_projection_index_fields, record_postgres_transaction_begin_duration,
-    record_postgres_transaction_commit_duration,
+    record_postgres_projection_index_fields, record_postgres_projection_index_reconciliation,
+    record_postgres_transaction_begin_duration, record_postgres_transaction_commit_duration,
 };
 
 const DISTINCT_RESOURCE_IDS_BUDGET: usize = 100;
@@ -28,6 +28,44 @@ const QUERY_PROJECTION_REMOVE_OPERATION: &str = "query_projection_remove";
 
 type ScalarFieldIndex = BTreeMap<String, String>;
 type ExistingFieldIndex = BTreeMap<String, (Option<String>, Option<String>)>;
+type CatalogProjectionFingerprint = (String, String);
+
+struct QueryProjectionCatalogUpdate<'a> {
+    tenant: &'a str,
+    entity_type: &'a str,
+    entity_id: &'a str,
+    status: &'a str,
+    fields: &'a serde_json::Value,
+    sequence_nr: u64,
+    projection_hash: &'a str,
+}
+
+async fn update_query_projection_catalog_row(
+    tx: &mut Transaction<'_, Postgres>,
+    update: QueryProjectionCatalogUpdate<'_>,
+) -> Result<(), PersistenceError> {
+    crate::dbm::postgres_query!(
+        "UPDATE entity_catalog \
+         SET status = $4, \
+             fields = CASE WHEN projection_hash IS DISTINCT FROM $7 THEN $5 ELSE fields END, \
+             sequence_nr = $6, \
+             projection_version = 2, \
+             projection_hash = $7, \
+             updated_at = now() \
+         WHERE tenant = $1 AND entity_type = $2 AND entity_id = $3",
+    )
+    .bind(update.tenant)
+    .bind(update.entity_type)
+    .bind(update.entity_id)
+    .bind(update.status)
+    .bind(update.fields)
+    .bind(update.sequence_nr as i64)
+    .bind(update.projection_hash)
+    .execute(&mut **tx)
+    .await
+    .map_err(storage_error)?;
+    Ok(())
+}
 
 #[derive(Clone, Copy, Debug)]
 pub struct PostgresSpecVerificationUpdate<'a> {
@@ -386,6 +424,7 @@ impl PostgresEventStore {
         sequence_nr: u64,
     ) -> Result<(), PersistenceError> {
         let projection_hash = json_hash(fields);
+        let (new_index, indexed_fields, skipped_fields) = scalar_index_fields(fields);
         let mut transaction_timer =
             PostgresTransactionTimer::start(QUERY_PROJECTION_UPSERT_OPERATION);
         let acquire_started = Instant::now();
@@ -426,93 +465,183 @@ impl PostgresEventStore {
                 return Err(storage_error(e));
             }
         };
-        // The catalog row is the per-entity projection serialization point. Doing
-        // this before diffing field-index rows also serializes first writers when
-        // no catalog row existed at transaction start.
-        crate::dbm::postgres_query!(
-            "INSERT INTO entity_catalog \
-             (tenant, entity_type, entity_id, status, fields, sequence_nr, projection_version, projection_hash, updated_at) \
-             VALUES ($1, $2, $3, $4, $5, $6, 2, $7, now()) \
-             ON CONFLICT (tenant, entity_type, entity_id) DO UPDATE SET \
-                 status = EXCLUDED.status, fields = EXCLUDED.fields, sequence_nr = EXCLUDED.sequence_nr, \
-                 projection_version = EXCLUDED.projection_version, projection_hash = EXCLUDED.projection_hash, updated_at = now()",
-        )
-        .bind(tenant)
-        .bind(entity_type)
-        .bind(entity_id)
-        .bind(status)
-        .bind(fields)
-        .bind(sequence_nr as i64)
-        .bind(projection_hash)
-        .execute(&mut *tx)
-        .await
-        .map_err(storage_error)?;
 
-        let existing_index_rows: Vec<(String, Option<String>, Option<String>)> =
+        let previous_catalog: Option<CatalogProjectionFingerprint> =
             crate::dbm::postgres_query_as!(
-                "SELECT field_name, field_value, status \
-                 FROM entity_field_index \
+                "SELECT status, projection_hash \
+                 FROM entity_catalog \
                  WHERE tenant = $1 AND entity_type = $2 AND entity_id = $3 \
                  FOR UPDATE",
             )
             .bind(tenant)
             .bind(entity_type)
             .bind(entity_id)
-            .fetch_all(&mut *tx)
+            .fetch_optional(&mut *tx)
             .await
             .map_err(storage_error)?;
-        let existing_index = existing_index_rows
-            .into_iter()
-            .map(|(field_name, field_value, field_status)| {
-                (field_name, (field_value, field_status))
-            })
-            .collect::<ExistingFieldIndex>();
 
-        let (new_index, indexed_fields, skipped_fields) = scalar_index_fields(fields);
+        let previous_catalog = if previous_catalog.is_some() {
+            update_query_projection_catalog_row(
+                &mut tx,
+                QueryProjectionCatalogUpdate {
+                    tenant,
+                    entity_type,
+                    entity_id,
+                    status,
+                    fields,
+                    sequence_nr,
+                    projection_hash: projection_hash.as_str(),
+                },
+            )
+            .await?;
+            previous_catalog
+        } else {
+            let inserted: Option<i32> = crate::dbm::postgres_query_scalar!(
+                "INSERT INTO entity_catalog \
+                 (tenant, entity_type, entity_id, status, fields, sequence_nr, projection_version, projection_hash, updated_at) \
+                 VALUES ($1, $2, $3, $4, $5, $6, 2, $7, now()) \
+                 ON CONFLICT (tenant, entity_type, entity_id) DO NOTHING \
+                 RETURNING 1",
+            )
+            .bind(tenant)
+            .bind(entity_type)
+            .bind(entity_id)
+            .bind(status)
+            .bind(fields)
+            .bind(sequence_nr as i64)
+            .bind(projection_hash.as_str())
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(storage_error)?;
 
-        for (field_name, (old_value, _old_status)) in &existing_index {
-            let should_delete = match (old_value.as_ref(), new_index.get(field_name)) {
-                (Some(old), Some(new)) => old != new,
-                _ => true,
-            };
-            if should_delete {
+            if inserted.is_some() {
+                None
+            } else {
+                let raced_catalog: Option<CatalogProjectionFingerprint> =
+                    crate::dbm::postgres_query_as!(
+                        "SELECT status, projection_hash \
+                         FROM entity_catalog \
+                         WHERE tenant = $1 AND entity_type = $2 AND entity_id = $3 \
+                         FOR UPDATE",
+                    )
+                    .bind(tenant)
+                    .bind(entity_type)
+                    .bind(entity_id)
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .map_err(storage_error)?;
+                update_query_projection_catalog_row(
+                    &mut tx,
+                    QueryProjectionCatalogUpdate {
+                        tenant,
+                        entity_type,
+                        entity_id,
+                        status,
+                        fields,
+                        sequence_nr,
+                        projection_hash: projection_hash.as_str(),
+                    },
+                )
+                .await?;
+                raced_catalog
+            }
+        };
+
+        let should_reconcile_index =
+            previous_catalog
+                .as_ref()
+                .is_none_or(|(old_status, old_hash)| {
+                    old_status.as_str() != status || old_hash.as_str() != projection_hash.as_str()
+                });
+        let reconciliation_path = if should_reconcile_index {
+            if previous_catalog.is_some() {
+                "diff"
+            } else {
+                "insert"
+            }
+        } else {
+            "skipped_unchanged"
+        };
+
+        if should_reconcile_index {
+            let existing_index = if previous_catalog.is_some() {
+                let existing_index_rows: Vec<(String, Option<String>, Option<String>)> =
+                    crate::dbm::postgres_query_as!(
+                        "SELECT field_name, field_value, status \
+                         FROM entity_field_index \
+                         WHERE tenant = $1 AND entity_type = $2 AND entity_id = $3 \
+                         FOR UPDATE",
+                    )
+                    .bind(tenant)
+                    .bind(entity_type)
+                    .bind(entity_id)
+                    .fetch_all(&mut *tx)
+                    .await
+                    .map_err(storage_error)?;
+                existing_index_rows
+                    .into_iter()
+                    .map(|(field_name, field_value, field_status)| {
+                        (field_name, (field_value, field_status))
+                    })
+                    .collect::<ExistingFieldIndex>()
+            } else {
                 crate::dbm::postgres_query!(
                     "DELETE FROM entity_field_index \
-                     WHERE tenant = $1 AND entity_type = $2 AND entity_id = $3 AND field_name = $4",
+                     WHERE tenant = $1 AND entity_type = $2 AND entity_id = $3",
                 )
                 .bind(tenant)
                 .bind(entity_type)
                 .bind(entity_id)
-                .bind(field_name)
                 .execute(&mut *tx)
                 .await
                 .map_err(storage_error)?;
-            }
-        }
+                ExistingFieldIndex::new()
+            };
 
-        for (field_name, field_value) in &new_index {
-            let should_upsert = !matches!(
-                existing_index.get(field_name),
-                Some((Some(old_value), Some(old_status)))
-                    if old_value == field_value && old_status.as_str() == status
-            );
-            if should_upsert {
-                crate::dbm::postgres_query!(
-                    "INSERT INTO entity_field_index \
-                     (tenant, entity_type, entity_id, field_name, field_value, status) \
-                     VALUES ($1, $2, $3, $4, $5, $6) \
-                     ON CONFLICT (tenant, entity_type, entity_id, field_name) DO UPDATE SET \
-                         field_value = EXCLUDED.field_value, status = EXCLUDED.status",
-                )
-                .bind(tenant)
-                .bind(entity_type)
-                .bind(entity_id)
-                .bind(field_name)
-                .bind(field_value)
-                .bind(status)
-                .execute(&mut *tx)
-                .await
-                .map_err(storage_error)?;
+            for (field_name, (old_value, _old_status)) in &existing_index {
+                let should_delete = match (old_value.as_ref(), new_index.get(field_name)) {
+                    (Some(old), Some(new)) => old != new,
+                    _ => true,
+                };
+                if should_delete {
+                    crate::dbm::postgres_query!(
+                        "DELETE FROM entity_field_index \
+                         WHERE tenant = $1 AND entity_type = $2 AND entity_id = $3 AND field_name = $4",
+                    )
+                    .bind(tenant)
+                    .bind(entity_type)
+                    .bind(entity_id)
+                    .bind(field_name)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(storage_error)?;
+                }
+            }
+
+            for (field_name, field_value) in &new_index {
+                let should_upsert = !matches!(
+                    existing_index.get(field_name),
+                    Some((Some(old_value), Some(old_status)))
+                        if old_value == field_value && old_status.as_str() == status
+                );
+                if should_upsert {
+                    crate::dbm::postgres_query!(
+                        "INSERT INTO entity_field_index \
+                         (tenant, entity_type, entity_id, field_name, field_value, status) \
+                         VALUES ($1, $2, $3, $4, $5, $6) \
+                         ON CONFLICT (tenant, entity_type, entity_id, field_name) DO UPDATE SET \
+                             field_value = EXCLUDED.field_value, status = EXCLUDED.status",
+                    )
+                    .bind(tenant)
+                    .bind(entity_type)
+                    .bind(entity_id)
+                    .bind(field_name)
+                    .bind(field_value)
+                    .bind(status)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(storage_error)?;
+                }
             }
         }
 
@@ -531,6 +660,7 @@ impl PostgresEventStore {
             "ok",
         );
         record_postgres_projection_index_fields(indexed_fields, skipped_fields);
+        record_postgres_projection_index_reconciliation(reconciliation_path);
         transaction_timer.set_outcome("ok");
         Ok(())
     }

--- a/crates/temper-store-postgres/src/store_projection_test.rs
+++ b/crates/temper-store-postgres/src/store_projection_test.rs
@@ -167,6 +167,91 @@ fn upsert_query_projection_diffs_field_index_rows() {
 }
 
 #[test]
+fn upsert_query_projection_advances_sequence_without_rewriting_unchanged_index() {
+    let database_url = match std::env::var("DATABASE_URL") {
+        Ok(url) => url,
+        Err(_) => return,
+    };
+
+    sqlx::test_block_on(async {
+        let pool = PgPool::connect(&database_url).await.unwrap();
+        run_migrations(&pool).await.unwrap();
+        let store = PostgresEventStore::new(pool.clone());
+        let tenant = format!("tenant-projection-noop-{}", uuid::Uuid::new_v4());
+        let entity_type = "Session";
+        let entity_id = "session-noop";
+        let fields = serde_json::json!({
+            "title": "Latency proof",
+            "owner": "temper",
+            "message_count": 7,
+        });
+
+        store
+            .upsert_query_projection(&tenant, entity_type, entity_id, "Active", &fields, 1)
+            .await
+            .unwrap();
+
+        let owner_xmin_before: String = crate::dbm::postgres_query_scalar!(
+            "SELECT xmin::text FROM entity_field_index \
+             WHERE tenant = $1 AND entity_type = $2 AND entity_id = $3 AND field_name = $4",
+        )
+        .bind(&tenant)
+        .bind(entity_type)
+        .bind(entity_id)
+        .bind("owner")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        store
+            .upsert_query_projection(&tenant, entity_type, entity_id, "Active", &fields, 2)
+            .await
+            .unwrap();
+
+        let owner_xmin_after: String = crate::dbm::postgres_query_scalar!(
+            "SELECT xmin::text FROM entity_field_index \
+             WHERE tenant = $1 AND entity_type = $2 AND entity_id = $3 AND field_name = $4",
+        )
+        .bind(&tenant)
+        .bind(entity_type)
+        .bind(entity_id)
+        .bind("owner")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            owner_xmin_before, owner_xmin_after,
+            "no-op projection updates should not rewrite unchanged field index rows"
+        );
+
+        let catalog_row: (String, serde_json::Value, i64) = crate::dbm::postgres_query_as!(
+            "SELECT status, fields, sequence_nr FROM entity_catalog \
+             WHERE tenant = $1 AND entity_type = $2 AND entity_id = $3",
+        )
+        .bind(&tenant)
+        .bind(entity_type)
+        .bind(entity_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(catalog_row.0, "Active");
+        assert_eq!(catalog_row.1, fields);
+        assert_eq!(catalog_row.2, 2);
+
+        crate::dbm::postgres_query!("DELETE FROM entity_field_index WHERE tenant = $1")
+            .bind(&tenant)
+            .execute(&pool)
+            .await
+            .unwrap();
+        crate::dbm::postgres_query!("DELETE FROM entity_catalog WHERE tenant = $1")
+            .bind(&tenant)
+            .execute(&pool)
+            .await
+            .unwrap();
+    });
+}
+
+#[test]
 fn upsert_query_projection_removes_index_row_when_value_becomes_too_long() {
     let database_url = match std::env::var("DATABASE_URL") {
         Ok(url) => url,

--- a/docs/adrs/0095-projection-transaction-fast-path.md
+++ b/docs/adrs/0095-projection-transaction-fast-path.md
@@ -1,0 +1,131 @@
+# ADR-0095: Projection Transaction Fast Path
+
+- Status: Proposed
+- Date: 2026-05-17
+- Deciders: Temper core maintainers
+- Related:
+  - ADR-0082: Projection Correctness Observability
+  - ADR-0091: Query Projection Diff Index Upserts
+  - ADR-0092: Bounded Background File Reactions
+  - `crates/temper-store-postgres/src/platform.rs`
+  - `crates/temper-store-postgres/src/store_projection_test.rs`
+
+## Context
+
+PERF-002 changed Postgres query-projection writes from delete-all/reinsert-all index maintenance to diffed index maintenance. That removed a major source of write amplification while preserving `entity_catalog` as the complete projected read model and `entity_field_index` as the scalar filter index.
+
+The next live production window after PERF-005D shows a different residual:
+
+- `temper_postgres_pool_acquire_duration_ms` p95 is only about 4.8-5.0 ms for `query_projection_upsert`.
+- `temper_postgres_transaction_duration_ms` p95 is about 429-443 ms for `query_projection_upsert`.
+- `temper_query_projection_update_end_to_end_duration_ms` p95 reaches about 471-478 ms for `Session` background dispatch and about 217 ms for `File` background dispatch.
+- Native blob transport p95 remains material, but is lower than the projection transaction tail in this window.
+
+That means the next measured bottleneck is not broad pool starvation. It is the shape and amount of work performed while a projection transaction is open.
+
+The current Postgres projection upsert still does these expensive things in the transaction:
+
+1. Write the catalog row.
+2. Read and lock all existing field-index rows for the entity.
+3. Convert the new JSON projection into the scalar field index.
+4. Diff every existing field against the new map.
+5. Delete and upsert changed rows.
+
+This is correct, but it still holds a database transaction open while doing CPU work and SQL work that can often be skipped. In particular, many background projection updates advance an entity sequence while leaving projected fields and status unchanged. Those updates still need `entity_catalog.sequence_nr` for replay parity and applied-sequence correctness, but they do not need to touch `entity_field_index`.
+
+## Decision
+
+Keep the projection correctness model from ADR-0091, but shorten the hot transaction path.
+
+### Precompute the New Scalar Index Before Begin
+
+Compute `scalar_index_fields(fields)` before acquiring the Postgres connection and before `BEGIN`.
+
+**Why this approach**: The scalar index is pure, deterministic CPU work over the incoming projected JSON. It does not need a database lock. Moving it outside the transaction reduces lock hold time without changing the index contents.
+
+### Lock the Existing Catalog Row First
+
+When the catalog row exists, load `status` and `projection_hash` with `FOR UPDATE` before writing the new row. The locked row becomes the serialization point for the projection update.
+
+When the catalog row does not exist, insert it. If a concurrent first writer wins the insert race, retry by locking the now-existing catalog row and follow the existing-row path.
+
+**Why this approach**: ADR-0091 correctly noted that `SELECT ... FOR UPDATE` alone does not serialize first writers when no row exists. The insert-or-retry path keeps that safety property while making the common existing-row path able to compare the previous projection before rewriting it.
+
+### Skip Field-Index Reconciliation on Projection No-Ops
+
+If the previous catalog `status` and `projection_hash` match the incoming `status` and hash, update only the catalog row fields that must advance, especially `sequence_nr` and `updated_at`, then commit. Do not read, lock, diff, delete, or upsert `entity_field_index` rows in this no-op case.
+
+**Why this approach**: The field-index rows are a function of projected fields plus denormalized status. If both the projection hash and status are unchanged, the scalar filter index is unchanged. Advancing the catalog sequence preserves correctness evidence for replay parity without paying index-maintenance cost.
+
+### Preserve Full Reconciliation When Projection Changes
+
+If status or projection hash changed, perform the ADR-0091 diffed reconciliation:
+
+- lock actual `entity_field_index` rows for the entity;
+- delete removed, unindexable, or changed fields;
+- upsert new, changed, or status-changed fields;
+- preserve unchanged rows.
+
+**Why this approach**: The no-op fast path must not weaken stale-index protection. Any actual projected-field or status change still follows the proven diff algorithm.
+
+### Emit Reconciliation Path Metrics
+
+Emit a low-cardinality counter for the projection index path: `insert`, `diff`, or `skipped_unchanged`.
+
+**Why this approach**: Datadog p95s can show whether the transaction tail improved, but the rollout also needs to prove whether live traffic is actually taking the no-op fast path. A path counter gives that proof without tagging entity IDs or field names.
+
+## Rollout Plan
+
+1. **Phase 0 (Immediate)** - Implement the Postgres-only fast path in `upsert_query_projection`, with tests for unchanged projection sequence advancement, unchanged index-row preservation, changed-field reconciliation, long-field removal, and concurrent first-writer safety where practical. Emit reconciliation path metrics for rollout proof.
+2. **Phase 1 (Production proof)** - Roll into TemperPaw, deploy, rerun File and OData proof flows, and compare current-version `query_projection_upsert` transaction p95 plus projection end-to-end p95 by entity/source.
+3. **Phase 2 (Follow-up)** - If projection tails remain high, evaluate set-based `UNNEST` index reconciliation and event-level projection coalescing for background dispatch.
+
+## Readiness Gates
+
+- Focused `temper-store-postgres` projection tests pass.
+- `cargo check -p temper-store-postgres` passes.
+- `cargo clippy -p temper-store-postgres --all-targets -- -D warnings` passes.
+- `cargo fmt --all -- --check` and `git diff --check` pass.
+- Production proof shows no projection drift, no read-after-write regression, and lower or explainably unchanged `query_projection_upsert` transaction p95.
+
+## Consequences
+
+### Positive
+
+- No-op projection updates advance catalog sequence without locking or diffing field-index rows.
+- Database transaction hold time shrinks because scalar-index extraction moves outside `BEGIN`.
+- Correctness remains durable and replayable; no cache is introduced.
+
+### Negative
+
+- `upsert_query_projection` becomes a little more branched because it distinguishes insert, existing changed, existing unchanged, and first-writer race paths.
+- Some cold-create work stays the same because new entities still need all index rows inserted.
+
+### Risks
+
+- A race in the first-writer path could skip needed field-index insertion. Mitigation: use insert-or-retry semantics, keep all field-index insertion in the successful insert path, and preserve tests around indexed-row presence.
+- A false no-op classification could leave stale index rows. Mitigation: classify no-op only when both previous `projection_hash` and previous `status` match the incoming values.
+- The optimization may not help if the p95 comes from changed large projections rather than no-op background updates. Mitigation: production proof must compare Datadog `entity_type`/`source` groups after rollout.
+
+### DST Compliance
+
+This change is confined to `temper-store-postgres`, which is not a simulation-visible crate. It introduces no wall-clock or random behavior beyond the existing production metrics timers.
+
+## Non-Goals
+
+- No change to OData semantics.
+- No change to projection replay parity rules.
+- No in-memory projection cache.
+- No Turso rewrite in this slice.
+- No event append sequence-table redesign in this first PERF-003 patch.
+
+## Alternatives Considered
+
+1. **Only move scalar extraction before `BEGIN`** - Safe but leaves no-op updates doing unnecessary row locks and diffing.
+2. **Skip catalog writes for unchanged projections** - Faster but loses applied-sequence evidence needed for replay parity and correctness dashboards.
+3. **Set-based `UNNEST` reconciliation immediately** - Promising for changed large projections, but it is a broader SQL rewrite. The no-op fast path is smaller and directly targets the measured transaction tail.
+4. **Add a projection cache** - Would complicate invalidation and multi-instance correctness; the current bottleneck can be attacked without cache semantics.
+
+## Rollback Policy
+
+Revert `upsert_query_projection` to the ADR-0091 diffed-index implementation. Because `entity_catalog.fields` stays complete and authoritative, any suspected field-index issue can be repaired by projection replay/backfill.


### PR DESCRIPTION
## Summary
- adds ADR-0095 for the projection transaction fast path
- moves scalar index extraction before DB checkout/BEGIN and locks the catalog fingerprint first
- skips entity_field_index reconciliation when status/projection hash are unchanged, preserving correctness via existing diff reconciliation when the fingerprint changes
- adds a low-cardinality reconciliation counter for insert/diff/skipped_unchanged paths

## Why
Datadog showed the remaining live latency residual on version 821d6c6ee28845e6b1365d78f3b85c3b5cc1ad15: query_projection_upsert p95 was around 429-443 ms while pool acquire p95 was only around 4.8-5.0 ms, pointing at transaction shape rather than pool starvation.

## Verification
- cargo fmt --all -- --check
- git diff --check
- cargo check -p temper-store-postgres
- cargo check -p temper-server
- cargo test -p temper-store-postgres metrics -- --nocapture
- cargo test -p temper-store-postgres upsert_query_projection -- --nocapture
- cargo test -p temper-store-postgres -- --nocapture
- cargo clippy -p temper-store-postgres --all-targets -- -D warnings
- pre-push gate: rustfmt, workspace clippy, readability ratchet, full workspace tests and doctests all passed

## Notes
- Local Postgres integration tests still require DATABASE_URL for a real DB-backed proof; that remains part of rollout/live validation.
- Code-quality review marker passed; DST marker was not required because this slice only touches temper-store-postgres and docs.