### PR TITLE
[codex] Preserve local TData host stream contract

### DIFF
--- a/crates/temper-server/src/state/dispatch/wasm/local_tdata_host.rs
+++ b/crates/temper-server/src/state/dispatch/wasm/local_tdata_host.rs
@@ -8,6 +8,9 @@ use axum::http::{HeaderMap, HeaderName, HeaderValue};
 use axum::response::IntoResponse;
 use reqwest::Url;
 use temper_wasm::WasmHost;
+use temper_wasm::http_stream::{
+    HttpRequestHead, HttpResponseHead, HttpStreamHandles, StreamError, StreamHandle,
+};
 use tracing::Instrument;
 
 use crate::state::ServerState;
@@ -129,6 +132,56 @@ impl WasmHost for LocalTDataWasmHost {
         self.delegate.connect_call(url, headers, body).await
     }
 
+    async fn http_stream_begin_outbound(
+        &self,
+        request: HttpRequestHead,
+    ) -> Result<HttpStreamHandles, String> {
+        self.delegate.http_stream_begin_outbound(request).await
+    }
+
+    async fn http_stream_read(&self, handle: StreamHandle) -> Result<Vec<u8>, StreamError> {
+        self.delegate.http_stream_read(handle).await
+    }
+
+    async fn http_stream_read_bounded(
+        &self,
+        handle: StreamHandle,
+        max_bytes: usize,
+    ) -> Result<Vec<u8>, StreamError> {
+        self.delegate
+            .http_stream_read_bounded(handle, max_bytes)
+            .await
+    }
+
+    async fn http_stream_try_write(
+        &self,
+        handle: StreamHandle,
+        chunk: Vec<u8>,
+    ) -> Result<usize, StreamError> {
+        self.delegate.http_stream_try_write(handle, chunk).await
+    }
+
+    async fn http_stream_close(&self, handle: StreamHandle) -> Result<(), StreamError> {
+        self.delegate.http_stream_close(handle).await
+    }
+
+    async fn http_stream_response_head(
+        &self,
+        response_body: StreamHandle,
+    ) -> Result<HttpResponseHead, String> {
+        self.delegate.http_stream_response_head(response_body).await
+    }
+
+    async fn http_stream_send_response_head(
+        &self,
+        response_body: StreamHandle,
+        head: HttpResponseHead,
+    ) -> Result<(), StreamError> {
+        self.delegate
+            .http_stream_send_response_head(response_body, head)
+            .await
+    }
+
     fn log(&self, level: &str, message: &str) {
         self.delegate.log(level, message);
     }
@@ -146,6 +199,18 @@ impl WasmHost for LocalTDataWasmHost {
 
     fn emit_progress(&self, event_json: &str) -> Result<(), String> {
         self.delegate.emit_progress(event_json)
+    }
+
+    fn emit_wide_event(&self, event_json: &str) -> Result<(), String> {
+        self.delegate.emit_wide_event(event_json)
+    }
+
+    fn log_structured(&self, log_json: &str) -> Result<(), String> {
+        self.delegate.log_structured(log_json)
+    }
+
+    fn emit_metric(&self, metric_json: &str) -> Result<(), String> {
+        self.delegate.emit_metric(metric_json)
     }
 }
 
