### PR TITLE
Bound catalog shadow read probes

### DIFF
--- a/crates/temper-server/src/odata/read.rs
+++ b/crates/temper-server/src/odata/read.rs
@@ -467,6 +467,8 @@ pub(super) async fn handle_odata_get_for_tenant(
     candidate_count = tracing::field::Empty,
     materialized_count = tracing::field::Empty,
     returned_count = tracing::field::Empty,
+    catalog_shadow_check_budget = tracing::field::Empty,
+    catalog_shadow_check_scheduled = tracing::field::Empty,
 ))]
 async fn handle_entity_set(
     state: &ServerState,
@@ -561,7 +563,7 @@ async fn handle_entity_set(
     );
     span.record("candidate_count", entity_ids.len() as u64);
 
-    let entities = materialize_entity_set_entities(
+    let materialized = materialize_entity_set_entities(
         state,
         tenant,
         &entity_type,
@@ -570,9 +572,17 @@ async fn handle_entity_set(
         prefer_catalog_materialization,
     )
     .await;
-    span.record("materialized_count", entities.len() as u64);
+    span.record("materialized_count", materialized.entities.len() as u64);
+    span.record(
+        "catalog_shadow_check_budget",
+        materialized.catalog_shadow_check_budget as u64,
+    );
+    span.record(
+        "catalog_shadow_check_scheduled",
+        materialized.catalog_shadow_check_scheduled as u64,
+    );
 
-    let (mut result, mut count) = apply_query_options(entities, &apply_options);
+    let (mut result, mut count) = apply_query_options(materialized.entities, &apply_options);
     span.record("returned_count", result.len() as u64);
     if count.is_none() {
         count = precomputed_count;

--- a/crates/temper-server/src/odata/read_support.rs
+++ b/crates/temper-server/src/odata/read_support.rs
@@ -12,7 +12,10 @@ use crate::storage::EntityCatalogRow;
 
 mod shadow;
 
-use shadow::maybe_spawn_catalog_shadow_check;
+use shadow::{
+    CatalogShadowReadBudget, maybe_spawn_catalog_shadow_check,
+    maybe_spawn_catalog_shadow_check_with_budget,
+};
 
 fn env_usize(name: &str, default: usize) -> usize {
     std::env::var(name) // determinism-ok: read once at startup
@@ -160,25 +163,34 @@ pub(super) async fn materialize_entity_set_entities(
     entity_set_name: &str,
     entity_ids: &[String],
     prefer_catalog: bool,
-) -> Vec<serde_json::Value> {
+) -> MaterializedEntitySet {
     let mut catalog_hits: BTreeMap<String, EntityCatalogRow> =
         if should_read_catalog_for_materialization(prefer_catalog) {
             try_load_catalog_rows(state, tenant, entity_type, entity_ids).await
         } else {
             BTreeMap::new()
         };
+    let mut shadow_budget = CatalogShadowReadBudget::for_entity_set();
 
     let concurrency = entity_set_materialization_concurrency();
-    stream::iter(entity_ids.iter().cloned())
+    let entities = stream::iter(entity_ids.iter().cloned())
         .map(|id| {
             let catalog_row = catalog_hits.remove(&id);
+            if let Some(row) = catalog_row.as_ref() {
+                let _ = maybe_spawn_catalog_shadow_check_with_budget(
+                    state,
+                    tenant,
+                    entity_type,
+                    row,
+                    &mut shadow_budget,
+                );
+            }
             let state = state.clone();
             let tenant = tenant.clone();
             let entity_type = entity_type.to_string();
             let entity_set_name = entity_set_name.to_string();
             async move {
                 if let Some(row) = catalog_row {
-                    maybe_spawn_catalog_shadow_check(&state, &tenant, &entity_type, &row);
                     let mut entity =
                         catalog_row_to_entity_body(&entity_type, &entity_set_name, row);
                     hydrate_blob_refs_for_tenant(&state, &tenant, &mut entity).await;
@@ -217,7 +229,19 @@ pub(super) async fn materialize_entity_set_entities(
         .await
         .into_iter()
         .flatten()
-        .collect::<Vec<_>>()
+        .collect::<Vec<_>>();
+
+    MaterializedEntitySet {
+        entities,
+        catalog_shadow_check_budget: shadow_budget.configured(),
+        catalog_shadow_check_scheduled: shadow_budget.scheduled(),
+    }
+}
+
+pub(super) struct MaterializedEntitySet {
+    pub(super) entities: Vec<serde_json::Value>,
+    pub(super) catalog_shadow_check_budget: usize,
+    pub(super) catalog_shadow_check_scheduled: usize,
 }
 
 pub(super) fn select_entity_ids_for_materialization(
@@ -317,171 +341,4 @@ pub(super) async fn record_entity_set_not_found(state: &ServerState, tenant: &st
 }
 
 #[cfg(test)]
-mod tests {
-    use super::{
-        EntityCatalogRow, catalog_row_to_entity_body, select_entity_ids_for_materialization,
-        should_read_catalog_for_materialization,
-    };
-    use temper_odata::query::types::{
-        FilterExpr, ODataValue, OrderByClause, OrderDirection, QueryOptions,
-    };
-
-    #[test]
-    fn catalog_row_serializes_to_entity_state_shape() {
-        let row = EntityCatalogRow {
-            entity_id: "en-123".to_string(),
-            status: "Published".to_string(),
-            fields: serde_json::json!({"Name": "Foo", "Score": 7}),
-            sequence_nr: 14,
-        };
-        let body = catalog_row_to_entity_body("DesignLanguage", "DesignLanguages", row);
-
-        // Mirrors EntityState serialization keys so enrich_entity_response and
-        // OData clients see no difference between catalog-served and actor-served bodies.
-        assert_eq!(body["entity_type"], "DesignLanguage");
-        assert_eq!(body["entity_id"], "en-123");
-        assert_eq!(body["status"], "Published");
-        assert_eq!(body["sequence_nr"], 14);
-        assert_eq!(body["total_event_count"], 14);
-        assert_eq!(body["item_count"], 0);
-        assert_eq!(body["counters"], serde_json::json!({}));
-        assert_eq!(body["booleans"], serde_json::json!({}));
-        assert_eq!(body["lists"], serde_json::json!({}));
-        assert_eq!(body["events"], serde_json::json!([]));
-        assert_eq!(body["fields"]["Name"], "Foo");
-        assert_eq!(body["fields"]["Score"], 7);
-        assert_eq!(body["@odata.id"], "DesignLanguages('en-123')");
-    }
-
-    #[test]
-    fn catalog_row_body_matches_actor_serialization_for_single_key_path() {
-        // The single-entity read path (handle_entity → load_existing_entity_body)
-        // expects the catalog-derived body to be a drop-in replacement for the
-        // actor's serialized state. Verify the keyset matches what the actor
-        // emits so enrich_entity_response and downstream clients see no diff.
-        let row = EntityCatalogRow {
-            entity_id: "fl-019dde81".to_string(),
-            status: "Ready".to_string(),
-            fields: serde_json::json!({
-                "Id": "fl-019dde81",
-                "Status": "Ready",
-                "Name": "phosphor-command-grid.html",
-                "MimeType": "text/html",
-                "content_hash": "sha256:c74e77",
-                "size_bytes": 8427,
-            }),
-            sequence_nr: 3,
-        };
-        let body = catalog_row_to_entity_body("File", "Files", row);
-        let obj = body.as_object().expect("entity body is an object");
-        // Required EntityState top-level keys.
-        for required in [
-            "entity_type",
-            "entity_id",
-            "status",
-            "item_count",
-            "counters",
-            "booleans",
-            "lists",
-            "fields",
-            "events",
-            "total_event_count",
-            "sequence_nr",
-            "@odata.id",
-        ] {
-            assert!(
-                obj.contains_key(required),
-                "missing required key: {required}"
-            );
-        }
-        // Verify @odata.id format matches what handle_entity uses.
-        assert_eq!(body["@odata.id"], "Files('fl-019dde81')");
-        // Fields blob is preserved verbatim.
-        assert_eq!(body["fields"]["Name"], "phosphor-command-grid.html");
-        assert_eq!(body["fields"]["content_hash"], "sha256:c74e77");
-    }
-
-    #[test]
-    fn pushed_down_filters_prefer_catalog_materialization() {
-        assert!(should_read_catalog_for_materialization(true));
-    }
-
-    #[test]
-    fn default_pagination_applies_when_top_missing_and_no_filter_orderby() {
-        let ids: Vec<String> = (0..150).map(|i| format!("id-{i}")).collect();
-        let opts = QueryOptions {
-            count: Some(true),
-            ..QueryOptions::default()
-        };
-
-        let (selected, apply_opts, count) =
-            select_entity_ids_for_materialization(ids, &opts, 100, 1000);
-
-        assert_eq!(selected.len(), 100);
-        assert_eq!(selected.first().unwrap(), "id-0");
-        assert_eq!(selected.last().unwrap(), "id-99");
-        assert_eq!(count, Some(150));
-        assert_eq!(apply_opts.top, None);
-        assert_eq!(apply_opts.skip, None);
-        assert_eq!(apply_opts.count, None);
-    }
-
-    #[test]
-    fn explicit_skip_top_are_applied_before_materialization() {
-        let ids: Vec<String> = (0..50).map(|i| format!("id-{i}")).collect();
-        let opts = QueryOptions {
-            top: Some(10),
-            skip: Some(5),
-            count: Some(true),
-            ..QueryOptions::default()
-        };
-
-        let (selected, _apply_opts, count) =
-            select_entity_ids_for_materialization(ids, &opts, 100, 1000);
-
-        assert_eq!(selected.len(), 10);
-        assert_eq!(selected.first().unwrap(), "id-5");
-        assert_eq!(selected.last().unwrap(), "id-14");
-        assert_eq!(count, Some(50));
-    }
-
-    #[test]
-    fn filtered_query_materialises_all_entities_under_safety_cap() {
-        // With max_entities=1000, the safety cap is 10_000.
-        // 2500 entities should ALL be materialised (no truncation).
-        let ids: Vec<String> = (0..2500).map(|i| format!("id-{i}")).collect();
-        let opts = QueryOptions {
-            filter: Some(FilterExpr::Literal(ODataValue::Boolean(true))),
-            orderby: Some(vec![OrderByClause {
-                property: "Status".to_string(),
-                direction: OrderDirection::Asc,
-            }]),
-            ..QueryOptions::default()
-        };
-
-        let (selected, apply_opts, count) =
-            select_entity_ids_for_materialization(ids, &opts, 100, 1000);
-
-        assert_eq!(selected.len(), 2500);
-        assert_eq!(count, None);
-        assert_eq!(apply_opts.top, Some(100));
-    }
-
-    #[test]
-    fn safety_cap_truncates_at_10x_max_entities() {
-        // With max_entities=1000, the safety cap is 10_000.
-        // 15_000 entities should be truncated to 10_000.
-        let ids: Vec<String> = (0..15_000).map(|i| format!("id-{i}")).collect();
-        let opts = QueryOptions {
-            filter: Some(FilterExpr::Literal(ODataValue::Boolean(true))),
-            ..QueryOptions::default()
-        };
-
-        let (selected, apply_opts, count) =
-            select_entity_ids_for_materialization(ids, &opts, 100, 1000);
-
-        assert_eq!(selected.len(), 10_000);
-        assert_eq!(count, None);
-        assert_eq!(apply_opts.top, Some(100));
-    }
-}
+mod tests;

--- a/crates/temper-server/src/odata/read_support/shadow.rs
+++ b/crates/temper-server/src/odata/read_support/shadow.rs
@@ -13,6 +13,12 @@ fn catalog_shadow_read_sample_every() -> usize {
     *SAMPLE_EVERY.get_or_init(|| super::env_usize("TEMPER_ODATA_CATALOG_SHADOW_READ_EVERY", 0))
 }
 
+fn catalog_shadow_read_max_per_response() -> usize {
+    static MAX_PER_RESPONSE: OnceLock<usize> = OnceLock::new();
+    *MAX_PER_RESPONSE
+        .get_or_init(|| super::env_usize("TEMPER_ODATA_CATALOG_SHADOW_READ_MAX_PER_RESPONSE", 2))
+}
+
 fn stable_shadow_sample_hash(tenant: &TenantId, entity_type: &str, entity_id: &str) -> u64 {
     let mut hasher = Sha256::new();
     hasher.update(tenant.as_str().as_bytes());
@@ -28,6 +34,15 @@ fn stable_shadow_sample_hash(tenant: &TenantId, entity_type: &str, entity_id: &s
 
 fn should_shadow_check_catalog_row(tenant: &TenantId, entity_type: &str, entity_id: &str) -> bool {
     let sample_every = catalog_shadow_read_sample_every();
+    should_shadow_check_catalog_row_with_sample_every(tenant, entity_type, entity_id, sample_every)
+}
+
+fn should_shadow_check_catalog_row_with_sample_every(
+    tenant: &TenantId,
+    entity_type: &str,
+    entity_id: &str,
+    sample_every: usize,
+) -> bool {
     sample_every > 0
         && stable_shadow_sample_hash(tenant, entity_type, entity_id)
             .is_multiple_of(sample_every as u64)
@@ -59,16 +74,101 @@ fn projection_drift_kind(
     }
 }
 
+pub(super) struct CatalogShadowReadBudget {
+    configured: usize,
+    remaining: usize,
+    scheduled: usize,
+}
+
+impl CatalogShadowReadBudget {
+    pub(super) fn for_entity_set() -> Self {
+        Self::new(catalog_shadow_read_max_per_response())
+    }
+
+    fn new(configured: usize) -> Self {
+        Self {
+            configured,
+            remaining: configured,
+            scheduled: 0,
+        }
+    }
+
+    pub(super) fn configured(&self) -> usize {
+        self.configured
+    }
+
+    pub(super) fn scheduled(&self) -> usize {
+        self.scheduled
+    }
+
+    fn take_if_eligible_with_sample_every(
+        &mut self,
+        tenant: &TenantId,
+        entity_type: &str,
+        entity_id: &str,
+        sample_every: usize,
+    ) -> bool {
+        if self.remaining == 0
+            || !should_shadow_check_catalog_row_with_sample_every(
+                tenant,
+                entity_type,
+                entity_id,
+                sample_every,
+            )
+        {
+            return false;
+        }
+
+        self.remaining -= 1;
+        self.scheduled += 1;
+        true
+    }
+
+    fn take_if_eligible(&mut self, tenant: &TenantId, entity_type: &str, entity_id: &str) -> bool {
+        self.take_if_eligible_with_sample_every(
+            tenant,
+            entity_type,
+            entity_id,
+            catalog_shadow_read_sample_every(),
+        )
+    }
+}
+
 pub(super) fn maybe_spawn_catalog_shadow_check(
     state: &ServerState,
     tenant: &TenantId,
     entity_type: &str,
     row: &EntityCatalogRow,
-) {
+) -> bool {
     if !should_shadow_check_catalog_row(tenant, entity_type, &row.entity_id) {
-        return;
+        return false;
     }
 
+    spawn_catalog_shadow_check_for_row(state, tenant, entity_type, row);
+    true
+}
+
+pub(super) fn maybe_spawn_catalog_shadow_check_with_budget(
+    state: &ServerState,
+    tenant: &TenantId,
+    entity_type: &str,
+    row: &EntityCatalogRow,
+    budget: &mut CatalogShadowReadBudget,
+) -> bool {
+    if !budget.take_if_eligible(tenant, entity_type, &row.entity_id) {
+        return false;
+    }
+
+    spawn_catalog_shadow_check_for_row(state, tenant, entity_type, row);
+    true
+}
+
+fn spawn_catalog_shadow_check_for_row(
+    state: &ServerState,
+    tenant: &TenantId,
+    entity_type: &str,
+    row: &EntityCatalogRow,
+) {
     let state = state.clone();
     let tenant = tenant.clone();
     let entity_type = entity_type.to_string();
@@ -142,7 +242,10 @@ pub(super) fn maybe_spawn_catalog_shadow_check(
 
 #[cfg(test)]
 mod tests {
-    use super::{projection_drift_kind, shadow_sequence_gap, stable_shadow_sample_hash};
+    use super::{
+        CatalogShadowReadBudget, projection_drift_kind, shadow_sequence_gap,
+        stable_shadow_sample_hash,
+    };
     use crate::storage::EntityCatalogRow;
     use temper_runtime::tenant::TenantId;
 
@@ -203,5 +306,33 @@ mod tests {
         assert_eq!(shadow_sequence_gap(4, 9), ("catalog_behind", 5));
         assert_eq!(shadow_sequence_gap(9, 4), ("catalog_ahead", 5));
         assert_eq!(shadow_sequence_gap(7, 7), ("equal", 0));
+    }
+
+    #[test]
+    fn catalog_shadow_budget_caps_eligible_rows_per_response() {
+        let tenant = TenantId::from("tenant-a");
+        let mut budget = CatalogShadowReadBudget::new(2);
+
+        for index in 0..10 {
+            let scheduled = budget.take_if_eligible_with_sample_every(
+                &tenant,
+                "Taxonomy",
+                &format!("tax-{index}"),
+                1,
+            );
+            assert_eq!(scheduled, index < 2);
+        }
+
+        assert_eq!(budget.configured(), 2);
+        assert_eq!(budget.scheduled(), 2);
+    }
+
+    #[test]
+    fn catalog_shadow_budget_preserves_disabled_sampling() {
+        let tenant = TenantId::from("tenant-a");
+        let mut budget = CatalogShadowReadBudget::new(2);
+
+        assert!(!budget.take_if_eligible_with_sample_every(&tenant, "Taxonomy", "tax-1", 0));
+        assert_eq!(budget.scheduled(), 0);
     }
 }

--- a/crates/temper-server/src/odata/read_support/tests.rs
+++ b/crates/temper-server/src/odata/read_support/tests.rs
@@ -1,0 +1,167 @@
+use super::{
+    catalog_row_to_entity_body, select_entity_ids_for_materialization,
+    should_read_catalog_for_materialization,
+};
+use crate::storage::EntityCatalogRow;
+use temper_odata::query::types::{
+    FilterExpr, ODataValue, OrderByClause, OrderDirection, QueryOptions,
+};
+
+#[test]
+fn catalog_row_serializes_to_entity_state_shape() {
+    let row = EntityCatalogRow {
+        entity_id: "en-123".to_string(),
+        status: "Published".to_string(),
+        fields: serde_json::json!({"Name": "Foo", "Score": 7}),
+        sequence_nr: 14,
+    };
+    let body = catalog_row_to_entity_body("DesignLanguage", "DesignLanguages", row);
+
+    // Mirrors EntityState serialization keys so enrich_entity_response and
+    // OData clients see no difference between catalog-served and actor-served bodies.
+    assert_eq!(body["entity_type"], "DesignLanguage");
+    assert_eq!(body["entity_id"], "en-123");
+    assert_eq!(body["status"], "Published");
+    assert_eq!(body["sequence_nr"], 14);
+    assert_eq!(body["total_event_count"], 14);
+    assert_eq!(body["item_count"], 0);
+    assert_eq!(body["counters"], serde_json::json!({}));
+    assert_eq!(body["booleans"], serde_json::json!({}));
+    assert_eq!(body["lists"], serde_json::json!({}));
+    assert_eq!(body["events"], serde_json::json!([]));
+    assert_eq!(body["fields"]["Name"], "Foo");
+    assert_eq!(body["fields"]["Score"], 7);
+    assert_eq!(body["@odata.id"], "DesignLanguages('en-123')");
+}
+
+#[test]
+fn catalog_row_body_matches_actor_serialization_for_single_key_path() {
+    // The single-entity read path (handle_entity -> load_existing_entity_body)
+    // expects the catalog-derived body to be a drop-in replacement for the
+    // actor's serialized state. Verify the keyset matches what the actor
+    // emits so enrich_entity_response and downstream clients see no diff.
+    let row = EntityCatalogRow {
+        entity_id: "fl-019dde81".to_string(),
+        status: "Ready".to_string(),
+        fields: serde_json::json!({
+            "Id": "fl-019dde81",
+            "Status": "Ready",
+            "Name": "phosphor-command-grid.html",
+            "MimeType": "text/html",
+            "content_hash": "sha256:c74e77",
+            "size_bytes": 8427,
+        }),
+        sequence_nr: 3,
+    };
+    let body = catalog_row_to_entity_body("File", "Files", row);
+    let obj = body.as_object().expect("entity body is an object");
+    // Required EntityState top-level keys.
+    for required in [
+        "entity_type",
+        "entity_id",
+        "status",
+        "item_count",
+        "counters",
+        "booleans",
+        "lists",
+        "fields",
+        "events",
+        "total_event_count",
+        "sequence_nr",
+        "@odata.id",
+    ] {
+        assert!(
+            obj.contains_key(required),
+            "missing required key: {required}"
+        );
+    }
+    // Verify @odata.id format matches what handle_entity uses.
+    assert_eq!(body["@odata.id"], "Files('fl-019dde81')");
+    // Fields blob is preserved verbatim.
+    assert_eq!(body["fields"]["Name"], "phosphor-command-grid.html");
+    assert_eq!(body["fields"]["content_hash"], "sha256:c74e77");
+}
+
+#[test]
+fn pushed_down_filters_prefer_catalog_materialization() {
+    assert!(should_read_catalog_for_materialization(true));
+}
+
+#[test]
+fn default_pagination_applies_when_top_missing_and_no_filter_orderby() {
+    let ids: Vec<String> = (0..150).map(|i| format!("id-{i}")).collect();
+    let opts = QueryOptions {
+        count: Some(true),
+        ..QueryOptions::default()
+    };
+
+    let (selected, apply_opts, count) =
+        select_entity_ids_for_materialization(ids, &opts, 100, 1000);
+
+    assert_eq!(selected.len(), 100);
+    assert_eq!(selected.first().unwrap(), "id-0");
+    assert_eq!(selected.last().unwrap(), "id-99");
+    assert_eq!(count, Some(150));
+    assert_eq!(apply_opts.top, None);
+    assert_eq!(apply_opts.skip, None);
+    assert_eq!(apply_opts.count, None);
+}
+
+#[test]
+fn explicit_skip_top_are_applied_before_materialization() {
+    let ids: Vec<String> = (0..50).map(|i| format!("id-{i}")).collect();
+    let opts = QueryOptions {
+        top: Some(10),
+        skip: Some(5),
+        count: Some(true),
+        ..QueryOptions::default()
+    };
+
+    let (selected, _apply_opts, count) =
+        select_entity_ids_for_materialization(ids, &opts, 100, 1000);
+
+    assert_eq!(selected.len(), 10);
+    assert_eq!(selected.first().unwrap(), "id-5");
+    assert_eq!(selected.last().unwrap(), "id-14");
+    assert_eq!(count, Some(50));
+}
+
+#[test]
+fn filtered_query_materialises_all_entities_under_safety_cap() {
+    // With max_entities=1000, the safety cap is 10_000.
+    // 2500 entities should ALL be materialised (no truncation).
+    let ids: Vec<String> = (0..2500).map(|i| format!("id-{i}")).collect();
+    let opts = QueryOptions {
+        filter: Some(FilterExpr::Literal(ODataValue::Boolean(true))),
+        orderby: Some(vec![OrderByClause {
+            property: "Status".to_string(),
+            direction: OrderDirection::Asc,
+        }]),
+        ..QueryOptions::default()
+    };
+
+    let (selected, apply_opts, count) =
+        select_entity_ids_for_materialization(ids, &opts, 100, 1000);
+
+    assert_eq!(selected.len(), 2500);
+    assert_eq!(count, None);
+    assert_eq!(apply_opts.top, Some(100));
+}
+
+#[test]
+fn safety_cap_truncates_at_10x_max_entities() {
+    // With max_entities=1000, the safety cap is 10_000.
+    // 15_000 entities should be truncated to 10_000.
+    let ids: Vec<String> = (0..15_000).map(|i| format!("id-{i}")).collect();
+    let opts = QueryOptions {
+        filter: Some(FilterExpr::Literal(ODataValue::Boolean(true))),
+        ..QueryOptions::default()
+    };
+
+    let (selected, apply_opts, count) =
+        select_entity_ids_for_materialization(ids, &opts, 100, 1000);
+
+    assert_eq!(selected.len(), 10_000);
+    assert_eq!(count, None);
+    assert_eq!(apply_opts.top, Some(100));
+}

--- a/docs/adrs/0110-bounded-catalog-shadow-read-probes.md
+++ b/docs/adrs/0110-bounded-catalog-shadow-read-probes.md
@@ -1,0 +1,153 @@
+# ADR-0110: Bounded Catalog Shadow Read Probes
+
+- Status: Proposed
+- Date: 2026-05-20
+- Deciders: Temper core maintainers
+- Related:
+  - ADR-0077: Catalog-first OData entity materialization
+  - ADR-0082: Projection Correctness Observability
+  - ADR-0104: Projection Read Parity And Local Tenant Propagation
+  - `crates/temper-server/src/odata/read.rs`
+  - `crates/temper-server/src/odata/read_support.rs`
+  - `crates/temper-server/src/odata/read_support/shadow.rs`
+
+## Context
+
+Catalog-first OData reads are intended to make projection-backed collection
+reads proportional to one indexed catalog query plus JSON response work. After
+ADR-0104, production traces showed that `GET /tdata/Taxonomies` can still take
+hundreds of milliseconds even when the span reports
+`catalog_materialization=true`.
+
+The slow trace shape is not dominated by Postgres. The catalog query for 182
+Taxonomy rows took about 12 ms, while the same request trace contained many
+`entity.get_tenant_entity_state` and
+`entity.get_or_spawn_tenant_actor_with_fields` spans. Those actor reads are
+projection shadow checks scheduled for catalog rows. They are valuable for
+detecting drift, but a high sample rate can reintroduce the actor fanout that
+catalog-first reads were created to remove.
+
+The platform still needs correctness proof. Disabling shadow reads entirely
+would make projection drift harder to catch. The problem is unbounded
+per-request probe volume, not the existence of probes.
+
+## Decision
+
+Bound catalog shadow probes per collection response.
+
+### Sub-Decision 1: Keep Stable Sampling, Add A Response Budget
+
+Continue using the stable tenant/entity-type/entity-id hash to decide whether a
+row is eligible for shadow checking. Add a per-response budget so a single
+OData collection read schedules only a small number of actor-backed shadow
+checks even if many rows match the sampling hash.
+
+The default budget is intentionally small. Operators can increase it when
+running a focused projection audit, but the default production posture should
+keep list-read latency governed by the catalog path.
+
+**Why this approach**: Stable sampling preserves deterministic coverage across
+requests and deployments. The response budget prevents one large list response
+from scheduling dozens of actor loads on the request's hot runtime path.
+
+### Sub-Decision 2: Expose Probe Counts On OData Read Spans
+
+Record the configured per-response budget and the number of scheduled shadow
+checks on `odata.entity_set_read` spans.
+
+**Why this approach**: Datadog should make the tradeoff visible. When a list
+read is unexpectedly slow, operators can distinguish response JSON size,
+catalog DB latency, actor fallback, and correctness-probe fanout.
+
+### Sub-Decision 3: Single Entity Reads Keep Their Existing Probe Behavior
+
+Single-entity catalog reads may still schedule their one eligible shadow check.
+The bounded response budget applies to collection materialization, where the
+fanout risk exists.
+
+**Why this approach**: A single entity read cannot create the dozens-of-actors
+shape observed in production, and it is useful for targeted drift detection.
+
+## Rollout Plan
+
+1. **Phase 0 (Immediate)** - Add the per-response budget, span fields, and
+   focused tests for bounded scheduling behavior.
+2. **Phase 1 (Rollout)** - Deploy through TemperPaw and rerun the
+   `/tdata/Taxonomies` before/after batch against the same production version
+   family.
+3. **Phase 2 (Continuous Proof)** - Keep a low default request-path sample
+   budget and move deeper projection audits to scheduled probes or replay
+   parity checks instead of user-facing list requests.
+
+## Readiness Gates
+
+- Local tests prove list materialization does not schedule more than the budget.
+- Existing catalog fast-read and projection parity tests still pass.
+- `odata.entity_set_read` spans include shadow probe budget and scheduled count.
+- Production after proof shows `GET /tdata/Taxonomies` no longer contains a
+  large actor shadow-check fanout on normal reads.
+- The latency report records before/after client timings and Datadog trace
+  evidence.
+
+## Consequences
+
+### Positive
+
+- Preserves projection drift detection while keeping catalog-backed list reads
+  fast.
+- Prevents observability work from recreating the actor materialization latency
+  it was meant to diagnose.
+- Adds explicit Datadog evidence for shadow-check cost and volume.
+
+### Negative
+
+- A single list request samples fewer rows than before when the eligible row
+  count exceeds the budget.
+- Focused audits that need high sample volume must explicitly raise the budget
+  or use replay/scheduled correctness probes.
+
+### Risks
+
+- Too low a default budget could delay detection of rare projection drift.
+  Mitigation: keep replay parity and continuous projection probes as the
+  broader correctness layer; request-path shadow reads are only one signal.
+- Operators might mistake a low scheduled count for disabled correctness
+  monitoring. Mitigation: expose both the budget and scheduled count on spans
+  and document the rollout posture in the latency report.
+
+### DST Compliance
+
+- This touches `temper-server`, a simulation-visible crate.
+- The sampling decision remains deterministic for a given tenant/entity/id set.
+- The new budget is read from process configuration once, matching existing
+  OData environment controls.
+- No new wall-clock time, random IDs, filesystem access, or blocking threads
+  are introduced.
+
+## Non-Goals
+
+- Do not remove catalog shadow checks.
+- Do not redesign projection replay or backfill in this patch.
+- Do not change the OData response contract.
+- Do not make actor materialization the default path for collection reads.
+
+## Alternatives Considered
+
+1. **Disable shadow reads in production** - Rejected because it removes a useful
+   drift signal and conflicts with the correctness requirements for projection
+   fast paths.
+2. **Leave sampling unbounded** - Rejected because production traces show that
+   it can dominate read latency for large collection responses.
+3. **Run every shadow check in a detached worker** - Deferred because it needs a
+   durable queue and lifecycle policy. A bounded request-path patch is smaller
+   and immediately reduces the observed latency risk.
+4. **Increase actor materialization concurrency** - Rejected because the actor
+   reads are diagnostic probes, not required response data; adding concurrency
+   treats the symptom while preserving unnecessary fanout.
+
+## Rollback Policy
+
+If the budget hides important drift in production, raise
+`TEMPER_ODATA_CATALOG_SHADOW_READ_MAX_PER_RESPONSE` or revert the budget while
+moving the deployment to a focused projection audit window. The span fields can
+remain because they are diagnostic and low-cardinality.


### PR DESCRIPTION
## Summary
- add ADR-0110 for bounded catalog shadow-read probes
- cap collection-response catalog shadow checks with a small per-response budget
- expose catalog shadow budget/scheduled counts on OData entity-set spans
- split read_support tests out of the production helper file to keep the readability ratchet green

## Evidence
- Datadog current production trace ddd4987342f54db866e6b2d538ff8217 shows /tdata/Taxonomies at 659.9 ms with catalog SQL only 11.7 ms and many actor-backed shadow checks
- cargo test -p temper-server odata::read_support::
- cargo check -p temper-server
- cargo clippy -p temper-server --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- bash scripts/readability-ratchet.sh check .ci/readability-baseline.env
- pre-push rustfmt, workspace clippy, and readability gates passed; full suite reached Docker-backed actor-runtime integration tests and failed because local Docker Desktop cannot create a containerd lease for postgres:11-alpine; direct docker pull postgres:11-alpine reproduces the daemon error

## Rollout proof needed
- merge Temper source after CI
- roll pinned Temper commit through TemperPaw
- deploy exact image to Railway
- rerun Taxonomies/list-read before/after batch and Datadog trace query, proving shadow fanout is bounded by catalog_shadow_check_scheduled