### PR TITLE
Add native data-only create storage path

### DIFF
--- a/crates/temper-server/src/state/entity_ops.rs
+++ b/crates/temper-server/src/state/entity_ops.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 use std::sync::{Arc, OnceLock, RwLock};
 use std::time::Instant;
 
-use tracing::instrument;
+use tracing::{Instrument, instrument};
 
 use temper_observe::wide_event;
 use temper_runtime::persistence::{EventMetadata, PersistenceEnvelope, PersistenceError};
@@ -17,6 +17,7 @@ use crate::entity_actor::{EntityActor, EntityEvent, EntityMsg, EntityResponse, E
 use crate::events::EntityStateChange;
 use crate::registry::{VerificationDetail, VerificationStatus};
 use crate::runtime_metrics;
+use crate::storage::DataOnlyCreateRecord;
 
 fn actor_idle_timeout_secs() -> i64 {
     static ACTOR_IDLE_TIMEOUT: OnceLock<i64> = OnceLock::new();
@@ -882,72 +883,139 @@ impl ServerState {
             },
         };
 
-        let append_started_at = Instant::now(); // determinism-ok: production-only append wait metric
-        let append_result = store
-            .append(&persistence_id, state.sequence_nr, &[envelope])
-            .await;
-        runtime_metrics::record_event_store_append_wait(
-            backend.as_str(),
-            "append",
-            append_started_at.elapsed(),
-        );
-        match append_result {
-            Ok(new_seq) => {
-                state.sequence_nr = new_seq;
-            }
-            Err(PersistenceError::ConcurrencyViolation { .. }) => {
-                return Ok(None);
-            }
-            Err(e) => {
-                return Err(format!(
-                    "failed to persist data-only Created event for {entity_type}:{entity_id}: {e}"
-                ));
-            }
-        }
-        state.push_event_bounded(created);
-
         let projection_fields = self.query_projection_fields(tenant, entity_type, &state.fields);
-        let operation = "upsert";
-        let source = "data_only_create_fast_path";
-        record_projection_update_started(tenant, entity_type, operation, source);
-        let projection_started_at = Instant::now(); // determinism-ok: production-only projection duration metric
-        if let Err(e) = query_plane
-            .upsert_projection(
-                tenant.as_str(),
+        if let Some(native_store) = self.data_only_create_store() {
+            let operation = "native_create";
+            let source = "data_only_create_fast_path";
+            record_projection_update_started(tenant, entity_type, operation, source);
+            let projection_started_at = Instant::now(); // determinism-ok: production-only projection duration metric
+            let native_span = tracing::info_span!(
+                "entity.data_only_create_native_storage",
+                otel.name = "entity.data_only_create_native_storage",
+                tenant = %tenant,
                 entity_type,
                 entity_id,
-                &state.status,
-                &projection_fields,
-                state.sequence_nr,
-            )
-            .await
-        {
-            record_projection_update_error(
+            );
+            match native_store
+                .create_data_only_entity(DataOnlyCreateRecord {
+                    tenant: tenant.as_str(),
+                    entity_type,
+                    entity_id,
+                    status: &state.status,
+                    fields: &projection_fields,
+                    event: &envelope,
+                })
+                .instrument(native_span)
+                .await
+            {
+                Ok(new_seq) => {
+                    state.sequence_nr = new_seq;
+                    record_projection_update_success(
+                        tenant,
+                        entity_type,
+                        operation,
+                        source,
+                        state.sequence_nr,
+                        projection_started_at,
+                    );
+                }
+                Err(PersistenceError::ConcurrencyViolation { .. }) => {
+                    record_projection_update_error(
+                        tenant,
+                        entity_type,
+                        operation,
+                        source,
+                        projection_started_at,
+                    );
+                    return Ok(None);
+                }
+                Err(e) => {
+                    record_projection_update_error(
+                        tenant,
+                        entity_type,
+                        operation,
+                        source,
+                        projection_started_at,
+                    );
+                    tracing::error!(
+                        error = %e,
+                        tenant = %tenant,
+                        entity_type = %entity_type,
+                        entity_id = %entity_id,
+                        "failed to update query projection during native data-only create fast path"
+                    );
+                    return Err(format!(
+                        "native data-only create failed for {entity_type}:{entity_id}: {e}"
+                    ));
+                }
+            }
+        } else {
+            let append_started_at = Instant::now(); // determinism-ok: production-only append wait metric
+            let append_result = store
+                .append(&persistence_id, state.sequence_nr, &[envelope])
+                .await;
+            runtime_metrics::record_event_store_append_wait(
+                backend.as_str(),
+                "append",
+                append_started_at.elapsed(),
+            );
+            match append_result {
+                Ok(new_seq) => {
+                    state.sequence_nr = new_seq;
+                }
+                Err(PersistenceError::ConcurrencyViolation { .. }) => {
+                    return Ok(None);
+                }
+                Err(e) => {
+                    return Err(format!(
+                        "failed to persist data-only Created event for {entity_type}:{entity_id}: {e}"
+                    ));
+                }
+            }
+
+            let operation = "upsert";
+            let source = "data_only_create_fast_path";
+            record_projection_update_started(tenant, entity_type, operation, source);
+            let projection_started_at = Instant::now(); // determinism-ok: production-only projection duration metric
+            if let Err(e) = query_plane
+                .upsert_projection(
+                    tenant.as_str(),
+                    entity_type,
+                    entity_id,
+                    &state.status,
+                    &projection_fields,
+                    state.sequence_nr,
+                )
+                .await
+            {
+                record_projection_update_error(
+                    tenant,
+                    entity_type,
+                    operation,
+                    source,
+                    projection_started_at,
+                );
+                tracing::error!(
+                    error = %e,
+                    tenant = %tenant,
+                    entity_type = %entity_type,
+                    entity_id = %entity_id,
+                    "failed to update query projection during data-only create fast path"
+                );
+                return Err(format!(
+                    "query projection write failed during data-only create: {e}"
+                ));
+            }
+            record_projection_update_success(
                 tenant,
                 entity_type,
                 operation,
                 source,
+                state.sequence_nr,
                 projection_started_at,
             );
-            tracing::error!(
-                error = %e,
-                tenant = %tenant,
-                entity_type = %entity_type,
-                entity_id = %entity_id,
-                "failed to update query projection during data-only create fast path"
-            );
-            return Err(format!(
-                "query projection write failed during data-only create: {e}"
-            ));
         }
-        record_projection_update_success(
-            tenant,
-            entity_type,
-            operation,
-            source,
-            state.sequence_nr,
-            projection_started_at,
-        );
+        state.push_event_bounded(created);
 
         {
             let index_key = format!("{tenant}:{entity_type}");

--- a/crates/temper-server/src/state/mod.rs
+++ b/crates/temper-server/src/state/mod.rs
@@ -59,8 +59,8 @@ use crate::idempotency::IdempotencyCache;
 use crate::registry::SpecRegistry;
 use crate::secrets::vault::SecretsVault;
 use crate::storage::{
-    BackendLabel, BoxedEventStore, MetadataStore, PolicyStore, QueryPlaneStore, StorageStack,
-    TrajectorySink,
+    BackendLabel, BoxedEventStore, DataOnlyCreateStore, MetadataStore, PolicyStore,
+    QueryPlaneStore, StorageStack, TrajectorySink,
 };
 use crate::trigger::ReactionDispatcher;
 use crate::wasm_registry::WasmModuleRegistry;
@@ -230,8 +230,8 @@ fn normalize_local_tdata_host(raw: &str) -> Option<String> {
 
 fn env_local_tdata_hosts() -> BTreeSet<String> {
     let mut hosts = BTreeSet::new();
-    if let Ok(raw) = std::env::var("TEMPER_LOCAL_TDATA_HOSTS") {
-        // determinism-ok: read once at startup
+    let configured_hosts = std::env::var("TEMPER_LOCAL_TDATA_HOSTS"); // determinism-ok: read once at startup
+    if let Ok(raw) = configured_hosts {
         for item in raw.split(',') {
             if let Some(host) = normalize_local_tdata_host(item) {
                 hosts.insert(host);
@@ -245,11 +245,11 @@ fn env_local_tdata_hosts() -> BTreeSet<String> {
         "RAILWAY_PUBLIC_DOMAIN",
         "RAILWAY_STATIC_URL",
     ] {
-        if let Ok(raw) = std::env::var(name) {
-            // determinism-ok: read once at startup
-            if let Some(host) = normalize_local_tdata_host(&raw) {
-                hosts.insert(host);
-            }
+        let raw = std::env::var(name); // determinism-ok: read once at startup
+        if let Ok(raw) = raw
+            && let Some(host) = normalize_local_tdata_host(&raw)
+        {
+            hosts.insert(host);
         }
     }
 
@@ -477,6 +477,13 @@ impl ServerState {
         self.storage_stack
             .as_ref()
             .and_then(|stack| stack.query_plane.clone())
+    }
+
+    /// Return the native data-only create capability when the backend supports it.
+    pub(crate) fn data_only_create_store(&self) -> Option<Arc<dyn DataOnlyCreateStore>> {
+        self.storage_stack
+            .as_ref()
+            .and_then(|stack| stack.data_only_create.clone())
     }
 
     /// Return the runtime event journal capability plus backend label.

--- a/crates/temper-server/src/storage/mod.rs
+++ b/crates/temper-server/src/storage/mod.rs
@@ -361,6 +361,39 @@ pub trait QueryPlaneStore: Send + Sync {
     ) -> Result<Option<Vec<(String, u64)>>, PersistenceError>;
 }
 
+/// Inputs for a native brand-new data-only entity create.
+///
+/// This capability is only valid for entities whose first durable event and
+/// first query projection row can be inserted atomically by a storage backend.
+pub struct DataOnlyCreateRecord<'a> {
+    /// Tenant that owns the entity.
+    pub tenant: &'a str,
+    /// Entity type being created.
+    pub entity_type: &'a str,
+    /// Entity id being created.
+    pub entity_id: &'a str,
+    /// Initial entity status.
+    pub status: &'a str,
+    /// Projection fields to store in the query catalog and scalar index.
+    pub fields: &'a serde_json::Value,
+    /// First event envelope to append at sequence number 1.
+    pub event: &'a PersistenceEnvelope,
+}
+
+/// Optional native storage capability for brand-new data-only creates.
+#[async_trait::async_trait]
+pub trait DataOnlyCreateStore: Send + Sync {
+    /// Persist the first event and initial projection atomically.
+    ///
+    /// Returns the new sequence number on success. Duplicate first events or
+    /// duplicate projection rows should return [`PersistenceError::ConcurrencyViolation`]
+    /// so the caller can decline the fast path and use the generic path.
+    async fn create_data_only_entity(
+        &self,
+        record: DataOnlyCreateRecord<'_>,
+    ) -> Result<u64, PersistenceError>;
+}
+
 /// Durable observe trajectory sink.
 #[async_trait::async_trait]
 pub trait TrajectorySink: Send + Sync {
@@ -718,6 +751,7 @@ pub struct StorageStack {
     pub platform: Option<Arc<dyn PlatformStore>>,
     pub policies: Option<Arc<dyn PolicyStore>>,
     pub query_plane: Option<Arc<dyn QueryPlaneStore>>,
+    pub data_only_create: Option<Arc<dyn DataOnlyCreateStore>>,
     pub trajectory: Option<Arc<dyn TrajectorySink>>,
     pub metadata: Option<Arc<dyn MetadataStoreProvider>>,
 }
@@ -732,6 +766,7 @@ impl StorageStack {
         platform: Option<Arc<dyn PlatformStore>>,
         policies: Option<Arc<dyn PolicyStore>>,
         query_plane: Option<Arc<dyn QueryPlaneStore>>,
+        data_only_create: Option<Arc<dyn DataOnlyCreateStore>>,
         trajectory: Option<Arc<dyn TrajectorySink>>,
         metadata: Option<Arc<dyn MetadataStoreProvider>>,
     ) -> Self {
@@ -743,6 +778,7 @@ impl StorageStack {
             platform,
             policies,
             query_plane,
+            data_only_create,
             trajectory,
             metadata,
         }
@@ -758,6 +794,7 @@ impl StorageStack {
             Some(store.clone() as Arc<dyn PlatformStore>),
             Some(store.clone() as Arc<dyn PolicyStore>),
             Some(store.clone() as Arc<dyn QueryPlaneStore>),
+            Some(store.clone() as Arc<dyn DataOnlyCreateStore>),
             Some(store.clone() as Arc<dyn TrajectorySink>),
             Some(Arc::new(SingleMetadataStoreProvider::new(store))),
         )
@@ -773,6 +810,7 @@ impl StorageStack {
             Some(store.clone() as Arc<dyn PlatformStore>),
             Some(store.clone() as Arc<dyn PolicyStore>),
             Some(store.clone() as Arc<dyn QueryPlaneStore>),
+            None,
             Some(store.clone() as Arc<dyn TrajectorySink>),
             Some(Arc::new(SingleMetadataStoreProvider::new(store))),
         )
@@ -791,6 +829,7 @@ impl StorageStack {
             Some(platform_store),
             Some(router.clone() as Arc<dyn PolicyStore>),
             Some(router.clone() as Arc<dyn QueryPlaneStore>),
+            None,
             Some(router.clone() as Arc<dyn TrajectorySink>),
             Some(Arc::new(TenantRoutedMetadataStoreProvider::new(
                 router.as_ref().clone(),
@@ -803,6 +842,7 @@ impl StorageStack {
         Self::new(
             BackendLabel::Redis,
             BoxedEventStore::from_arc(store),
+            None,
             None,
             None,
             None,
@@ -826,6 +866,7 @@ impl StorageStack {
             None,
             None,
             platform,
+            None,
             None,
             None,
             None,
@@ -2301,6 +2342,24 @@ impl QueryPlaneStore for TursoEventStore {
         TursoEventStore::projected_entity_counts_by_tenant(self)
             .await
             .map(Some)
+    }
+}
+
+#[async_trait::async_trait]
+impl DataOnlyCreateStore for PostgresEventStore {
+    async fn create_data_only_entity(
+        &self,
+        record: DataOnlyCreateRecord<'_>,
+    ) -> Result<u64, PersistenceError> {
+        self.create_data_only_entity_native(
+            record.tenant,
+            record.entity_type,
+            record.entity_id,
+            record.status,
+            record.fields,
+            record.event,
+        )
+        .await
     }
 }
 

--- a/crates/temper-server/tests/storage_stack.rs
+++ b/crates/temper-server/tests/storage_stack.rs
@@ -224,6 +224,7 @@ fn storage_stack_labels_backend_and_exposes_boxed_events() {
         None,
         None,
         None,
+        None,
     );
 
     assert_eq!(stack.backend, BackendLabel::Postgres);
@@ -245,6 +246,7 @@ async fn storage_stack_exposes_query_plane_and_trajectory_capabilities() {
         None,
         None,
         Some(Arc::new(RecordingQueryPlane)),
+        None,
         Some(Arc::new(RecordingTrajectorySink)),
         None,
     );

--- a/crates/temper-store-postgres/src/data_only_create.rs
+++ b/crates/temper-store-postgres/src/data_only_create.rs
@@ -1,0 +1,178 @@
+//! Native storage path for brand-new data-only entity creates.
+
+use std::time::Instant;
+
+use sqlx::Acquire;
+use temper_runtime::persistence::{PersistenceEnvelope, PersistenceError};
+
+use crate::PostgresEventStore;
+use crate::metrics::{
+    PostgresTransactionTimer, record_postgres_pool_acquire_duration,
+    record_postgres_projection_index_fields, record_postgres_projection_index_reconciliation,
+    record_postgres_transaction_begin_duration, record_postgres_transaction_commit_duration,
+};
+use crate::platform::{json_hash, scalar_index_fields, storage_error};
+
+const DATA_ONLY_CREATE_OPERATION: &str = "data_only_create";
+
+impl PostgresEventStore {
+    /// Atomically insert the first data-only event and its initial query projection.
+    pub async fn create_data_only_entity_native(
+        &self,
+        tenant: &str,
+        entity_type: &str,
+        entity_id: &str,
+        status: &str,
+        fields: &serde_json::Value,
+        event: &PersistenceEnvelope,
+    ) -> Result<u64, PersistenceError> {
+        assert_eq!(
+            event.sequence_nr, 1,
+            "native data-only create requires first event sequence"
+        );
+        let projection_hash = json_hash(fields);
+        let (new_index, indexed_fields, skipped_fields) = scalar_index_fields(fields);
+        let mut field_names = Vec::with_capacity(new_index.len());
+        let mut field_values = Vec::with_capacity(new_index.len());
+        for (field_name, field_value) in &new_index {
+            field_names.push(field_name.clone());
+            field_values.push(field_value.clone());
+        }
+
+        let mut transaction_timer = PostgresTransactionTimer::start(DATA_ONLY_CREATE_OPERATION);
+        let acquire_started = Instant::now();
+        let mut conn = match self.pool().acquire().await {
+            Ok(conn) => {
+                record_postgres_pool_acquire_duration(
+                    acquire_started.elapsed(),
+                    DATA_ONLY_CREATE_OPERATION,
+                    "ok",
+                );
+                conn
+            }
+            Err(e) => {
+                record_postgres_pool_acquire_duration(
+                    acquire_started.elapsed(),
+                    DATA_ONLY_CREATE_OPERATION,
+                    "error",
+                );
+                return Err(storage_error(e));
+            }
+        };
+        let begin_started = Instant::now();
+        let mut tx = match conn.begin().await {
+            Ok(tx) => {
+                record_postgres_transaction_begin_duration(
+                    begin_started.elapsed(),
+                    DATA_ONLY_CREATE_OPERATION,
+                    "ok",
+                );
+                tx
+            }
+            Err(e) => {
+                record_postgres_transaction_begin_duration(
+                    begin_started.elapsed(),
+                    DATA_ONLY_CREATE_OPERATION,
+                    "error",
+                );
+                return Err(storage_error(e));
+            }
+        };
+
+        let metadata_json = serde_json::to_value(&event.metadata)
+            .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
+        if let Err(e) = crate::dbm::postgres_query!(
+            "INSERT INTO events \
+             (tenant, entity_type, entity_id, sequence_nr, event_type, payload, metadata) \
+             VALUES ($1, $2, $3, 1, $4, $5, $6)",
+        )
+        .bind(tenant)
+        .bind(entity_type)
+        .bind(entity_id)
+        .bind(&event.event_type)
+        .bind(&event.payload)
+        .bind(metadata_json)
+        .execute(&mut *tx)
+        .await
+        {
+            let msg = e.to_string();
+            if msg.contains("unique") || msg.contains("duplicate key") {
+                transaction_timer.set_outcome("concurrency_violation");
+                return Err(PersistenceError::ConcurrencyViolation {
+                    expected: 0,
+                    actual: 1,
+                });
+            }
+            return Err(storage_error(e));
+        }
+
+        if let Err(e) = crate::dbm::postgres_query!(
+            "INSERT INTO entity_catalog \
+             (tenant, entity_type, entity_id, status, fields, sequence_nr, projection_version, projection_hash, updated_at) \
+             VALUES ($1, $2, $3, $4, $5, 1, 2, $6, now())",
+        )
+        .bind(tenant)
+        .bind(entity_type)
+        .bind(entity_id)
+        .bind(status)
+        .bind(fields)
+        .bind(projection_hash.as_str())
+        .execute(&mut *tx)
+        .await
+        {
+            let msg = e.to_string();
+            if msg.contains("unique") || msg.contains("duplicate key") {
+                transaction_timer.set_outcome("concurrency_violation");
+                return Err(PersistenceError::ConcurrencyViolation {
+                    expected: 0,
+                    actual: 1,
+                });
+            }
+            return Err(storage_error(e));
+        }
+
+        if !field_names.is_empty() {
+            crate::dbm::postgres_query!(
+                "INSERT INTO entity_field_index \
+                 (tenant, entity_type, entity_id, field_name, field_value, status) \
+                 SELECT $1, $2, $3, incoming.field_name, incoming.field_value, $6 \
+                 FROM unnest($4::text[], $5::text[]) AS incoming(field_name, field_value)",
+            )
+            .bind(tenant)
+            .bind(entity_type)
+            .bind(entity_id)
+            .bind(&field_names)
+            .bind(&field_values)
+            .bind(status)
+            .execute(&mut *tx)
+            .await
+            .map_err(storage_error)?;
+        }
+
+        let commit_started = Instant::now();
+        tx.commit().await.map_err(|e| {
+            record_postgres_transaction_commit_duration(
+                commit_started.elapsed(),
+                DATA_ONLY_CREATE_OPERATION,
+                "error",
+            );
+            storage_error(e)
+        })?;
+        record_postgres_transaction_commit_duration(
+            commit_started.elapsed(),
+            DATA_ONLY_CREATE_OPERATION,
+            "ok",
+        );
+        record_postgres_projection_index_fields(
+            DATA_ONLY_CREATE_OPERATION,
+            indexed_fields,
+            skipped_fields,
+        );
+        record_postgres_projection_index_reconciliation(
+            DATA_ONLY_CREATE_OPERATION,
+            "native_insert",
+        );
+        transaction_timer.set_outcome("ok");
+        Ok(1)
+    }
+}

--- a/crates/temper-store-postgres/src/lib.rs
+++ b/crates/temper-store-postgres/src/lib.rs
@@ -12,6 +12,7 @@
 //! - **Schema migration** — a simple, idempotent migration runner that
 //!   creates the required tables on startup.
 
+mod data_only_create;
 pub mod dbm;
 mod metrics;
 pub mod migration;

--- a/crates/temper-store-postgres/src/metrics.rs
+++ b/crates/temper-store-postgres/src/metrics.rs
@@ -117,24 +117,29 @@ pub(crate) fn record_postgres_transaction_commit_duration(
     );
 }
 
-pub(crate) fn record_postgres_projection_index_fields(indexed_fields: u64, skipped_fields: u64) {
-    metrics().projection_index_fields.record(
-        indexed_fields,
-        &[KeyValue::new("operation", "query_projection_upsert")],
-    );
+pub(crate) fn record_postgres_projection_index_fields(
+    operation: &'static str,
+    indexed_fields: u64,
+    skipped_fields: u64,
+) {
+    metrics()
+        .projection_index_fields
+        .record(indexed_fields, &[KeyValue::new("operation", operation)]);
     if skipped_fields > 0 {
-        metrics().projection_skipped_index_fields_total.add(
-            skipped_fields,
-            &[KeyValue::new("operation", "query_projection_upsert")],
-        );
+        metrics()
+            .projection_skipped_index_fields_total
+            .add(skipped_fields, &[KeyValue::new("operation", operation)]);
     }
 }
 
-pub(crate) fn record_postgres_projection_index_reconciliation(path: &'static str) {
+pub(crate) fn record_postgres_projection_index_reconciliation(
+    operation: &'static str,
+    path: &'static str,
+) {
     metrics().projection_index_reconciliations_total.add(
         1,
         &[
-            KeyValue::new("operation", "query_projection_upsert"),
+            KeyValue::new("operation", operation),
             KeyValue::new("path", path),
         ],
     );
@@ -183,8 +188,11 @@ mod tests {
         record_postgres_pool_acquire_duration(Duration::from_millis(2), "event_append", "ok");
         record_postgres_transaction_begin_duration(Duration::from_millis(1), "event_append", "ok");
         record_postgres_transaction_commit_duration(Duration::from_millis(3), "event_append", "ok");
-        record_postgres_projection_index_fields(4, 1);
-        record_postgres_projection_index_reconciliation("skipped_unchanged");
+        record_postgres_projection_index_fields("query_projection_upsert", 4, 1);
+        record_postgres_projection_index_reconciliation(
+            "query_projection_upsert",
+            "skipped_unchanged",
+        );
 
         let mut timer = PostgresTransactionTimer::start("event_append");
         timer.set_outcome("ok");

--- a/crates/temper-store-postgres/src/platform.rs
+++ b/crates/temper-store-postgres/src/platform.rs
@@ -26,7 +26,7 @@ const MAX_INDEXABLE_FIELD_VALUE_BYTES: usize = 2000;
 const QUERY_PROJECTION_UPSERT_OPERATION: &str = "query_projection_upsert";
 const QUERY_PROJECTION_REMOVE_OPERATION: &str = "query_projection_remove";
 
-type ScalarFieldIndex = BTreeMap<String, String>;
+pub(crate) type ScalarFieldIndex = BTreeMap<String, String>;
 type CatalogProjectionFingerprint = (String, String);
 
 struct QueryProjectionCatalogUpdate<'a> {
@@ -652,8 +652,15 @@ impl PostgresEventStore {
             QUERY_PROJECTION_UPSERT_OPERATION,
             "ok",
         );
-        record_postgres_projection_index_fields(indexed_fields, skipped_fields);
-        record_postgres_projection_index_reconciliation(reconciliation_path);
+        record_postgres_projection_index_fields(
+            QUERY_PROJECTION_UPSERT_OPERATION,
+            indexed_fields,
+            skipped_fields,
+        );
+        record_postgres_projection_index_reconciliation(
+            QUERY_PROJECTION_UPSERT_OPERATION,
+            reconciliation_path,
+        );
         transaction_timer.set_outcome("ok");
         Ok(())
     }
@@ -2265,7 +2272,7 @@ impl PostgresEventStore {
     }
 }
 
-fn storage_error(err: impl std::fmt::Display) -> PersistenceError {
+pub(crate) fn storage_error(err: impl std::fmt::Display) -> PersistenceError {
     PersistenceError::Storage(err.to_string())
 }
 
@@ -2289,7 +2296,7 @@ fn parse_optional_rfc3339(
     value.map(parse_rfc3339).transpose()
 }
 
-fn json_hash(value: &serde_json::Value) -> String {
+pub(crate) fn json_hash(value: &serde_json::Value) -> String {
     let mut hasher = Sha256::new();
     hasher.update(value.to_string().as_bytes());
     format!("{:x}", hasher.finalize())
@@ -2311,7 +2318,7 @@ fn scalar_field_value(value: &serde_json::Value) -> Option<String> {
     }
 }
 
-fn scalar_index_fields(fields: &serde_json::Value) -> (ScalarFieldIndex, u64, u64) {
+pub(crate) fn scalar_index_fields(fields: &serde_json::Value) -> (ScalarFieldIndex, u64, u64) {
     let mut indexed = ScalarFieldIndex::new();
     let mut skipped_fields = 0_u64;
 

--- a/crates/temper-store-postgres/src/store_projection_test.rs
+++ b/crates/temper-store-postgres/src/store_projection_test.rs
@@ -281,6 +281,116 @@ fn upsert_query_projection_diffs_field_index_rows() {
 }
 
 #[test]
+fn native_data_only_create_inserts_event_catalog_and_index_atomically() {
+    let database_url = match std::env::var("DATABASE_URL") {
+        Ok(url) => url,
+        Err(_) => return,
+    };
+
+    sqlx::test_block_on(async {
+        let pool = PgPool::connect(&database_url).await.unwrap();
+        run_migrations(&pool).await.unwrap();
+        let store = PostgresEventStore::new(pool.clone());
+        let tenant = format!("tenant-native-data-only-{}", uuid::Uuid::new_v4());
+        let entity_type = "SessionEntry";
+        let entity_id = "entry-native";
+        let fields = serde_json::json!({
+            "Id": entity_id,
+            "SessionId": "ss-native",
+            "EntryId": entity_id,
+            "Role": "assistant",
+            "Sequence": 2,
+            "Content": "hello"
+        });
+        let mut envelope = test_envelope("Created", fields.clone());
+        envelope.sequence_nr = 1;
+
+        let sequence_nr = store
+            .create_data_only_entity_native(
+                &tenant,
+                entity_type,
+                entity_id,
+                "Active",
+                &fields,
+                &envelope,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(sequence_nr, 1);
+        let event_count: i64 = crate::dbm::postgres_query_scalar!(
+            "SELECT COUNT(*)::bigint FROM events \
+             WHERE tenant = $1 AND entity_type = $2 AND entity_id = $3",
+        )
+        .bind(&tenant)
+        .bind(entity_type)
+        .bind(entity_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(event_count, 1);
+
+        let catalog: Option<(String, serde_json::Value, i64)> = crate::dbm::postgres_query_as!(
+            "SELECT status, fields, sequence_nr FROM entity_catalog \
+             WHERE tenant = $1 AND entity_type = $2 AND entity_id = $3",
+        )
+        .bind(&tenant)
+        .bind(entity_type)
+        .bind(entity_id)
+        .fetch_optional(&pool)
+        .await
+        .unwrap();
+        let (status, stored_fields, stored_sequence) = catalog.unwrap();
+        assert_eq!(status, "Active");
+        assert_eq!(stored_fields, fields);
+        assert_eq!(stored_sequence, 1);
+
+        let indexed_count: i64 = crate::dbm::postgres_query_scalar!(
+            "SELECT COUNT(*)::bigint FROM entity_field_index \
+             WHERE tenant = $1 AND entity_type = $2 AND entity_id = $3",
+        )
+        .bind(&tenant)
+        .bind(entity_type)
+        .bind(entity_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(indexed_count >= 5);
+
+        let duplicate = store
+            .create_data_only_entity_native(
+                &tenant,
+                entity_type,
+                entity_id,
+                "Active",
+                &fields,
+                &envelope,
+            )
+            .await;
+        assert!(matches!(
+            duplicate,
+            Err(PersistenceError::ConcurrencyViolation { .. })
+        ));
+
+        crate::dbm::postgres_query!("DELETE FROM entity_field_index WHERE tenant = $1")
+            .bind(&tenant)
+            .execute(&pool)
+            .await
+            .unwrap();
+        crate::dbm::postgres_query!("DELETE FROM entity_catalog WHERE tenant = $1")
+            .bind(&tenant)
+            .execute(&pool)
+            .await
+            .unwrap();
+        crate::dbm::postgres_query!("DELETE FROM events WHERE tenant = $1")
+            .bind(&tenant)
+            .execute(&pool)
+            .await
+            .unwrap();
+    });
+}
+
+#[test]
 fn upsert_query_projection_advances_sequence_without_rewriting_unchanged_index() {
     let database_url = match std::env::var("DATABASE_URL") {
         Ok(url) => url,

--- a/docs/adrs/0108-native-data-only-create-storage-path.md
+++ b/docs/adrs/0108-native-data-only-create-storage-path.md
@@ -1,0 +1,125 @@
+# ADR-0108: Native Data-Only Create Storage Path
+
+- Status: Proposed
+- Date: 2026-05-19
+- Deciders: Temper core maintainers
+- Related:
+  - ADR-0081: Latency Observability Acceleration Program
+  - ADR-0091: Query Projection Diff Index Upserts
+  - ADR-0095: Projection Transaction Fast Path
+  - ADR-0096: Set-Based Projection Index Reconciliation
+  - ADR-0105: Data-Only Entity Create Fast Path
+  - ADR-0106: WASM Integration Envelope Attribution
+  - ADR-0107: WASM Lazy Secret Authorization
+  - `crates/temper-server/src/state/entity_ops.rs`
+  - `crates/temper-server/src/storage/mod.rs`
+  - `crates/temper-store-postgres/src/data_only_create.rs`
+  - `crates/temper-store-postgres/src/platform.rs`
+  - `crates/temper-store-postgres/src/store.rs`
+
+## Context
+
+PERF-030 removed the first dominant WASM dispatch envelope phase by changing eager all-secret authorization into bounded bootstrap secrets plus lazy per-key authorization. The fixed-version production after batch on `sha-2b1f1a9` moved `dispatch.wasm.phase.authz_secret_resolution` from about `78.7 ms` average / `87.8 ms` p95 to about `14.0 ms` average / `15.1 ms` p95.
+
+The next production trace shape is now storage-bound. In the PERF-030 after batch `perf-030-after-batch-20260519121906`, `provider_response_applier` still spends about `99.7 ms` average in `dispatch.wasm.phase.engine_invoke_and_handle`, while Datadog span metrics show only about `1-2 ms` of busy time and about `93-106 ms` of idle wait per invocation. A representative trace (`5b6c886d955b3cd8f3b065010b085a2f`) shows the large child as local `POST /odata/{path}` for SessionEntry creation through `entity.create_data_only_tenant_entity_fast_path`, around `59-64 ms`.
+
+The current data-only path avoids actor hydration, but it still composes two generic storage operations:
+
+1. Append the first `Created` event through the generic event journal path, including a `SELECT COALESCE(MAX(sequence_nr), 0)` and an `INSERT INTO events` in one transaction.
+2. Acknowledge query projection synchronously through the generic projection upsert path, including a catalog `SELECT ... FOR UPDATE`, a catalog insert/update, field-index delete reconciliation, field-index insert/upsert, and commit.
+
+This is correct, but it is over-general for a brand-new data-only entity. On a new entity, Temper already knows the first event sequence is `1`, the projection has no previous field-index rows, and the event append plus projection acknowledgement must succeed or fail atomically for the fast path to count as a create acknowledgement.
+
+## Decision
+
+Add a native storage capability for brand-new data-only entity creation. For storage backends that implement it, the server data-only fast path will persist the first event and the initial query projection in one storage transaction instead of composing generic append plus generic projection upsert.
+
+### Sub-Decision 1: Capability Boundary
+
+Introduce a server storage trait such as `DataOnlyCreateStore` and attach it to `StorageStack` as an optional capability. The method should accept the already-derived tenant, entity type, entity id, status, full fields, scalar projection fields, and first `Created` event envelope.
+
+**Why this approach**: The optimization is storage-specific and should not pollute the general `EventStore` trait with a method only valid for first-event creates. Keeping it as an optional capability preserves existing Redis/Turso/sim behavior and lets unsupported backends fall back to the current generic path.
+
+### Sub-Decision 2: PostgreSQL Native Path
+
+Implement the native capability for `PostgresEventStore` with one transaction:
+
+1. Acquire a connection and begin a transaction.
+2. Insert the first event at `sequence_nr = 1`.
+3. Insert the `entity_catalog` row with `projection_version = 2` and a projection hash.
+4. Insert scalar `entity_field_index` rows using set-based `unnest`.
+5. Commit.
+
+Duplicate event or catalog keys must surface as a concurrency conflict so the caller can decline the fast path and fall back to the existing actor/generic path. Any other failure must abort the transaction and return an error so callers do not receive a false 201 acknowledgement.
+
+**Why this approach**: It removes generic read-before-write and delete-reconciliation queries from the hot first-create path while keeping the same durable event journal, full catalog row, scalar index, tenant isolation, and all-or-nothing acknowledgement semantics.
+
+### Sub-Decision 3: Observability Contract
+
+The native path must emit a distinct span/resource name and preserve the existing event append, projection update, and Postgres transaction metrics where practical. The dashboard must record before and after Datadog evidence:
+
+- Before: PERF-030 after batch on `sha-2b1f1a9`, especially `entity.create_data_only_tenant_entity_fast_path`, `POST /odata/{path}`, `provider_response_applier engine_invoke_and_handle`, and Session correctness read-back.
+- After: fixed-version production batch for the new revision, the same span distributions, exact deployment SHA, zero error spans, and exact SessionEntry read-back.
+
+**Why this approach**: The prior slices showed that removing work is not enough. The program only counts the change as a performance win if Datadog and live correctness evidence prove it.
+
+## Rollout Plan
+
+1. **Phase 0 (Immediate)** - Add the native optional storage capability, Postgres implementation, server fast-path call site, unit/integration coverage, and dashboard status.
+2. **Phase 1 (Rollout)** - Merge Temper, bump TemperPaw to the exact Temper commit, run local Paw checks, open a rollout PR, and deploy the fixed version.
+3. **Phase 2 (Production Proof)** - Run a controlled live mock-provider Session proof plus a five-run batch, read back exact SessionEntries, collect Datadog before/after spans and logs, and accept or reject the latency claim in the dashboard.
+
+## Readiness Gates
+
+- Native create returns the same OData acknowledgement shape as the existing data-only path.
+- Duplicate creates do not corrupt events or projections.
+- Projection read-back sees the new entity immediately after the create acknowledgement.
+- Generic fallback still works for unsupported backends, action-bearing entities, non-object payloads, and concurrency conflicts.
+- Tests cover event journal row, catalog row, scalar field index row, duplicate conflict, and fallback behavior.
+- Production proof shows lower `entity.create_data_only_tenant_entity_fast_path` and lower provider-response storage wait without new projection drift or missing SessionEntry rows.
+
+## Consequences
+
+### Positive
+
+- Removes several serial Postgres round trips from new data-only creates.
+- Preserves correctness by keeping event and projection acknowledgement atomic.
+- Reduces the hot SessionEntry materialization cost currently visible inside `provider_response_applier`.
+- Keeps the optimization behind an explicit storage capability instead of hardcoding PostgreSQL assumptions into OData or WASM code.
+
+### Negative
+
+- Adds a storage-specific capability beside the generic event and query-plane traits.
+- Creates a second write implementation that must stay aligned with projection schema changes.
+- Does not address remaining host-chain construction, callback dispatch, or workflow drain costs.
+
+### Risks
+
+- A bug in the native path could create event/projection drift. Mitigation: one transaction, projection read-back tests, duplicate conflict tests, and live SessionEntry read-back.
+- Metrics could fragment across native and generic paths. Mitigation: keep existing high-level data-only span and add a low-cardinality native storage span/resource.
+- Backend parity could regress. Mitigation: make the capability optional and keep generic fallback as the default.
+
+### DST Compliance
+
+- `temper-server` is simulation-visible, so the call site must preserve deterministic state construction and ordering.
+- Production-only timing uses existing `Instant`-based metric patterns with `// determinism-ok` comments where new timers are introduced.
+- No wall-clock time or random UUID sources are added beyond the existing `sim_now()` and `sim_uuid()` event envelope construction.
+
+## Non-Goals
+
+- Do not make all query projection updates asynchronous.
+- Do not weaken projection acknowledgement for SessionEntry creates.
+- Do not remove the event journal.
+- Do not change Cedar governance, tenant isolation, or spec-governed action semantics.
+- Do not optimize non-data-only or action-bearing entity creates in this slice.
+
+## Alternatives Considered
+
+1. **Only add more instrumentation** - Useful but insufficient now that Datadog identifies the stacked storage path clearly enough for a targeted PR. Rejected as a standalone slice, though the implementation will preserve observability.
+2. **Make SessionEntry projection eventually consistent** - Faster, but it risks exactly the data-drift class the program is trying to prevent. Rejected for this slice.
+3. **Optimize only generic projection upsert** - Safer and smaller, but it leaves event append and first-create assumptions unused. Rejected as the primary approach because the measured hot path is a new-entity create where a native atomic path can remove more serial work.
+4. **Create a TemperPaw-only batch endpoint** - Could reduce WASM host calls, but it would duplicate platform write semantics in the app. Rejected until the platform-native path is proven or disproven.
+
+## Rollback Policy
+
+Disable use of the optional native capability in the server data-only fast path and fall back to the current generic append plus projection upsert. Because the native path uses the same events, catalog, and field-index tables, no data migration is required for rollback.


### PR DESCRIPTION
## Summary
- add an optional Postgres native storage capability for brand-new data-only entity creates
- persist the initial event, catalog projection, and scalar field index in one transaction
- expose Datadog-visible spans/metrics for `entity.data_only_create_native_storage` and Postgres `operation=data_only_create`
- keep non-Postgres backends on the existing append + projection-upsert path

## Why
PERF-031 targets the slowest remaining local storage segment in the Session projection flow after PERF-030. The before baseline is the PERF-030 production deployment:

- version: `sha-2b1f1a9` / `2b1f1a9c7f0eed71e9cd3d9f84f41ba9066dd6be`
- live client configure-to-terminal: avg `728.2 ms`, p50 `631.6 ms`, p95 `1125.5 ms`
- Datadog: `Session.ProviderResponseReady.integrations` avg `161.7 ms`, p95 `163.2 ms`
- Datadog: `dispatch.background_wasm_integrations` avg `134.1 ms`, p95 `163.2 ms`
- Datadog: local entity create POST avg about `58.0 ms`, p95 about `125.8 ms`
- Datadog: `entity.create_data_only_tenant_entity_fast_path` avg about `47.0 ms`, p95 about `70.5 ms`

Trace inspection showed the hot path was waiting on local storage/projection HTTP work, not guest CPU. The native path removes one generic persistence/projection round trip for brand-new data-only creates while keeping event sourcing and query projection correctness in the same DB transaction.

## Correctness model
- only applies to data-only entity create when the first event has `sequence_nr = 1`
- inserts event, `entity_catalog`, and `entity_field_index` rows atomically
- converts duplicate inserts into a concurrency violation so the caller declines the fast path cleanly
- preserves event sourcing as source of truth and still emits the same in-memory, observe, and SSE updates after commit
- leaves action-bearing entities and non-Postgres storage unchanged

## Observability
Adds explicit measurement points for the after run:

- span: `entity.data_only_create_native_storage`
- Postgres timing operation: `data_only_create`
- projection/index field metrics operation: `data_only_create`
- existing parent spans remain comparable: `entity.create_data_only_tenant_entity_fast_path`, local `POST /odata/{path}`, `dispatch.background_wasm_integrations`, and `Session.ProviderResponseReady.integrations`

## Validation
- `cargo fmt --all -- --check`
- `cargo check -p temper-store-postgres -p temper-server`
- `cargo clippy -p temper-store-postgres -p temper-server --all-targets -- -D warnings`
- `cargo test -p temper-store-postgres native_data_only_create_inserts_event_catalog_and_index_atomically` (compiled and passed; skipped real DB round trip when local `DATABASE_URL` was unset)
- `cargo test -p temper-store-postgres metrics::tests`
- `cargo test -p temper-server test_data_only_entity_create_fast_path_persists_projection_without_actor_spawn`
- `cargo test -p temper-server test_data_only_create_fast_path_declines_action_bearing_entities`
- `cargo test -p temper-server --test storage_stack`
- `cargo test -p temper-server --test wasm_dispatch`
- manual DST/code review markers written for the session
- full pre-push gate passed, including rustfmt, clippy/readability, workspace tests, and doctests

## Rollout measurement gate
This PR is not considered a proven performance win until the Temper + TemperPaw rollout produces an after batch with:

- live client before/after configure-to-terminal timings
- fixed-version Datadog queries for the new native storage span
- fixed-version Datadog comparisons for the parent workflow spans
- read-back correctness proof for the created SessionEntry data
- DBM/trace confirmation that `data_only_create` replaces the prior local storage segment for eligible creates