@@ -214,279 +279,5 @@ fn header_map(headers: &[(String, String)]) -> HeaderMap {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use axum::http::StatusCode;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-    use temper_runtime::ActorSystem;
-    use temper_spec::csdl::parse_csdl;
-
-    const ORDER_CSDL_XML: &str = r#"<?xml version="1.0" encoding="utf-8"?>
-<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
-  <edmx:DataServices>
-    <Schema Namespace="Temper.Local" xmlns="http://docs.oasis-open.org/odata/ns/edm">
-      <EntityType Name="Order">
-        <Key><PropertyRef Name="Id"/></Key>
-        <Property Name="Id" Type="Edm.String" Nullable="false"/>
-        <Property Name="Customer" Type="Edm.String"/>
-        <Property Name="Status" Type="Edm.String"/>
-      </EntityType>
-      <Action Name="SubmitOrder" IsBound="true">
-        <Parameter Name="bindingParameter" Type="Temper.Local.Order"/>
-      </Action>
-      <EntityContainer Name="Container">
-        <EntitySet Name="Orders" EntityType="Temper.Local.Order"/>
-      </EntityContainer>
-    </Schema>
-  </edmx:DataServices>
-</edmx:Edmx>"#;
-
-    const ORDER_IOA: &str = r#"
-[automaton]
-name = "Order"
-states = ["Draft", "Submitted"]
-initial = "Draft"
-
-[[action]]
-name = "SubmitOrder"
-kind = "input"
-from = ["Draft"]
-to = "Submitted"
-"#;
-
-    struct FailingHost;
-
-    #[async_trait]
-    impl WasmHost for FailingHost {
-        async fn http_call(
-            &self,
-            _method: &str,
-            _url: &str,
-            _headers: &[(String, String)],
-            _body: &str,
-        ) -> Result<(u16, String), String> {
-            Err("delegate should not receive local TData calls".to_string())
-        }
-
-        fn get_secret(&self, key: &str) -> Result<String, String> {
-            Err(format!("secret not found: {key}"))
-        }
-
-        async fn http_call_binary(
-            &self,
-            _method: &str,
-            _url: &str,
-            _headers: &[(String, String)],
-            _body: &[u8],
-        ) -> Result<(u16, Vec<u8>), String> {
-            Err("binary delegate not used".to_string())
-        }
-
-        fn log(&self, _level: &str, _message: &str) {}
-    }
-
-    struct CountingHost {
-        calls: Arc<AtomicUsize>,
-    }
-
-    #[async_trait]
-    impl WasmHost for CountingHost {
-        async fn http_call(
-            &self,
-            _method: &str,
-            _url: &str,
-            _headers: &[(String, String)],
-            _body: &str,
-        ) -> Result<(u16, String), String> {
-            self.calls.fetch_add(1, Ordering::SeqCst);
-            Ok((299, "delegated".to_string()))
-        }
-
-        fn get_secret(&self, key: &str) -> Result<String, String> {
-            Err(format!("secret not found: {key}"))
-        }
-
-        async fn http_call_binary(
-            &self,
-            _method: &str,
-            _url: &str,
-            _headers: &[(String, String)],
-            _body: &[u8],
-        ) -> Result<(u16, Vec<u8>), String> {
-            Ok((299, b"delegated-binary".to_vec()))
-        }
-
-        fn log(&self, _level: &str, _message: &str) {}
-    }
-
-    fn test_state() -> ServerState {
-        let csdl = parse_csdl(ORDER_CSDL_XML).expect("test CSDL should parse");
-        let system = ActorSystem::new("local-tdata-wasm-host-test");
-        let mut specs = BTreeMap::new();
-        specs.insert("Order".to_string(), ORDER_IOA.to_string());
-        ServerState::with_specs(system, csdl, ORDER_CSDL_XML.to_string(), specs)
-            .expect("test state should build")
-    }
-
-    #[test]
-    fn parses_loopback_tdata_request() {
-        let request = LocalTDataRequest::parse(
-            "http://127.0.0.1:8787/tdata/SessionEntries?$filter=SessionId%20eq%20%27s1%27&$top=1",
-            &BTreeSet::new(),
-        )
-        .expect("loopback TData URL should parse");
-
-        assert_eq!(request.path, "SessionEntries");
-        assert_eq!(
-            request.query.get("$filter").map(String::as_str),
-            Some("SessionId eq 's1'")
-        );
-        assert_eq!(request.query.get("$top").map(String::as_str), Some("1"));
-    }
-
-    #[test]
-    fn ignores_non_tdata_or_non_loopback_urls() {
-        assert!(
-            LocalTDataRequest::parse("https://api.example.com/tdata/Orders", &BTreeSet::new())
-                .is_none()
-        );
-        assert!(
-            LocalTDataRequest::parse("http://127.0.0.1:8787/api/health", &BTreeSet::new())
-                .is_none()
-        );
-        assert!(LocalTDataRequest::parse("not a url", &BTreeSet::new()).is_none());
-    }
-
-    #[test]
-    fn parses_allowlisted_public_tdata_request() {
-        let local_hosts = BTreeSet::from(["temper.example".to_string()]);
-        let request =
-            LocalTDataRequest::parse("https://TEMPER.example/tdata/Orders?$top=1", &local_hosts)
-                .expect("allowlisted public TData URL should parse");
-
-        assert_eq!(request.path, "Orders");
-        assert_eq!(request.query.get("$top").map(String::as_str), Some("1"));
-    }
-
-    #[tokio::test]
-    async fn local_tdata_calls_use_odata_handlers() {
-        let host = LocalTDataWasmHost::new(test_state(), Arc::new(FailingHost));
-        let headers = vec![
-            ("x-tenant-id".to_string(), "default".to_string()),
-            ("content-type".to_string(), "application/json".to_string()),
-            ("accept".to_string(), "application/json".to_string()),
-        ];
-
-        let (status, body) = host
-            .http_call(
-                "POST",
-                "http://127.0.0.1:8787/tdata/Orders",
-                &headers,
-                r#"{"id":"order-local-1","Customer":"Ada"}"#,
-            )
-            .await
-            .expect("local create should succeed");
-        assert_eq!(status, StatusCode::CREATED.as_u16());
-        let created: serde_json::Value = serde_json::from_str(&body).expect("created JSON");
-        assert_eq!(created["entity_id"], "order-local-1");
-
-        let (status, body) = host
-            .http_call(
-                "GET",
-                "http://localhost:8787/tdata/Orders('order-local-1')",
-                &headers,
-                "",
-            )
-            .await
-            .expect("local read should succeed");
-        assert_eq!(status, StatusCode::OK.as_u16());
-        let fetched: serde_json::Value = serde_json::from_str(&body).expect("fetched JSON");
-        assert_eq!(fetched["fields"]["Customer"], "Ada");
-
-        let (status, body) = host
-            .http_call(
-                "POST",
-                "http://[::1]:8787/tdata/Orders('order-local-1')/Temper.Local.SubmitOrder",
-                &headers,
-                "{}",
-            )
-            .await
-            .expect("local action should succeed");
-        assert_eq!(status, StatusCode::OK.as_u16());
-        let submitted: serde_json::Value = serde_json::from_str(&body).expect("action JSON");
-        assert_eq!(submitted["status"], "Submitted");
-    }
-
-    #[tokio::test]
-    async fn boundary_paths_delegate_to_production_host() {
-        let calls = Arc::new(AtomicUsize::new(0));
-        let host = LocalTDataWasmHost::new(
-            test_state(),
-            Arc::new(CountingHost {
-                calls: calls.clone(),
-            }),
-        );
-        let headers = vec![("x-tenant-id".to_string(), "default".to_string())];
-
-        let delegated = [
-            (
-                "DELETE",
-                "http://127.0.0.1:8787/tdata/Orders('order-local-1')",
-            ),
-            (
-                "GET",
-                "http://127.0.0.1:8787/tdata/Files('file-local-1')/$value",
-            ),
-            ("GET", "https://api.example.com/tdata/Orders"),
-        ];
-
-        for (method, url) in delegated {
-            let (status, body) = host
-                .http_call(method, url, &headers, "")
-                .await
-                .expect("boundary path should delegate");
-            assert_eq!(status, 299);
-            assert_eq!(body, "delegated");
-        }
-
-        assert_eq!(calls.load(Ordering::SeqCst), delegated.len());
-    }
-
-    #[tokio::test]
-    async fn allowlisted_public_tdata_calls_use_odata_handlers() {
-        let mut state = test_state();
-        state.local_tdata_hosts = Arc::new(BTreeSet::from(["temper.example".to_string()]));
-        let host = LocalTDataWasmHost::new(state, Arc::new(FailingHost));
-        let headers = vec![
-            ("x-tenant-id".to_string(), "default".to_string()),
-            ("content-type".to_string(), "application/json".to_string()),
-            ("accept".to_string(), "application/json".to_string()),
-        ];
-
-        let (status, body) = host
-            .http_call(
-                "POST",
-                "https://temper.example/tdata/Orders",
-                &headers,
-                r#"{"id":"order-public-local-1","Customer":"Grace"}"#,
-            )
-            .await
-            .expect("allowlisted public host should dispatch locally");
-        assert_eq!(status, StatusCode::CREATED.as_u16());
-        let created: serde_json::Value = serde_json::from_str(&body).expect("created JSON");
-        assert_eq!(created["entity_id"], "order-public-local-1");
-
-        let (status, body) = host
-            .http_call(
-                "GET",
-                "https://temper.example/tdata/Orders('order-public-local-1')",
-                &headers,
-                "",
-            )
-            .await
-            .expect("allowlisted public host read should dispatch locally");
-        assert_eq!(status, StatusCode::OK.as_u16());
-        let fetched: serde_json::Value = serde_json::from_str(&body).expect("fetched JSON");
-        assert_eq!(fetched["fields"]["Customer"], "Grace");
-    }
-}
+#[path = "local_tdata_host_test.rs"]
+mod tests;

