### PR TITLE
Add data-only entity create fast path

### DIFF
--- a/crates/temper-platform/src/os_apps/mod_test.rs
+++ b/crates/temper-platform/src/os_apps/mod_test.rs
@@ -1557,6 +1557,9 @@ startup_loading = "lazy"
     let tenant_name = "test-wasm-digest-reconcile";
     let tenant = TenantId::new(tenant_name);
 
+    // Re-add the temp dir before install because other concurrent catalog
+    // tests can reload the global catalog and drop this synthetic app.
+    add_os_apps_dir(app_root.clone());
     install_os_app(&state, tenant_name, "wasm-digest-app")
         .await
         .expect("initial app install should succeed");
@@ -1674,6 +1677,9 @@ startup_loading = "lazy"
     let tenant_name = "test-wasm-preserve";
     let tenant = TenantId::new(tenant_name);
 
+    // Re-add the temp dir before install because other concurrent catalog
+    // tests can reload the global catalog and drop this synthetic app.
+    add_os_apps_dir(app_root.clone());
     install_os_app(&state, tenant_name, "wasm-preserve-app")
         .await
         .expect("initial app install should succeed");

--- a/crates/temper-server/src/odata/write.rs
+++ b/crates/temper-server/src/odata/write.rs
@@ -355,6 +355,36 @@ pub async fn handle_odata_post(
             }
 
             match state
