### PR TITLE
PERF-030 lazy WASM secret authorization

### DIFF
--- a/crates/temper-server/src/state/dispatch/wasm.rs
+++ b/crates/temper-server/src/state/dispatch/wasm.rs
@@ -216,7 +216,7 @@ fn local_blob_binary_interceptor(
 }
 
 fn internal_api_base_url(state: &crate::state::ServerState) -> Option<String> {
-    std::env::var("TEMPER_API_URL")
+    std::env::var("TEMPER_API_URL") // determinism-ok: production host loopback config
         .ok()
         .map(|value| value.trim_end_matches('/').to_string())
         .filter(|value| !value.is_empty())
@@ -552,7 +552,18 @@ impl crate::state::ServerState {
             ctx,
             &module_name,
             WASM_DISPATCH_PHASE_AUTHZ_SECRET_RESOLUTION,
-            || self.get_authorized_wasm_secrets(ctx.entity_ref.tenant, &*gate, &authz_ctx),
+            || {
+                self.get_authorized_wasm_host_bootstrap_secrets(
+                    ctx.entity_ref.tenant,
+                    &*gate,
+                    &authz_ctx,
+                )
+            },
+        );
+        let secret_resolver = self.authorized_wasm_secret_resolver(
+            ctx.entity_ref.tenant,
+            Arc::clone(&gate),
+            authz_ctx.clone(),
         );
         let (host, limits) = with_wasm_dispatch_phase(
             &active_parent_span,
@@ -619,9 +630,9 @@ impl crate::state::ServerState {
                     module_name.clone(),
                 );
                 let host_invocation_context = inv_ctx.clone();
-                let internal_api_key = std::env::var("TEMPER_API_KEY").ok();
+                let internal_api_key = std::env::var("TEMPER_API_KEY").ok(); // determinism-ok: production host loopback config
                 let internal_api_url = internal_api_base_url(self);
-                let production_host: Arc<dyn WasmHost> = Arc::new(
+                let mut production_host_builder =
                     ProductionWasmHost::with_timeout(tenant_secrets, http_timeout)
                         .with_binary_http_interceptor(
                             local_blob_interceptor
@@ -639,8 +650,12 @@ impl crate::state::ServerState {
                         .with_trace_id(
                             current_otel_trace_id(active_span)
                                 .or_else(|| ctx.agent_ctx.trace_id.clone()),
-                        ),
-                );
+                        );
+                if let Some(resolver) = secret_resolver.clone() {
+                    production_host_builder =
+                        production_host_builder.with_secret_resolver(resolver);
+                }
+                let production_host: Arc<dyn WasmHost> = Arc::new(production_host_builder);
                 let inner: Arc<dyn WasmHost> = Arc::new(LocalTDataWasmHost::new(
                     self.clone(),
                     ctx.entity_ref.tenant.clone(),
@@ -1265,7 +1280,10 @@ impl crate::state::ServerState {
             entity_type: context.entity_type.clone(),
             trigger_action: context.trigger_action.clone(),
         };
-        let tenant_secrets = self.get_authorized_wasm_secrets(tenant, &*base_gate, &authz_ctx);
+        let tenant_secrets =
+            self.get_authorized_wasm_host_bootstrap_secrets(tenant, &*base_gate, &authz_ctx);
+        let secret_resolver =
+            self.authorized_wasm_secret_resolver(tenant, Arc::clone(&base_gate), authz_ctx.clone());
         let local_blob_interceptor = local_blob_binary_interceptor(
             self.clone(),
             tenant.clone(),
@@ -1282,8 +1300,11 @@ impl crate::state::ServerState {
             .with_spec_evaluator(spec_evaluator_fn())
             .with_progress_emitter(progress_emitter)
             .with_internal_api_base_url(internal_api_base_url(self))
-            .with_internal_api_key(std::env::var("TEMPER_API_KEY").ok())
+            .with_internal_api_key(std::env::var("TEMPER_API_KEY").ok()) // determinism-ok: production host loopback config
             .with_invocation_context(context.clone());
+        if let Some(resolver) = secret_resolver {
+            base_host = base_host.with_secret_resolver(resolver);
+        }
         if let Some(interceptor) = local_blob_interceptor {
             base_host = base_host.with_binary_http_interceptor(interceptor);
         }
@@ -1827,7 +1848,7 @@ fn llmobs_agent_start_ns_for_duration(duration_ms: u64) -> u64 {
 }
 
 fn current_unix_ns() -> u64 {
-    SystemTime::now()
+    SystemTime::now() // determinism-ok: LLM observability timestamp translation
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_nanos() as u64

--- a/crates/temper-server/src/state/dispatch/wasm_secrets.rs
+++ b/crates/temper-server/src/state/dispatch/wasm_secrets.rs
@@ -1,29 +1,246 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
 use temper_runtime::tenant::TenantId;
-use temper_wasm::{WasmAuthzContext, WasmAuthzDecision, WasmAuthzGate};
+use temper_wasm::{SecretResolverFn, WasmAuthzContext, WasmAuthzDecision, WasmAuthzGate};
+
+const WASM_BOOTSTRAP_SECRET_KEYS: [&str; 3] = ["blob_endpoint", "temper_api_key", "temper_api_url"];
+
+fn is_wasm_bootstrap_secret(key: &str) -> bool {
+    WASM_BOOTSTRAP_SECRET_KEYS.contains(&key) || key.starts_with("ca_cert:")
+}
 
 impl crate::state::ServerState {
-    /// Get secrets filtered through the WASM authorization gate.
+    /// Get the small eager secret set needed to construct a production host.
     ///
-    /// Phase 3 defense-in-depth: only inject secrets that the gate authorizes
-    /// into the `ProductionWasmHost`. Even if the decorator is somehow
-    /// bypassed, unauthorized secrets aren't in memory.
-    pub(crate) fn get_authorized_wasm_secrets(
+    /// Most WASM invocations never call `host_get_secret`, so dispatch should
+    /// not authorize and clone every tenant secret up front. This helper keeps
+    /// eager materialization limited to host-bootstrap values required before
+    /// guest code runs.
+    pub(crate) fn get_authorized_wasm_host_bootstrap_secrets(
         &self,
         tenant: &TenantId,
         gate: &dyn WasmAuthzGate,
         authz_ctx: &WasmAuthzContext,
-    ) -> std::collections::BTreeMap<String, String> {
-        let all_secrets = self
-            .secrets_vault
-            .as_ref()
-            .map(|v| v.get_tenant_secrets(&tenant.to_string()))
-            .unwrap_or_default();
+    ) -> BTreeMap<String, String> {
+        let Some(vault) = self.secrets_vault.as_ref() else {
+            return BTreeMap::new();
+        };
+        let tenant_str = tenant.to_string();
 
-        all_secrets
+        vault
+            .list_keys(&tenant_str)
             .into_iter()
-            .filter(|(key, _)| {
-                gate.authorize_secret_access(key, authz_ctx) == WasmAuthzDecision::Allow
+            .filter(|key| is_wasm_bootstrap_secret(key))
+            .filter_map(|key| {
+                if gate.authorize_secret_access(&key, authz_ctx) != WasmAuthzDecision::Allow {
+                    return None;
+                }
+                vault
+                    .get_secret(&tenant_str, &key)
+                    .map(|value| (key, value))
             })
             .collect()
+    }
+
+    /// Build an authorization-aware lazy resolver for guest secret lookups.
+    pub(crate) fn authorized_wasm_secret_resolver(
+        &self,
+        tenant: &TenantId,
+        gate: Arc<dyn WasmAuthzGate>,
+        authz_ctx: WasmAuthzContext,
+    ) -> Option<SecretResolverFn> {
+        let vault = Arc::clone(self.secrets_vault.as_ref()?);
+        let tenant_str = tenant.to_string();
+
+        Some(Arc::new(move |key: &str| {
+            match gate.authorize_secret_access(key, &authz_ctx) {
+                WasmAuthzDecision::Allow => vault
+                    .get_secret(&tenant_str, key)
+                    .ok_or_else(|| format!("secret not found: {key}")),
+                WasmAuthzDecision::Deny(reason) => {
+                    Err(format!("authorization denied for secret '{key}': {reason}"))
+                }
+            }
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+    use std::sync::Mutex;
+
+    use crate::registry::SpecRegistry;
+    use crate::secrets::SecretsVault;
+    use crate::state::ServerState;
+    use temper_runtime::ActorSystem;
+
+    #[derive(Clone)]
+    struct RecordingSecretGate {
+        allowed: BTreeSet<String>,
+        requested: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl RecordingSecretGate {
+        fn allowing(keys: &[&str]) -> Self {
+            Self {
+                allowed: keys.iter().map(|key| (*key).to_string()).collect(),
+                requested: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        fn requested_keys(&self) -> Vec<String> {
+            self.requested
+                .lock()
+                .expect("requested keys lock poisoned")
+                .clone()
+        }
+    }
+
+    impl WasmAuthzGate for RecordingSecretGate {
+        fn authorize_http_call(
+            &self,
+            _domain: &str,
+            _method: &str,
+            _url: &str,
+            _ctx: &WasmAuthzContext,
+        ) -> WasmAuthzDecision {
+            WasmAuthzDecision::Allow
+        }
+
+        fn authorize_secret_access(
+            &self,
+            secret_key: &str,
+            _ctx: &WasmAuthzContext,
+        ) -> WasmAuthzDecision {
+            self.requested
+                .lock()
+                .expect("requested keys lock poisoned")
+                .push(secret_key.to_string());
+            if self.allowed.contains(secret_key) {
+                WasmAuthzDecision::Allow
+            } else {
+                WasmAuthzDecision::Deny("denied by test gate".to_string())
+            }
+        }
+    }
+
+    fn test_authz_ctx() -> WasmAuthzContext {
+        WasmAuthzContext {
+            tenant: "tenant-a".to_string(),
+            module_name: "provider_caller".to_string(),
+            agent_id: Some("agent-1".to_string()),
+            session_id: Some("ss-1".to_string()),
+            entity_type: "Session".to_string(),
+            trigger_action: "CallProvider".to_string(),
+        }
+    }
+
+    fn state_with_vault(vault: SecretsVault) -> ServerState {
+        ServerState::from_registry(ActorSystem::new("wasm-secret-tests"), SpecRegistry::new())
+            .with_secrets_vault(vault)
+    }
+
+    #[test]
+    fn host_bootstrap_secret_resolution_authorizes_only_bootstrap_keys() {
+        let tenant = TenantId::new("tenant-a");
+        let vault = SecretsVault::new(&[7u8; 32]);
+        vault
+            .cache_secret(
+                tenant.as_str(),
+                "blob_endpoint",
+                "https://blob.example".into(),
+            )
+            .unwrap();
+        vault
+            .cache_secret(
+                tenant.as_str(),
+                "temper_api_url",
+                "https://temper.example".into(),
+            )
+            .unwrap();
+        vault
+            .cache_secret(tenant.as_str(), "temper_api_key", "internal-token".into())
+            .unwrap();
+        vault
+            .cache_secret(
+                tenant.as_str(),
+                "ca_cert:internal",
+                "-----BEGIN CERT-----".into(),
+            )
+            .unwrap();
+        vault
+            .cache_secret(tenant.as_str(), "provider_api_key", "sk-provider".into())
+            .unwrap();
+        vault
+            .cache_secret(tenant.as_str(), "unrelated_secret", "unused".into())
+            .unwrap();
+        let state = state_with_vault(vault);
+        let gate = RecordingSecretGate::allowing(&[
+            "blob_endpoint",
+            "temper_api_key",
+            "temper_api_url",
+            "ca_cert:internal",
+            "provider_api_key",
+            "unrelated_secret",
+        ]);
+
+        let secrets =
+            state.get_authorized_wasm_host_bootstrap_secrets(&tenant, &gate, &test_authz_ctx());
+
+        assert_eq!(secrets.len(), 4);
+        assert!(secrets.contains_key("blob_endpoint"));
+        assert!(secrets.contains_key("temper_api_key"));
+        assert!(secrets.contains_key("temper_api_url"));
+        assert!(secrets.contains_key("ca_cert:internal"));
+        assert!(!secrets.contains_key("provider_api_key"));
+        assert!(!secrets.contains_key("unrelated_secret"));
+        assert_eq!(
+            gate.requested_keys(),
+            vec![
+                "blob_endpoint".to_string(),
+                "ca_cert:internal".to_string(),
+                "temper_api_key".to_string(),
+                "temper_api_url".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn lazy_secret_resolver_authorizes_requested_key_and_reads_current_value() {
+        let tenant = TenantId::new("tenant-a");
+        let vault = SecretsVault::new(&[8u8; 32]);
+        vault
+            .cache_secret(tenant.as_str(), "provider_api_key", "first".into())
+            .unwrap();
+        vault
+            .cache_secret(tenant.as_str(), "blocked_key", "blocked".into())
+            .unwrap();
+        let state = state_with_vault(vault);
+        let vault = Arc::clone(state.secrets_vault.as_ref().expect("vault installed"));
+        let gate = RecordingSecretGate::allowing(&["provider_api_key"]);
+        let requested = gate.requested.clone();
+        let resolver = state
+            .authorized_wasm_secret_resolver(&tenant, Arc::new(gate), test_authz_ctx())
+            .expect("resolver should exist when vault is configured");
+
+        assert_eq!(resolver("provider_api_key"), Ok("first".to_string()));
+        vault
+            .cache_secret(tenant.as_str(), "provider_api_key", "second".into())
+            .unwrap();
+        assert_eq!(resolver("provider_api_key"), Ok("second".to_string()));
+
+        let denied = resolver("blocked_key").expect_err("blocked key should be denied");
+        assert!(denied.contains("authorization denied for secret 'blocked_key'"));
+        assert_eq!(
+            *requested.lock().expect("requested keys lock poisoned"),
+            vec![
+                "provider_api_key".to_string(),
+                "provider_api_key".to_string(),
+                "blocked_key".to_string()
+            ]
+        );
     }
 }

--- a/crates/temper-wasm/src/host_trait.rs
+++ b/crates/temper-wasm/src/host_trait.rs
@@ -283,6 +283,15 @@ pub type SpecEvaluatorFn =
 /// Callback for replayable progress events emitted by guest WASM modules.
 pub type ProgressEmitterFn = Arc<dyn Fn(&str) -> Result<(), String> + Send + Sync>;
 
+/// Callback for lazily resolving a secret by key.
+///
+/// Production hosts can use this to avoid eagerly materializing every tenant
+/// secret before invocation. When configured, the resolver is authoritative for
+/// guest `host_get_secret` lookups; the eager secret map remains available for
+/// host-internal bootstrap behavior. The callback is responsible for any
+/// authorization checks needed before returning the plaintext value.
+pub type SecretResolverFn = Arc<dyn Fn(&str) -> Result<String, String> + Send + Sync>;
+
 /// Future returned by a binary HTTP interceptor.
 pub type BinaryHttpInterceptorFuture =
     Pin<Box<dyn Future<Output = Option<Result<(u16, Vec<u8>), String>>> + Send>>;
@@ -317,6 +326,8 @@ pub struct ProductionWasmHost {
     client: reqwest::Client,
     /// Secrets from env vars or a secret store.
     secrets: BTreeMap<String, String>,
+    /// Optional lazy secret resolver authoritative for guest secret lookups.
+    secret_resolver: Option<SecretResolverFn>,
     /// Canonical base URL for the local Temper API when known directly by the server.
     internal_api_base_url: Option<String>,
     /// Ambient platform bearer token for internal loopback calls.
@@ -503,6 +514,7 @@ impl ProductionWasmHost {
         Self {
             client: builder.build().unwrap_or_default(),
             secrets,
+            secret_resolver: None,
             internal_api_base_url: None,
             internal_api_key: None,
             spec_evaluator: None,
@@ -524,6 +536,12 @@ impl ProductionWasmHost {
     /// Create with a progress emitter for `host_emit_progress` support.
     pub fn with_progress_emitter(mut self, emitter: ProgressEmitterFn) -> Self {
         self.progress_emitter = Some(emitter);
+        self
+    }
+
+    /// Create with a lazy secret resolver for `host_get_secret` support.
+    pub fn with_secret_resolver(mut self, resolver: SecretResolverFn) -> Self {
+        self.secret_resolver = Some(resolver);
         self
     }
 
@@ -1271,10 +1289,15 @@ impl WasmHost for ProductionWasmHost {
         record_invocation_context_on_span(&span, self.invocation_context.as_ref(), "secret_lookup");
         let _guard = span.enter();
         let result = self
-            .secrets
-            .get(key)
-            .cloned()
-            .ok_or_else(|| format!("secret not found: {key}"));
+            .secret_resolver
+            .as_ref()
+            .map(|resolver| resolver(key))
+            .unwrap_or_else(|| {
+                self.secrets
+                    .get(key)
+                    .cloned()
+                    .ok_or_else(|| format!("secret not found: {key}"))
+            });
         tracing::Span::current().record("success", result.is_ok());
         tracing::Span::current().record("duration_ms", started.elapsed().as_millis() as u64);
         if let Err(error) = &result {
@@ -2659,4 +2682,5 @@ impl WasmHost for SimWasmHost {
 }
 
 #[cfg(test)]
+#[path = "host_trait/host_trait_test.rs"]
 mod tests;

--- a/crates/temper-wasm/src/host_trait/host_trait_test.rs
+++ b/crates/temper-wasm/src/host_trait/host_trait_test.rs
@@ -26,6 +26,57 @@ fn guest_metric_tags_reject_high_cardinality_correlation_ids() {
     assert!(!guest_metric_tag_allowed("tool.call_id"));
 }
 
+#[test]
+fn production_host_uses_lazy_secret_resolver_for_missing_eager_key() {
+    let requested = Arc::new(Mutex::new(Vec::new()));
+    let requested_for_resolver = Arc::clone(&requested);
+    let resolver: SecretResolverFn = Arc::new(move |key| {
+        requested_for_resolver
+            .lock()
+            .expect("requested keys lock poisoned")
+            .push(key.to_string());
+        Ok(format!("lazy:{key}"))
+    });
+    let host = ProductionWasmHost::new(BTreeMap::new()).with_secret_resolver(resolver);
+
+    assert_eq!(
+        host.get_secret("provider_api_key"),
+        Ok("lazy:provider_api_key".to_string())
+    );
+    assert_eq!(
+        *requested.lock().expect("requested keys lock poisoned"),
+        vec!["provider_api_key".to_string()]
+    );
+}
+
+#[test]
+fn production_host_uses_lazy_resolver_for_guest_lookup_even_when_eager_key_exists() {
+    let requested = Arc::new(Mutex::new(Vec::<String>::new()));
+    let requested_for_resolver = Arc::clone(&requested);
+    let resolver: SecretResolverFn = Arc::new(move |key| {
+        requested_for_resolver
+            .lock()
+            .expect("requested keys lock poisoned")
+            .push(key.to_string());
+        Ok(format!("lazy:{key}"))
+    });
+    let mut secrets = BTreeMap::new();
+    secrets.insert(
+        "blob_endpoint".to_string(),
+        "https://blob.example".to_string(),
+    );
+    let host = ProductionWasmHost::new(secrets).with_secret_resolver(resolver);
+
+    assert_eq!(
+        host.get_secret("blob_endpoint"),
+        Ok("lazy:blob_endpoint".to_string())
+    );
+    assert_eq!(
+        *requested.lock().expect("requested keys lock poisoned"),
+        vec!["blob_endpoint".to_string()]
+    );
+}
+
 /// Build a Connect frame: [flags(1)][length(4 big-endian)][payload].
 fn make_frame(flags: u8, payload: &[u8]) -> Vec<u8> {
     let mut frame = Vec::with_capacity(5 + payload.len());
@@ -455,6 +506,9 @@ fn guest_log_span_event_is_named_for_trace_export() {
     assert!(names.iter().any(|name| name == "wasm_guest.log"));
 }
 
+#[path = "tests/host_boundary_observability.rs"]
 mod host_boundary_observability;
+#[path = "tests/log_correlation.rs"]
 mod log_correlation;
+#[path = "tests/span_hint_tests.rs"]
 mod span_hint_tests;

--- a/crates/temper-wasm/src/lib.rs
+++ b/crates/temper-wasm/src/lib.rs
@@ -17,8 +17,8 @@ mod workflow_headers;
 pub use authorized_host::{AuthorizedWasmHost, WasmAuthzDecision, WasmAuthzGate, extract_domain};
 pub use engine::{WasmEngine, WasmError};
 pub use host_trait::{
-    BinaryHttpInterceptorFn, ProductionWasmHost, ProgressEmitterFn, SimWasmHost, SpecEvaluatorFn,
-    TextHttpInterceptorFn, WasmHost, parse_connect_frames,
+    BinaryHttpInterceptorFn, ProductionWasmHost, ProgressEmitterFn, SecretResolverFn, SimWasmHost,
+    SpecEvaluatorFn, TextHttpInterceptorFn, WasmHost, parse_connect_frames,
 };
 pub use stream::{StreamRegistry, StreamRegistryConfig};
 pub use types::{

--- a/docs/adrs/0107-wasm-lazy-secret-authorization.md
+++ b/docs/adrs/0107-wasm-lazy-secret-authorization.md
@@ -1,0 +1,181 @@
+# ADR-0107: WASM Lazy Secret Authorization
+
+- Status: Proposed
+- Date: 2026-05-19
+- Deciders: Temper core maintainers
+- Related:
+  - ADR-0004: Cedar Authorization for Agents
+  - ADR-0012: OAuth2 Enablement - Webhooks, Timers, and Secret Templates
+  - ADR-0075: Tenant Secrets Key Management
+  - ADR-0084: Authz Latency Phase Instrumentation
+  - ADR-0106: WASM Integration Envelope Attribution
+  - `crates/temper-server/src/state/dispatch/wasm.rs`
+  - `crates/temper-server/src/state/dispatch/wasm_secrets.rs`
+  - `crates/temper-wasm/src/host_trait.rs`
+
+## Context
+
+ADR-0106 moved the remaining WASM integration envelope into Datadog child spans. The first live
+TemperPaw proof after deployment found that `dispatch.wasm.phase.authz_secret_resolution` is now the
+largest proven server-side phase outside guest work:
+
+- Single controlled after trace: `authz_secret_resolution` about 72 ms for the provider-response
+  applier.
+- Five-session after batch: `authz_secret_resolution` count 20, average about 79 ms, p50 about
+  76 ms, p95 about 88 ms.
+- The phase appears on every WASM integration in a session, including modules whose config does not
+  reference `{secret:...}` and whose successful path does not call `host_get_secret`.
+
+The current dispatch path obtains the merged platform+tenant secret map, clones all plaintext
+values, and evaluates Cedar `access_secret` for every key before constructing the host. That was a
+reasonable defense-in-depth implementation when the secret set was small, but it turns every WASM
+invocation into an O(number of visible secrets) authorization pass even when the module is
+effectively secretless.
+
+This is an overlooked host-bridge cost, not a fundamental Temper architecture limitation. Temper's
+mission still requires generated specs, Cedar governance, tenant isolation, replayable audit, and
+secret safety. The fix must make the common path fast without putting unauthorized secrets into
+memory or allowing stale authorization decisions to drift.
+
+## Decision
+
+### Move Guest Secret Reads To Lazy Per-Key Authorization
+
+`ProductionWasmHost` will support an optional secret resolver callback. When the resolver is
+configured, guest `host_get_secret` calls will use it as the authoritative secret path. The eager
+in-memory secret map remains available for host-internal bootstrap behavior, not as the guest secret
+read path.
+
+Temper Server will install an authorization-aware resolver that:
+
+- Receives the requested secret key at `host_get_secret` time.
+- Evaluates Cedar `access_secret` for exactly that key and the invocation's `WasmAuthzContext`.
+- Reads the current tenant/platform secret value only after Cedar allows the key.
+- Returns the same "secret not found" shape when the value is absent.
+- Does not cache plaintext values across invocations.
+
+**Why this approach**: Most hot TemperPaw session integrations do not need arbitrary secrets on the
+successful path. Lazy per-key authorization changes the cost from "authorize every secret on every
+WASM invocation" to "authorize the secret actually requested." Correctness remains tied to the live
+Cedar engine and the live secrets vault, so policy reloads and secret updates take effect without a
+new invalidation protocol.
+
+### Keep Host Bootstrap Secrets Eager And Bounded
+
+The host still needs a small set of server-side bootstrap values before the guest runs:
+
+- `blob_endpoint`, used to detect and short-circuit configured blob transport URLs.
+- `temper_api_url`, used to detect and short-circuit local file-value transport URLs.
+- `temper_api_key`, used as the fallback internal API bearer token when no ambient
+  `TEMPER_API_KEY` is configured.
+- `ca_cert:*`, used to add tenant-provisioned CA roots to the outbound HTTP client.
+
+Temper Server will build an eager bootstrap map by listing secret keys only, selecting the known
+bootstrap keys/prefixes, authorizing those selected keys, and then fetching only allowed values.
+Other secrets stay out of the host's eager map.
+
+**Why this approach**: It preserves existing transport behavior and private-CA support while bounding
+startup authorization by the small host-bootstrap surface instead of the entire tenant secret set.
+
+### Preserve Defense In Depth
+
+The outer `AuthorizedWasmHost` will continue to authorize `host_get_secret` before delegating. The
+new resolver will also authorize before reading the vault, and `ProductionWasmHost` will prefer the
+resolver over its eager bootstrap map for guest secret lookups. This means arbitrary secrets are not
+eagerly materialized and guest secret reads remain authorization-gated even if a key is also needed
+for host bootstrap.
+
+**Why this approach**: ADR-0004 explicitly requires secret pre-filtering as defense in depth. The new
+shape preserves the security property as "authorize before value materialization" rather than
+"authorize all values before invocation." Unauthorized plaintext values are not eagerly cloned into
+the host.
+
+## Rollout Plan
+
+1. **Phase 0 (Immediate)** - Add tests that prove the eager path authorizes only bootstrap secrets
+   and that lazy `get_secret` authorizes and reads only the requested key.
+2. **Phase 1 (Temper core PR)** - Add the resolver callback to `ProductionWasmHost`, add the
+   bounded bootstrap-secret helper in Temper Server, and wire the dispatch and direct-invocation
+   host paths through the lazy resolver.
+3. **Phase 2 (TemperPaw bump and deploy)** - Rebuild TemperPaw on the merged Temper revision and
+   deploy to production.
+4. **Phase 3 (Before/after proof)** - Re-run the same live Session proof and batch used for
+   ADR-0106. The report must compare the pre-change `authz_secret_resolution` baseline to the
+   post-change Datadog distribution and controlled trace.
+
+## Readiness Gates
+
+- Unit tests prove bootstrap selection does not authorize or load arbitrary non-bootstrap secrets.
+- Unit tests prove lazy secret reads return allowed values, deny unauthorized values, and reflect
+  updated vault values without stale cache.
+- Existing `temper-wasm` and `temper-server` WASM dispatch tests pass.
+- `cargo fmt --all -- --check` and targeted clippy pass.
+- Live TemperPaw sessions complete correctly after deployment.
+- Datadog after traces show lower `dispatch.wasm.phase.authz_secret_resolution` duration with no
+  increase in `wasm.host.get_secret` errors or authorization-denial regressions.
+- `docs/temper-latency-observability-report.html` records before and after timings, trace links,
+  Datadog distributions, correctness checks, and any residual latency.
+
+## Consequences
+
+### Positive
+
+- Removes O(number of secrets) Cedar work from the common WASM invocation path.
+- Keeps Cedar, tenant isolation, and secret update correctness live at the moment of access.
+- Reduces plaintext secret materialization in hot hosts.
+- Produces a clean before/after target for the latency program.
+
+### Negative
+
+- Actual `host_get_secret` calls now pay per-key authorization at call time.
+- `ProductionWasmHost` gains a resolver callback surface, making the host slightly more abstract.
+- The host-bootstrap key list must remain intentionally small and reviewed when new bootstrap needs
+  appear.
+
+### Risks
+
+- A module that relied on arbitrary eager secrets without calling `host_get_secret` would break. The
+  current public host contract exposes secrets through `host_get_secret`, so this would indicate an
+  undocumented coupling rather than a supported API.
+- Missing a bootstrap key could disable a local transport optimization. The mitigation is a focused
+  allowlist and tests for blob/file transport bootstrap keys.
+- Double authorization on real `host_get_secret` calls adds overhead for secret-heavy modules. That
+  is acceptable because secret-heavy modules are not the hot path being optimized; a later PR can
+  introduce request-local memoization if Datadog proves it is necessary.
+
+### DST Compliance
+
+- This change touches `temper-server`, which is simulation-visible, and `temper-wasm`, which hosts
+  production effects.
+- No actor transition, scheduler, mailbox, persistence, spec, or replay decision changes.
+- Secret vault access, Cedar authorization, HTTP client construction, and wall-clock trace timing are
+  production host behavior, not deterministic simulation inputs.
+- Existing `BTreeMap` ordering remains in the eager bootstrap map.
+
+## Non-Goals
+
+- This ADR does not bypass Cedar authorization for secrets.
+- This ADR does not cache plaintext secrets across invocations.
+- This ADR does not change secret template syntax or persistence.
+- This ADR does not remove the outer `AuthorizedWasmHost`.
+- This ADR does not claim a latency win until live before/after evidence is recorded.
+
+## Alternatives Considered
+
+1. **Cache the full authorized secret map per module** - Rejected for this PR because it creates
+   policy and secret invalidation complexity, risks stale plaintext values, and still materializes
+   many unused secrets.
+2. **Remove secret pre-filtering entirely and rely only on `AuthorizedWasmHost`** - Rejected because
+   ADR-0004 requires defense in depth if the outer decorator is bypassed or miswired.
+3. **Hardcode a secretless fast path by module name** - Rejected because it would violate Temper's
+   generated-app architecture and turn runtime behavior into a TemperPaw-specific special case.
+4. **Require specs to declare every secret dependency first** - Attractive longer-term governance,
+   but too large for the immediate measured latency improvement and not necessary to remove the
+   current O(all secrets) cost.
+
+## Rollback Policy
+
+Rollback is code-only: restore eager authorized secret map construction and remove the resolver
+callback wiring. No data migration, spec change, or secret-store migration is required. If live
+traces show regressions, keep ADR-0106 envelope spans enabled so the rollback and follow-up can be
+measured with the same before/after protocol.


### PR DESCRIPTION
## What changed

PERF-030 changes WASM secret materialization from eager all-tenant-secret injection to a bounded host-bootstrap set plus an authorization-aware lazy resolver for guest `host_get_secret` calls.

- Eager bootstrap secrets are limited to `blob_endpoint`, `temper_api_key`, `temper_api_url`, and `ca_cert:*`.
- Guest secret lookups go through the lazy resolver even when an eager/bootstrap value exists.
- The resolver authorizes each requested key through the existing WASM Cedar gate before reading the current vault value.
- The production dispatch path and direct WASM invocation path both use the same resolver shape.
- ADR-0107 documents the decision, safety constraints, and before/after evidence plan.

## Why

PERF-029 Datadog evidence made `dispatch.wasm.phase.authz_secret_resolution` the next measured target:

- all-module after baseline: avg 78.7 ms, p50 76.3 ms, p95 87.8 ms
- provider-response after baseline: avg 78.0 ms, p50 73.4 ms, p95 79.4 ms

That phase was paying to list, authorize, decrypt/clone, and inject every tenant secret for every WASM invocation, even when the guest never requested most secrets. This PR preserves defense in depth while moving non-bootstrap secrets onto a per-key, on-demand path.

## Correctness and safety

- Guest secret access still requires Cedar authorization per key.
- The resolver reads from the current vault value, avoiding stale eager copies for non-bootstrap keys.
- Bootstrap eager values are still authorized before host construction.
- Unauthorized keys return an explicit authorization-denied error.
- Internal loopback host configuration remains host-internal and is not exposed as an authorization bypass.

## Validation

Focused local checks:

- `cargo fmt --all -- --check`
- `git diff --check`
- `.claude/hooks/check-determinism.sh` for changed `temper-server` files
- `cargo test -p temper-wasm production_host_ --lib`
- `cargo test -p temper-server wasm_secrets --lib`
- `cargo test -p temper-server --test wasm_dispatch`
- `cargo clippy -p temper-wasm -p temper-server --all-targets -- -D warnings`
- `bash scripts/readability-ratchet.sh check .ci/readability-baseline.env`

Pre-push gate passed:

- rustfmt
- workspace clippy
- readability ratchet
- full workspace test suite
- doctests

## Measurement plan

This PR does not claim a production latency win until deployed. After merge/deploy, the program dashboard will record a controlled live after-batch and Datadog trace window against the PERF-029 baseline above, including `authz_secret_resolution` avg/p50/p95, correctness checks, version tag, trace URL, and rollback criteria.