--- a/crates/temper-server/src/state/dispatch/wasm/local_tdata_host_test.rs
+++ b/crates/temper-server/src/state/dispatch/wasm/local_tdata_host_test.rs
@@ -1,0 +1,397 @@
+use super::*;
+use axum::http::StatusCode;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use temper_runtime::ActorSystem;
+use temper_spec::csdl::parse_csdl;
+
+const ORDER_CSDL_XML: &str = r#"<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="Temper.Local" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="Order">
+        <Key><PropertyRef Name="Id"/></Key>
+        <Property Name="Id" Type="Edm.String" Nullable="false"/>
+        <Property Name="Customer" Type="Edm.String"/>
+        <Property Name="Status" Type="Edm.String"/>
+      </EntityType>
+      <Action Name="SubmitOrder" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Temper.Local.Order"/>
+      </Action>
+      <EntityContainer Name="Container">
+        <EntitySet Name="Orders" EntityType="Temper.Local.Order"/>
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>"#;
+
+const ORDER_IOA: &str = r#"
+[automaton]
+name = "Order"
+states = ["Draft", "Submitted"]
+initial = "Draft"
+
+[[action]]
+name = "SubmitOrder"
+kind = "input"
+from = ["Draft"]
+to = "Submitted"
+"#;
+
+struct FailingHost;
+
+#[async_trait]
+impl WasmHost for FailingHost {
+    async fn http_call(
+        &self,
+        _method: &str,
+        _url: &str,
+        _headers: &[(String, String)],
+        _body: &str,
+    ) -> Result<(u16, String), String> {
+        Err("delegate should not receive local TData calls".to_string())
+    }
+
+    fn get_secret(&self, key: &str) -> Result<String, String> {
+        Err(format!("secret not found: {key}"))
+    }
+
+    async fn http_call_binary(
+        &self,
+        _method: &str,
+        _url: &str,
+        _headers: &[(String, String)],
+        _body: &[u8],
+    ) -> Result<(u16, Vec<u8>), String> {
+        Err("binary delegate not used".to_string())
+    }
+
+    fn log(&self, _level: &str, _message: &str) {}
+}
+
+struct CountingHost {
+    calls: Arc<AtomicUsize>,
+    stream_calls: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl WasmHost for CountingHost {
+    async fn http_call(
+        &self,
+        _method: &str,
+        _url: &str,
+        _headers: &[(String, String)],
+        _body: &str,
+    ) -> Result<(u16, String), String> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok((299, "delegated".to_string()))
+    }
+
+    fn get_secret(&self, key: &str) -> Result<String, String> {
+        Err(format!("secret not found: {key}"))
+    }
+
+    async fn http_call_binary(
+        &self,
+        _method: &str,
+        _url: &str,
+        _headers: &[(String, String)],
+        _body: &[u8],
+    ) -> Result<(u16, Vec<u8>), String> {
+        Ok((299, b"delegated-binary".to_vec()))
+    }
+
+    fn log(&self, _level: &str, _message: &str) {}
+
+    async fn http_stream_begin_outbound(
+        &self,
+        _request: HttpRequestHead,
+    ) -> Result<HttpStreamHandles, String> {
+        self.stream_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(HttpStreamHandles {
+            request_body: StreamHandle(11),
+            response_body: StreamHandle(12),
+        })
+    }
+
+    async fn http_stream_read(&self, _handle: StreamHandle) -> Result<Vec<u8>, StreamError> {
+        self.stream_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(b"delegated-direct-read".to_vec())
+    }
+
+    async fn http_stream_read_bounded(
+        &self,
+        _handle: StreamHandle,
+        _max_bytes: usize,
+    ) -> Result<Vec<u8>, StreamError> {
+        self.stream_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(b"delegated-bounded-read".to_vec())
+    }
+
+    async fn http_stream_try_write(
+        &self,
+        _handle: StreamHandle,
+        chunk: Vec<u8>,
+    ) -> Result<usize, StreamError> {
+        self.stream_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(chunk.len())
+    }
+
+    async fn http_stream_close(&self, _handle: StreamHandle) -> Result<(), StreamError> {
+        self.stream_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn http_stream_response_head(
+        &self,
+        _response_body: StreamHandle,
+    ) -> Result<HttpResponseHead, String> {
+        self.stream_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(HttpResponseHead {
+            status: 299,
+            headers: vec![("x-test-stream".to_string(), "delegated".to_string())],
+        })
+    }
+
+    async fn http_stream_send_response_head(
+        &self,
+        _response_body: StreamHandle,
+        _head: HttpResponseHead,
+    ) -> Result<(), StreamError> {
+        self.stream_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+fn test_state() -> ServerState {
+    let csdl = parse_csdl(ORDER_CSDL_XML).expect("test CSDL should parse");
+    let system = ActorSystem::new("local-tdata-wasm-host-test");
+    let mut specs = BTreeMap::new();
+    specs.insert("Order".to_string(), ORDER_IOA.to_string());
+    ServerState::with_specs(system, csdl, ORDER_CSDL_XML.to_string(), specs)
+        .expect("test state should build")
+}
+
+#[test]
+fn parses_loopback_tdata_request() {
+    let request = LocalTDataRequest::parse(
+        "http://127.0.0.1:8787/tdata/SessionEntries?$filter=SessionId%20eq%20%27s1%27&$top=1",
+        &BTreeSet::new(),
+    )
+    .expect("loopback TData URL should parse");
+
+    assert_eq!(request.path, "SessionEntries");
+    assert_eq!(
+        request.query.get("$filter").map(String::as_str),
+        Some("SessionId eq 's1'")
+    );
+    assert_eq!(request.query.get("$top").map(String::as_str), Some("1"));
+}
+
+#[test]
+fn ignores_non_tdata_or_non_loopback_urls() {
+    assert!(
+        LocalTDataRequest::parse("https://api.example.com/tdata/Orders", &BTreeSet::new())
+            .is_none()
+    );
+    assert!(
+        LocalTDataRequest::parse("http://127.0.0.1:8787/api/health", &BTreeSet::new()).is_none()
+    );
+    assert!(LocalTDataRequest::parse("not a url", &BTreeSet::new()).is_none());
+}
+
+#[test]
+fn parses_allowlisted_public_tdata_request() {
+    let local_hosts = BTreeSet::from(["temper.example".to_string()]);
+    let request =
+        LocalTDataRequest::parse("https://TEMPER.example/tdata/Orders?$top=1", &local_hosts)
+            .expect("allowlisted public TData URL should parse");
+
+    assert_eq!(request.path, "Orders");
+    assert_eq!(request.query.get("$top").map(String::as_str), Some("1"));
+}
+
+#[tokio::test]
+async fn local_tdata_calls_use_odata_handlers() {
+    let host = LocalTDataWasmHost::new(test_state(), Arc::new(FailingHost));
+    let headers = vec![
+        ("x-tenant-id".to_string(), "default".to_string()),
+        ("content-type".to_string(), "application/json".to_string()),
+        ("accept".to_string(), "application/json".to_string()),
+    ];
+
+    let (status, body) = host
+        .http_call(
+            "POST",
+            "http://127.0.0.1:8787/tdata/Orders",
+            &headers,
+            r#"{"id":"order-local-1","Customer":"Ada"}"#,
+        )
+        .await
+        .expect("local create should succeed");
+    assert_eq!(status, StatusCode::CREATED.as_u16());
+    let created: serde_json::Value = serde_json::from_str(&body).expect("created JSON");
+    assert_eq!(created["entity_id"], "order-local-1");
+
+    let (status, body) = host
+        .http_call(
+            "GET",
+            "http://localhost:8787/tdata/Orders('order-local-1')",
+            &headers,
+            "",
+        )
+        .await
+        .expect("local read should succeed");
+    assert_eq!(status, StatusCode::OK.as_u16());
+    let fetched: serde_json::Value = serde_json::from_str(&body).expect("fetched JSON");
+    assert_eq!(fetched["fields"]["Customer"], "Ada");
+
+    let (status, body) = host
+        .http_call(
+            "POST",
+            "http://[::1]:8787/tdata/Orders('order-local-1')/Temper.Local.SubmitOrder",
+            &headers,
+            "{}",
+        )
+        .await
+        .expect("local action should succeed");
+    assert_eq!(status, StatusCode::OK.as_u16());
+    let submitted: serde_json::Value = serde_json::from_str(&body).expect("action JSON");
+    assert_eq!(submitted["status"], "Submitted");
+}
+
+#[tokio::test]
+async fn boundary_paths_delegate_to_production_host() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let host = LocalTDataWasmHost::new(
+        test_state(),
+        Arc::new(CountingHost {
+            calls: calls.clone(),
+            stream_calls: Arc::new(AtomicUsize::new(0)),
+        }),
+    );
+    let headers = vec![("x-tenant-id".to_string(), "default".to_string())];
+
+    let delegated = [
+        (
+            "DELETE",
+            "http://127.0.0.1:8787/tdata/Orders('order-local-1')",
+        ),
+        (
+            "GET",
+            "http://127.0.0.1:8787/tdata/Files('file-local-1')/$value",
+        ),
+        ("GET", "https://api.example.com/tdata/Orders"),
+    ];
+
+    for (method, url) in delegated {
+        let (status, body) = host
+            .http_call(method, url, &headers, "")
+            .await
+            .expect("boundary path should delegate");
+        assert_eq!(status, 299);
+        assert_eq!(body, "delegated");
+    }
+
+    assert_eq!(calls.load(Ordering::SeqCst), delegated.len());
+}
+
+#[tokio::test]
+async fn outbound_streaming_delegates_to_production_host() {
+    let stream_calls = Arc::new(AtomicUsize::new(0));
+    let host = LocalTDataWasmHost::new(
+        test_state(),
+        Arc::new(CountingHost {
+            calls: Arc::new(AtomicUsize::new(0)),
+            stream_calls: stream_calls.clone(),
+        }),
+    );
+
+    let handles = host
+        .http_stream_begin_outbound(HttpRequestHead {
+            method: "POST".to_string(),
+            url: "https://chatgpt.com/backend-api/codex/responses".to_string(),
+            headers: vec![("accept".to_string(), "text/event-stream".to_string())],
+        })
+        .await
+        .expect("local TData wrapper must preserve outbound streaming support");
+
+    assert_eq!(handles.request_body, StreamHandle(11));
+    assert_eq!(handles.response_body, StreamHandle(12));
+    assert_eq!(
+        host.http_stream_try_write(handles.request_body, b"hello".to_vec())
+            .await
+            .expect("stream writes must delegate"),
+        5
+    );
+    let head = host
+        .http_stream_response_head(handles.response_body)
+        .await
+        .expect("stream response head must delegate");
+    assert_eq!(head.status, 299);
+    assert_eq!(
+        head.headers,
+        vec![("x-test-stream".to_string(), "delegated".to_string())]
+    );
+    let bounded_chunk = host
+        .http_stream_read_bounded(handles.response_body, 1024)
+        .await
+        .expect("bounded stream reads must delegate");
+    assert_eq!(bounded_chunk, b"delegated-bounded-read");
+    let direct_chunk = host
+        .http_stream_read(handles.response_body)
+        .await
+        .expect("direct stream reads must delegate");
+    assert_eq!(direct_chunk, b"delegated-direct-read");
+    host.http_stream_send_response_head(
+        handles.response_body,
+        HttpResponseHead {
+            status: 204,
+            headers: Vec::new(),
+        },
+    )
+    .await
+    .expect("inbound stream response heads must delegate");
+    host.http_stream_close(handles.request_body)
+        .await
+        .expect("stream close must delegate");
+
+    assert_eq!(stream_calls.load(Ordering::SeqCst), 7);
+}
+
+#[tokio::test]
+async fn allowlisted_public_tdata_calls_use_odata_handlers() {
+    let mut state = test_state();
+    state.local_tdata_hosts = Arc::new(BTreeSet::from(["temper.example".to_string()]));
+    let host = LocalTDataWasmHost::new(state, Arc::new(FailingHost));
+    let headers = vec![
+        ("x-tenant-id".to_string(), "default".to_string()),
+        ("content-type".to_string(), "application/json".to_string()),
+        ("accept".to_string(), "application/json".to_string()),
+    ];
+
+    let (status, body) = host
+        .http_call(
+            "POST",
+            "https://temper.example/tdata/Orders",
+            &headers,
+            r#"{"id":"order-public-local-1","Customer":"Grace"}"#,
+        )
+        .await
+        .expect("allowlisted public host should dispatch locally");
+    assert_eq!(status, StatusCode::CREATED.as_u16());
+    let created: serde_json::Value = serde_json::from_str(&body).expect("created JSON");
+    assert_eq!(created["entity_id"], "order-public-local-1");
+
+    let (status, body) = host
+        .http_call(
+            "GET",
+            "https://temper.example/tdata/Orders('order-public-local-1')",
+            &headers,
+            "",
+        )
+        .await
+        .expect("allowlisted public host read should dispatch locally");
+    assert_eq!(status, StatusCode::OK.as_u16());
+    let fetched: serde_json::Value = serde_json::from_str(&body).expect("fetched JSON");
+    assert_eq!(fetched["fields"]["Customer"], "Grace");
+}

--- a/crates/temper-wasm/src/engine/host_functions.rs
+++ b/crates/temper-wasm/src/engine/host_functions.rs
@@ -72,6 +72,15 @@ where
     }
 }
 