+                .try_create_data_only_tenant_entity(
+                    &tenant,
+                    &entity_type,
+                    &entity_id,
+                    initial_fields.clone(),
+                )
+                .await
+            {
+                Ok(Some(response)) => {
+                    let mut state_json = serde_json::to_value(&response.state).unwrap_or_default();
+                    hydrate_blob_refs_for_tenant(&state, &tenant, &mut state_json).await;
+                    let body = annotate_entity(
+                        state_json,
+                        format!("$metadata#{name}/$entity"),
+                        Some(format!("{name}('{entity_id}')")),
+                    );
+                    return ODataResponse {
+                        status: StatusCode::CREATED,
+                        body,
+                    }
+                    .into_response();
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    return odata_error(StatusCode::INTERNAL_SERVER_ERROR, "CreateError", &e)
+                        .into_response();
+                }
+            }
+
+            match state
                 .get_or_create_tenant_entity(&tenant, &entity_type, &entity_id, initial_fields)
                 .await
             {

--- a/crates/temper-server/src/router_test.rs
+++ b/crates/temper-server/src/router_test.rs
@@ -2,10 +2,13 @@ use super::*;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use temper_runtime::ActorSystem;
+use temper_runtime::tenant::TenantId;
 use temper_spec::csdl::parse_csdl;
+use temper_store_turso::TursoEventStore;
 use tower::ServiceExt;
 
 use crate::events::EntityStateChange;
+use crate::storage::StorageStack;
 
 fn test_state() -> ServerState {
     let csdl_xml = include_str!("../../../test-fixtures/specs/model.csdl.xml");
@@ -75,6 +78,54 @@ params = ["RepositoryId", "Size", "Content", "CanonicalBytes", "CreatedAt"]
     let mut specs = std::collections::BTreeMap::new();
     specs.insert("Blob".to_string(), blob_ioa.to_string());
     ServerState::with_specs(system, csdl, csdl_xml.to_string(), specs).unwrap()
+}
+
+async fn test_state_with_data_only_ioa_and_turso() -> ServerState {
+    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let id = COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    let db_url = format!(
+        "file:/tmp/temper-data-only-fast-path-test-{}-{}.db",
+        std::process::id(),
+        id
+    );
+    let _ = std::fs::remove_file(db_url.strip_prefix("file:").unwrap_or(&db_url));
+    let turso = TursoEventStore::new(&db_url, None)
+        .await
+        .expect("create local turso db");
+    let csdl_xml = r#"<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="Temper.DataOnly" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="LogEntry">
+        <Key><PropertyRef Name="Id"/></Key>
+        <Property Name="Id" Type="Edm.String" Nullable="false"/>
+        <Property Name="Status" Type="Edm.String" Nullable="false"/>
+        <Property Name="Body" Type="Edm.String" Nullable="false"/>
+      </EntityType>
+      <EntityContainer Name="Container">
+        <EntitySet Name="LogEntries" EntityType="Temper.DataOnly.LogEntry"/>
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>"#;
+    let log_entry_ioa = r#"
+[automaton]
+name = "LogEntry"
+states = ["Recorded"]
+initial = "Recorded"
+
+[[state]]
+name = "Body"
+type = "string"
+initial = ""
+"#;
+    let csdl = parse_csdl(csdl_xml).unwrap();
+    let system = ActorSystem::new("test-data-only-fast-path");
+    let mut specs = std::collections::BTreeMap::new();
+    specs.insert("LogEntry".to_string(), log_entry_ioa.to_string());
+    let mut state = ServerState::with_specs(system, csdl, csdl_xml.to_string(), specs).unwrap();
+    state.set_storage_stack(StorageStack::from_turso(turso));
+    state
 }
 
 #[tokio::test]
@@ -239,6 +290,75 @@ async fn test_post_entity_creation_uses_odata_id_property() {
         .await
         .unwrap();
     assert_eq!(get_response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_data_only_entity_create_fast_path_persists_projection_without_actor_spawn() {
+    let state = test_state_with_data_only_ioa_and_turso().await;
+    let app = build_router(state.clone());
+
+    let create_response = app
+        .clone()
+        .oneshot(
+            Request::post("/tdata/LogEntries")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    r#"{"Id": "entry-1", "Body": "created through fast path"}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(create_response.status(), StatusCode::CREATED);
+    let create_body = axum::body::to_bytes(create_response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let create_json: serde_json::Value = serde_json::from_slice(&create_body).unwrap();
+    assert_eq!(create_json["status"], "Recorded");
+    assert_eq!(create_json["fields"]["Body"], "created through fast path");
+
+    let actor_key = "default:LogEntry:entry-1";
+    assert!(
+        !state.actor_registry.read().unwrap().contains_key(actor_key),
+        "data-only fast path should not hydrate an actor during create"
+    );
+
+    let get_response = app
+        .oneshot(
+            Request::get("/tdata/LogEntries('entry-1')")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(get_response.status(), StatusCode::OK);
+
+    let hydrated = state
+        .get_tenant_entity_state(&TenantId::default(), "LogEntry", "entry-1")
+        .await
+        .expect("fast-path entity should replay through actor hydration");
+    assert_eq!(hydrated.state.status, "Recorded");
+    assert_eq!(hydrated.state.sequence_nr, 1);
+    assert_eq!(hydrated.state.fields["Body"], "created through fast path");
+    assert!(state.actor_registry.read().unwrap().contains_key(actor_key));
+}
+
+#[tokio::test]
+async fn test_data_only_create_fast_path_declines_action_bearing_entities() {
+    let state = test_state_with_ioa();
+    let response = state
+        .try_create_data_only_tenant_entity(
+            &TenantId::default(),
+            "Order",
+            "order-fast-path-skip",
+            serde_json::json!({"Id": "order-fast-path-skip", "Status": "Draft"}),
+        )
+        .await
+        .unwrap();
+    assert!(
+        response.is_none(),
+        "entities with transition rules must stay on the actor-backed create path"
+    );
 }
 
 #[tokio::test]

--- a/crates/temper-server/src/state/entity_ops.rs
+++ b/crates/temper-server/src/state/entity_ops.rs
@@ -7,13 +7,13 @@ use std::time::Instant;
 use tracing::instrument;
 
 use temper_observe::wide_event;
-use temper_runtime::persistence::PersistenceEnvelope;
-use temper_runtime::scheduler::sim_now;
+use temper_runtime::persistence::{EventMetadata, PersistenceEnvelope, PersistenceError};
+use temper_runtime::scheduler::{sim_now, sim_uuid};
 use temper_runtime::tenant::TenantId;
 
 use super::dispatch::retry;
 use super::{ServerState, projection_backfill};
-use crate::entity_actor::{EntityActor, EntityMsg, EntityResponse};
+use crate::entity_actor::{EntityActor, EntityEvent, EntityMsg, EntityResponse, EntityState};
 use crate::events::EntityStateChange;
 use crate::registry::{VerificationDetail, VerificationStatus};
 use crate::runtime_metrics;
@@ -788,6 +788,207 @@ impl ServerState {
         }
 
         Ok(response)
+    }
+
+    /// Create a durable data-only entity without spawning an actor.
+    ///
+    /// This path is only eligible for transition tables with no rules. It
+    /// preserves the event journal, projection acknowledgement, in-memory
+    /// entity index, and observe/SSE event contracts used by the actor path.
+    #[instrument(skip_all, fields(otel.name = "entity.create_data_only_tenant_entity_fast_path", tenant = %tenant, entity_type, entity_id))]
+    pub async fn try_create_data_only_tenant_entity(
+        &self,
+        tenant: &TenantId,
+        entity_type: &str,
+        entity_id: &str,
+        initial_fields: serde_json::Value,
+    ) -> Result<Option<EntityResponse>, String> {
+        if !initial_fields.is_object() {
+            return Ok(None);
+        }
+        if self.is_pg_actor_backed(tenant, entity_type) {
+            return Ok(None);
+        }
+
+        let table = {
+            let reg = self.registry.read().unwrap();
+            reg.get_table_live(tenant, entity_type)
+        }
+        .or_else(|| {
+            self.transition_tables
+                .get(entity_type)
+                .map(|t| Arc::new(RwLock::new((**t).clone())))
+        });
+        let Some(table_ref) = table else {
+            return Ok(None);
+        };
+        let table = table_ref
+            .read()
+            .expect("transition table lock poisoned")
+            .clone();
+        if !table.rules.is_empty() {
+            return Ok(None);
+        }
+
+        let Some((store, backend)) = self.event_journal() else {
+            return Ok(None);
+        };
+        let Some(query_plane) = self.query_plane_store() else {
+            return Ok(None);
+        };
+
+        let persistence_id = format!("{tenant}:{entity_type}:{entity_id}");
+        let mut fields = initial_fields.clone();
+        if let Some(obj) = fields.as_object_mut() {
+            obj.entry("Id".to_string())
+                .or_insert(serde_json::Value::String(entity_id.to_string()));
+            obj.entry("Status".to_string())
+                .or_insert(serde_json::Value::String(table.initial_state.clone()));
+        }
+
+        let mut state = EntityState {
+            entity_type: entity_type.to_string(),
+            entity_id: entity_id.to_string(),
+            status: table.initial_state.clone(),
+            item_count: 0,
+            counters: BTreeMap::new(),
+            booleans: BTreeMap::new(),
+            lists: BTreeMap::new(),
+            fields,
+            events: std::collections::VecDeque::new(),
+            total_event_count: 0,
+            sequence_nr: 0,
+        };
+
+        let created = EntityEvent {
+            action: "Created".to_string(),
+            from_status: String::new(),
+            to_status: state.status.clone(),
+            timestamp: sim_now(),
+            params: initial_fields,
+        };
+        let payload = serde_json::to_value(&created)
+            .map_err(|e| format!("failed to serialize Created event: {e}"))?;
+        let envelope = PersistenceEnvelope {
+            sequence_nr: 1,
+            event_type: created.action.clone(),
+            payload,
+            metadata: EventMetadata {
+                event_id: sim_uuid(),
+                causation_id: sim_uuid(),
+                correlation_id: sim_uuid(),
+                timestamp: created.timestamp,
+                actor_id: persistence_id.clone(),
+            },
+        };
+
+        let append_started_at = Instant::now(); // determinism-ok: production-only append wait metric
+        let append_result = store
+            .append(&persistence_id, state.sequence_nr, &[envelope])
+            .await;
+        runtime_metrics::record_event_store_append_wait(
+            backend.as_str(),
+            "append",
+            append_started_at.elapsed(),
+        );
+        match append_result {
+            Ok(new_seq) => {
+                state.sequence_nr = new_seq;
+            }
+            Err(PersistenceError::ConcurrencyViolation { .. }) => {
+                return Ok(None);
+            }
+            Err(e) => {
+                return Err(format!(
+                    "failed to persist data-only Created event for {entity_type}:{entity_id}: {e}"
+                ));
+            }
+        }
+        state.push_event_bounded(created);
+
+        let projection_fields = self.query_projection_fields(tenant, entity_type, &state.fields);
+        let operation = "upsert";
+        let source = "data_only_create_fast_path";
+        record_projection_update_started(tenant, entity_type, operation, source);
+        let projection_started_at = Instant::now(); // determinism-ok: production-only projection duration metric
+        if let Err(e) = query_plane
+            .upsert_projection(
+                tenant.as_str(),
+                entity_type,
+                entity_id,
+                &state.status,
+                &projection_fields,
+                state.sequence_nr,
+            )
+            .await
+        {
+            record_projection_update_error(
+                tenant,
+                entity_type,
+                operation,
+                source,
+                projection_started_at,
+            );
+            tracing::error!(
+                error = %e,
+                tenant = %tenant,
+                entity_type = %entity_type,
+                entity_id = %entity_id,
+                "failed to update query projection during data-only create fast path"
+            );
+            return Err(format!(
+                "query projection write failed during data-only create: {e}"
+            ));
+        }
+        record_projection_update_success(
+            tenant,
+            entity_type,
+            operation,
+            source,
+            state.sequence_nr,
+            projection_started_at,
+        );
+
+        {
+            let index_key = format!("{tenant}:{entity_type}");
+            let mut index = self.entity_index.write().unwrap();
+            index
+                .entry(index_key)
+                .or_default()
+                .insert(entity_id.to_string());
+        }
+        runtime_metrics::record_server_state_metrics(self);
+
+        let seq = self.next_entity_event_sequence(tenant.as_str(), entity_type, entity_id);
+        let change = EntityStateChange {
+            seq,
+            entity_type: entity_type.to_string(),
+            entity_id: entity_id.to_string(),
+            action: "Created".to_string(),
+            status: state.status.clone(),
+            tenant: tenant.to_string(),
+            agent_id: None,
+            session_id: None,
+        };
+        self.record_entity_observe_event_with_seq(
+            tenant.as_str(),
+            entity_type,
+            entity_id,
+            seq,
+            "state_change",
+            serde_json::to_value(&change).unwrap_or_default(),
+        );
+        let _ = self.event_tx.send(change);
+
+        Ok(Some(EntityResponse {
+            success: true,
+            state,
+            error: None,
+            custom_effects: vec![],
+            scheduled_actions: vec![],
+            spawn_requests: vec![],
+            spec_governed: true,
+        }))
     }
 
     /// Update fields on an existing entity.

--- a/docs/adrs/0105-data-only-entity-create-fast-path.md
+++ b/docs/adrs/0105-data-only-entity-create-fast-path.md
@@ -1,0 +1,188 @@
+# ADR-0105: Data-Only Entity Create Fast Path
+
+- Status: Proposed
+- Date: 2026-05-19
+- Deciders: Temper core maintainers
+- Related:
+  - ADR-0082: Projection Correctness Observability
+  - ADR-0095: Projection Transaction Fast Path
+  - ADR-0096: Set-Based Projection Index Reconciliation
+  - ADR-0099: Local WASM TData Host Path
+  - ADR-0104: Projection Read Parity And Local Tenant Propagation
+  - `crates/temper-server/src/odata/write.rs`
+  - `crates/temper-server/src/state/entity_ops.rs`
+
+## Context
+
+PERF-026 made TemperPaw's first-turn `SessionEntry` shape headerless. Production
+Datadog evidence on `service.version=8c726f172e709f862b01b5b9c6ed5c1e9ccdd10d`
+shows the provider-response apply envelope is now much lower, but the remaining
+tail is still dominated by creating two `SessionEntry` rows:
+
+- `Session.ProviderResponseReady.integrations`: average about `290.1 ms`
+- `wasm:provider_response_applier`: average about `290.1 ms`
+- `provider_response_applier` `append_session_tree`: average about `136.9 ms`
+- accepted trace `11156646544924625715`: one SessionEntry `POST` costs about
+  `109.7 ms`, the other about `77.9 ms`, and their `http_call_batch` overlap
+  leaves `wasm.invoke.run` at about `145.0 ms`
+
+The `SessionEntry` entity is spec-governed, durable, tenant-scoped, and part of
+the conversation audit trail. It must not become an ad hoc side table. But its
+IOA spec has exactly one state, `Recorded`, and no actions. Creating a
+`SessionEntry` through generic OData currently pays the full actor path anyway:
+
+1. resolve the entity type;
+2. run write prechecks;
+3. spawn a new entity actor;
+4. have actor `pre_start` persist the bootstrap `Created` event;
+5. ask the actor for `GetState`;
+6. write the query projection;
+7. return the OData entity.
+
+That path is correct, but it does more orchestration than a no-transition entity
+needs. The actor has no future transition to evaluate during creation, and the
+initial state can be constructed from the transition table plus request fields.
+
+## Decision
+
+Add a generic data-only create fast path for entities whose `TransitionTable`
+has no transition rules.
+
+### Sub-Decision 1: Detect Eligibility From The Transition Table
+
+An entity type is eligible only when its live transition table has an empty
+`rules` list.
+
+**Why this approach**: The gate is architectural, not entity-name based. It does
+not hardcode `SessionEntry`, `Recorded`, or TemperPaw. A no-rule table means
+there are no input/internal transitions, custom effects, scheduled actions,
+spawns, or WASM triggers to run during create. Entities with any action keep the
+existing actor path.
+
+### Sub-Decision 2: Persist The Same Bootstrap Event
+
+The fast path still writes a `Created` event to the configured event journal
+with sequence `1`, the same action name, initial fields, timestamps, and actor
+ID shape used by entity actors.
+
+**Why this approach**: The event journal remains the source of truth. If the
+entity is later hydrated through `get_tenant_entity_state`, normal actor replay
+can recover the same state from the persisted event.
+
+### Sub-Decision 3: Update The Query Projection Before Acknowledgement
+
+The fast path calls the existing query projection writer before returning HTTP
+`201`. Projection write failure remains a request failure.
+
+**Why this approach**: This preserves the read-after-write contract restored by
+ADR-0104. TemperPaw's `SessionEntry` helper keeps its session-scoped read-back
+verification, so a `201` followed by an invisible row is still detected.
+
+### Sub-Decision 4: Populate In-Memory Indexes Without Hydrating Actors
+
+After the durable event and projection are written, the server updates the
+entity index and emits the same observe/SSE creation event. It does not insert
+an actor into the registry.
+
+**Why this approach**: Collection reads and observe streams remain useful, while
+the hot create path avoids actor spawn and `GetState`. Any later point lookup can
+hydrate the actor from the event journal on demand.
+
+### Sub-Decision 5: Keep OData, Cedar, Tenant, And Precheck Boundaries
+
+The OData write handler still resolves the entity set, applies tenant
+extraction, verification gates, and write prechecks before invoking the fast
+path.
+
+**Why this approach**: The fast path is only a replacement for unnecessary actor
+hydration after the request has already passed the normal public contract.
+
+## Rollout Plan
+
+1. **Phase 0 (Immediate)** - Add the Temper server fast path behind the
+   no-transition-rule eligibility check. Add focused tests using a no-action
+   IOA entity and a normal action-bearing entity.
+2. **Phase 1 (TemperPaw adoption)** - Merge Temper, bump TemperPaw's Temper git
+   rev, deploy, and rerun the headerless `SessionEntry` live proof.
+3. **Phase 2 (Production proof)** - Compare before/after Datadog windows for
+   `Session.ProviderResponseReady.integrations`,
+   `wasm:provider_response_applier`, `POST /tdata/SessionEntries`,
+   `entity.get_or_create_tenant_entity`, and `append_session_tree`.
+
+## Readiness Gates
+
+- Focused Temper server tests prove no-rule entities create through the fast
+  path, write projections, and replay correctly through actor hydration.
+- Focused tests prove action-bearing entities keep the existing actor path.
+- `cargo test -p temper-server` passes.
+- DST review and code review pass before commit.
+- TemperPaw dependency bump passes focused `SessionEntry` tests and full
+  `cargo test --locked -p temperpaw`.
+- Production proof shows no projection/read-back drift and a lower fixed-version
+  provider-response apply tail.
+
+## Consequences
+
+### Positive
+
+- Data-only entities avoid needless actor spawn and `GetState` on create.
+- The optimization is reusable for any generated app entity that is immutable
+  or append-only with no transitions.
+- Event audit, projection correctness, tenant isolation, and OData semantics are
+  preserved.
+
+### Negative
+
+- Entity creation gains a second internal path, so tests must prove both paths
+  stay semantically equivalent.
+- The fast path duplicates a small amount of initial-state/event construction
+  that is currently private to `EntityActor`.
+
+### Risks
+
+- A spec with hidden side effects could be incorrectly classified as data-only.
+  Mitigation: gate strictly on empty `TransitionTable.rules`, which is produced
+  after IOA actions are translated.
+- A projection failure after the event append could leave an event without an
+  indexed row. Mitigation: return an error so callers retry, and keep projection
+  replay/backfill as the repair path.
+- Hydrating an actor after a fast-path create could differ from the returned
+  OData body. Mitigation: add a test that creates through OData, reads through
+  observe/actor state, and compares status/fields/sequence.
+
+### DST Compliance
+
+This touches `temper-server`, a simulation-visible crate. The fast path uses the
+same deterministic scheduler primitives as `EntityActor` for event metadata
+(`sim_now()` and `sim_uuid()`), keeps `BTreeMap`/`BTreeSet` conventions, and
+does not introduce filesystem, network, thread, random, or wall-clock behavior
+inside simulation-visible logic.
+
+## Non-Goals
+
+- No entity-name-specific `SessionEntry` shortcut.
+- No bypass of Cedar/write prechecks.
+- No bypass of event journaling.
+- No bypass of query projection acknowledgement.
+- No change to entities that have any IOA action or integration trigger.
+- No OData `$batch` implementation in this slice.
+
+## Alternatives Considered
+
+1. **Add a TemperPaw-specific SessionEntry bulk endpoint** - Rejected because it
+   would hardcode a product entity into framework code and weaken the platform
+   mission.
+2. **Use OData `$batch`** - Rejected for this slice because it still leaves each
+   entity create on the full actor path unless the server also gets a data-only
+   fast path.
+3. **Remove SessionEntry read-back verification** - Rejected because the recent
+   projection incidents proved that correctness must stay visible.
+4. **Leave the path unchanged** - Safe, but Datadog shows this is now one of the
+   larger remaining avoidable hot-path costs.
+
+## Rollback Policy
+
+Revert the fast-path branch in OData create handling and route all entity-set
+creates back through `get_or_create_tenant_entity`. Persisted events and
+projection rows written by the fast path use the same shape as the actor path, so
+rollback does not require data migration.


### PR DESCRIPTION
## Summary

- Adds a generic OData create fast path for data-only entity specs whose transition table has no action rules.
- Persists the same sequence-1 `Created` event, writes the query projection before acknowledging, updates the entity index, and emits the normal observe/SSE state-change event.
- Falls back to the existing actor path for action-bearing specs, PG actor-backed deployments, duplicates/concurrency, missing storage/query-plane support, or non-object creates.
- Hardens two OS-app reconcile tests against the existing global catalog race that surfaced during the full pre-push suite.

## Why

PERF-026 reduced the provider-response append path, but Datadog trace `11156646544924625715` on production version `8c726f172e709f862b01b5b9c6ed5c1e9ccdd10d` still showed `wasm:provider_response_applier` at `290.616768 ms`, with two data-only `POST /tdata/SessionEntries` spans at roughly `109.7 ms` and `77.9 ms`. Those creates were dominated by actor get/create and spawn work even though `SessionEntry` is a data-only read-model entity.

Baseline window after PERF-026: `2026-05-19T03:25Z..03:50Z`, `Session.ProviderResponseReady.integrations` avg `290.1 ms` / p95 `297.4 ms`, `wasm:provider_response_applier` avg `290.1 ms` / p95 `297.4 ms`, `append_session_tree` avg `136.9 ms`.

This PR is not counted as a performance win until it is deployed and measured against that baseline in TemperPaw production.

## Correctness boundaries

- No entity-name special casing; eligibility is derived from the live `TransitionTable` shape.
- Same durable event contract as actor creation: sequence 1, event type `Created`, deterministic runtime metadata.
- Projection write is part of the acknowledgement path to avoid confirming data that the read model cannot serve.
- Concurrency conflicts fall back to the actor path so current duplicate/idempotency behavior remains intact.
- PG actor-backed runtime stays on the actor path for now.

## Validation

- `cargo fmt`
- `cargo test -p temper-server data_only -- --nocapture`
- `cargo test -p temper-server`
- `cargo test -p temper-platform os_apps::mod_test::test_reconcile_os_app -- --nocapture`
- `scripts/check-determinism.sh` (known repository-wide findings only; new timing line is marked `determinism-ok`)
- `cargo clippy -p temper-server --all-targets -- -D warnings`
- Pre-push gates passed: rustfmt, workspace clippy, readability ratchet, full workspace tests and doctests

## Rollout / measurement plan

1. Merge after review/CI.
2. Update TemperPaw to this Temper revision in a separate PR.
3. Deploy TemperPaw.
4. Run production live proof with new session markers and read-back correctness checks.
5. Query Datadog after-window metrics/traces and compare to the baseline above before marking PERF-027 complete.
