### PR TITLE
Add bounded projection replay parity probe

### DIFF
--- a/crates/temper-server/src/observe/mod.rs
+++ b/crates/temper-server/src/observe/mod.rs
@@ -7,6 +7,7 @@ mod agents;
 mod entities;
 pub(crate) mod evolution;
 mod metrics;
+mod projections;
 mod refresh;
 pub(crate) mod specs;
 mod specs_helpers;
@@ -179,6 +180,10 @@ pub fn build_observe_router() -> Router<ServerState> {
         .route("/workflows", get(verification::handle_workflows))
         .route("/health", get(metrics::handle_health))
         .route("/metrics", get(metrics::handle_metrics))
+        .route(
+            "/projections/replay-parity",
+            get(projections::handle_replay_parity),
+        )
         .route("/trajectories", get(evolution::handle_trajectories))
         .route(
             "/evolution/records",

--- a/crates/temper-server/src/observe/mod_test.rs
+++ b/crates/temper-server/src/observe/mod_test.rs
@@ -109,6 +109,98 @@ async fn wait_for_trajectory_total(app: Router, uri: &str, min_total: u64) -> se
     observe_json(app, uri).await
 }
 
+// -- Projection correctness probe tests --
+
+#[tokio::test]
+async fn projection_replay_parity_endpoint_reports_clean_bounded_scope() {
+    let state = test_state_with_turso().await;
+    let tenant = TenantId::default();
+    state
+        .get_or_create_tenant_entity(
+            &tenant,
+            "Order",
+            "projection-probe-clean-a",
+            serde_json::json!({"Title": "Projection Probe Clean"}),
+        )
+        .await
+        .expect("create projected entity");
+    state
+        .get_or_create_tenant_entity(
+            &tenant,
+            "Order",
+            "projection-probe-clean-b",
+            serde_json::json!({"Title": "Projection Probe Clean Extra"}),
+        )
+        .await
+        .expect("create second projected entity");
+
+    let app = build_app_with_state(state);
+    let json = observe_json(
+        app,
+        "/observe/projections/replay-parity?entity_type=Order&limit=1",
+    )
+    .await;
+
+    assert_eq!(json["kind"], "query_projection_replay_parity");
+    assert_eq!(json["clean"], true);
+    assert_eq!(json["limit"], 1);
+    assert_eq!(json["report"]["tenant"], "default");
+    assert_eq!(json["report"]["entity_type"], "Order");
+    assert_eq!(json["report"]["entity_limit"], 1);
+    assert_eq!(json["report"]["checked"], 1);
+    assert_eq!(json["report"]["matched"], 1);
+    assert_eq!(json["report"]["drifted"], 0);
+}
+
+#[tokio::test]
+async fn projection_replay_parity_endpoint_reports_projection_drift() {
+    let state = test_state_with_turso().await;
+    let tenant = TenantId::default();
+    let entity_id = "projection-probe-drift";
+    state
+        .get_or_create_tenant_entity(
+            &tenant,
+            "Order",
+            entity_id,
+            serde_json::json!({"Title": "Projection Probe Original"}),
+        )
+        .await
+        .expect("create projected entity");
+    let actor_state = state
+        .get_tenant_entity_state(&tenant, "Order", entity_id)
+        .await
+        .expect("load authoritative entity");
+    let projection_state = state.query_projection_state(&actor_state.state);
+    state
+        .query_plane_store()
+        .expect("query-plane store")
+        .upsert_projection(
+            tenant.as_str(),
+            "Order",
+            entity_id,
+            &actor_state.state.status,
+            &serde_json::json!({"Title": "Projection Probe Drift"}),
+            &projection_state,
+            actor_state.state.sequence_nr,
+        )
+        .await
+        .expect("inject projection drift");
+
+    let app = build_app_with_state(state);
+    let json = observe_json(
+        app,
+        "/observe/projections/replay-parity?entity_type=Order&limit=10",
+    )
+    .await;
+
+    assert_eq!(json["clean"], false);
+    assert_eq!(json["report"]["checked"], 1);
+    assert_eq!(json["report"]["matched"], 0);
+    assert_eq!(json["report"]["drifted"], 1);
+    assert_eq!(json["report"]["drift_examples"][0]["entity_id"], entity_id);
+    assert_eq!(json["report"]["drift_examples"][0]["drift_kind"], "fields");
+}
+
 /// Build a POST request with admin auth headers for observe endpoints.
 fn system_post(uri: &str, body: &str) -> Request<Body> {
     Request::post(uri)

--- a/crates/temper-server/src/observe/projections.rs
+++ b/crates/temper-server/src/observe/projections.rs
@@ -1,0 +1,83 @@
+//! Projection correctness observe endpoints.
+
+use axum::extract::{Query, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::Json;
+use serde::Deserialize;
+use tracing::instrument;
+
+use crate::authz::require_observe_auth;
+use crate::odata::extract_tenant;
+use crate::state::ServerState;
+
+const DEFAULT_REPLAY_PARITY_LIMIT: usize = 100;
+const MAX_REPLAY_PARITY_LIMIT: usize = 1_000;
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct ReplayParityParams {
+    entity_type: Option<String>,
+    limit: Option<usize>,
+}
+
+/// GET /observe/projections/replay-parity -- bounded event-replay parity probe.
+#[instrument(
+    skip_all,
+    fields(
+        otel.name = "GET /observe/projections/replay-parity",
+        tenant = tracing::field::Empty,
+        entity_type = tracing::field::Empty,
+        limit = tracing::field::Empty,
+        checked = tracing::field::Empty,
+        drifted = tracing::field::Empty,
+        missing = tracing::field::Empty,
+        errors = tracing::field::Empty,
+        clean = tracing::field::Empty
+    )
+)]
+pub(crate) async fn handle_replay_parity(
+    State(state): State<ServerState>,
+    headers: HeaderMap,
+    Query(params): Query<ReplayParityParams>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    require_observe_auth(&state, &headers, "read_entities", "Projection")?;
+    let tenant = extract_tenant(&headers, &state).map_err(|(code, _)| code)?;
+    let entity_type = params
+        .entity_type
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let limit = params
+        .limit
+        .unwrap_or(DEFAULT_REPLAY_PARITY_LIMIT)
+        .clamp(1, MAX_REPLAY_PARITY_LIMIT);
+
+    tracing::Span::current().record("tenant", tenant.as_str());
+    tracing::Span::current().record("entity_type", entity_type.unwrap_or("*"));
+    tracing::Span::current().record("limit", limit as u64);
+
+    let report = state
+        .verify_query_projection_replay_parity_bounded(
+            &tenant,
+            entity_type,
+            Some(limit),
+            "observe_probe",
+        )
+        .await
+        .map_err(|error| {
+            tracing::warn!(tenant = %tenant, error = %error, "projection replay parity probe failed");
+            StatusCode::SERVICE_UNAVAILABLE
+        })?;
+
+    tracing::Span::current().record("checked", report.checked);
+    tracing::Span::current().record("drifted", report.drifted);
+    tracing::Span::current().record("missing", report.missing);
+    tracing::Span::current().record("errors", report.errors);
+    tracing::Span::current().record("clean", report.is_clean());
+
+    Ok(Json(serde_json::json!({
+        "kind": "query_projection_replay_parity",
+        "clean": report.is_clean(),
+        "limit": limit,
+        "report": report,
+    })))
+}

--- a/crates/temper-server/src/query_projection_metrics.rs
+++ b/crates/temper-server/src/query_projection_metrics.rs
@@ -25,6 +25,12 @@ struct QueryProjectionMetrics {
     replay_parity_check_total: Counter<u64>,
     replay_parity_duration_ms: Histogram<f64>,
     replay_parity_sequence_gap: Histogram<u64>,
+    replay_parity_run_total: Counter<u64>,
+    replay_parity_run_duration_ms: Histogram<f64>,
+    replay_parity_run_checked_entities: Histogram<u64>,
+    replay_parity_run_drifted_entities: Histogram<u64>,
+    replay_parity_run_missing_entities: Histogram<u64>,
+    replay_parity_run_error_entities: Histogram<u64>,
 }
 
 fn metrics() -> &'static QueryProjectionMetrics {
@@ -129,6 +135,33 @@ fn metrics() -> &'static QueryProjectionMetrics {
                 .with_description(
                     "Absolute sequence-number gap found by query-projection replay parity verification.",
                 )
+                .build(),
+            replay_parity_run_total: meter
+                .u64_counter("temper_query_projection_replay_parity_run_total")
+                .with_description(
+                    "Bounded query-projection replay parity verifier runs by scope and result.",
+                )
+                .build(),
+            replay_parity_run_duration_ms: meter
+                .f64_histogram("temper_query_projection_replay_parity_run_duration_ms")
+                .with_unit("ms")
+                .with_description("Wall time spent by one replay parity verifier run.")
+                .build(),
+            replay_parity_run_checked_entities: meter
+                .u64_histogram("temper_query_projection_replay_parity_run_checked_entities")
+                .with_description("Entities checked by one replay parity verifier run.")
+                .build(),
+            replay_parity_run_drifted_entities: meter
+                .u64_histogram("temper_query_projection_replay_parity_run_drifted_entities")
+                .with_description("Drifted entities found by one replay parity verifier run.")
+                .build(),
+            replay_parity_run_missing_entities: meter
+                .u64_histogram("temper_query_projection_replay_parity_run_missing_entities")
+                .with_description("Active entities missing from projection during one parity verifier run.")
+                .build(),
+            replay_parity_run_error_entities: meter
+                .u64_histogram("temper_query_projection_replay_parity_run_error_entities")
+                .with_description("Entities the replay parity verifier could not compare in one run.")
                 .build(),
         }
     })
