### PR TITLE
Record observe wait span identity

### DIFF
--- a/crates/temper-server/src/observe/entities.rs
+++ b/crates/temper-server/src/observe/entities.rs
@@ -168,8 +168,9 @@ pub(crate) struct EntityEventStreamParams {
     skip_all,
     fields(
         otel.name = "GET /observe/entities/{entity_type}/{entity_id}/wait",
-        entity_type,
-        entity_id,
+        tenant = tracing::field::Empty,
+        entity_type = tracing::field::Empty,
+        entity_id = tracing::field::Empty,
         wait.mode = "event_driven",
         wait.wake_reason = tracing::field::Empty,
         wait.poll_ms = tracing::field::Empty,
@@ -184,6 +185,7 @@ pub(crate) async fn handle_wait_for_entity_state(
 ) -> Result<Json<serde_json::Value>, StatusCode> {
     require_observe_auth(&state, &headers, "read", &entity_type)?;
     let tenant = extract_tenant(&headers, &state).map_err(|(code, _)| code)?;
+    record_wait_span_identity(&tenant, &entity_type, &entity_id);
 
     let target_statuses: std::collections::BTreeSet<String> = params
         .statuses
@@ -256,6 +258,17 @@ pub(crate) async fn handle_wait_for_entity_state(
             }
         }
     }
+}
+
+pub(super) fn record_wait_span_identity(
+    tenant: &temper_runtime::tenant::TenantId,
+    entity_type: &str,
+    entity_id: &str,
+) {
+    let span = tracing::Span::current();
+    span.record("tenant", tenant.as_str());
+    span.record("entity_type", entity_type);
+    span.record("entity_id", entity_id);
 }
 
 async fn load_wait_entity_state(

--- a/crates/temper-server/src/observe/mod_test.rs
+++ b/crates/temper-server/src/observe/mod_test.rs
@@ -1,7 +1,8 @@
 use super::*;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
-use std::sync::Arc;
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use temper_runtime::ActorSystem;
 use temper_runtime::scheduler::sim_now;
@@ -9,6 +10,12 @@ use temper_runtime::tenant::TenantId;
 use temper_spec::csdl::parse_csdl;
 use temper_store_turso::TursoEventStore;
 use tower::ServiceExt;
+use tracing::field::{Field, Visit};
+use tracing::span::{Attributes, Record};
+use tracing::{Id, Subscriber};
+use tracing_subscriber::Layer;
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::registry::LookupSpan;
 
 use crate::registry::SpecRegistry;
 use crate::request_context::AgentContext;
@@ -178,6 +185,93 @@ fn build_app_with_state(state: ServerState) -> Router {
         .nest("/observe", build_observe_router())
         .nest("/api", crate::api::build_api_router())
         .with_state(state)
+}
+
+#[derive(Clone, Default)]
+struct CapturedSpans {
+    spans: Arc<Mutex<Vec<CapturedSpan>>>,
+}
+
+#[derive(Clone, Debug)]
+struct CapturedSpan {
+    name: String,
+    fields: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Copy)]
+struct CapturedSpanIndex(usize);
+
+impl<S> Layer<S> for CapturedSpans
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let mut visitor = CapturedFieldVisitor::default();
+        attrs.record(&mut visitor);
+
+        let mut spans = self.spans.lock().expect("span capture lock poisoned");
+        let index = spans.len();
+        spans.push(CapturedSpan {
+            name: attrs.metadata().name().to_string(),
+            fields: visitor.fields,
+        });
+
+        if let Some(span) = ctx.span(id) {
+            span.extensions_mut().insert(CapturedSpanIndex(index));
+        }
+    }
+
+    fn on_record(&self, id: &Id, values: &Record<'_>, ctx: Context<'_, S>) {
+        let Some(span) = ctx.span(id) else {
+            return;
+        };
+        let Some(index) = span.extensions().get::<CapturedSpanIndex>().copied() else {
+            return;
+        };
+
+        let mut visitor = CapturedFieldVisitor::default();
+        values.record(&mut visitor);
+        if let Some(captured) = self
+            .spans
+            .lock()
+            .expect("span capture lock poisoned")
+            .get_mut(index.0)
+        {
+            captured.fields.extend(visitor.fields);
+        }
+    }
+}
+
+#[derive(Default)]
+struct CapturedFieldVisitor {
+    fields: BTreeMap<String, String>,
+}
+
+impl Visit for CapturedFieldVisitor {
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.fields
+            .insert(field.name().to_string(), value.to_string());
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.fields
+            .insert(field.name().to_string(), value.to_string());
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.fields
+            .insert(field.name().to_string(), value.to_string());
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.fields
+            .insert(field.name().to_string(), value.to_string());
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.fields
+            .insert(field.name().to_string(), format!("{value:?}"));
+    }
 }
 
 #[tokio::test]
