### PR TITLE
Handle pinned Genesis dependency refs in app installs

### DIFF
--- a/crates/temper-platform/src/os_apps/mod.rs
+++ b/crates/temper-platform/src/os_apps/mod.rs
@@ -929,13 +929,33 @@ fn os_app_dependencies(name: &str) -> Vec<String> {
     if let Some(entry) = cat.entries.iter().find(|e| e.name == name)
         && !entry.dependencies.is_empty()
     {
-        return entry.dependencies.clone();
+        return entry
+            .dependencies
+            .iter()
+            .filter_map(|dependency| local_os_app_dependency_name(dependency))
+            .collect();
     }
     // Hardcoded fallback.
     match name {
         // TemperAgent persists conversation/files in TemperFS entities.
         "temper-agent" => vec!["temper-fs".to_string()],
         _ => vec![],
+    }
+}
+
+fn local_os_app_dependency_name(dependency: &str) -> Option<String> {
+    let unpinned = dependency
+        .trim()
+        .split_once('@')
+        .map_or(dependency.trim(), |(left, _)| left);
+    let name = unpinned
+        .rsplit_once('/')
+        .map_or(unpinned, |(_, name)| name)
+        .trim();
+    if name.is_empty() {
+        None
+    } else {
+        Some(name.to_string())
     }
 }
 

--- a/crates/temper-platform/src/os_apps/mod_test.rs
+++ b/crates/temper-platform/src/os_apps/mod_test.rs
@@ -176,6 +176,20 @@ fn test_resolve_os_app_install_order_dedupes_shared_dependencies() {
 }
 
 #[test]
+fn test_manifest_dependencies_accept_pinned_genesis_refs_for_local_install_order() {
+    assert_eq!(
+        local_os_app_dependency_name("temperpaw/paw-fs@65f3ee9659500d11a54c22b9e5519d52dd0db1d4")
+            .as_deref(),
+        Some("paw-fs")
+    );
+    assert_eq!(
+        local_os_app_dependency_name("katagami-commons").as_deref(),
+        Some("katagami-commons")
+    );
+    assert_eq!(local_os_app_dependency_name("  "), None);
+}
+
+#[test]
 fn test_reconcile_plan_for_wasm_only_digest_skips_unrelated_phases() {
     let current = OsAppBundleDigest {
         app_name: "paw-agent".to_string(),


### PR DESCRIPTION
## Summary
- normalize manifest dependencies such as `owner/app@hash` to the local materialized app name during OS-app install order resolution
- keep Genesis closure materialization pinned by owner/hash while letting the existing installer operate on local app directories
- add a focused unit test for the dependency normalizer

## Tests
- `cargo test -p temper-platform test_manifest_dependencies_accept_pinned_genesis_refs_for_local_install_order`
- `cargo fmt --check`
- `git diff --check`

## Database safety
No database reset, wipe, truncate, restore, or row deletion is involved.