+fn redact_url_for_log(url: &str) -> String {
+    let without_fragment = url.split('#').next().unwrap_or(url);
+    without_fragment
+        .split('?')
+        .next()
+        .unwrap_or(without_fragment)
+        .to_string()
+}
+
 /// Outcome of resolving an entity-state field against a `HostState`.
 ///
 /// Pulled out of the `host_read_field` closure so the pure logic is unit-testable
@@ -1471,6 +1480,8 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                     url,
                     headers,
                 };
+                let method_for_log = head.method.clone();
+                let url_for_log = redact_url_for_log(&head.url);
                 let result = tokio::task::block_in_place(|| {
                     tokio::runtime::Handle::current()
                         .block_on(host.http_stream_begin_outbound(head))
@@ -1478,7 +1489,15 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
 
                 let handles = match result {
                     Ok(h) => h,
-                    Err(_) => return -4,
+                    Err(err) => {
+                        tracing::warn!(
+                            http_method = %method_for_log,
+                            url = %url_for_log,
+                            error = %err,
+                            "WASM outbound HTTP stream begin failed"
+                        );
+                        return -4;
+                    }
                 };
 
                 let req_bytes = handles.request_body.0.to_le_bytes();
@@ -1537,7 +1556,14 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                     Err(crate::http_stream::StreamError::WouldBlock) => -1,
                     Err(crate::http_stream::StreamError::Closed) => -2,
                     Err(crate::http_stream::StreamError::InvalidHandle) => -3,
-                    Err(crate::http_stream::StreamError::Aborted(_)) => -4,
+                    Err(crate::http_stream::StreamError::Aborted(reason)) => {
+                        tracing::warn!(
+                            stream_handle = handle,
+                            error = %reason,
+                            "WASM HTTP stream read aborted"
+                        );
+                        -4
+                    }
                 }
             },
         )