@@ -332,6 +365,45 @@ pub(crate) fn record_replay_parity_check(
         .record(sequence_gap, &attrs);
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "metric emission needs explicit low-cardinality dimensions and counts"
+)]
+pub(crate) fn record_replay_parity_run(
+    tenant: &str,
+    entity_type: &str,
+    source: &str,
+    result: &str,
+    checked: u64,
+    drifted: u64,
+    missing: u64,
+    errors: u64,
+    duration: Duration,
+) {
+    let attrs = [
+        KeyValue::new("tenant", tenant.to_string()),
+        KeyValue::new("entity_type", entity_type.to_string()),
+        KeyValue::new("source", source.to_string()),
+        KeyValue::new("result", result.to_string()),
+    ];
+    metrics().replay_parity_run_total.add(1, &attrs);
+    metrics()
+        .replay_parity_run_duration_ms
+        .record(duration.as_secs_f64() * 1000.0, &attrs);
+    metrics()
+        .replay_parity_run_checked_entities
+        .record(checked, &attrs);
+    metrics()
+        .replay_parity_run_drifted_entities
+        .record(drifted, &attrs);
+    metrics()
+        .replay_parity_run_missing_entities
+        .record(missing, &attrs);
+    metrics()
+        .replay_parity_run_error_entities
+        .record(errors, &attrs);
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
@@ -391,6 +463,17 @@ mod tests {
             "catalog_behind",
             2,
             Duration::from_millis(21),
+        );
+        super::record_replay_parity_run(
+            "tenant",
+            "Session",
+            "observe_probe",
+            "drift",
+            10,
+            1,
+            0,
+            0,
+            Duration::from_millis(34),
         );
     }
 }

