### PR TITLE
[codex] Instrument WASM dispatch envelope phases

### DIFF
--- a/crates/temper-server/src/state/dispatch/wasm.rs
+++ b/crates/temper-server/src/state/dispatch/wasm.rs
@@ -1,5 +1,6 @@
+use std::future::Future;
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use opentelemetry::trace::{Status, TraceContextExt};
 use serde_json::{Value, json};
@@ -42,6 +43,25 @@ struct WasmDispatchCtx<'a> {
 
 const HTTP_CALL_AUTHZ_DENIED_PREFIX: &str = "authorization denied for http_call";
 const MONTY_REPL_MODULE: &str = "monty_repl";
+const WASM_DISPATCH_PHASE_MODULE_CACHE: &str = "dispatch.wasm.phase.module_cache";
+const WASM_DISPATCH_PHASE_REPLAY_INPUT_INJECTION: &str =
+    "dispatch.wasm.phase.replay_input_injection";
+const WASM_DISPATCH_PHASE_INVOCATION_CONTEXT_BUILD: &str =
+    "dispatch.wasm.phase.invocation_context_build";
+const WASM_DISPATCH_PHASE_BLOB_REF_HYDRATION: &str = "dispatch.wasm.phase.blob_ref_hydration";
+const WASM_DISPATCH_PHASE_AUTHZ_SECRET_RESOLUTION: &str =
+    "dispatch.wasm.phase.authz_secret_resolution";
+const WASM_DISPATCH_PHASE_HOST_CHAIN_BUILD: &str = "dispatch.wasm.phase.host_chain_build";
+const WASM_DISPATCH_PHASE_INTEGRATION_OBSERVE_START: &str =
+    "dispatch.wasm.phase.integration_observe_start";
+const WASM_DISPATCH_PHASE_ENGINE_INVOKE_AND_HANDLE: &str =
+    "dispatch.wasm.phase.engine_invoke_and_handle";
+const WASM_DISPATCH_PHASE_ENGINE_INVOKE: &str = "dispatch.wasm.phase.engine_invoke";
+const WASM_DISPATCH_PHASE_RESULT_OBSERVE_COMPLETE: &str =
+    "dispatch.wasm.phase.result_observe_complete";
+const WASM_DISPATCH_PHASE_RECORD_INVOCATION: &str = "dispatch.wasm.phase.record_invocation";
+const WASM_DISPATCH_PHASE_DISPATCH_CALLBACK: &str = "dispatch.wasm.phase.dispatch_callback";
+const WASM_DISPATCH_PHASE_LLMOBS_SUBMIT: &str = "dispatch.wasm.phase.llmobs_submit";
 
 fn http_call_authz_denied_error(reason: &str) -> String {
     format!("{HTTP_CALL_AUTHZ_DENIED_PREFIX}: {reason}")
@@ -63,6 +83,90 @@ fn llmobs_service_name() -> String {
         return value;
     }
     "temper-platform".to_string()
+}
+
+fn wasm_dispatch_phase_slug(phase_name: &'static str) -> &'static str {
+    phase_name
+        .strip_prefix("dispatch.wasm.phase.")
+        .unwrap_or(phase_name)
+}
+
+fn wasm_dispatch_phase_span(
+    parent_span: &Span,
+    ctx: &WasmDispatchCtx<'_>,
+    module_name: &str,
+    phase_name: &'static str,
+) -> Span {
+    let phase = wasm_dispatch_phase_slug(phase_name);
+    tracing::info_span!(
+        parent: parent_span,
+        "dispatch.wasm.phase",
+        otel.name = phase_name,
+        phase = phase,
+        tenant = %ctx.entity_ref.tenant,
+        entity_type = ctx.entity_ref.entity_type,
+        entity_id = ctx.entity_ref.entity_id,
+        trigger_action = ctx.action,
+        wasm.module = module_name,
+        result = tracing::field::Empty,
+        duration_ms = tracing::field::Empty,
+    )
+}
+
+fn record_wasm_dispatch_phase(span: &Span, started_at: Instant, result: &'static str) {
+    span.record("duration_ms", started_at.elapsed().as_secs_f64() * 1_000.0);
+    span.record("result", result);
+}
+
+fn with_wasm_dispatch_phase<T>(
+    parent_span: &Span,
+    ctx: &WasmDispatchCtx<'_>,
+    module_name: &str,
+    phase_name: &'static str,
+    work: impl FnOnce() -> T,
+) -> T {
+    let span = wasm_dispatch_phase_span(parent_span, ctx, module_name, phase_name);
+    let started_at = Instant::now(); // determinism-ok: observability-only span duration
+    let _guard = span.enter();
+    let output = work();
+    drop(_guard);
+    record_wasm_dispatch_phase(&span, started_at, "ok");
+    output
+}
+
+async fn instrument_wasm_dispatch_phase<T, F>(
+    parent_span: Span,
+    ctx: &WasmDispatchCtx<'_>,
+    module_name: &str,
+    phase_name: &'static str,
+    future: F,
+) -> T
+where
+    F: Future<Output = T>,
+{
+    let span = wasm_dispatch_phase_span(&parent_span, ctx, module_name, phase_name);
+    let started_at = Instant::now(); // determinism-ok: observability-only span duration
+    let output = future.instrument(span.clone()).await;
+    record_wasm_dispatch_phase(&span, started_at, "ok");
+    output
+}
+
+async fn instrument_wasm_dispatch_phase_result<T, E, F>(
+    parent_span: Span,
+    ctx: &WasmDispatchCtx<'_>,
+    module_name: &str,
+    phase_name: &'static str,
+    future: F,
+) -> Result<T, E>
+where
+    F: Future<Output = Result<T, E>>,
+{
+    let span = wasm_dispatch_phase_span(&parent_span, ctx, module_name, phase_name);
+    let started_at = Instant::now(); // determinism-ok: observability-only span duration
+    let result = future.instrument(span.clone()).await;
+    let status = if result.is_ok() { "ok" } else { "error" };
+    record_wasm_dispatch_phase(&span, started_at, status);
+    result
 }
 
 fn local_blob_binary_interceptor(
@@ -343,6 +447,7 @@ impl crate::state::ServerState {
             None
         };
         let active_span = llm_root_span.as_ref().unwrap_or(&current_span);
+        let active_parent_span: Span = active_span.clone();
         active_span.record("otel.name", format!("wasm:{module_name}").as_str());
         active_span.record("wasm.module", module_name.as_str());
 
@@ -360,55 +465,81 @@ impl crate::state::ServerState {
                 .handle_module_not_found(ctx, integration, &module_name)
                 .await;
         };
-        self.ensure_wasm_module_cached(ctx.entity_ref.tenant, &module_name, &hash)
-            .await?;
-        let trigger_params = self
-            .maybe_inject_ots_trajectory_actions(&module_name, ctx, action_params)
-            .await;
+        instrument_wasm_dispatch_phase_result(
+            active_parent_span.clone(),
+            ctx,
+            &module_name,
+            WASM_DISPATCH_PHASE_MODULE_CACHE,
+            self.ensure_wasm_module_cached(ctx.entity_ref.tenant, &module_name, &hash),
+        )
+        .await?;
+        let trigger_params = instrument_wasm_dispatch_phase(
+            active_parent_span.clone(),
+            ctx,
+            &module_name,
+            WASM_DISPATCH_PHASE_REPLAY_INPUT_INJECTION,
+            self.maybe_inject_ots_trajectory_actions(&module_name, ctx, action_params),
+        )
+        .await;
 
         // --- Build invocation context + host chain ---
-        let authz_ctx = WasmAuthzContext {
-            tenant: ctx.entity_ref.tenant.to_string(),
-            module_name: module_name.clone(),
-            agent_id: ctx.agent_ctx.agent_id.clone(),
-            session_id: ctx.agent_ctx.session_id.clone(),
-            entity_type: ctx.entity_ref.entity_type.to_string(),
-            trigger_action: ctx.action.to_string(),
-        };
-        let mut inv_ctx = WasmInvocationContext {
-            tenant: ctx.entity_ref.tenant.to_string(),
-            entity_type: ctx.entity_ref.entity_type.to_string(),
-            entity_id: ctx.entity_ref.entity_id.to_string(),
-            trigger_action: ctx.action.to_string(),
-            wasm_module: Some(module_name.clone()),
-            trigger_params,
-            entity_state: serde_json::to_value(entity_state).unwrap_or_default(),
-            agent_id: ctx.agent_ctx.agent_id.clone(),
-            session_id: ctx.agent_ctx.session_id.clone(),
-            integration_config: match self.secrets_vault.as_ref() {
-                Some(vault) => resolve_secret_templates(
-                    &integration.config,
-                    vault,
-                    &ctx.entity_ref.tenant.to_string(),
-                ),
-                None => integration.config.clone(),
+        let (authz_ctx, mut inv_ctx) = with_wasm_dispatch_phase(
+            &active_parent_span,
+            ctx,
+            &module_name,
+            WASM_DISPATCH_PHASE_INVOCATION_CONTEXT_BUILD,
+            || {
+                let authz_ctx = WasmAuthzContext {
+                    tenant: ctx.entity_ref.tenant.to_string(),
+                    module_name: module_name.clone(),
+                    agent_id: ctx.agent_ctx.agent_id.clone(),
+                    session_id: ctx.agent_ctx.session_id.clone(),
+                    entity_type: ctx.entity_ref.entity_type.to_string(),
+                    trigger_action: ctx.action.to_string(),
+                };
+                let inv_ctx = WasmInvocationContext {
+                    tenant: ctx.entity_ref.tenant.to_string(),
+                    entity_type: ctx.entity_ref.entity_type.to_string(),
+                    entity_id: ctx.entity_ref.entity_id.to_string(),
+                    trigger_action: ctx.action.to_string(),
+                    wasm_module: Some(module_name.clone()),
+                    trigger_params,
+                    entity_state: serde_json::to_value(entity_state).unwrap_or_default(),
+                    agent_id: ctx.agent_ctx.agent_id.clone(),
+                    session_id: ctx.agent_ctx.session_id.clone(),
+                    integration_config: match self.secrets_vault.as_ref() {
+                        Some(vault) => resolve_secret_templates(
+                            &integration.config,
+                            vault,
+                            &ctx.entity_ref.tenant.to_string(),
+                        ),
+                        None => integration.config.clone(),
+                    },
+                    trace_id: current_otel_trace_id(active_span)
+                        .or_else(|| ctx.agent_ctx.trace_id.clone())
+                        .unwrap_or_default(),
+                    workflow_root_entity_type: ctx.agent_ctx.workflow_root_entity_type.clone(),
+                    workflow_root_entity_id: ctx.agent_ctx.workflow_root_entity_id.clone(),
+                    workflow_run_id: ctx.agent_ctx.workflow_run_id.clone(),
+                    http_request: None,
+                };
+                (authz_ctx, inv_ctx)
             },
-            trace_id: current_otel_trace_id(active_span)
-                .or_else(|| ctx.agent_ctx.trace_id.clone())
-                .unwrap_or_default(),
-            workflow_root_entity_type: ctx.agent_ctx.workflow_root_entity_type.clone(),
-            workflow_root_entity_id: ctx.agent_ctx.workflow_root_entity_id.clone(),
-            workflow_run_id: ctx.agent_ctx.workflow_run_id.clone(),
-            http_request: None,
-        };
+        );
         // ADR-0046: inline-hydrate blob refs below the 128KB ceiling; defer
         // oversize refs into a blob_cache the WASM guest can read via
         // host_read_field_stream. No-op on tenants without a Turso store.
-        let blob_cache = crate::blobs::hydrate_blob_refs_for_tenant_with_ceiling(
-            self,
-            ctx.entity_ref.tenant,
-            &mut inv_ctx.entity_state,
-            crate::entity_actor::effects::DEFAULT_FIELD_INLINE_MAX,
+        let blob_cache = instrument_wasm_dispatch_phase(
+            active_parent_span.clone(),
+            ctx,
+            &module_name,
+            WASM_DISPATCH_PHASE_BLOB_REF_HYDRATION,
+            crate::blobs::hydrate_blob_refs_for_tenant_with_ceiling(
+                self,
+                ctx.entity_ref.tenant,
+                &mut inv_ctx.entity_state,
+                crate::entity_actor::effects::DEFAULT_FIELD_INLINE_MAX,
+            ),
         )
         .await;
         let denial_tracker = HttpCallAuthzDenialTracker::default();
@@ -416,157 +547,187 @@ impl crate::state::ServerState {
             base_gate.clone(),
             denial_tracker.clone(),
         ));
-        let tenant_secrets =
-            self.get_authorized_wasm_secrets(ctx.entity_ref.tenant, &*gate, &authz_ctx);
-        let local_blob_interceptor = local_blob_binary_interceptor(
-            self.clone(),
-            ctx.entity_ref.tenant.clone(),
-            tenant_secrets.get("blob_endpoint").cloned(),
+        let tenant_secrets = with_wasm_dispatch_phase(
+            &active_parent_span,
+            ctx,
+            &module_name,
+            WASM_DISPATCH_PHASE_AUTHZ_SECRET_RESOLUTION,
+            || self.get_authorized_wasm_secrets(ctx.entity_ref.tenant, &*gate, &authz_ctx),
         );
-        let local_file_interceptor = local_file_value_text_interceptor(
-            self.clone(),
-            ctx.entity_ref.tenant.clone(),
-            ctx.agent_ctx.clone(),
-            tenant_secrets.get("temper_api_url").cloned(),
+        let (host, limits) = with_wasm_dispatch_phase(
+            &active_parent_span,
+            ctx,
+            &module_name,
+            WASM_DISPATCH_PHASE_HOST_CHAIN_BUILD,
+            || {
+                let local_blob_interceptor = local_blob_binary_interceptor(
+                    self.clone(),
+                    ctx.entity_ref.tenant.clone(),
+                    tenant_secrets.get("blob_endpoint").cloned(),
+                );
+                let local_file_interceptor = local_file_value_text_interceptor(
+                    self.clone(),
+                    ctx.entity_ref.tenant.clone(),
+                    ctx.agent_ctx.clone(),
+                    tenant_secrets.get("temper_api_url").cloned(),
+                );
+                // Use integration config timeout for both WASM execution and HTTP client.
+                //
+                // When no explicit `timeout_secs` is configured, fall back to the
+                // platform default (`WasmResourceLimits::default().max_duration`, 120s
+                // per ADR-0045). The fallback is observable:
+                //   - `tracing::warn!` for human debugging
+                //   - counter `temper_wasm_integration_default_timeout_used_total` for alerting
+                //   - span attribute `wasm.timeout_source = default` for APM correlation
+                //
+                // Apps that fire the counter frequently should wire an explicit
+                // `timeout_secs` in their integration config.
+                let explicit_timeout = integration
+                    .config
+                    .get("timeout_secs")
+                    .and_then(|s| s.parse::<u64>().ok())
+                    .map(std::time::Duration::from_secs);
+                let http_timeout =
+                    explicit_timeout.unwrap_or_else(|| WasmResourceLimits::default().max_duration);
+                if explicit_timeout.is_some() {
+                    active_span.record("wasm.timeout_source", "explicit");
+                } else {
+                    active_span.record("wasm.timeout_source", "default");
+                    // ADR-0054 warn-audit: default-timeout fallback is a configuration
+                    // observation, not an actionable condition. The metric below is
+                    // the alerting signal; this log is purely local-dev diagnostic.
+                    tracing::debug!(
+                        tenant = %ctx.entity_ref.tenant,
+                        entity_type = ctx.entity_ref.entity_type,
+                        entity_id = ctx.entity_ref.entity_id,
+                        integration = %integration.name,
+                        module = %module_name,
+                        default_timeout_secs = http_timeout.as_secs(),
+                        "WASM integration falling back to default timeout — wire `timeout_secs` explicitly in integration config"
+                    );
+                    crate::runtime_metrics::record_wasm_default_timeout_used(
+                        ctx.entity_ref.tenant.as_str(),
+                        ctx.entity_ref.entity_type,
+                        module_name.as_str(),
+                    );
+                }
+                let progress_emitter = progress_emitter_fn(
+                    self.clone(),
+                    ctx.entity_ref.tenant.to_string(),
+                    ctx.entity_ref.entity_type.to_string(),
+                    ctx.entity_ref.entity_id.to_string(),
+                    module_name.clone(),
+                );
+                let host_invocation_context = inv_ctx.clone();
+                let internal_api_key = std::env::var("TEMPER_API_KEY").ok();
+                let internal_api_url = internal_api_base_url(self);
+                let production_host: Arc<dyn WasmHost> = Arc::new(
+                    ProductionWasmHost::with_timeout(tenant_secrets, http_timeout)
+                        .with_binary_http_interceptor(
+                            local_blob_interceptor
+                                .unwrap_or_else(|| Arc::new(|_, _, _, _| Box::pin(async { None }))),
+                        )
+                        .with_spec_evaluator(spec_evaluator_fn())
+                        .with_progress_emitter(progress_emitter)
+                        .with_internal_api_base_url(internal_api_url)
+                        .with_internal_api_key(internal_api_key)
+                        .with_invocation_context(host_invocation_context)
+                        .with_text_http_interceptor(
+                            local_file_interceptor
+                                .unwrap_or_else(|| Arc::new(|_, _, _, _| Box::pin(async { None }))),
+                        )
+                        .with_trace_id(
+                            current_otel_trace_id(active_span)
+                                .or_else(|| ctx.agent_ctx.trace_id.clone()),
+                        ),
+                );
+                let inner: Arc<dyn WasmHost> = Arc::new(LocalTDataWasmHost::new(
+                    self.clone(),
+                    ctx.entity_ref.tenant.clone(),
+                    production_host,
+                ));
+                let host: Arc<dyn WasmHost> =
+                    Arc::new(AuthorizedWasmHost::new(inner, gate, authz_ctx));
+                let max_response_bytes = integration
+                    .config
+                    .get("max_response_bytes")
+                    .and_then(|s| s.parse::<usize>().ok())
+                    .unwrap_or(WasmResourceLimits::default().max_response_bytes);
+                let max_fuel = integration
+                    .config
+                    .get("max_fuel")
+                    .and_then(|s| s.parse::<u64>().ok())
+                    .unwrap_or(WasmResourceLimits::default().max_fuel);
+                let max_memory = integration
+                    .config
+                    .get("max_memory")
+                    .and_then(|s| s.parse::<usize>().ok())
+                    .unwrap_or(WasmResourceLimits::default().max_memory);
+                let limits = WasmResourceLimits {
+                    max_duration: http_timeout,
+                    max_response_bytes,
+                    max_fuel,
+                    max_memory,
+                };
+                (host, limits)
+            },
         );
-        // Use integration config timeout for both WASM execution and HTTP client.
-        //
-        // When no explicit `timeout_secs` is configured, fall back to the
-        // platform default (`WasmResourceLimits::default().max_duration`, 120s
-        // per ADR-0045). The fallback is observable:
-        //   - `tracing::warn!` for human debugging
-        //   - counter `temper_wasm_integration_default_timeout_used_total` for alerting
-        //   - span attribute `wasm.timeout_source = default` for APM correlation
-        //
-        // Apps that fire the counter frequently should wire an explicit
-        // `timeout_secs` in their integration config.
-        let explicit_timeout = integration
-            .config
-            .get("timeout_secs")
-            .and_then(|s| s.parse::<u64>().ok())
-            .map(std::time::Duration::from_secs);
-        let http_timeout =
-            explicit_timeout.unwrap_or_else(|| WasmResourceLimits::default().max_duration);
-        if explicit_timeout.is_some() {
-            active_span.record("wasm.timeout_source", "explicit");
-        } else {
-            active_span.record("wasm.timeout_source", "default");
-            // ADR-0054 warn-audit: default-timeout fallback is a configuration
-            // observation, not an actionable condition. The metric below is
-            // the alerting signal; this log is purely local-dev diagnostic.
-            tracing::debug!(
-                tenant = %ctx.entity_ref.tenant,
-                entity_type = ctx.entity_ref.entity_type,
-                entity_id = ctx.entity_ref.entity_id,
-                integration = %integration.name,
-                module = %module_name,
-                default_timeout_secs = http_timeout.as_secs(),
-                "WASM integration falling back to default timeout — wire `timeout_secs` explicitly in integration config"
-            );
-            crate::runtime_metrics::record_wasm_default_timeout_used(
-                ctx.entity_ref.tenant.as_str(),
-                ctx.entity_ref.entity_type,
-                module_name.as_str(),
-            );
-        }
-        let progress_emitter = progress_emitter_fn(
-            self.clone(),
-            ctx.entity_ref.tenant.to_string(),
-            ctx.entity_ref.entity_type.to_string(),
-            ctx.entity_ref.entity_id.to_string(),
-            module_name.clone(),
-        );
-        let host_invocation_context = inv_ctx.clone();
-        let internal_api_key = std::env::var("TEMPER_API_KEY").ok();
-        let internal_api_url = internal_api_base_url(self);
-        let production_host: Arc<dyn WasmHost> = Arc::new(
-            ProductionWasmHost::with_timeout(tenant_secrets, http_timeout)
-                .with_binary_http_interceptor(
-                    local_blob_interceptor
-                        .unwrap_or_else(|| Arc::new(|_, _, _, _| Box::pin(async { None }))),
-                )
-                .with_spec_evaluator(spec_evaluator_fn())
-                .with_progress_emitter(progress_emitter)
-                .with_internal_api_base_url(internal_api_url)
-                .with_internal_api_key(internal_api_key)
-                .with_invocation_context(host_invocation_context)
-                .with_text_http_interceptor(
-                    local_file_interceptor
-                        .unwrap_or_else(|| Arc::new(|_, _, _, _| Box::pin(async { None }))),
-                )
-                .with_trace_id(
-                    current_otel_trace_id(active_span).or_else(|| ctx.agent_ctx.trace_id.clone()),
-                ),
-        );
-        let inner: Arc<dyn WasmHost> = Arc::new(LocalTDataWasmHost::new(
-            self.clone(),
-            ctx.entity_ref.tenant.clone(),
-            production_host,
-        ));
-        let host: Arc<dyn WasmHost> = Arc::new(AuthorizedWasmHost::new(inner, gate, authz_ctx));
-        let max_response_bytes = integration
-            .config
-            .get("max_response_bytes")
-            .and_then(|s| s.parse::<usize>().ok())
-            .unwrap_or(WasmResourceLimits::default().max_response_bytes);
-        let max_fuel = integration
-            .config
-            .get("max_fuel")
-            .and_then(|s| s.parse::<u64>().ok())
-            .unwrap_or(WasmResourceLimits::default().max_fuel);
-        let max_memory = integration
-            .config
-            .get("max_memory")
-            .and_then(|s| s.parse::<usize>().ok())
-            .unwrap_or(WasmResourceLimits::default().max_memory);
-        let limits = WasmResourceLimits {
-            max_duration: http_timeout,
-            max_response_bytes,
-            max_fuel,
-            max_memory,
-        };
 
-        tracing::info!(
-            tenant = %ctx.entity_ref.tenant,
-            entity_type = ctx.entity_ref.entity_type,
-            entity_id = ctx.entity_ref.entity_id,
-            integration = %integration.name,
-            module = %module_name,
-            hash = %hash,
-            "invoking WASM integration module"
-        );
-        let start_seq = self.next_entity_event_sequence(
-            ctx.entity_ref.tenant.as_str(),
-            ctx.entity_ref.entity_type,
-            ctx.entity_ref.entity_id,
-        );
-        self.record_entity_observe_event_with_seq(
-            ctx.entity_ref.tenant.as_str(),
-            ctx.entity_ref.entity_type,
-            ctx.entity_ref.entity_id,
-            start_seq,
-            "integration_start",
-            serde_json::json!({
-                "seq": start_seq,
-                "integration": integration.name,
-                "module": module_name,
-                "trigger_action": ctx.action,
-            }),
+        with_wasm_dispatch_phase(
+            &active_parent_span,
+            ctx,
+            &module_name,
+            WASM_DISPATCH_PHASE_INTEGRATION_OBSERVE_START,
+            || {
+                tracing::info!(
+                    tenant = %ctx.entity_ref.tenant,
+                    entity_type = ctx.entity_ref.entity_type,
+                    entity_id = ctx.entity_ref.entity_id,
+                    integration = %integration.name,
+                    module = %module_name,
+                    hash = %hash,
+                    "invoking WASM integration module"
+                );
+                let start_seq = self.next_entity_event_sequence(
+                    ctx.entity_ref.tenant.as_str(),
+                    ctx.entity_ref.entity_type,
+                    ctx.entity_ref.entity_id,
+                );
+                self.record_entity_observe_event_with_seq(
+                    ctx.entity_ref.tenant.as_str(),
+                    ctx.entity_ref.entity_type,
+                    ctx.entity_ref.entity_id,
+                    start_seq,
+                    "integration_start",
+                    serde_json::json!({
+                        "seq": start_seq,
+                        "integration": integration.name,
+                        "module": module_name,
+                        "trigger_action": ctx.action,
+                    }),
+                );
+            },
         );
 
         // --- Invoke and handle result ---
-        let invoke = self.invoke_and_handle_result(
+        let invoke = instrument_wasm_dispatch_phase_result(
+            active_parent_span,
             ctx,
-            integration,
             &module_name,
-            &hash,
-            entity_state,
-            inv_ctx,
-            host,
-            &limits,
-            &denial_tracker,
-            blob_cache,
-            llm_parent_span_id.as_deref(),
+            WASM_DISPATCH_PHASE_ENGINE_INVOKE_AND_HANDLE,
+            self.invoke_and_handle_result(
+                ctx,
+                integration,
+                &module_name,
+                &hash,
+                entity_state,
+                inv_ctx,
+                host,
+                &limits,
+                &denial_tracker,
+                blob_cache,
+                llm_parent_span_id.as_deref(),
+            ),
         );
 
         if let Some(span) = llm_root_span {
@@ -758,11 +919,17 @@ impl crate::state::ServerState {
     ) -> Result<Option<EntityResponse>, String> {
         // Existing action-triggered invocations don't use streams — pass empty registry.
         let streams = Arc::new(std::sync::RwLock::new(StreamRegistry::default()));
-        match self
-            .wasm_engine
-            .invoke_with_blobs(hash, &inv_ctx, host, limits, streams, blob_cache)
-            .await
-        {
+        let phase_parent_span = Span::current();
+        let invoke_result = instrument_wasm_dispatch_phase_result(
+            phase_parent_span.clone(),
+            ctx,
+            module_name,
+            WASM_DISPATCH_PHASE_ENGINE_INVOKE,
+            self.wasm_engine
+                .invoke_with_blobs(hash, &inv_ctx, host, limits, streams, blob_cache),
+        )
+        .await;
+        match invoke_result {
             Ok(mut result) if result.success => {
                 if integration.llm {
                     let session_id = ctx
@@ -830,26 +997,34 @@ impl crate::state::ServerState {
                     }
                 }
 
-                let complete_seq = self.next_entity_event_sequence(
-                    ctx.entity_ref.tenant.as_str(),
-                    ctx.entity_ref.entity_type,
-                    ctx.entity_ref.entity_id,
-                );
-                self.record_entity_observe_event_with_seq(
-                    ctx.entity_ref.tenant.as_str(),
-                    ctx.entity_ref.entity_type,
-                    ctx.entity_ref.entity_id,
-                    complete_seq,
-                    "integration_complete",
-                    serde_json::json!({
-                        "seq": complete_seq,
-                        "integration": integration.name,
-                        "module": module_name,
-                        "trigger_action": ctx.action,
-                        "result": "success",
-                        "callback_action": result.callback_action.clone(),
-                        "duration_ms": result.duration_ms,
-                    }),
+                with_wasm_dispatch_phase(
+                    &phase_parent_span,
+                    ctx,
+                    module_name,
+                    WASM_DISPATCH_PHASE_RESULT_OBSERVE_COMPLETE,
+                    || {
+                        let complete_seq = self.next_entity_event_sequence(
+                            ctx.entity_ref.tenant.as_str(),
+                            ctx.entity_ref.entity_type,
+                            ctx.entity_ref.entity_id,
+                        );
+                        self.record_entity_observe_event_with_seq(
+                            ctx.entity_ref.tenant.as_str(),
+                            ctx.entity_ref.entity_type,
+                            ctx.entity_ref.entity_id,
+                            complete_seq,
+                            "integration_complete",
+                            serde_json::json!({
+                                "seq": complete_seq,
+                                "integration": integration.name,
+                                "module": module_name,
+                                "trigger_action": ctx.action,
+                                "result": "success",
+                                "callback_action": result.callback_action.clone(),
+                                "duration_ms": result.duration_ms,
+                            }),
+                        );
+                    },
                 );
                 if let Some(reason) = denial_tracker.take_denial() {
                     let error_str = http_call_authz_denied_error(&reason);
@@ -867,32 +1042,58 @@ impl crate::state::ServerState {
                 }
 
                 if integration.llm {
-                    let event =
-                        llm_call_wide_event(ctx, entity_state, callback_params, result.duration_ms);
-                    temper_observe::wide_event::emit_span(&event);
-                    temper_observe::wide_event::emit_metrics(&event);
-                    submit_llmobs_llm_span(
+                    instrument_wasm_dispatch_phase(
+                        phase_parent_span.clone(),
                         ctx,
-                        entity_state,
-                        callback_params,
-                        result.duration_ms,
                         module_name,
+                        WASM_DISPATCH_PHASE_LLMOBS_SUBMIT,
+                        async {
+                            let event = llm_call_wide_event(
+                                ctx,
+                                entity_state,
+                                callback_params,
+                                result.duration_ms,
+                            );
+                            temper_observe::wide_event::emit_span(&event);
+                            temper_observe::wide_event::emit_metrics(&event);
+                            submit_llmobs_llm_span(
+                                ctx,
+                                entity_state,
+                                callback_params,
+                                result.duration_ms,
+                                module_name,
+                            )
+                            .await;
+                        },
                     )
                     .await;
                 }
                 if module_name == MONTY_REPL_MODULE {
-                    submit_llmobs_tool_spans(ctx, entity_state, callback_params).await;
+                    instrument_wasm_dispatch_phase(
+                        phase_parent_span.clone(),
+                        ctx,
+                        module_name,
+                        WASM_DISPATCH_PHASE_LLMOBS_SUBMIT,
+                        submit_llmobs_tool_spans(ctx, entity_state, callback_params),
+                    )
+                    .await;
                 }
 
-                self.record_invocation(
-                    ctx.entity_ref,
+                instrument_wasm_dispatch_phase(
+                    phase_parent_span.clone(),
+                    ctx,
                     module_name,
-                    ctx.action,
-                    Some(result.callback_action.clone()),
-                    true,
-                    None,
-                    result.duration_ms,
-                    None,
+                    WASM_DISPATCH_PHASE_RECORD_INVOCATION,
+                    self.record_invocation(
+                        ctx.entity_ref,
+                        module_name,
+                        ctx.action,
+                        Some(result.callback_action.clone()),
+                        true,
+                        None,
+                        result.duration_ms,
+                        None,
+                    ),
                 )
                 .await;
 
@@ -903,43 +1104,57 @@ impl crate::state::ServerState {
                     .as_deref()
                     .unwrap_or(&result.callback_action);
 
-                if !callback_action.is_empty()
-                    && let Some(resp) = self
-                        .dispatch_wasm_callback(
+                if !callback_action.is_empty() {
+                    let callback_response = instrument_wasm_dispatch_phase_result(
+                        phase_parent_span.clone(),
+                        ctx,
+                        module_name,
+                        WASM_DISPATCH_PHASE_DISPATCH_CALLBACK,
+                        self.dispatch_wasm_callback(
                             ctx.entity_ref,
                             callback_action,
                             strip_private_observability_params(result.callback_params),
                             ctx.agent_ctx,
                             ctx.mode,
-                        )
-                        .await?
-                {
-                    return Ok(Some(resp));
+                        ),
+                    )
+                    .await?;
+                    if let Some(resp) = callback_response {
+                        return Ok(Some(resp));
+                    }
                 }
                 Ok(None)
             }
             Ok(result) => {
-                let complete_seq = self.next_entity_event_sequence(
-                    ctx.entity_ref.tenant.as_str(),
-                    ctx.entity_ref.entity_type,
-                    ctx.entity_ref.entity_id,
-                );
-                self.record_entity_observe_event_with_seq(
-                    ctx.entity_ref.tenant.as_str(),
-                    ctx.entity_ref.entity_type,
-                    ctx.entity_ref.entity_id,
-                    complete_seq,
-                    "integration_complete",
-                    serde_json::json!({
-                        "seq": complete_seq,
-                        "integration": integration.name,
-                        "module": module_name,
-                        "trigger_action": ctx.action,
-                        "result": "failure",
-                        "callback_action": result.callback_action.clone(),
-                        "duration_ms": result.duration_ms,
-                        "error": result.error.clone(),
-                    }),
+                with_wasm_dispatch_phase(
+                    &phase_parent_span,
+                    ctx,
+                    module_name,
+                    WASM_DISPATCH_PHASE_RESULT_OBSERVE_COMPLETE,
+                    || {
+                        let complete_seq = self.next_entity_event_sequence(
+                            ctx.entity_ref.tenant.as_str(),
+                            ctx.entity_ref.entity_type,
+                            ctx.entity_ref.entity_id,
+                        );
+                        self.record_entity_observe_event_with_seq(
+                            ctx.entity_ref.tenant.as_str(),
+                            ctx.entity_ref.entity_type,
+                            ctx.entity_ref.entity_id,
+                            complete_seq,
+                            "integration_complete",
+                            serde_json::json!({
+                                "seq": complete_seq,
+                                "integration": integration.name,
+                                "module": module_name,
+                                "trigger_action": ctx.action,
+                                "result": "failure",
+                                "callback_action": result.callback_action.clone(),
+                                "duration_ms": result.duration_ms,
+                                "error": result.error.clone(),
+                            }),
+                        );
+                    },
                 );
                 let mut error_str = result.error.unwrap_or_else(|| {
                     format!(
@@ -962,26 +1177,34 @@ impl crate::state::ServerState {
                 .await
             }
             Err(e) => {
-                let complete_seq = self.next_entity_event_sequence(
-                    ctx.entity_ref.tenant.as_str(),
-                    ctx.entity_ref.entity_type,
-                    ctx.entity_ref.entity_id,
-                );
-                self.record_entity_observe_event_with_seq(
-                    ctx.entity_ref.tenant.as_str(),
-                    ctx.entity_ref.entity_type,
-                    ctx.entity_ref.entity_id,
-                    complete_seq,
-                    "integration_complete",
-                    serde_json::json!({
-                        "seq": complete_seq,
-                        "integration": integration.name,
-                        "module": module_name,
-                        "trigger_action": ctx.action,
-                        "result": "error",
-                        "duration_ms": 0,
-                        "error": e.to_string(),
-                    }),
+                with_wasm_dispatch_phase(
+                    &phase_parent_span,
+                    ctx,
+                    module_name,
+                    WASM_DISPATCH_PHASE_RESULT_OBSERVE_COMPLETE,
+                    || {
+                        let complete_seq = self.next_entity_event_sequence(
+                            ctx.entity_ref.tenant.as_str(),
+                            ctx.entity_ref.entity_type,
+                            ctx.entity_ref.entity_id,
+                        );
+                        self.record_entity_observe_event_with_seq(
+                            ctx.entity_ref.tenant.as_str(),
+                            ctx.entity_ref.entity_type,
+                            ctx.entity_ref.entity_id,
+                            complete_seq,
+                            "integration_complete",
+                            serde_json::json!({
+                                "seq": complete_seq,
+                                "integration": integration.name,
+                                "module": module_name,
+                                "trigger_action": ctx.action,
+                                "result": "error",
+                                "duration_ms": 0,
+                                "error": e.to_string(),
+                            }),
+                        );
+                    },
                 );
                 let mut error_str = e.to_string();
                 if let Some(reason) = denial_tracker.take_denial()

--- a/crates/temper-server/tests/wasm_dispatch_observability_contract.rs
+++ b/crates/temper-server/tests/wasm_dispatch_observability_contract.rs
@@ -1,0 +1,29 @@
+//! Observability contract tests for WASM dispatch attribution.
+
+const WASM_DISPATCH_SOURCE: &str = include_str!("../src/state/dispatch/wasm.rs");
+
+#[test]
+fn wasm_dispatch_emits_integration_envelope_phase_spans() {
+    let required_phases = [
+        "dispatch.wasm.phase.module_cache",
+        "dispatch.wasm.phase.replay_input_injection",
+        "dispatch.wasm.phase.invocation_context_build",
+        "dispatch.wasm.phase.blob_ref_hydration",
+        "dispatch.wasm.phase.authz_secret_resolution",
+        "dispatch.wasm.phase.host_chain_build",
+        "dispatch.wasm.phase.integration_observe_start",
+        "dispatch.wasm.phase.engine_invoke_and_handle",
+        "dispatch.wasm.phase.engine_invoke",
+        "dispatch.wasm.phase.result_observe_complete",
+        "dispatch.wasm.phase.record_invocation",
+        "dispatch.wasm.phase.dispatch_callback",
+        "dispatch.wasm.phase.llmobs_submit",
+    ];
+
+    for phase in required_phases {
+        assert!(
+            WASM_DISPATCH_SOURCE.contains(phase),
+            "missing required WASM dispatch observability phase span: {phase}"
+        );
+    }
+}

--- a/docs/adrs/0106-wasm-integration-envelope-attribution.md
+++ b/docs/adrs/0106-wasm-integration-envelope-attribution.md
@@ -1,0 +1,157 @@
+# ADR-0106: WASM Integration Envelope Attribution
+
+- Status: Proposed
+- Date: 2026-05-19
+- Deciders: Temper core maintainers
+- Related:
+  - ADR-0083: WASM Host Span Hint Datadog Fields
+  - ADR-0086: WASM Host Boundary Observability
+  - ADR-0087: WASM Guest Observability Host API
+  - ADR-0100: WASM Invocation Phase Observability
+  - ADR-0105: Data-Only Entity Create Fast Path
+  - `crates/temper-server/src/state/dispatch/wasm.rs`
+  - `crates/temper-wasm/src/engine/mod.rs`
+
+## Context
+
+The latency program now requires every improvement to carry before/after evidence from live runs
+and Datadog. PERF-028 proved this discipline is necessary: after replacing strict SessionEntry
+read-back with an acknowledgement contract, live production sessions remained correct, but the
+`Session.ProviderResponseReady.integrations` span did not materially improve.
+
+Datadog now shows a sharper split:
+
+- The broad `Session.ProviderResponseReady.integrations` and `wasm:provider_response_applier`
+  spans remain about 400-600 ms on warm live sessions.
+- Guest-level TemperPaw logs show the hot business step, `append_session_tree`, is usually about
+  50-91 ms, with artifact reads at 0-1 ms.
+- ADR-0100 added `wasm.invoke.*` engine phase spans, but the production trace still has a large
+  un-attributed envelope outside guest business logic and outside the engine child spans.
+
+This means the next responsible step is not another speculative speed patch. We need to attribute
+the server-side integration envelope around module cache resolution, context building, blob
+hydration, secret resolution, host construction, observe-event writes, engine invocation, result
+recording, and callback dispatch. Without this attribution, the program cannot distinguish an
+architectural limitation of Temper's WASM/spec model from an overlooked synchronous step in the
+host bridge.
+
+## Decision
+
+### Add Dispatch Envelope Phase Spans
+
+`dispatch_single_integration` will emit child spans under the existing `wasm:<module>` span for the
+major server-side envelope phases:
+
+- `dispatch.wasm.phase.module_cache`
+- `dispatch.wasm.phase.replay_input_injection`
+- `dispatch.wasm.phase.invocation_context_build`
+- `dispatch.wasm.phase.blob_ref_hydration`
+- `dispatch.wasm.phase.authz_secret_resolution`
+- `dispatch.wasm.phase.host_chain_build`
+- `dispatch.wasm.phase.integration_observe_start`
+- `dispatch.wasm.phase.engine_invoke_and_handle`
+
+Where practical, result handling will also emit child spans for the large post-engine phases:
+
+- `dispatch.wasm.phase.engine_invoke`
+- `dispatch.wasm.phase.result_observe_complete`
+- `dispatch.wasm.phase.record_invocation`
+- `dispatch.wasm.phase.dispatch_callback`
+- `dispatch.wasm.phase.llmobs_submit`
+
+Each span will record safe operational attributes only: phase name, module name, tenant, entity
+type, entity id, trigger action, result status, duration in milliseconds, and count/byte-size
+metadata where useful. The spans must not record entity payloads, prompts, secrets, reply content,
+trajectory JSON, artifact bodies, or WASM result bodies.
+
+**Why this approach**: The missing latency is currently between the high-level module span and the
+guest/engine child spans. Envelope spans put Datadog evidence exactly at that boundary without
+changing the IOA spec model, guest WASM contract, or production semantics.
+
+### Treat This As A Measurement Slice, Not A Speed Claim
+
+This PR will not claim a latency reduction unless live before/after data proves one. Its success
+condition is attribution: after deployment, Datadog must show which envelope phase consumes the
+remaining hundreds of milliseconds. The next optimization will target the dominant proven phase and
+will carry its own before/after proof.
+
+**Why this approach**: The program has already found a correctness-positive change that was not a
+latency win. Separating measurement from optimization keeps the work honest and prevents premature
+architecture changes.
+
+## Rollout Plan
+
+1. **Phase 0 (Immediate)** — Add a source-level observability contract test that fails if required
+   dispatch envelope phase names disappear.
+2. **Phase 1 (Temper core PR)** — Add the envelope spans around existing dispatch phases without
+   changing behavior.
+3. **Phase 2 (TemperPaw bump and deploy)** — Build TemperPaw against the Temper revision, deploy,
+   and run the same live Session proof used for PERF-028.
+4. **Phase 3 (Datadog readout)** — Compare the new trace shape to the PERF-028 baseline and select
+   the next latency PR from the dominant envelope phase.
+
+## Readiness Gates
+
+- A focused `temper-server` test asserts the required dispatch envelope span names exist.
+- Existing WASM dispatch tests pass.
+- `cargo fmt --all -- --check` passes.
+- Live TemperPaw sessions complete correctly after deployment.
+- Datadog traces for live `Session.ProviderResponseReady` executions show the new
+  `dispatch.wasm.phase.*` child spans.
+- The living latency report records both the PERF-028 baseline and the new after-deploy attribution.
+
+## Consequences
+
+### Positive
+
+- Turns the current 400-600 ms parent-span gap into actionable phase evidence.
+- Preserves Temper's core mission: generated specs, WASM integrations, and governed runtime behavior
+  remain intact.
+- Makes out-of-the-box future options easier to evaluate because the cost boundary is explicit.
+
+### Negative
+
+- Adds trace volume to each WASM integration invocation.
+- Does not directly reduce latency in this PR.
+- Dense traces require disciplined span naming so the flamegraph stays readable.
+
+### Risks
+
+- Span fields could accidentally leak sensitive data. The mitigation is to record identifiers,
+  sizes, counts, phase names, and status only.
+- Holding tracing span guards across `.await` points can distort async context. The implementation
+  should use `Instrument` for async work and short enter guards for synchronous blocks.
+- Some phases may initially show small durations because deeper child spans already cover the work.
+  That is acceptable; the goal is to close the un-attributed gap.
+
+### DST Compliance
+
+- This change touches `temper-server`, which is simulation-visible.
+- The implementation adds observability spans and elapsed-time fields only. It does not change actor
+  transitions, scheduling, mailbox behavior, random sources, persistence semantics, network calls, or
+  tenant scoping.
+- Wall-clock duration is observability-only and does not feed decisions in simulation-visible logic.
+
+## Non-Goals
+
+- This ADR does not introduce slim invocation contexts.
+- This ADR does not bypass WASM integrations or generated specs.
+- This ADR does not move SessionEntry materialization to a new storage model.
+- This ADR does not change OData, projection, or Cedar authorization semantics.
+- This ADR does not claim a performance improvement without live before/after evidence.
+
+## Alternatives Considered
+
+1. **Optimize the TemperPaw guest helper again** — Rejected for this slice because the helper already
+   batches initial SessionEntry creation and guest logs show the dominant parent-span gap is outside
+   the obvious guest step.
+2. **Jump directly to native provider-response adapters** — Still a possible future direction, but
+   premature until Datadog proves the dispatch envelope or WASM architecture is the limiting factor.
+3. **Rely on profiler data only** — Profiling is useful, but request-scoped spans are required for
+   live before/after comparison, PR review, and production correctness correlation.
+
+## Rollback Policy
+
+Remove the `dispatch.wasm.phase.*` spans if trace volume is too high or if a field is found to be
+unsafe. The runtime behavior is unchanged, so rollback does not require data migration, spec changes,
+or TemperPaw app changes.


### PR DESCRIPTION
## What changed

PERF-029 instruments the Temper server WASM integration dispatch envelope with low-cardinality phase spans so Datadog can split platform overhead from guest WASM business logic.

The new spans are named `dispatch.wasm.phase.*` and cover module cache lookup, replay input injection, invocation context build, blob-ref hydration, authz/secret resolution, host-chain construction, observe start/complete, engine invoke, invocation recording, callbacks, and LLMObs submission. Span attributes are limited to safe operational fields: `duration_ms` and `result`.

## Why

Before evidence from Datadog showed a representative fixed-version trace where `Session.ProviderResponseReady.integrations` was about 486 ms and `wasm:provider_response_applier` was about 486 ms, while the inner `wasm.invoke.run` child was only about 74 ms. Guest TemperPaw logs in the same proof window showed artifact reads near 0-1 ms and session-tree appends usually around 50-91 ms. That leaves a large platform-envelope gap that could not be attributed cleanly.

This PR does not claim a latency win by itself. It creates the measurement layer required for the next optimization PR to have a real before/after.

## Validation

- Red contract test first: `cargo test -p temper-server --test wasm_dispatch_observability_contract wasm_dispatch_emits_integration_envelope_phase_spans -- --nocapture` failed before instrumentation on the missing `dispatch.wasm.phase.module_cache` span.
- Contract test passes after implementation.
- `cargo test -p temper-server --test wasm_dispatch -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy -p temper-server --all-targets -- -D warnings`
- `scripts/check-determinism.sh` exits 0. Existing repository-wide findings remain; this PR's observability-only `Instant::now()` calls are annotated with `determinism-ok` and do not appear as unsuppressed findings.
- Full pre-push gate passed: rustfmt, workspace clippy, readability ratchet, full workspace test suite, doctests.

## Deployment / after evidence required

After merge and deploy, run a live TemperPaw session proof and capture Datadog traces with the new `dispatch.wasm.phase.*` children. The living dashboard at `docs/temper-latency-observability-report.html` tracks this as PERF-029 and will record the after trace IDs, phase timing distribution, and the next speed PR selected from the measured dominant phase.