@@ -1569,7 +1595,14 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                     Err(crate::http_stream::StreamError::WouldBlock) => -1,
                     Err(crate::http_stream::StreamError::Closed) => -2,
                     Err(crate::http_stream::StreamError::InvalidHandle) => -3,
-                    Err(crate::http_stream::StreamError::Aborted(_)) => -4,
+                    Err(crate::http_stream::StreamError::Aborted(reason)) => {
+                        tracing::warn!(
+                            stream_handle = handle,
+                            error = %reason,
+                            "WASM HTTP stream write aborted"
+                        );
+                        -4
+                    }
                 }
             },
         )
@@ -1592,7 +1625,28 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 match result {
                     Ok(()) => 0,
                     Err(crate::http_stream::StreamError::InvalidHandle) => -3,
-                    Err(_) => -4,
+                    Err(crate::http_stream::StreamError::WouldBlock) => {
+                        tracing::warn!(
+                            stream_handle = handle,
+                            "WASM HTTP stream close unexpectedly returned WouldBlock"
+                        );
+                        -4
+                    }
+                    Err(crate::http_stream::StreamError::Closed) => {
+                        tracing::warn!(
+                            stream_handle = handle,
+                            "WASM HTTP stream close saw already closed handle"
+                        );
+                        -4
+                    }
+                    Err(crate::http_stream::StreamError::Aborted(reason)) => {
+                        tracing::warn!(
+                            stream_handle = handle,
+                            error = %reason,
+                            "WASM HTTP stream close aborted"
+                        );
+                        -4
+                    }
                 }
             },
         )
