### PR TITLE
[codex] Add local public TData host bypass

### DIFF
--- a/crates/temper-server/src/state/dispatch/wasm/local_tdata_host.rs
+++ b/crates/temper-server/src/state/dispatch/wasm/local_tdata_host.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -36,7 +36,8 @@ impl LocalTDataWasmHost {
         headers: &[(String, String)],
         body: &str,
     ) -> Result<Option<(u16, String)>, String> {
-        let Some(request) = LocalTDataRequest::parse(url) else {
+        let Some(request) = LocalTDataRequest::parse(url, self.state.local_tdata_hosts.as_ref())
+        else {
             return Ok(None);
         };
 
@@ -155,13 +156,13 @@ struct LocalTDataRequest {
 }
 
 impl LocalTDataRequest {
-    fn parse(url: &str) -> Option<Self> {
+    fn parse(url: &str, local_tdata_hosts: &BTreeSet<String>) -> Option<Self> {
         let parsed = Url::parse(url).ok()?;
         if !matches!(parsed.scheme(), "http" | "https") {
             return None;
         }
         let host = parsed.host_str()?;
-        if !is_loopback_host(host) {
+        if !is_local_tdata_host(host, local_tdata_hosts) {
             return None;
         }
 
@@ -185,6 +186,13 @@ impl LocalTDataRequest {
 
 fn is_loopback_host(host: &str) -> bool {
     matches!(host, "127.0.0.1" | "localhost" | "::1" | "[::1]")
+}
+
+fn is_local_tdata_host(host: &str, local_tdata_hosts: &BTreeSet<String>) -> bool {
+    if is_loopback_host(host) {
+        return true;
+    }
+    local_tdata_hosts.contains(&host.to_ascii_lowercase())
 }
 
 fn is_file_value_path(path: &str) -> bool {
@@ -324,6 +332,7 @@ to = "Submitted"
     fn parses_loopback_tdata_request() {
         let request = LocalTDataRequest::parse(
             "http://127.0.0.1:8787/tdata/SessionEntries?$filter=SessionId%20eq%20%27s1%27&$top=1",
+            &BTreeSet::new(),
         )
         .expect("loopback TData URL should parse");
 
@@ -337,9 +346,26 @@ to = "Submitted"
 
     #[test]
     fn ignores_non_tdata_or_non_loopback_urls() {
-        assert!(LocalTDataRequest::parse("https://api.example.com/tdata/Orders").is_none());
-        assert!(LocalTDataRequest::parse("http://127.0.0.1:8787/api/health").is_none());
-        assert!(LocalTDataRequest::parse("not a url").is_none());
+        assert!(
+            LocalTDataRequest::parse("https://api.example.com/tdata/Orders", &BTreeSet::new())
+                .is_none()
+        );
+        assert!(
+            LocalTDataRequest::parse("http://127.0.0.1:8787/api/health", &BTreeSet::new())
+                .is_none()
+        );
+        assert!(LocalTDataRequest::parse("not a url", &BTreeSet::new()).is_none());
+    }
+
+    #[test]
+    fn parses_allowlisted_public_tdata_request() {
+        let local_hosts = BTreeSet::from(["temper.example".to_string()]);
+        let request =
+            LocalTDataRequest::parse("https://TEMPER.example/tdata/Orders?$top=1", &local_hosts)
+                .expect("allowlisted public TData URL should parse");
+
+        assert_eq!(request.path, "Orders");
+        assert_eq!(request.query.get("$top").map(String::as_str), Some("1"));
     }
 
     #[tokio::test]
@@ -424,5 +450,43 @@ to = "Submitted"
         }
 
         assert_eq!(calls.load(Ordering::SeqCst), delegated.len());
+    }
+
+    #[tokio::test]
+    async fn allowlisted_public_tdata_calls_use_odata_handlers() {
+        let mut state = test_state();
+        state.local_tdata_hosts = Arc::new(BTreeSet::from(["temper.example".to_string()]));
+        let host = LocalTDataWasmHost::new(state, Arc::new(FailingHost));
+        let headers = vec![
+            ("x-tenant-id".to_string(), "default".to_string()),
+            ("content-type".to_string(), "application/json".to_string()),
+            ("accept".to_string(), "application/json".to_string()),
+        ];
+
+        let (status, body) = host
+            .http_call(
+                "POST",
+                "https://temper.example/tdata/Orders",
+                &headers,
+                r#"{"id":"order-public-local-1","Customer":"Grace"}"#,
+            )
+            .await
+            .expect("allowlisted public host should dispatch locally");
+        assert_eq!(status, StatusCode::CREATED.as_u16());
+        let created: serde_json::Value = serde_json::from_str(&body).expect("created JSON");
+        assert_eq!(created["entity_id"], "order-public-local-1");
+
+        let (status, body) = host
+            .http_call(
+                "GET",
+                "https://temper.example/tdata/Orders('order-public-local-1')",
+                &headers,
+                "",
+            )
+            .await
+            .expect("allowlisted public host read should dispatch locally");
+        assert_eq!(status, StatusCode::OK.as_u16());
+        let fetched: serde_json::Value = serde_json::from_str(&body).expect("fetched JSON");
+        assert_eq!(fetched["fields"]["Customer"], "Grace");
     }
 }

--- a/crates/temper-server/src/state/mod.rs
+++ b/crates/temper-server/src/state/mod.rs
@@ -194,6 +194,68 @@ fn env_usize(name: &str, default: usize) -> usize {
         .unwrap_or(default)
 }
 
+fn normalize_local_tdata_host(raw: &str) -> Option<String> {
+    let trimmed = raw.trim().trim_end_matches('/');
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let hostish = trimmed
+        .split_once("://")
+        .map(|(_, rest)| rest)
+        .unwrap_or(trimmed)
+        .split('/')
+        .next()
+        .unwrap_or("")
+        .trim();
+    if hostish.is_empty() {
+        return None;
+    }
+
+    let host = if let Some(rest) = hostish.strip_prefix('[') {
+        rest.split(']').next().unwrap_or("")
+    } else {
+        hostish.split(':').next().unwrap_or("")
+    }
+    .trim()
+    .trim_matches('.')
+    .to_ascii_lowercase();
+
+    if host.is_empty() || host.chars().any(char::is_whitespace) {
+        return None;
+    }
+
+    Some(host)
+}
+
+fn env_local_tdata_hosts() -> BTreeSet<String> {
+    let mut hosts = BTreeSet::new();
+    if let Ok(raw) = std::env::var("TEMPER_LOCAL_TDATA_HOSTS") {
+        // determinism-ok: read once at startup
+        for item in raw.split(',') {
+            if let Some(host) = normalize_local_tdata_host(item) {
+                hosts.insert(host);
+            }
+        }
+    }
+
+    for name in [
+        "TEMPER_PUBLIC_BASE_URL",
+        "PUBLIC_BASE_URL",
+        "RAILWAY_PUBLIC_DOMAIN",
+        "RAILWAY_STATIC_URL",
+    ] {
+        if let Ok(raw) = std::env::var(name) {
+            // determinism-ok: read once at startup
+            if let Some(host) = normalize_local_tdata_host(&raw) {
+                hosts.insert(host);
+            }
+        }
+    }
+
+    hosts
+}
+
 fn state_cache_budget() -> usize {
     static STATE_CACHE_BUDGET: OnceLock<usize> = OnceLock::new();
     *STATE_CACHE_BUDGET.get_or_init(|| env_usize("TEMPER_STATE_CACHE_BUDGET", 10_000))
@@ -386,6 +448,9 @@ pub struct ServerState {
     pub http_stream_registry: Arc<temper_wasm::http_stream::HttpStreamRegistry>,
     /// Long-lived workflow root spans keyed by workflow.run_id.
     pub(crate) workflow_spans: Arc<crate::workflow_tracing::WorkflowSpanRegistry>,
+    /// Public hostnames owned by this process that may use in-process TData
+    /// dispatch from WASM guests instead of leaving through the public edge.
+    pub(crate) local_tdata_hosts: Arc<BTreeSet<String>>,
 }
 
 /// Install a one-time hook so liveness violations surfaced by temper-spec
@@ -517,6 +582,7 @@ impl ServerState {
             http_endpoint_tables: Arc::new(crate::http_endpoint::HttpEndpointTables::new()),
             http_stream_registry: Arc::new(temper_wasm::http_stream::HttpStreamRegistry::new()),
             workflow_spans: Arc::new(crate::workflow_tracing::WorkflowSpanRegistry::default()),
+            local_tdata_hosts: Arc::new(env_local_tdata_hosts()),
         };
 
         // Pre-register built-in WASM modules (http_fetch for generic HTTP integrations).
@@ -753,6 +819,7 @@ impl ServerState {
             http_endpoint_tables: Arc::new(crate::http_endpoint::HttpEndpointTables::new()),
             http_stream_registry: Arc::new(temper_wasm::http_stream::HttpStreamRegistry::new()),
             workflow_spans: Arc::new(crate::workflow_tracing::WorkflowSpanRegistry::default()),
+            local_tdata_hosts: Arc::new(env_local_tdata_hosts()),
         };
         state.register_builtin_wasm_modules();
         state
@@ -1183,5 +1250,33 @@ impl ServerState {
             return Vec::new();
         };
         provider.all_stores().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_local_tdata_host;
+
+    #[test]
+    fn normalize_local_tdata_host_accepts_urls_domains_and_ports() {
+        assert_eq!(
+            normalize_local_tdata_host("https://Temper.Example/tdata"),
+            Some("temper.example".to_string())
+        );
+        assert_eq!(
+            normalize_local_tdata_host("openpaw-production.up.railway.app"),
+            Some("openpaw-production.up.railway.app".to_string())
+        );
+        assert_eq!(
+            normalize_local_tdata_host("http://127.0.0.1:8080"),
+            Some("127.0.0.1".to_string())
+        );
+    }
+
+    #[test]
+    fn normalize_local_tdata_host_rejects_empty_or_whitespace_hosts() {
+        assert_eq!(normalize_local_tdata_host(""), None);
+        assert_eq!(normalize_local_tdata_host("https:///tdata"), None);
+        assert_eq!(normalize_local_tdata_host("bad host.example"), None);
     }
 }

--- a/docs/adrs/0102-local-tdata-public-origin-bypass.md
+++ b/docs/adrs/0102-local-tdata-public-origin-bypass.md
@@ -1,0 +1,172 @@
+# ADR-0102: Local TData Public Origin Bypass
+
+- Status: Proposed
+- Date: 2026-05-18
+- Deciders: Temper core maintainers
+- Related:
+  - ADR-0099: Local WASM TData Host Path
+  - ADR-0100: WASM Invocation Phase Observability
+  - `crates/temper-server/src/state/dispatch/wasm/local_tdata_host.rs`
+  - `crates/temper-server/src/state/mod.rs`
+
+## Context
+
+ADR-0099 added `LocalTDataWasmHost`, which keeps WASM guest `/tdata` calls
+inside the process when the URL points at loopback. That preserved the Temper
+mission: guests still traverse the same OData handlers, Cedar authorization,
+spec verification gates, entity actors, event journal, and query projection
+updates, but without a network hop back into the same service.
+
+The current production trace evidence shows an uncovered shape. The
+TemperPaw live proof on version
+`f5ffa7d10192fca607943c384bfdeebd71360cf5` used public URLs such as
+`openpaw-production.up.railway.app/tdata/SessionEntries` from WASM guest code.
+The routed proof trace `9d0317bdbf78eeb763235a443d9fe34a` showed:
+
+- `workspace_provisioner` issuing two `POST /tdata/SessionEntries` calls
+  through the public Railway origin, with host-span durations around
+  `127 ms` and `131 ms`;
+- the child OData spans were still in the same `temperpaw` service and were
+  dominated by the normal `entity.get_or_create_tenant_entity` create path;
+- Datadog aggregation for the same version showed recent WASM hot-path calls
+  grouped under `openpaw-production.up.railway.app/tdata/...`, not local
+  in-process TData.
+
+This means the platform already has the semantics-preserving local dispatch
+architecture, but it only recognizes loopback hostnames. When an app, route,
+or direct caller supplies the service's public origin as `temper_api_url`, the
+guest leaves the process, enters the public HTTP edge, and returns to the same
+service before running identical OData code.
+
+That is not a fundamental Temper limitation. It is an overlooked origin
+normalization gap at the host boundary.
+
+## Decision
+
+Extend the local TData host to recognize explicitly allowlisted public origins
+for the current service, in addition to loopback hosts.
+
+### Public Self-Host Allowlist
+
+`ServerState` will carry a bounded set of local TData public hosts loaded once
+at startup from:
+
+- `TEMPER_LOCAL_TDATA_HOSTS`: comma-separated hostnames, with optional full
+  URLs accepted for operator ergonomics;
+- `TEMPER_PUBLIC_BASE_URL`: full base URL for generic Temper deployments;
+- `PUBLIC_BASE_URL`: app-level public URL used by TemperPaw and webhook
+  transports;
+- `RAILWAY_PUBLIC_DOMAIN`: Railway-provided domain, interpreted as HTTPS host.
+
+Only hostnames are stored. Schemes, paths, trailing slashes, and ports are
+discarded. Empty and invalid values are ignored.
+
+### Dispatch Rule
+
+`LocalTDataWasmHost` will treat a guest URL as local when:
+
+1. the scheme is `http` or `https`;
+2. the path is under `/tdata`;
+3. the method is `GET` or `POST`;
+4. the host is either loopback or appears in `ServerState.local_tdata_hosts`;
+5. the path is not a `Files('...')/$value` stream path, which remains on the
+   existing binary/stream handling.
+
+The intercepted request still uses the same in-process OData handlers as
+ADR-0099. Headers, tenant identity, principal headers, authorization, entity
+state transitions, projection writes, and response bodies remain unchanged.
+
+### Observability
+
+The existing `wasm.local_tdata_http_call` span remains the proof point. When
+the bypass is active, traces should show:
+
+- no `wasm.host.http_call` span to the public `/tdata` origin for that call;
+- a `wasm.local_tdata_http_call` span with `local_tdata = true`;
+- unchanged child OData, dispatch, projection, and database spans.
+
+## Rollout Plan
+
+1. **Phase 0 (Immediate)**: ship the core allowlist and parser tests, with no
+   default behavior change unless one of the public-origin environment
+   variables is set.
+2. **Phase 1 (TemperPaw deploy)**: ensure production has `PUBLIC_BASE_URL` or
+   `RAILWAY_PUBLIC_DOMAIN` available and run direct plus routed live proofs.
+3. **Phase 2 (Broader platform)**: consider extending the same self-origin
+   bypass to selected `/api/*` internal endpoints after separate evidence and
+   ADR review.
+
+## Readiness Gates
+
+- Unit tests prove loopback behavior still works.
+- Unit tests prove public hosts are intercepted only when allowlisted.
+- Unit tests prove non-allowlisted external `/tdata` URLs still delegate.
+- Local focused `temper-server` tests pass.
+- Live Datadog traces prove public-origin `/tdata` spans are replaced by local
+  TData spans, with SessionEntry correctness checks still passing.
+
+## Consequences
+
+### Positive
+
+- Removes unnecessary public-edge round trips from WASM guest calls back into
+  the same service.
+- Keeps Temper's correctness model intact because the OData handlers and
+  downstream actor/projection path are unchanged.
+- Works even when a direct caller or legacy route config supplies a public
+  `temper_api_url`.
+- Gives operators an explicit rollout knob instead of guessing from every
+  external hostname.
+
+### Negative
+
+- Adds one more runtime configuration surface to document and test.
+- Cross-deployment calls to another Temper server with a matching hostname
+  would be intercepted, so the allowlist must only contain origins owned by the
+  current process.
+
+### Risks
+
+- Misconfigured allowlists could route intended remote calls locally. Mitigation:
+  keep the default allowlist empty except for explicit environment-derived
+  current-service origins, and preserve external delegation for all other hosts.
+- The bypass removes public edge latency from traces, which may make before/after
+  comparisons look like missing HTTP spans. Mitigation: rely on
+  `wasm.local_tdata_http_call` and child OData spans for continuity.
+
+### DST Compliance
+
+- Environment is read only during `ServerState` initialization, matching
+  existing startup-only configuration helpers and using `// determinism-ok`
+  annotations.
+- The per-call URL decision is deterministic from request URL plus immutable
+  state carried by `ServerState`.
+- No wall-clock, random, filesystem, or threaded behavior is introduced.
+
+## Non-Goals
+
+- Do not bypass OData, Cedar, entity actors, projection writes, or event
+  journaling.
+- Do not optimize the `entity.get_or_create_tenant_entity` internals in this
+  slice.
+- Do not intercept arbitrary external `/tdata` services.
+- Do not intercept `/api/ots`, file `$value`, or other non-TData endpoints in
+  this ADR.
+
+## Alternatives Considered
+
+1. **Normalize every guest `temper_api_url` to loopback in TemperPaw**.
+   Rejected as incomplete: direct callers and stale route configs can still
+   pass the public origin, and the semantic boundary belongs at the host.
+2. **Intercept every `/tdata` URL regardless of host**. Rejected because it
+   breaks legitimate cross-service Temper calls and violates explicit
+   multi-tenant/multi-deployment boundaries.
+3. **Create an app-specific SessionEntry fast path**. Deferred. It may still
+   be useful, but the trace shows a transport-origin gap that can be removed
+   without changing application semantics.
+
+## Rollback Policy
+
+Unset `TEMPER_LOCAL_TDATA_HOSTS`, `TEMPER_PUBLIC_BASE_URL`, `PUBLIC_BASE_URL`,
+and `RAILWAY_PUBLIC_DOMAIN`, or revert the code change. Loopback local TData
+dispatch from ADR-0099 remains unchanged.


### PR DESCRIPTION
## What changed

Adds ADR-0102 and extends `LocalTDataWasmHost` so WASM guest calls to explicitly allowlisted same-service public `/tdata` origins dispatch through the existing in-process OData handlers instead of leaving the service through the public Railway edge.

`ServerState` now carries normalized local TData hostnames from deployment environment (`TEMPER_LOCAL_TDATA_HOSTS`, public base URL variables, and Railway public-domain variables). Loopback behavior remains unchanged, non-allowlisted external hosts still delegate to the production host, and file `$value` stream paths are still excluded from local dispatch.

## Why

Datadog routed trace `9d0317bdbf78eeb763235a443d9fe34a` showed hot Session WASM modules calling `openpaw-production.up.railway.app/tdata/SessionEntries`, leaving the process and re-entering the same service before running identical OData/entity actor work. This is an overlooked host-boundary dispatch cost, not a fundamental Temper semantics limitation.

## Correctness guardrails

- No bypass of OData, Cedar, entity actors, event history, query projection, or OTS.
- Allowlist-only public-origin interception; arbitrary external `/tdata` URLs still delegate.
- Streaming `Files('...')/$value` paths continue through the existing binary/streaming path.
- Startup-only environment parsing with deterministic request-time lookup.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p temper-server local_tdata`
- `.claude/hooks/check-determinism.sh crates/temper-server/src/state/mod.rs crates/temper-server/src/state/dispatch/wasm/local_tdata_host.rs`
- `cargo clippy -p temper-server --all-targets -- -D warnings`
- manual code-quality and DST review markers, zero findings
- full pre-push gate: rustfmt, workspace clippy, readability ratchet, full `cargo test --workspace`, doctests
- one earlier full-suite push attempt hit a late `temper-platform --lib` SIGSEGV after listed tests passed; exact rerun of `cargo test -p temper-platform --lib` passed, and the subsequent full pre-push gate passed completely
