### PR TITLE
Repair projection read parity and local tenant propagation

### DIFF
--- a/crates/temper-server/src/odata/read.rs
+++ b/crates/temper-server/src/odata/read.rs
@@ -456,6 +456,18 @@ pub(super) async fn handle_odata_get_for_tenant(
 }
 
 /// Handle `EntitySet` path: list all entities in a set with query options.
+#[instrument(skip_all, fields(
+    otel.name = "odata.entity_set_read",
+    tenant = %tenant,
+    entity_set = %name,
+    entity_type = tracing::field::Empty,
+    filter_pushdown = tracing::field::Empty,
+    id_source = tracing::field::Empty,
+    catalog_materialization = tracing::field::Empty,
+    candidate_count = tracing::field::Empty,
+    materialized_count = tracing::field::Empty,
+    returned_count = tracing::field::Empty,
+))]
 async fn handle_entity_set(
     state: &ServerState,
     tenant: &TenantId,
@@ -467,6 +479,8 @@ async fn handle_entity_set(
         Some(t) => t,
         None => return entity_set_not_found_response(state, tenant, name).await,
     };
+    let span = tracing::Span::current();
+    span.record("entity_type", entity_type.as_str());
 
     let default_page_size = odata_default_page_size();
     let max_entities = odata_max_entities();
@@ -511,7 +525,8 @@ async fn handle_entity_set(
         None // no filter
     };
 
-    let prefer_catalog_materialization = sql_pushdown_ids.is_some();
+    let filter_pushdown = sql_pushdown_ids.is_some();
+    let prefer_catalog_materialization = filter_pushdown || state.query_plane_store().is_some();
     let (entity_ids, apply_options, precomputed_count) = if let Some(pushed_ids) = sql_pushdown_ids
     {
         // SQL push-down already filtered — apply pagination only.
@@ -534,6 +549,17 @@ async fn handle_entity_set(
             max_entities,
         )
     };
+    span.record("filter_pushdown", filter_pushdown);
+    span.record("catalog_materialization", prefer_catalog_materialization);
+    span.record(
+        "id_source",
+        if filter_pushdown {
+            "filter_pushdown"
+        } else {
+            "read_source_union"
+        },
+    );
+    span.record("candidate_count", entity_ids.len() as u64);
 
     let entities = materialize_entity_set_entities(
         state,
@@ -544,8 +570,10 @@ async fn handle_entity_set(
         prefer_catalog_materialization,
     )
     .await;
+    span.record("materialized_count", entities.len() as u64);
 
     let (mut result, mut count) = apply_query_options(entities, &apply_options);
+    span.record("returned_count", result.len() as u64);
     if count.is_none() {
         count = precomputed_count;
     }

--- a/crates/temper-server/src/state/dispatch/wasm.rs
+++ b/crates/temper-server/src/state/dispatch/wasm.rs
@@ -498,8 +498,11 @@ impl crate::state::ServerState {
                     current_otel_trace_id(active_span).or_else(|| ctx.agent_ctx.trace_id.clone()),
                 ),
         );
-        let inner: Arc<dyn WasmHost> =
-            Arc::new(LocalTDataWasmHost::new(self.clone(), production_host));
+        let inner: Arc<dyn WasmHost> = Arc::new(LocalTDataWasmHost::new(
+            self.clone(),
+            ctx.entity_ref.tenant.clone(),
+            production_host,
+        ));
         let host: Arc<dyn WasmHost> = Arc::new(AuthorizedWasmHost::new(inner, gate, authz_ctx));
         let max_response_bytes = integration
             .config
@@ -1062,8 +1065,11 @@ impl crate::state::ServerState {
             base_host = base_host.with_binary_http_interceptor(interceptor);
         }
         let production_host: Arc<dyn WasmHost> = Arc::new(base_host);
-        let inner: Arc<dyn WasmHost> =
-            Arc::new(LocalTDataWasmHost::new(self.clone(), production_host));
+        let inner: Arc<dyn WasmHost> = Arc::new(LocalTDataWasmHost::new(
+            self.clone(),
+            tenant.clone(),
+            production_host,
+        ));
         let host: Arc<dyn WasmHost> =
             Arc::new(AuthorizedWasmHost::new(inner, base_gate, authz_ctx));
         let limits = WasmResourceLimits::default();

--- a/crates/temper-server/src/state/dispatch/wasm/local_tdata_host.rs
+++ b/crates/temper-server/src/state/dispatch/wasm/local_tdata_host.rs
@@ -7,6 +7,7 @@ use axum::extract::{Path, Query, State};
 use axum::http::{HeaderMap, HeaderName, HeaderValue};
 use axum::response::IntoResponse;
 use reqwest::Url;
+use temper_runtime::tenant::TenantId;
 use temper_wasm::WasmHost;
 use temper_wasm::http_stream::{
     HttpRequestHead, HttpResponseHead, HttpStreamHandles, StreamError, StreamHandle,
@@ -23,13 +24,18 @@ const LOCAL_TDATA_RESPONSE_LIMIT_BYTES: usize = 64 * 1024 * 1024;
 /// through the same OData handlers as external HTTP traffic.
 pub(super) struct LocalTDataWasmHost {
     state: ServerState,
+    tenant: TenantId,
     delegate: Arc<dyn WasmHost>,
 }
 
 impl LocalTDataWasmHost {
     /// Create a local-TData wrapper around an existing host implementation.
-    pub(super) fn new(state: ServerState, delegate: Arc<dyn WasmHost>) -> Self {
-        Self { state, delegate }
+    pub(super) fn new(state: ServerState, tenant: TenantId, delegate: Arc<dyn WasmHost>) -> Self {
+        Self {
+            state,
+            tenant,
+            delegate,
+        }
     }
 
     async fn local_http_call(
@@ -48,7 +54,7 @@ impl LocalTDataWasmHost {
         if !matches!(method_upper.as_str(), "GET" | "POST") {
             return Ok(None);
         }
-        let headers = header_map(headers);
+        let headers = header_map(headers, &self.tenant);
         let path_for_span = request.path.clone();
         let span = tracing::info_span!(
             "wasm.local_tdata_http_call",
@@ -264,7 +270,7 @@ fn is_file_value_path(path: &str) -> bool {
     path.starts_with("Files('") && path.ends_with("')/$value")
 }
 
-fn header_map(headers: &[(String, String)]) -> HeaderMap {
+fn header_map(headers: &[(String, String)], tenant: &TenantId) -> HeaderMap {
     let mut map = HeaderMap::new();
     for (name, value) in headers {
         let Ok(name) = HeaderName::from_bytes(name.as_bytes()) else {
@@ -274,6 +280,11 @@ fn header_map(headers: &[(String, String)]) -> HeaderMap {
             continue;
         };
         map.insert(name, value);
+    }
+    if !map.contains_key("x-tenant-id") {
+        let value =
+            HeaderValue::from_str(tenant.as_str()).expect("TenantId is a valid HTTP header value");
+        map.insert(HeaderName::from_static("x-tenant-id"), value);
     }
     map
 }

--- a/crates/temper-server/src/state/dispatch/wasm/local_tdata_host_test.rs
+++ b/crates/temper-server/src/state/dispatch/wasm/local_tdata_host_test.rs
@@ -212,7 +212,11 @@ fn parses_allowlisted_public_tdata_request() {
 
 #[tokio::test]
 async fn local_tdata_calls_use_odata_handlers() {
-    let host = LocalTDataWasmHost::new(test_state(), Arc::new(FailingHost));
+    let host = LocalTDataWasmHost::new(
+        test_state(),
+        temper_runtime::tenant::TenantId::default(),
+        Arc::new(FailingHost),
+    );
     let headers = vec![
         ("x-tenant-id".to_string(), "default".to_string()),
         ("content-type".to_string(), "application/json".to_string()),
@@ -260,10 +264,50 @@ async fn local_tdata_calls_use_odata_handlers() {
 }
 
 #[tokio::test]
+async fn local_tdata_synthesizes_invocation_tenant_header() {
+    let mut state = test_state();
+    state.single_tenant_mode = false;
+    let host = LocalTDataWasmHost::new(
+        state,
+        temper_runtime::tenant::TenantId::default(),
+        Arc::new(FailingHost),
+    );
+    let headers = vec![
+        ("content-type".to_string(), "application/json".to_string()),
+        ("accept".to_string(), "application/json".to_string()),
+    ];
+
+    let (status, body) = host
+        .http_call(
+            "POST",
+            "http://127.0.0.1:8787/tdata/Orders",
+            &headers,
+            r#"{"id":"order-local-no-header","Customer":"Lin"}"#,
+        )
+        .await
+        .expect("local create should synthesize tenant header");
+    assert_eq!(status, StatusCode::CREATED.as_u16(), "{body}");
+
+    let (status, body) = host
+        .http_call(
+            "GET",
+            "http://127.0.0.1:8787/tdata/Orders('order-local-no-header')",
+            &headers,
+            "",
+        )
+        .await
+        .expect("local read should synthesize tenant header");
+    assert_eq!(status, StatusCode::OK.as_u16(), "{body}");
+    let fetched: serde_json::Value = serde_json::from_str(&body).expect("fetched JSON");
+    assert_eq!(fetched["fields"]["Customer"], "Lin");
+}
+
+#[tokio::test]
 async fn boundary_paths_delegate_to_production_host() {
     let calls = Arc::new(AtomicUsize::new(0));
     let host = LocalTDataWasmHost::new(
         test_state(),
+        temper_runtime::tenant::TenantId::default(),
         Arc::new(CountingHost {
             calls: calls.clone(),
             stream_calls: Arc::new(AtomicUsize::new(0)),
@@ -300,6 +344,7 @@ async fn outbound_streaming_delegates_to_production_host() {
     let stream_calls = Arc::new(AtomicUsize::new(0));
     let host = LocalTDataWasmHost::new(
         test_state(),
+        temper_runtime::tenant::TenantId::default(),
         Arc::new(CountingHost {
             calls: Arc::new(AtomicUsize::new(0)),
             stream_calls: stream_calls.clone(),
@@ -362,7 +407,11 @@ async fn outbound_streaming_delegates_to_production_host() {
 async fn allowlisted_public_tdata_calls_use_odata_handlers() {
     let mut state = test_state();
     state.local_tdata_hosts = Arc::new(BTreeSet::from(["temper.example".to_string()]));
-    let host = LocalTDataWasmHost::new(state, Arc::new(FailingHost));
+    let host = LocalTDataWasmHost::new(
+        state,
+        temper_runtime::tenant::TenantId::default(),
+        Arc::new(FailingHost),
+    );
     let headers = vec![
         ("x-tenant-id".to_string(), "default".to_string()),
         ("content-type".to_string(), "application/json".to_string()),

--- a/crates/temper-store-postgres/src/store.rs
+++ b/crates/temper-store-postgres/src/store.rs
@@ -297,19 +297,48 @@ impl EventStore for PostgresEventStore {
         entity_type: &str,
     ) -> Result<Vec<String>, PersistenceError> {
         let rows: Vec<String> = crate::dbm::postgres_query_scalar!(
-            "SELECT DISTINCT e.entity_id \
-             FROM events e \
-             WHERE e.tenant = $1 \
-               AND e.entity_type = $2 \
-               AND NOT EXISTS ( \
-                 SELECT 1 \
-                 FROM events d \
-                 WHERE d.tenant = e.tenant \
-                   AND d.entity_type = e.entity_type \
-                   AND d.entity_id = e.entity_id \
-                   AND d.event_type = 'Deleted' \
-               ) \
-             ORDER BY e.entity_id",
+            "SELECT entity_id \
+             FROM ( \
+               SELECT c.entity_id \
+               FROM entity_catalog c \
+               WHERE c.tenant = $1 \
+                 AND c.entity_type = $2 \
+                 AND NOT EXISTS ( \
+                   SELECT 1 \
+                   FROM events d \
+                   WHERE d.tenant = c.tenant \
+                     AND d.entity_type = c.entity_type \
+                     AND d.entity_id = c.entity_id \
+                     AND d.event_type = 'Deleted' \
+                 ) \
+               UNION \
+               SELECT f.entity_id \
+               FROM entity_field_index f \
+               WHERE f.tenant = $1 \
+                 AND f.entity_type = $2 \
+                 AND NOT EXISTS ( \
+                   SELECT 1 \
+                   FROM events d \
+                   WHERE d.tenant = f.tenant \
+                     AND d.entity_type = f.entity_type \
+                     AND d.entity_id = f.entity_id \
+                     AND d.event_type = 'Deleted' \
+                 ) \
+               UNION \
+               SELECT DISTINCT e.entity_id \
+               FROM events e \
+               WHERE e.tenant = $1 \
+                 AND e.entity_type = $2 \
+                 AND NOT EXISTS ( \
+                   SELECT 1 \
+                   FROM events d \
+                   WHERE d.tenant = e.tenant \
+                     AND d.entity_type = e.entity_type \
+                     AND d.entity_id = e.entity_id \
+                     AND d.event_type = 'Deleted' \
+                 ) \
+             ) ids \
+             ORDER BY entity_id",
         )
         .bind(tenant)
         .bind(entity_type)

--- a/crates/temper-store-postgres/src/store_projection_test.rs
+++ b/crates/temper-store-postgres/src/store_projection_test.rs
@@ -2,6 +2,120 @@ use super::*;
 use crate::migration::run_migrations;
 use sqlx::PgPool;
 
+fn test_envelope(event_type: &str, payload: serde_json::Value) -> PersistenceEnvelope {
+    PersistenceEnvelope {
+        sequence_nr: 0,
+        event_type: event_type.to_string(),
+        payload,
+        metadata: EventMetadata {
+            event_id: uuid::Uuid::new_v4(),
+            causation_id: uuid::Uuid::new_v4(),
+            correlation_id: uuid::Uuid::new_v4(),
+            timestamp: chrono::Utc::now(),
+            actor_id: "store-projection-test".to_string(),
+        },
+    }
+}
+
+#[test]
+fn list_entity_ids_by_type_unions_catalog_field_index_and_events() {
+    let database_url = match std::env::var("DATABASE_URL") {
+        Ok(url) => url,
+        Err(_) => return,
+    };
+
+    sqlx::test_block_on(async {
+        let pool = PgPool::connect(&database_url).await.unwrap();
+        run_migrations(&pool).await.unwrap();
+        let store = PostgresEventStore::new(pool.clone());
+        let tenant = format!("tenant-projection-list-{}", uuid::Uuid::new_v4());
+        let entity_type = "DesignLanguage";
+
+        store
+            .upsert_query_projection(
+                &tenant,
+                entity_type,
+                "dl-catalog",
+                "Published",
+                &serde_json::json!({ "Name": "Catalog" }),
+                1,
+            )
+            .await
+            .unwrap();
+        store
+            .upsert_query_projection(
+                &tenant,
+                entity_type,
+                "dl-deleted",
+                "Published",
+                &serde_json::json!({ "Name": "Deleted" }),
+                1,
+            )
+            .await
+            .unwrap();
+        crate::dbm::postgres_query!(
+            "INSERT INTO entity_field_index \
+             (tenant, entity_type, entity_id, field_name, field_value, status) \
+             VALUES ($1, $2, $3, $4, $5, $6)",
+        )
+        .bind(&tenant)
+        .bind(entity_type)
+        .bind("dl-index")
+        .bind("Name")
+        .bind("Index")
+        .bind("Published")
+        .execute(&pool)
+        .await
+        .unwrap();
+        store
+            .append(
+                &format!("{tenant}:{entity_type}:dl-event"),
+                0,
+                &[test_envelope("Created", serde_json::json!({}))],
+            )
+            .await
+            .unwrap();
+        store
+            .append(
+                &format!("{tenant}:{entity_type}:dl-deleted"),
+                0,
+                &[test_envelope("Deleted", serde_json::json!({}))],
+            )
+            .await
+            .unwrap();
+
+        let ids = store
+            .list_entity_ids_by_type(&tenant, entity_type)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            ids,
+            vec![
+                "dl-catalog".to_string(),
+                "dl-event".to_string(),
+                "dl-index".to_string(),
+            ]
+        );
+
+        crate::dbm::postgres_query!("DELETE FROM entity_field_index WHERE tenant = $1")
+            .bind(&tenant)
+            .execute(&pool)
+            .await
+            .unwrap();
+        crate::dbm::postgres_query!("DELETE FROM entity_catalog WHERE tenant = $1")
+            .bind(&tenant)
+            .execute(&pool)
+            .await
+            .unwrap();
+        crate::dbm::postgres_query!("DELETE FROM events WHERE tenant = $1")
+            .bind(&tenant)
+            .execute(&pool)
+            .await
+            .unwrap();
+    });
+}
+
 #[test]
 fn upsert_query_projection_diffs_field_index_rows() {
     let database_url = match std::env::var("DATABASE_URL") {

--- a/crates/temper-store-turso/src/store/entity_listing.rs
+++ b/crates/temper-store-turso/src/store/entity_listing.rs
@@ -12,7 +12,7 @@ impl TursoEventStore {
         entity_type,
         otel.name = "turso.list_entity_ids_by_type"
     ))]
-    pub(crate) async fn list_entity_ids_by_type_catalog_first(
+    pub(crate) async fn list_entity_ids_by_type_from_read_sources(
         &self,
         tenant: &str,
         entity_type: &str,
@@ -21,37 +21,47 @@ impl TursoEventStore {
         let mut rows = conn
             .query(
                 "SELECT entity_id
-                 FROM entity_catalog
-                 WHERE tenant = ?1 AND entity_type = ?2
+                 FROM (
+                   SELECT c.entity_id
+                   FROM entity_catalog c
+                   WHERE c.tenant = ?1
+                     AND c.entity_type = ?2
+                     AND NOT EXISTS (
+                       SELECT 1
+                       FROM events d
+                       WHERE d.tenant = c.tenant
+                         AND d.entity_type = c.entity_type
+                         AND d.entity_id = c.entity_id
+                         AND d.event_type = 'Deleted'
+                     )
+                   UNION
+                   SELECT f.entity_id
+                   FROM entity_field_index f
+                   WHERE f.tenant = ?1
+                     AND f.entity_type = ?2
+                     AND NOT EXISTS (
+                       SELECT 1
+                       FROM events d
+                       WHERE d.tenant = f.tenant
+                         AND d.entity_type = f.entity_type
+                         AND d.entity_id = f.entity_id
+                         AND d.event_type = 'Deleted'
+                     )
+                   UNION
+                   SELECT DISTINCT e.entity_id
+                   FROM events e
+                   WHERE e.tenant = ?1
+                     AND e.entity_type = ?2
+                     AND NOT EXISTS (
+                       SELECT 1
+                       FROM events d
+                       WHERE d.tenant = e.tenant
+                         AND d.entity_type = e.entity_type
+                         AND d.entity_id = e.entity_id
+                         AND d.event_type = 'Deleted'
+                     )
+                 )
                  ORDER BY entity_id",
-                params![tenant, entity_type],
-            )
-            .await
-            .map_err(storage_error)?;
-
-        let mut catalog_ids = Vec::new();
-        while let Some(row) = rows.next().await.map_err(storage_error)? {
-            catalog_ids.push(row.get::<String>(0).map_err(storage_error)?);
-        }
-        if !catalog_ids.is_empty() {
-            return Ok(catalog_ids);
-        }
-
-        let mut rows = conn
-            .query(
-                "SELECT DISTINCT e.entity_id
-                 FROM events e
-                 WHERE e.tenant = ?1
-                   AND e.entity_type = ?2
-                   AND NOT EXISTS (
-                     SELECT 1
-                     FROM events d
-                     WHERE d.tenant = e.tenant
-                       AND d.entity_type = e.entity_type
-                       AND d.entity_id = e.entity_id
-                       AND d.event_type = 'Deleted'
-                   )
-                 ORDER BY e.entity_id",
                 params![tenant, entity_type],
             )
             .await

--- a/crates/temper-store-turso/src/store/event_store.rs
+++ b/crates/temper-store-turso/src/store/event_store.rs
@@ -251,7 +251,7 @@ impl EventStore for TursoEventStore {
         tenant: &str,
         entity_type: &str,
     ) -> Result<Vec<String>, PersistenceError> {
-        self.list_entity_ids_by_type_catalog_first(tenant, entity_type)
+        self.list_entity_ids_by_type_from_read_sources(tenant, entity_type)
             .await
     }
 }

--- a/crates/temper-store-turso/src/store/tests/mod.rs
+++ b/crates/temper-store-turso/src/store/tests/mod.rs
@@ -274,7 +274,84 @@ async fn list_entity_ids_by_type_uses_entity_catalog() {
 }
 
 #[tokio::test]
-async fn list_entity_ids_by_type_falls_back_to_events_and_excludes_deleted() {
+async fn list_entity_ids_by_type_unions_catalog_field_index_and_events() {
+    let store = make_store("entity-list-by-type-union").await;
+    let tenant = format!("tenant-{}", uuid::Uuid::new_v4());
+
+    store
+        .upsert_query_projection(
+            &tenant,
+            "AgentRoute",
+            "route-catalog",
+            "Ready",
+            &serde_json::json!({ "Name": "catalog" }),
+            3,
+        )
+        .await
+        .expect("upsert catalog projection");
+    store
+        .upsert_query_projection(
+            &tenant,
+            "AgentRoute",
+            "route-deleted",
+            "Ready",
+            &serde_json::json!({ "Name": "deleted" }),
+            3,
+        )
+        .await
+        .expect("upsert deleted projection");
+
+    let conn = store.connection().expect("connection");
+    conn.execute(
+        "INSERT INTO entity_field_index \
+         (tenant, entity_type, entity_id, field_name, field_value, status) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![
+            tenant.clone(),
+            "AgentRoute",
+            "route-index",
+            "Name",
+            "index",
+            "Ready"
+        ],
+    )
+    .await
+    .expect("insert field-index-only row");
+
+    store
+        .append(
+            &format!("{tenant}:AgentRoute:route-event"),
+            0,
+            &[test_envelope("Created", serde_json::json!({}))],
+        )
+        .await
+        .expect("append event-only route");
+    store
+        .append(
+            &format!("{tenant}:AgentRoute:route-deleted"),
+            0,
+            &[test_envelope("Deleted", serde_json::json!({}))],
+        )
+        .await
+        .expect("append deleted tombstone");
+
+    let ids = store
+        .list_entity_ids_by_type(&tenant, "AgentRoute")
+        .await
+        .expect("list AgentRoute IDs by type");
+
+    assert_eq!(
+        ids,
+        vec![
+            "route-catalog".to_string(),
+            "route-event".to_string(),
+            "route-index".to_string(),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn list_entity_ids_by_type_includes_events_and_excludes_deleted() {
     let store = make_store("entity-list-by-type-events").await;
     let tenant = format!("tenant-{}", uuid::Uuid::new_v4());
 
@@ -314,7 +391,7 @@ async fn list_entity_ids_by_type_falls_back_to_events_and_excludes_deleted() {
     let ids = store
         .list_entity_ids_by_type(&tenant, "Order")
         .await
-        .expect("list Order IDs by type from event fallback");
+        .expect("list Order IDs by type from events");
 
     assert_eq!(ids, vec!["ord-active".to_string()]);
 }

--- a/docs/adrs/0104-projection-read-parity-and-local-tenant-propagation.md
+++ b/docs/adrs/0104-projection-read-parity-and-local-tenant-propagation.md
@@ -1,0 +1,212 @@
+# ADR-0104: Projection Read Parity And Local Tenant Propagation
+
+- Status: Proposed
+- Date: 2026-05-18
+- Deciders: Temper core maintainers
+- Related:
+  - ADR-0082: Projection Correctness Observability
+  - ADR-0091: Query Projection Diff Index Upserts
+  - ADR-0095: Projection Transaction Fast Path
+  - ADR-0096: Set-Based Projection Index Reconciliation
+  - ADR-0099: Local WASM TData Host Path
+  - ADR-0103: Local TData Host Stream Contract Preservation
+  - `crates/temper-server/src/odata/read.rs`
+  - `crates/temper-server/src/state/dispatch/wasm/local_tdata_host.rs`
+  - `crates/temper-store-postgres/src/store.rs`
+  - `crates/temper-store-turso/src/store/entity_listing.rs`
+
+## Context
+
+Production investigation found a projection/read-model correctness violation:
+
+```text
+GET /tdata/DesignLanguages
+  -> 6 rows
+
+GET /tdata/DesignLanguages?$filter=Status eq 'Published'
+  -> 173 rows
+```
+
+An unfiltered collection read must be a superset of every filtered collection
+read for the same tenant and entity type. The current architecture can violate
+that invariant because collection reads use two different ID sources:
+
+- unfiltered collection reads start from `ServerState::list_entity_ids_lazy`;
+- filtered reads can use SQL pushdown through the query plane;
+- the two sources can be event-log IDs, `entity_catalog`, or
+  `entity_field_index` depending on backend and route.
+
+The frontend mitigation that queries each state separately is acceptable as an
+emergency workaround, but it does not fix the root read-model contract.
+
+A second production symptom appeared while inspecting or pausing cron jobs:
+
+```text
+Missing required X-Tenant-Id header
+```
+
+That error is emitted by the OData tenant resolver in multi-tenant mode. After
+ADR-0103, `LocalTDataWasmHost` forwards eligible local `/tdata` calls directly
+to in-process OData handlers. This path preserves the guest-supplied headers,
+but does not synthesize `X-Tenant-Id` from the WASM execution context when the
+guest omits it. A direct HTTP caller should still send the header explicitly,
+but a local host optimization must not make internal same-tenant calls less
+reliable than the external host path.
+
+## Decision
+
+Fix the projection read path and the local TData tenant contract in one
+correctness-focused patch because both are read/control-plane routing contracts.
+
+### Sub-Decision 1: Unfiltered Reads Use The Query Plane When Available
+
+For durable query-plane backends, collection reads should derive unfiltered IDs
+from the same authoritative live projection source used by filtered reads.
+
+Postgres already uses `entity_catalog` for filter pushdown. It should also be
+able to list entity IDs by type from `entity_catalog` when the query-plane
+catalog is populated, rather than starting unfiltered reads from the event log.
+
+Turso already has a catalog-first listing path, but the same invariant must be
+tested against catalog and field-index divergence.
+
+**Why this approach**: The projection API is a read-model API. If filtered reads
+are served from the projection, unfiltered reads must not use a different stale
+or narrower source. Falling back to the event log is still useful when the
+query-plane catalog is empty or unavailable, but a non-empty projection catalog
+must not be bypassed for unfiltered reads.
+
+### Sub-Decision 2: Add Superset Regression Tests
+
+Tests must prove:
+
+- `All(entity_type)` includes every filtered subset returned by `Status`;
+- unfiltered count is greater than or equal to each filtered count;
+- a non-empty projection catalog with more rows than the event-source listing
+  does not cause the unfiltered API to return a smaller set.
+
+**Why this approach**: The production failure is a semantic contradiction, not
+just a performance regression. The invariant should be executable and backend
+agnostic enough to catch future planner changes.
+
+### Sub-Decision 3: Local TData Synthesizes Missing Tenant Header From Context
+
+`LocalTDataWasmHost` should carry the invocation tenant and add
+`X-Tenant-Id: <tenant>` when a local `/tdata` call omits it. It must not
+override an explicit guest header.
+
+**Why this approach**: A same-process local transport optimization has access
+to the invocation tenant through `ServerState` dispatch context. Internal calls
+should be tenant-scoped by construction, while still preserving explicit caller
+headers for tests and future cross-tenant administrative flows.
+
+### Sub-Decision 4: Add Datadog-Facing Read Diagnostics
+
+OData collection spans should expose enough fields to diagnose the next parity
+issue without reconstructing it from DB queries:
+
+- tenant;
+- entity set and entity type;
+- whether filter pushdown ran;
+- materialization ID source;
+- candidate count before pagination;
+- returned count after query options.
+
+**Why this approach**: Datadog already proved useful for latency and runtime
+version attribution, but this incident shows we also need correctness counters
+on the read path itself.
+
+## Rollout Plan
+
+1. **Phase 0 (Immediate)** - Add the ADR, regression tests, Postgres
+   catalog-first listing support, local TData tenant synthesis, and OData read
+   diagnostics.
+2. **Phase 1 (Production proof)** - Deploy to TemperPaw and run live
+   `DesignLanguages` all-vs-state queries plus a cron inspect/pause path that
+   previously returned the missing-header error.
+3. **Phase 2 (Monitoring)** - Add a Datadog monitor or scheduled parity probe
+   that alerts when any filtered OData collection count exceeds the unfiltered
+   collection count for the same entity type and tenant.
+
+## Readiness Gates
+
+- Regression tests fail before the fix and pass after it.
+- Focused `temper-server` and store tests pass.
+- `cargo fmt --all -- --check`, `cargo clippy`, and `git diff --check` pass
+  for the touched crates.
+- Production proof shows `All(DesignLanguages) >= Published(DesignLanguages)`.
+- Production proof shows cron inspect/pause sends or synthesizes `X-Tenant-Id`
+  and no longer returns the missing-header error.
+- The latency report HTML records the incident, PR, test evidence, and live
+  proof.
+
+## Consequences
+
+### Positive
+
+- Restores OData collection semantics for projection-backed reads.
+- Makes the projection API safe for frontends to consume without fragile
+  state-by-state workarounds.
+- Keeps local TData latency benefits while preserving tenant scoping.
+- Gives Datadog enough read-path attributes to distinguish drift, pagination,
+  and planner behavior.
+
+### Negative
+
+- A catalog-first unfiltered path trusts the query-plane projection more
+  strongly, so projection replay/backfill health becomes even more important.
+- Additional span fields add a small amount of telemetry cardinality, though
+  the chosen fields are bounded by tenant and entity types already present in
+  the system.
+
+### Risks
+
+- If `entity_catalog` has stale rows that the event log has already deleted,
+  catalog-first listing could temporarily include too many IDs. Mitigation:
+  keep deletion projection paths covered and add parity checks against replay.
+- If local TData synthesizes the wrong tenant, internal calls could cross tenant
+  boundaries. Mitigation: synthesize only from the invocation tenant and never
+  default from global state in multi-tenant mode.
+- If a caller intentionally omits `X-Tenant-Id` to test external HTTP contract
+  behavior, local TData will now differ. Mitigation: this synthesis is only for
+  in-process local TData host calls, not external HTTP requests.
+
+### DST Compliance
+
+- This touches `temper-server`, a simulation-visible crate.
+- No new wall-clock time, random IDs, filesystem access, or background threads
+  are introduced.
+- Collection ordering remains deterministic through existing ordered SQL and
+  `BTree*` usage.
+- Tenant synthesis is derived from existing deterministic invocation context.
+
+## Non-Goals
+
+- Do not remove the frontend mitigation in this patch.
+- Do not redesign projection replay, backfill, or event sourcing.
+- Do not weaken the external HTTP requirement that multi-tenant OData callers
+  provide `X-Tenant-Id`.
+- Do not make local TData support cross-tenant administrative calls without an
+  explicit header and policy review.
+
+## Alternatives Considered
+
+1. **Frontend-only workaround** - Rejected because it hides the contradiction
+   and leaves other clients with incorrect `All` reads.
+2. **Always read unfiltered IDs from the event log** - Rejected because filtered
+   reads are already projection-backed and can then return supersets of
+   unfiltered reads.
+3. **Disable filter pushdown** - Rejected because it gives up the latency win
+   and still leaves source divergence unresolved for catalog fast reads.
+4. **Force every WASM guest to add tenant headers manually** - Rejected for
+   local TData because the host already knows the invocation tenant and should
+   preserve same-tenant execution semantics.
+
+## Rollback Policy
+
+If the projection listing change causes unexpected reads, revert the
+catalog-first listing change while keeping the parity tests as ignored
+regressions and run a projection replay/backfill. If tenant synthesis causes
+unexpected local TData behavior, revert only the synthesis and require all
+affected WASM guests to pass `X-Tenant-Id` explicitly until a narrower host
+contract is approved.


### PR DESCRIPTION
## Summary
- make entity ID listing for Postgres and Turso use a unified durable read-source union across entity_catalog, entity_field_index, and events while preserving Deleted tombstone exclusion
- prefer catalog materialization for collection reads when the query plane exists, so catalog/projection-only rows do not disappear after ID enumeration
- synthesize the invocation tenant as X-Tenant-Id for local TData host calls when guest code omits the header, while preserving explicit tenant headers
- add OData collection span fields for id source, filter pushdown, catalog materialization, and materialization/return counts

## Causality
The X-Tenant-Id validation predates this branch, but the local TData host path plausibly exposed missing headers for internal cron/agent calls after same-process OData routing. This PR treats that as an owned regression in effect and fixes it in Temper core.

The DesignLanguage count contradiction is a separate projection/read-model parity issue: unfiltered and filtered reads could enumerate from different durable sources. This PR makes the unfiltered source a superset of catalog, field index, and event journal rows, minus Deleted tombstones.

## Verification
- cargo test -p temper-store-turso list_entity_ids_by_type
- cargo test -p temper-store-postgres list_entity_ids_by_type_unions_catalog_field_index_and_events
- cargo test -p temper-server local_tdata
- cargo clippy -p temper-server -p temper-store-postgres -p temper-store-turso --all-targets -- -D warnings
- git diff --check
- pre-push gate: cargo fmt --check, cargo clippy --workspace -- -D warnings, readability ratchet, cargo test --workspace including doctests