@@ -1625,7 +1679,14 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 });
                 let head = match result {
                     Ok(h) => h,
-                    Err(_) => return -4,
+                    Err(err) => {
+                        tracing::warn!(
+                            stream_handle = resp_handle,
+                            error = %err,
+                            "WASM HTTP stream response head failed"
+                        );
+                        return -4;
+                    }
                 };
                 let encoded = serde_json::json!({
                     "status": head.status,
@@ -1695,7 +1756,28 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 match result {
                     Ok(()) => 0,
                     Err(crate::http_stream::StreamError::InvalidHandle) => -3,
-                    Err(_) => -4,
+                    Err(crate::http_stream::StreamError::WouldBlock) => {
+                        tracing::warn!(
+                            stream_handle = resp_handle,
+                            "WASM HTTP stream send response head unexpectedly returned WouldBlock"
+                        );
+                        -4
+                    }
+                    Err(crate::http_stream::StreamError::Closed) => {
+                        tracing::warn!(
+                            stream_handle = resp_handle,
+                            "WASM HTTP stream send response head saw closed handle"
+                        );
+                        -4
+                    }
+                    Err(crate::http_stream::StreamError::Aborted(reason)) => {
+                        tracing::warn!(
+                            stream_handle = resp_handle,
+                            error = %reason,
+                            "WASM HTTP stream send response head aborted"
+                        );
+                        -4
+                    }
                 }
             },
         )

