### PR TITLE
PERF-015: Add local WASM TData host path

### DIFF
--- a/crates/temper-server/src/state/dispatch/wasm.rs
+++ b/crates/temper-server/src/state/dispatch/wasm.rs
@@ -24,7 +24,10 @@ use super::{
 use replay_inputs::{extract_trajectory_actions_from_ots, has_replay_trajectory_input};
 
 mod invocation_artifacts;
+mod local_tdata_host;
 mod replay_inputs;
+
+use local_tdata_host::LocalTDataWasmHost;
 
 /// Shared context threaded through the WASM dispatch call chain.
 ///
@@ -476,7 +479,7 @@ impl crate::state::ServerState {
         let host_invocation_context = inv_ctx.clone();
         let internal_api_key = std::env::var("TEMPER_API_KEY").ok();
         let internal_api_url = internal_api_base_url(self);
-        let inner: Arc<dyn WasmHost> = Arc::new(
+        let production_host: Arc<dyn WasmHost> = Arc::new(
             ProductionWasmHost::with_timeout(tenant_secrets, http_timeout)
                 .with_binary_http_interceptor(
                     local_blob_interceptor
@@ -495,6 +498,8 @@ impl crate::state::ServerState {
                     current_otel_trace_id(active_span).or_else(|| ctx.agent_ctx.trace_id.clone()),
                 ),
         );
+        let inner: Arc<dyn WasmHost> =
+            Arc::new(LocalTDataWasmHost::new(self.clone(), production_host));
         let host: Arc<dyn WasmHost> = Arc::new(AuthorizedWasmHost::new(inner, gate, authz_ctx));
         let max_response_bytes = integration
             .config
@@ -1056,7 +1061,9 @@ impl crate::state::ServerState {
         if let Some(interceptor) = local_blob_interceptor {
             base_host = base_host.with_binary_http_interceptor(interceptor);
         }
-        let inner: Arc<dyn WasmHost> = Arc::new(base_host);
+        let production_host: Arc<dyn WasmHost> = Arc::new(base_host);
+        let inner: Arc<dyn WasmHost> =
+            Arc::new(LocalTDataWasmHost::new(self.clone(), production_host));
         let host: Arc<dyn WasmHost> =
             Arc::new(AuthorizedWasmHost::new(inner, base_gate, authz_ctx));
         let limits = WasmResourceLimits::default();

--- a/crates/temper-server/src/state/dispatch/wasm/local_tdata_host.rs
+++ b/crates/temper-server/src/state/dispatch/wasm/local_tdata_host.rs
@@ -1,0 +1,428 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use axum::body::{Bytes, to_bytes};
+use axum::extract::{Path, Query, State};
+use axum::http::{HeaderMap, HeaderName, HeaderValue};
+use axum::response::IntoResponse;
+use reqwest::Url;
+use temper_wasm::WasmHost;
+use tracing::Instrument;
+
+use crate::state::ServerState;
+
+const LOCAL_TDATA_RESPONSE_LIMIT_BYTES: usize = 64 * 1024 * 1024;
+
+/// WASM host wrapper that executes loopback `/tdata` calls in-process.
+///
+/// This is intentionally a transport optimization only: local calls still run
+/// through the same OData handlers as external HTTP traffic.
+pub(super) struct LocalTDataWasmHost {
+    state: ServerState,
+    delegate: Arc<dyn WasmHost>,
+}
+
+impl LocalTDataWasmHost {
+    /// Create a local-TData wrapper around an existing host implementation.
+    pub(super) fn new(state: ServerState, delegate: Arc<dyn WasmHost>) -> Self {
+        Self { state, delegate }
+    }
+
+    async fn local_http_call(
+        &self,
+        method: &str,
+        url: &str,
+        headers: &[(String, String)],
+        body: &str,
+    ) -> Result<Option<(u16, String)>, String> {
+        let Some(request) = LocalTDataRequest::parse(url) else {
+            return Ok(None);
+        };
+
+        let method_upper = method.to_ascii_uppercase();
+        if !matches!(method_upper.as_str(), "GET" | "POST") {
+            return Ok(None);
+        }
+        let headers = header_map(headers);
+        let path_for_span = request.path.clone();
+        let span = tracing::info_span!(
+            "wasm.local_tdata_http_call",
+            otel.name = "wasm.local_tdata_http_call",
+            http.method = %method_upper,
+            url.path = %path_for_span,
+            local_tdata = true,
+        );
+
+        let response = async {
+            match method_upper.as_str() {
+                "GET" => crate::odata::handle_odata_get(
+                    State(self.state.clone()),
+                    headers,
+                    Path(request.path),
+                    Query(request.query),
+                )
+                .await
+                .into_response(),
+                "POST" => crate::odata::handle_odata_post(
+                    State(self.state.clone()),
+                    None,
+                    headers,
+                    Path(request.path),
+                    Query(request.query),
+                    Bytes::copy_from_slice(body.as_bytes()),
+                )
+                .await
+                .into_response(),
+                _ => unreachable!("local TData method filtered before dispatch"),
+            }
+        }
+        .instrument(span)
+        .await;
+
+        let status = response.status().as_u16();
+        let body = to_bytes(response.into_body(), LOCAL_TDATA_RESPONSE_LIMIT_BYTES)
+            .await
+            .map_err(|err| format!("failed to read local TData response body: {err}"))?;
+        Ok(Some((status, String::from_utf8_lossy(&body).into_owned())))
+    }
+}
+
+#[async_trait]
+impl WasmHost for LocalTDataWasmHost {
+    async fn http_call(
+        &self,
+        method: &str,
+        url: &str,
+        headers: &[(String, String)],
+        body: &str,
+    ) -> Result<(u16, String), String> {
+        if let Some(response) = self.local_http_call(method, url, headers, body).await? {
+            return Ok(response);
+        }
+        self.delegate.http_call(method, url, headers, body).await
+    }
+
+    fn get_secret(&self, key: &str) -> Result<String, String> {
+        self.delegate.get_secret(key)
+    }
+
+    async fn http_call_binary(
+        &self,
+        method: &str,
+        url: &str,
+        headers: &[(String, String)],
+        body: &[u8],
+    ) -> Result<(u16, Vec<u8>), String> {
+        self.delegate
+            .http_call_binary(method, url, headers, body)
+            .await
+    }
+
+    async fn connect_call(
+        &self,
+        url: &str,
+        headers: &[(String, String)],
+        body: &str,
+    ) -> Result<Vec<String>, String> {
+        self.delegate.connect_call(url, headers, body).await
+    }
+
+    fn log(&self, level: &str, message: &str) {
+        self.delegate.log(level, message);
+    }
+
+    fn evaluate_spec(
+        &self,
+        ioa_source: &str,
+        current_state: &str,
+        action: &str,
+        params_json: &str,
+    ) -> Result<String, String> {
+        self.delegate
+            .evaluate_spec(ioa_source, current_state, action, params_json)
+    }
+
+    fn emit_progress(&self, event_json: &str) -> Result<(), String> {
+        self.delegate.emit_progress(event_json)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LocalTDataRequest {
+    path: String,
+    query: BTreeMap<String, String>,
+}
+
+impl LocalTDataRequest {
+    fn parse(url: &str) -> Option<Self> {
+        let parsed = Url::parse(url).ok()?;
+        if !matches!(parsed.scheme(), "http" | "https") {
+            return None;
+        }
+        let host = parsed.host_str()?;
+        if !is_loopback_host(host) {
+            return None;
+        }
+
+        let raw_path = parsed.path();
+        let path = match raw_path {
+            "/tdata" | "/tdata/" => String::new(),
+            _ => raw_path.strip_prefix("/tdata/")?.to_string(),
+        };
+        if is_file_value_path(&path) {
+            return None;
+        }
+
+        let query = parsed
+            .query_pairs()
+            .map(|(key, value)| (key.into_owned(), value.into_owned()))
+            .collect::<BTreeMap<_, _>>();
+
+        Some(Self { path, query })
+    }
+}
+
+fn is_loopback_host(host: &str) -> bool {
+    matches!(host, "127.0.0.1" | "localhost" | "::1" | "[::1]")
+}
+
+fn is_file_value_path(path: &str) -> bool {
+    path.starts_with("Files('") && path.ends_with("')/$value")
+}
+
+fn header_map(headers: &[(String, String)]) -> HeaderMap {
+    let mut map = HeaderMap::new();
+    for (name, value) in headers {
+        let Ok(name) = HeaderName::from_bytes(name.as_bytes()) else {
+            continue;
+        };
+        let Ok(value) = HeaderValue::from_str(value) else {
+            continue;
+        };
+        map.insert(name, value);
+    }
+    map
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::StatusCode;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use temper_runtime::ActorSystem;
+    use temper_spec::csdl::parse_csdl;
+
+    const ORDER_CSDL_XML: &str = r#"<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="Temper.Local" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="Order">
+        <Key><PropertyRef Name="Id"/></Key>
+        <Property Name="Id" Type="Edm.String" Nullable="false"/>
+        <Property Name="Customer" Type="Edm.String"/>
+        <Property Name="Status" Type="Edm.String"/>
+      </EntityType>
+      <Action Name="SubmitOrder" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.Local.Order"/>
+      </Action>
+      <EntityContainer Name="Container">
+        <EntitySet Name="Orders" EntityType="Temper.Local.Order"/>
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>"#;
+
+    const ORDER_IOA: &str = r#"
+[automaton]
+name = "Order"
+states = ["Draft", "Submitted"]
+initial = "Draft"
+
+[[action]]
+name = "SubmitOrder"
+kind = "input"
+from = ["Draft"]
+to = "Submitted"
+"#;
+
+    struct FailingHost;
+
+    #[async_trait]
+    impl WasmHost for FailingHost {
+        async fn http_call(
+            &self,
+            _method: &str,
+            _url: &str,
+            _headers: &[(String, String)],
+            _body: &str,
+        ) -> Result<(u16, String), String> {
+            Err("delegate should not receive local TData calls".to_string())
+        }
+
+        fn get_secret(&self, key: &str) -> Result<String, String> {
+            Err(format!("secret not found: {key}"))
+        }
+
+        async fn http_call_binary(
+            &self,
+            _method: &str,
+            _url: &str,
+            _headers: &[(String, String)],
+            _body: &[u8],
+        ) -> Result<(u16, Vec<u8>), String> {
+            Err("binary delegate not used".to_string())
+        }
+
+        fn log(&self, _level: &str, _message: &str) {}
+    }
+
+    struct CountingHost {
+        calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl WasmHost for CountingHost {
+        async fn http_call(
+            &self,
+            _method: &str,
+            _url: &str,
+            _headers: &[(String, String)],
+            _body: &str,
+        ) -> Result<(u16, String), String> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok((299, "delegated".to_string()))
+        }
+
+        fn get_secret(&self, key: &str) -> Result<String, String> {
+            Err(format!("secret not found: {key}"))
+        }
+
+        async fn http_call_binary(
+            &self,
+            _method: &str,
+            _url: &str,
+            _headers: &[(String, String)],
+            _body: &[u8],
+        ) -> Result<(u16, Vec<u8>), String> {
+            Ok((299, b"delegated-binary".to_vec()))
+        }
+
+        fn log(&self, _level: &str, _message: &str) {}
+    }
+
+    fn test_state() -> ServerState {
+        let csdl = parse_csdl(ORDER_CSDL_XML).expect("test CSDL should parse");
+        let system = ActorSystem::new("local-tdata-wasm-host-test");
+        let mut specs = BTreeMap::new();
+        specs.insert("Order".to_string(), ORDER_IOA.to_string());
+        ServerState::with_specs(system, csdl, ORDER_CSDL_XML.to_string(), specs)
+            .expect("test state should build")
+    }
+
+    #[test]
+    fn parses_loopback_tdata_request() {
+        let request = LocalTDataRequest::parse(
+            "http://127.0.0.1:8787/tdata/SessionEntries?$filter=SessionId%20eq%20%27s1%27&$top=1",
+        )
+        .expect("loopback TData URL should parse");
+
+        assert_eq!(request.path, "SessionEntries");
+        assert_eq!(
+            request.query.get("$filter").map(String::as_str),
+            Some("SessionId eq 's1'")
+        );
+        assert_eq!(request.query.get("$top").map(String::as_str), Some("1"));
+    }
+
+    #[test]
+    fn ignores_non_tdata_or_non_loopback_urls() {
+        assert!(LocalTDataRequest::parse("https://api.example.com/tdata/Orders").is_none());
+        assert!(LocalTDataRequest::parse("http://127.0.0.1:8787/api/health").is_none());
+        assert!(LocalTDataRequest::parse("not a url").is_none());
+    }
+
+    #[tokio::test]
+    async fn local_tdata_calls_use_odata_handlers() {
+        let host = LocalTDataWasmHost::new(test_state(), Arc::new(FailingHost));
+        let headers = vec![
+            ("x-tenant-id".to_string(), "default".to_string()),
+            ("content-type".to_string(), "application/json".to_string()),
+            ("accept".to_string(), "application/json".to_string()),
+        ];
+
+        let (status, body) = host
+            .http_call(
+                "POST",
+                "http://127.0.0.1:8787/tdata/Orders",
+                &headers,
+                r#"{"id":"order-local-1","Customer":"Ada"}"#,
+            )
+            .await
+            .expect("local create should succeed");
+        assert_eq!(status, StatusCode::CREATED.as_u16());
+        let created: serde_json::Value = serde_json::from_str(&body).expect("created JSON");
+        assert_eq!(created["entity_id"], "order-local-1");
+
+        let (status, body) = host
+            .http_call(
+                "GET",
+                "http://localhost:8787/tdata/Orders('order-local-1')",
+                &headers,
+                "",
+            )
+            .await
+            .expect("local read should succeed");
+        assert_eq!(status, StatusCode::OK.as_u16());
+        let fetched: serde_json::Value = serde_json::from_str(&body).expect("fetched JSON");
+        assert_eq!(fetched["fields"]["Customer"], "Ada");
+
+        let (status, body) = host
+            .http_call(
+                "POST",
+                "http://[::1]:8787/tdata/Orders('order-local-1')/Temper.Local.SubmitOrder",
+                &headers,
+                "{}",
+            )
+            .await
+            .expect("local action should succeed");
+        assert_eq!(status, StatusCode::OK.as_u16());
+        let submitted: serde_json::Value = serde_json::from_str(&body).expect("action JSON");
+        assert_eq!(submitted["status"], "Submitted");
+    }
+
+    #[tokio::test]
+    async fn boundary_paths_delegate_to_production_host() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let host = LocalTDataWasmHost::new(
+            test_state(),
+            Arc::new(CountingHost {
+                calls: calls.clone(),
+            }),
+        );
+        let headers = vec![("x-tenant-id".to_string(), "default".to_string())];
+
+        let delegated = [
+            (
+                "DELETE",
+                "http://127.0.0.1:8787/tdata/Orders('order-local-1')",
+            ),
+            (
+                "GET",
+                "http://127.0.0.1:8787/tdata/Files('file-local-1')/$value",
+            ),
+            ("GET", "https://api.example.com/tdata/Orders"),
+        ];
+
+        for (method, url) in delegated {
+            let (status, body) = host
+                .http_call(method, url, &headers, "")
+                .await
+                .expect("boundary path should delegate");
+            assert_eq!(status, 299);
+            assert_eq!(body, "delegated");
+        }
+
+        assert_eq!(calls.load(Ordering::SeqCst), delegated.len());
+    }
+}

--- a/docs/adrs/0099-local-wasm-tdata-host-path.md
+++ b/docs/adrs/0099-local-wasm-tdata-host-path.md
@@ -1,0 +1,168 @@
+# ADR-0099: Local WASM TData Host Path
+
+- Status: Proposed
+- Date: 2026-05-17
+- Deciders: Temper core maintainers
+- Related:
+  - ADR-0095: Projection Transaction Fast Path
+  - ADR-0098: Background WASM Trace Retention
+  - `crates/temper-server/src/state/dispatch/wasm.rs`
+  - `crates/temper-wasm/src/host_trait.rs`
+
+## Context
+
+TemperPaw's staged Session turn is now observable enough to distinguish cold
+start effects from warm-path transport cost. The PERF-014 production proof on
+TemperPaw version `2fe2d2178951e180c004539d2c3d39fc4e7750b2` showed that the
+declared Session hot WASM modules no longer perform lazy blob fetches. The same
+proof still spends meaningful user-visible time in same-service calls made by
+WASM modules:
+
+- `workspace_provisioner` spends about 150-170 ms creating and verifying the
+  initial `SessionEntry` chain.
+- `provider_response_applier` spends about 100-110 ms appending and verifying
+  the assistant `SessionEntry`.
+- routed replies still pay local TData action dispatch and Channel reply work.
+
+The existing guest contract is intentionally simple: WASM modules call
+`host_http_call` against the configured `temper_api_url`, and Temper's normal
+OData/TData handlers apply verification gates, relation checks, projection
+updates, state-change events, and action dispatch. In production TemperPaw,
+`temper_api_url` is a loopback URL to the same process. This means hot WASM
+modules often leave the process through `reqwest`, traverse the Axum router over
+TCP, and then immediately re-enter the same server.
+
+That loopback transport does not add mission value. The mission value is in the
+governed write/read path, event audit, Cedar/WASM authorization boundary, tenant
+isolation, and projection correctness. We can preserve those while removing the
+same-process HTTP hop.
+
+## Decision
+
+Introduce a server-side WASM host wrapper for local TData calls.
+
+When a WASM integration calls textual `host_http_call` with `GET` or `POST`
+against a loopback URL whose path is under `/tdata`, the Temper server will
+execute the existing OData handlers in-process and return the same status/body
+shape to the guest. All other HTTP calls continue through the existing
+`ProductionWasmHost`.
+
+### Sub-Decision 1: Reuse Existing OData Handlers
+
+The local path must call the same OData handler functions used by external HTTP
+requests instead of writing directly to actors or stores.
+
+**Why this approach**: this keeps verification gates, relation/invariant checks,
+entity creation semantics, bound-action dispatch, response formatting, and
+projection visibility on the same code path. The optimization is transport
+shape, not data semantics. File `$value` paths are delegated in the first cut so
+they continue using the existing native blob fast path.
+
+### Sub-Decision 2: Keep WASM HTTP Authorization Outside The Wrapper
+
+The wrapper sits inside the existing `AuthorizedWasmHost` chain. The current
+WASM authorization gate still evaluates the module, tenant, trigger action,
+target domain, method, and URL before the local OData handler runs.
+
+**Why this approach**: local execution should not become a privilege bypass.
+If a module is not allowed to call a TData URL today, the local path must deny it
+the same way.
+
+### Sub-Decision 3: Fallback To Network For Everything Else
+
+The first implementation only intercepts textual `GET` and `POST`
+`host_http_call` requests to loopback `/tdata` URLs. Non-loopback URLs,
+non-TData URLs, `PUT`/`PATCH`/`DELETE`, File `$value` paths, streaming/binary
+host calls, Connect calls, and malformed URLs delegate to the existing
+production host.
+
+**Why this approach**: this limits blast radius to the measured hot path while
+keeping external provider calls, sandbox calls, blob streaming, and future API
+surfaces unchanged.
+
+## Rollout Plan
+
+1. **Phase 0 (Immediate)** — Add the local host wrapper, wire it into triggered
+   and direct WASM invocations, and add focused unit/integration coverage.
+2. **Phase 1 (TemperPaw Bump)** — Bump TemperPaw's Temper dependency to the
+   merged Temper commit and run Session direct/routed proofs.
+3. **Phase 2 (Production Proof)** — Deploy, verify `/paw/version`, direct and
+   routed live runs, and compare Datadog traces for reduced OData loopback span
+   cost in SessionEntry create/verify and local TData action calls.
+
+## Readiness Gates
+
+- Existing OData create, action, read, and `$value` tests still pass.
+- WASM dispatch tests prove successful callback behavior still works.
+- New tests prove local `GET`/`POST` `/tdata` calls return OData-compatible
+  status/body without using network transport, and that delegated boundary paths
+  still reach the production host.
+- Datadog traces distinguish local TData host calls from delegated external HTTP
+  calls.
+- Live TemperPaw proofs preserve valid SessionEntry chains and routed replies.
+
+## Consequences
+
+### Positive
+
+- Removes loopback TCP/client overhead from hot same-process WASM calls.
+- Keeps guest modules unchanged.
+- Preserves the OData/write path rather than adding app-specific backdoors.
+- Makes future hot-path work easier because the next bottlenecks will be actor,
+  projection, or module execution rather than artificial local transport.
+
+### Negative
+
+- The WASM host now depends on server routing behavior, so tests must protect
+  parity with external OData responses.
+- In-process calls will not naturally appear as outbound HTTP client spans.
+  They need explicit tracing to remain visible.
+
+### Risks
+
+- A too-broad loopback detector could intercept a non-Temper local service.
+  Mitigation: only intercept loopback URLs under `/tdata`; delegate all other
+  URLs.
+- Handler parity could drift if future OData handlers gain new extractor
+  requirements. Mitigation: call the public handler functions directly and keep
+  focused tests around create/read/action shapes.
+- Binary `$value` traffic might still pay loopback cost. Mitigation: leave
+  binary/streaming out of scope until a separate trace proves it is hot again.
+
+### DST Compliance
+
+- This touches `temper-server`, a simulation-visible crate.
+- The wrapper does not spawn threads, introduce wall-clock sleeps, use random
+  IDs, or alter actor scheduling.
+- It reuses existing request handlers and delegates non-local HTTP to the
+  existing production host.
+- URL/query/header conversion uses deterministic iteration where maps are
+  required.
+
+## Non-Goals
+
+- Do not create a TemperPaw-specific `SessionEntry` side channel.
+- Do not collapse the Session state machine or skip SessionEntry read-back
+  verification.
+- Do not change Cedar policy semantics.
+- Do not optimize external provider calls, sandbox calls, or binary blob
+  streaming in this ADR.
+
+## Alternatives Considered
+
+1. **Native SessionEntry host function** — This would be faster for the current
+   Session path, but it would expose an app-specific primitive from Temper core
+   and risk bypassing generic OData correctness behavior.
+2. **Composite provider-only Session executor** — This could remove more staged
+   work, but it crosses a larger semantic boundary and needs a separate proof
+   that event audit, recovery, trajectories, and approvals remain explainable.
+3. **Remove read-after-write verification** — Rejected. The verification exists
+   because production previously observed missing `SessionEntry` parents. Speed
+   cannot come from making correctness probabilistic.
+
+## Rollback Policy
+
+The wrapper is a construction-time host choice. If it causes parity problems,
+wire WASM invocation back to the plain `ProductionWasmHost` and keep all guest
+WASM modules unchanged. If the feature needs a runtime kill switch, add it
+before deployment rather than after a production incident.


### PR DESCRIPTION
## Summary
- add ADR-0099 for the local WASM TData host path
- route safe loopback WASM GET/POST /tdata calls through in-process OData handlers under AuthorizedWasmHost
- delegate non-loopback, non-TData, DELETE/PUT/PATCH, binary/Connect, malformed, and File  paths to the existing production host
- add focused local parity and delegation-boundary tests

## Verification
- cargo fmt --all -- --check
- git diff --check
- cargo check --locked -p temper-server
- cargo test --locked -p temper-server local_tdata -- --nocapture
- cargo test --locked -p temper-server --test wasm_dispatch -- --nocapture
- cargo test --locked -p temper-server --test file_value_fast_path -- --nocapture
- cargo clippy --locked -p temper-server --all-targets -- -D warnings
- cargo test --locked -p temper-server
- pre-push gate: cargo fmt --check, cargo clippy --workspace -- -D warnings, readability ratchet, cargo test --workspace, doctests

## Notes
- scripts/check-determinism.sh still reports the known 26 pre-existing repository patterns; this diff adds no new nondeterministic constructs.
- Local DST/code-quality review markers were written with zero findings for the changed files.