--- a/crates/temper-server/src/state/entity_ops.rs
+++ b/crates/temper-server/src/state/entity_ops.rs
@@ -395,7 +395,32 @@ impl ServerState {
         &self,
         tenant: &TenantId,
     ) -> Result<super::QueryProjectionReplayParityReport, String> {
-        projection_backfill::verify_query_projection_replay_parity(self, tenant).await
+        projection_backfill::verify_query_projection_replay_parity(
+            self,
+            tenant,
+            None,
+            None,
+            "manual_full",
+        )
+        .await
+    }
+
+    /// Compare a bounded projection scope with authoritative event replay.
+    pub async fn verify_query_projection_replay_parity_bounded(
+        &self,
+        tenant: &TenantId,
+        entity_type: Option<&str>,
+        entity_limit: Option<usize>,
+        source: &str,
+    ) -> Result<super::QueryProjectionReplayParityReport, String> {
+        projection_backfill::verify_query_projection_replay_parity(
+            self,
+            tenant,
+            entity_type,
+            entity_limit,
+            source,
+        )
+        .await
     }
 
     /// Hydrate actor state from the event store by spawning actors for all

--- a/crates/temper-server/src/state/mod.rs
+++ b/crates/temper-server/src/state/mod.rs
@@ -262,10 +262,16 @@ fn state_cache_budget() -> usize {
 }
 
 /// Summary of a query-projection replay parity verification run.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize)]
 pub struct QueryProjectionReplayParityReport {
     /// Tenant whose persisted journals and projection rows were compared.
     pub tenant: String,
+    /// Optional entity type scope applied to this verifier run.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entity_type: Option<String>,
+    /// Optional maximum number of entities considered by this verifier run.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entity_limit: Option<u64>,
     /// Number of persisted entities considered by the verifier.
     pub checked: u64,
     /// Number of non-deleted entities whose projection row matched replayed state.
@@ -290,7 +296,7 @@ impl QueryProjectionReplayParityReport {
 }
 
 /// One bounded replay parity drift or error example.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
 pub struct QueryProjectionReplayParityDrift {
     /// Entity type whose projection diverged from replayed state.
     pub entity_type: String,

--- a/crates/temper-server/src/state/projection_backfill/replay_parity.rs
+++ b/crates/temper-server/src/state/projection_backfill/replay_parity.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use temper_runtime::tenant::TenantId;
 
@@ -79,21 +79,82 @@ fn push_replay_parity_example(
         });
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "run-level projection parity metric mirrors the metric dimensions and counters"
+)]
+fn record_replay_parity_run_summary(
+    tenant: &TenantId,
+    entity_type_filter: Option<&str>,
+    source: &str,
+    result: &str,
+    checked: u64,
+    drifted: u64,
+    missing: u64,
+    errors: u64,
+    duration: Duration,
+) {
+    crate::query_projection_metrics::record_replay_parity_run(
+        tenant.as_str(),
+        entity_type_filter.unwrap_or("*"),
+        source,
+        result,
+        checked,
+        drifted,
+        missing,
+        errors,
+        duration,
+    );
+}
+
 pub(in crate::state) async fn verify_query_projection_replay_parity(
     state: &ServerState,
     tenant: &TenantId,
+    entity_type_filter: Option<&str>,
+    entity_limit: Option<usize>,
+    source: &str,
 ) -> Result<QueryProjectionReplayParityReport, String> {
+    let run_started_at = Instant::now(); // determinism-ok: production-only parity verifier duration metric
     let Some((store, backend)) = state.event_journal() else {
+        record_replay_parity_run_summary(
+            tenant,
+            entity_type_filter,
+            source,
+            "error",
+            0,
+            0,
+            0,
+            1,
+            run_started_at.elapsed(),
+        );
         return Err("event journal is not configured".to_string());
     };
     let Some(query_plane) = state.query_plane_store() else {
+        record_replay_parity_run_summary(
+            tenant,
+            entity_type_filter,
+            source,
+            "error",
+            0,
+            0,
+            0,
+            1,
+            run_started_at.elapsed(),
+        );
         return Err("query-plane store is not configured".to_string());
     };
 
-    let entities = store
+    let mut entities = store
         .list_entity_ids(tenant.as_str())
         .await
         .map_err(|error| format!("list persisted entity ids failed: {error}"))?;
+    entities.sort();
+    if let Some(entity_type_filter) = entity_type_filter {
+        entities.retain(|(entity_type, _)| entity_type == entity_type_filter);
+    }
+    if let Some(entity_limit) = entity_limit {
+        entities.truncate(entity_limit);
+    }
     let mut by_type = BTreeMap::<String, Vec<String>>::new();
     for (entity_type, entity_id) in entities {
         by_type.entry(entity_type).or_default().push(entity_id);
@@ -101,6 +162,8 @@ pub(in crate::state) async fn verify_query_projection_replay_parity(
 
     let mut report = QueryProjectionReplayParityReport {
         tenant: tenant.as_str().to_string(),
+        entity_type: entity_type_filter.map(str::to_string),
+        entity_limit: entity_limit.map(|limit| limit as u64),
         ..Default::default()
     };
 
@@ -348,6 +411,8 @@ pub(in crate::state) async fn verify_query_projection_replay_parity(
 
     tracing::info!(
         tenant = %tenant,
+        entity_type = entity_type_filter.unwrap_or("*"),
+        entity_limit = entity_limit.unwrap_or(usize::MAX),
         checked = report.checked,
         matched = report.matched,
         drifted = report.drifted,
@@ -355,6 +420,24 @@ pub(in crate::state) async fn verify_query_projection_replay_parity(
         deleted_absent = report.deleted_absent,
         errors = report.errors,
         "query projection replay parity verification complete"
+    );
+    let result = if report.errors > 0 {
+        "error"
+    } else if report.drifted > 0 || report.missing > 0 {
+        "drift"
+    } else {
+        "clean"
+    };
+    record_replay_parity_run_summary(
+        tenant,
+        entity_type_filter,
+        source,
+        result,
+        report.checked,
+        report.drifted,
+        report.missing,
+        report.errors,
+        run_started_at.elapsed(),
     );
     Ok(report)
 }

--- a/docs/adrs/0114-bounded-projection-replay-parity-probe.md
+++ b/docs/adrs/0114-bounded-projection-replay-parity-probe.md
@@ -1,0 +1,100 @@
+# ADR-0114: Bounded Projection Replay Parity Probe
+
+- Status: Proposed
+- Date: 2026-05-21
+- Deciders: Temper core maintainers
+- Related:
+  - ADR-0039: Latency Observability Acceleration Program
+  - ADR-0110: Bounded Catalog Shadow Read Probes
+  - ADR-0111: Full-State Catalog Fast Read
+  - ADR-0113: Catalog Status State Parity
+  - `crates/temper-server/src/state/projection_backfill/replay_parity.rs`
+  - `crates/temper-server/src/observe/mod.rs`
+
+## Context
+
+Projection-backed reads are now fast enough to serve large collections without hydrating every entity actor, but that only remains correct if the durable query projection keeps matching the event-sourced authority. Recent Taxonomies work proved the risk: the unfiltered read path recovered rows from event/actor fallback while status-filter pushdown trusted an incomplete catalog.
+
+Temper already has a replay-parity verifier that rebuilds authoritative state from the event journal and compares it with `entity_catalog`. Today that verifier is internal and all-scope. Operators need a bounded Observe API surface that can be run repeatedly against one tenant and, when useful, one entity type. The probe must emit run-level Datadog evidence so drift, missing coverage, sequence gaps, and verifier cost can be monitored without waiting for a frontend route to expose bad projection behavior.
+
+## Decision
+
+Add a bounded projection replay parity Observe endpoint:
+
+`GET /observe/projections/replay-parity?entity_type=Taxonomies&limit=100`
+
+The endpoint uses the existing Observe authorization path, resolves tenant through `X-Tenant-Id` or single-tenant fallback, and rejects/limits work through a bounded `limit` parameter. It returns the existing replay parity report plus the applied scope.
+
+### Sub-Decision 1: Bound The Probe By Entity Count
+
+The verifier gains an optional entity type filter and an optional entity limit. Entity pairs are sorted deterministically before filtering and truncation, preserving repeatable probe behavior.
+
+**Why this approach**: Full replay parity is correct but can be expensive in tenants with large journals. A bounded probe lets us run production canaries frequently and reserve full sweeps for lower-frequency maintenance windows.
+
+### Sub-Decision 2: Emit Run-Level Datadog Evidence
+
+In addition to per-entity replay parity metrics, each probe run records:
+
+- total runs by tenant/entity_type/result/source
+- run duration
+- entities checked
+- drifted entities
+- missing projection rows
+- verifier errors
+
+The Observe handler also records span fields for `checked`, `drifted`, `missing`, `errors`, `clean`, `entity_type`, and `limit`.
+
+**Why this approach**: The existing per-entity metrics answer "what did each comparison find." Run-level metrics answer "is this canary healthy right now" and give dashboards a low-cardinality acceptance signal.
+
+## Rollout Plan
+
+1. **Phase 0 (Immediate)** — Add the bounded state method, Observe endpoint, run metrics, and focused Turso-backed tests.
+2. **Phase 1 (Follow-up)** — Roll into TemperPaw, run the endpoint against production Taxonomies, DesignLanguages, and Session-adjacent entities, and record Datadog before/after evidence in the latency dashboard.
+3. **Phase 2** — Decide whether to automate the probe as a low-frequency cron or heartbeat once cost is measured.
+
+## Readiness Gates
+
+- The endpoint returns a clean report for a known-good projection fixture.
+- The endpoint returns drift/missing details for an intentionally damaged projection fixture.
+- The handler enforces a bounded limit and records run-level metrics.
+- Production proof records endpoint response, Datadog span fields, and run metric samples.
+
+## Consequences
+
+### Positive
+
+- Projection correctness becomes continuously provable outside user-facing requests.
+- Future read-model speed work can be gated by a repeatable production canary.
+- Drift diagnosis includes bounded entity examples without high-cardinality metric tags.
+
+### Negative
+
+- Replay parity still consumes store reads and event replay CPU, so it must remain bounded by default.
+- Full-tenant sweeps still need an explicit operational window or separate maintenance job.
+
+### Risks
+
+- A too-large limit can compete with production work. Mitigation: cap the Observe endpoint and keep defaults small.
+- Operators may treat a clean bounded sample as a full proof. Mitigation: report the applied limit and checked count explicitly.
+
+### DST Compliance
+
+- The implementation touches `temper-server`, a simulation-visible crate, but the endpoint and metrics are production Observe surfaces.
+- Entity ordering is deterministic through sorted `(entity_type, entity_id)` pairs.
+- Wall-clock timings are used only for production observability metrics and marked with existing `determinism-ok` style comments where new timing is added.
+
+## Non-Goals
+
+- This ADR does not make projection reads eventually consistent by accepting drift.
+- This ADR does not replace startup backfill or request-time repair.
+- This ADR does not add a production scheduler in the first PR.
+
+## Alternatives Considered
+
+1. **Only rely on request-time shadow reads** — Rejected because shadow checks are sampled and tied to user routes; they cannot prove a projection class before users hit it.
+2. **Run full replay parity on every probe** — Rejected because tenants can grow large and replay cost must not become an observability tax.
+3. **Store entity IDs in metric labels** — Rejected because entity IDs are high cardinality; examples belong in the JSON report and logs, not metric tags.
+
+## Rollback Policy
+
+Remove the Observe route and run-level metric calls. The existing internal replay parity verifier remains usable by tests and maintenance code.


### PR DESCRIPTION
## Summary
- add ADR-0114 for a bounded Observe replay-parity probe
- add GET /observe/projections/replay-parity with entity_type and bounded limit scope
- serialize replay-parity reports and add run-level Datadog metrics for clean/drift/error canary runs
- add observe-feature endpoint tests for clean bounded scope and injected drift

## Validation
- cargo fmt --all -- --check
- git diff --check
- cargo test -p temper-server --features observe projection_replay_parity_endpoint -- --nocapture
- cargo test -p temper-server replay_parity -- --nocapture
- cargo check --locked -p temper-server --features observe
- cargo clippy --locked -p temper-server --features observe --all-targets -- -D warnings
- normal pre-push passed rustfmt, workspace clippy, and readability ratchet; full workspace test gate reached temper-actor-runtime Docker-backed integration tests and failed locally because Testcontainers could not create Postgres containers: Client(CreateContainer(RequestTimeoutError)). GitHub CI should be the full Docker-backed proof.