@@ -1009,6 +1103,54 @@ async fn test_entity_wait_returns_terminal_state() {
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(json["status"], "Submitted");
     assert_eq!(json["timed_out"], false);
+}
+
+#[test]
+fn test_wait_span_identity_recorder_sets_datadog_filter_fields() {
+    use tracing_subscriber::prelude::*;
+
+    let captured = CapturedSpans::default();
+    let subscriber = tracing_subscriber::registry().with(captured.clone());
+    let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+
+    let span = tracing::info_span!(
+        "handle_wait_for_entity_state",
+        otel.name = "GET /observe/entities/{entity_type}/{entity_id}/wait",
+        tenant = tracing::field::Empty,
+        entity_type = tracing::field::Empty,
+        entity_id = tracing::field::Empty,
+        wait.wake_reason = tracing::field::Empty
+    );
+    let _span_guard = span.enter();
+    entities::record_wait_span_identity(&TenantId::default(), "Order", "order-wait-span-1");
+    tracing::Span::current().record("wait.wake_reason", "initial_state");
+
+    let spans = captured.spans.lock().expect("span capture lock poisoned");
+    let wait_span = spans
+        .iter()
+        .find(|span| span.name == "handle_wait_for_entity_state")
+        .expect("wait route span should be captured");
+
+    assert_eq!(
+        wait_span.fields.get("otel.name").map(String::as_str),
+        Some("GET /observe/entities/{entity_type}/{entity_id}/wait")
+    );
+    assert_eq!(
+        wait_span.fields.get("tenant").map(String::as_str),
+        Some("default")
+    );
+    assert_eq!(
+        wait_span.fields.get("entity_type").map(String::as_str),
+        Some("Order")
+    );
+    assert_eq!(
+        wait_span.fields.get("entity_id").map(String::as_str),
+        Some("order-wait-span-1")
+    );
+    assert_eq!(
+        wait_span.fields.get("wait.wake_reason").map(String::as_str),
+        Some("initial_state")
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- explicitly records tenant, entity_type, and entity_id on the observe wait route span after auth and tenant extraction
- keeps the event-driven wait response shape and wake behavior unchanged
- adds a span-capture regression guard so Datadog proof batches can be filtered by wait-route entity identity

## Validation
- CARGO_INCREMENTAL=0 cargo test -p temper-server --lib --features observe test_wait_span_identity_recorder_sets_datadog_filter_fields -- --nocapture
- CARGO_INCREMENTAL=0 cargo test -p temper-server --lib --features observe entity_wait -- --nocapture
- CARGO_INCREMENTAL=0 cargo check -p temper-server --features observe
- CARGO_INCREMENTAL=0 cargo clippy -p temper-server --features observe --lib -- -D warnings
- CARGO_INCREMENTAL=0 cargo test -p temper-server --lib --features observe (459 tests)
- cargo fmt --all -- --check
- git diff --check
- .claude/hooks/check-determinism.sh on crates/temper-server/src/observe/entities.rs

## Pre-push note
The normal pre-push gate passed rustfmt, workspace clippy, and readability ratchet, then failed in Docker-backed integration tests because Docker Desktop cannot create a containerd lease while pulling postgres:11-alpine: write /var/lib/desktop-containerd/daemon/io.containerd.metadata.v1.bolt/meta.db: input/output error. A direct docker pull postgres:11-alpine reproduces the same daemon error locally. GitHub CI should provide the full-suite Docker proof.

## Acceptance gate
This is an observability/proof-quality slice, not a latency win. After merge and TemperPaw rollout, a live wait proof should show Datadog can filter GET /observe/entities/{entity_type}/{entity_id}/wait by exact @entity_id.