--- a/docs/adrs/0103-local-tdata-host-stream-contract.md
+++ b/docs/adrs/0103-local-tdata-host-stream-contract.md
@@ -1,0 +1,164 @@
+# ADR-0103: Local TData Host Stream Contract Preservation
+
+- Status: Proposed
+- Date: 2026-05-18
+- Deciders: Temper core maintainers
+- Related:
+  - ADR-0099: Local WASM TData Host Path
+  - ADR-0102: Local TData Public Origin Bypass
+  - ADR-0100: WASM Invocation Phase Observability
+  - `crates/temper-server/src/state/dispatch/wasm/local_tdata_host.rs`
+  - `crates/temper-wasm/src/host_trait.rs`
+
+## Context
+
+ADR-0099 introduced `LocalTDataWasmHost` as a server-side wrapper around the
+production WASM host. Its mission is deliberately narrow: intercept eligible
+textual `GET` and `POST` calls to local `/tdata` and run the existing OData
+handlers in-process, while every non-local capability continues through the
+wrapped host.
+
+Production Datadog evidence from May 17-18, 2026 shows that the wrapper did
+not preserve the full `WasmHost` contract. Codex provider calls reached the
+streaming boundary after successful auth refresh and context preparation, then
+failed before the outbound OpenAI Codex HTTP stream span was created:
+
+```text
+http_stream::streaming_call: begin_outbound rc -4
+```
+
+The first bad TemperPaw deployment was `d230d3c...`, which rolled Temper from
+last-good `ed3d0c...` to `6d09be...`. That Temper commit added
+`LocalTDataWasmHost`. The wrapper delegated `http_call`, `http_call_binary`,
+`connect_call`, secrets, logging, and progress, but not the `http_stream_*`
+methods. Because the `WasmHost` trait provides default "not supported" stream
+methods, the wrapper became a capability sink for streaming calls even though
+the inner `ProductionWasmHost` supported them.
+
+This is a host-contract bug, not a provider, prompt, Discord, or OpenAI API
+behavior issue.
+
+## Decision
+
+`LocalTDataWasmHost` must be a transparent wrapper for every `WasmHost`
+capability it does not intentionally intercept.
+
+### Sub-Decision 1: Forward All Streaming Methods
+
+The wrapper will explicitly delegate:
+
+- `http_stream_begin_outbound`
+- `http_stream_read`
+- `http_stream_read_bounded`
+- `http_stream_try_write`
+- `http_stream_close`
+- `http_stream_response_head`
+- `http_stream_send_response_head`
+
+**Why this approach**: local TData routing optimizes only textual local OData
+calls. Streaming provider calls, inbound streaming responses, sandbox streams,
+and future streaming users must keep the exact production host behavior.
+
+### Sub-Decision 2: Forward Remaining Non-TData Host Capabilities
+
+The wrapper will also delegate the structured observability host methods that
+were added after the original wrapper shape:
+
+- `emit_wide_event`
+- `log_structured`
+- `emit_metric`
+
+**Why this approach**: wrapper code must not silently inherit "not supported"
+defaults for host features it does not own. A local transport optimization
+should not reduce guest observability or diagnostics.
+
+### Sub-Decision 3: Add Regression Coverage At The Wrapper Boundary
+
+The test suite will include a host double that proves stream begin, write,
+read, response-head, response-head-send, and close all reach the delegate
+through `LocalTDataWasmHost`.
+
+**Why this approach**: the previous local TData tests proved interception and
+delegation for regular HTTP calls, but did not prove that unrelated host
+capabilities stayed intact. The regression test protects the exact failure
+boundary Datadog exposed.
+
+## Rollout Plan
+
+1. **Phase 0 (Immediate)**: ship the wrapper forwarding patch and regression
+   tests in Temper.
+2. **Phase 1 (TemperPaw Bump)**: roll the fixed Temper revision into
+   TemperPaw, preserving any production rollback that has already restored
+   service health.
+3. **Phase 2 (Production Proof)**: run a live Codex streaming request and
+   confirm Datadog shows the normal outbound Codex stream span instead of
+   `begin_outbound rc -4`.
+
+## Readiness Gates
+
+- Focused `local_tdata` tests prove regular local TData behavior still works.
+- New stream delegation test proves all streaming methods forward through the
+  wrapper.
+- `temper-server` check, format, clippy, and relevant integration tests pass.
+- The TemperPaw rollout passes CI/Docker before deployment.
+- Live production proof shows Codex streaming reaches the outbound provider
+  request path and does not emit the previous `rc -4` burst.
+
+## Consequences
+
+### Positive
+
+- Restores Codex/OpenAI streaming through the local TData wrapper.
+- Keeps the local TData latency win without making the wrapper a capability
+  sink.
+- Provides a reusable test pattern for future `WasmHost` wrappers.
+
+### Negative
+
+- Wrapper implementations remain somewhat verbose because Rust has no automatic
+  "delegate every trait method" syntax.
+- Future `WasmHost` trait additions still need reviewer attention unless we add
+  a broader compile-time or test-time contract check.
+
+### Risks
+
+- Another future host method could be added and not forwarded. Mitigation:
+  review wrapper diffs against the full `WasmHost` trait and prefer explicit
+  regression tests when adding host capabilities.
+- Production could still return `rc -4` for a different bridge failure after
+  forwarding is fixed. Mitigation: use Datadog proof to distinguish wrapper
+  failure from downstream stream-bridge/provider failure.
+
+### DST Compliance
+
+- This touches `temper-server`, a simulation-visible crate.
+- The change only forwards calls to an existing delegate and does not add
+  threads, wall-clock time, random IDs, filesystem access, network access beyond
+  what the delegate already performed, or nondeterministic collection behavior.
+- The added test double uses deterministic counters and fixed stream handles.
+
+## Non-Goals
+
+- Do not change the guest streaming ABI.
+- Do not intercept streaming `/tdata` or File `$value` traffic locally.
+- Do not change provider auth, OpenAI request construction, or retry policy.
+- Do not tune latency further until production streaming health is restored.
+
+## Alternatives Considered
+
+1. **Disable `LocalTDataWasmHost` entirely**. This is a valid emergency rollback
+   but gives up the measured local `/tdata` latency improvement instead of
+   fixing the wrapper contract.
+2. **Move local TData routing into `ProductionWasmHost` directly**. Rejected for
+   this patch because it broadens the change and mixes server OData state into
+   the generic WASM host.
+3. **Rely on trait defaults for unsupported methods**. Rejected because this is
+   exactly how the regression escaped: defaults are useful for simple hosts, but
+   transparent wrappers must preserve supported inner capabilities.
+
+## Rollback Policy
+
+If the forwarding patch causes unexpected behavior, revert this ADR's code
+change or temporarily remove the local TData wrapper wiring from WASM
+invocation construction. Emergency production recovery can continue to use the
+last-known-good TemperPaw version before `d230d3c...`.


### PR DESCRIPTION
## Summary
- Preserve the LocalTDataWasmHost wrapper's host contract by forwarding every `http_stream_*` method to the production delegate.
- Forward structured observability host methods through the wrapper too, so local `/tdata` dispatch does not accidentally weaken telemetry.
- Add a regression test that exercises outbound streaming through the local TData wrapper.
- Log the underlying host stream error before the WASM bridge returns opaque `rc -4`.
- Document the decision in ADR-0103.

## Root Cause
The local `/tdata` fast path wrapped the production `WasmHost` but only delegated regular HTTP calls and a subset of host methods. Streaming calls therefore hit the default non-streaming trait implementation, so Codex provider calls failed at `http_stream_begin_outbound` before the OpenAI outbound stream span could be created.

## Validation
- `cargo fmt --all`
- `cargo test -p temper-server local_tdata -- --nocapture`
- `cargo test -p temper-wasm http_stream -- --nocapture`
- `cargo test -p temper-wasm outbound_streaming -- --nocapture`
- `cargo test -p temper-server --test wasm_dispatch -- --nocapture`
- `cargo check --locked -p temper-server -p temper-wasm`
- `cargo clippy --locked -p temper-server -p temper-wasm --all-targets -- -D warnings`
- `bash scripts/readability-ratchet.sh check .ci/readability-baseline.env`
- Full pre-push pipeline: rustfmt, workspace clippy, readability ratchet, full workspace tests, and doctests

## Rollout
After this merges, roll the fixed Temper revision through TemperPaw, deploy the new image, and accept only after a live Codex streaming request creates the expected outbound stream span in Datadog.