### PR TITLE
[codex] package bundled OS apps in runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,10 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/target/release/temper /usr/local/bin/temper
+COPY --from=builder /app/os-apps /opt/temper-os-apps
 
 ENV RUST_LOG=info,temper=info
+ENV TEMPER_OS_APPS_DIR=/opt/temper-os-apps
 EXPOSE 3000
 
 # No ENTRYPOINT — Railway's startCommand provides the full command.

--- a/docs/adrs/0121-bundled-os-apps-in-runtime-image.md
+++ b/docs/adrs/0121-bundled-os-apps-in-runtime-image.md
@@ -1,0 +1,97 @@
+# ADR-0121: Bundled OS Apps In Runtime Image
+
+- Status: Accepted
+- Date: 2026-05-26
+- Deciders: Temper core maintainers
+- Related:
+  - ADR-0027: OS App Catalog
+  - ADR-0120: Directed Evolution Control Plane
+  - `Dockerfile`
+  - `crates/temper-platform/src/os_apps/app_catalog.rs`
+
+## Context
+
+Temper production images currently copy only the compiled `temper` binary into the
+runtime stage. That lets the server boot, but deployed processes cannot discover
+repository-bundled OS apps because `os-apps/` is absent from the image. The
+runtime log then reports:
+
+```text
+No os-apps directory found. Set TEMPER_OS_APPS_DIR for dev/local apps.
+```
+
+That was tolerable while deployed apps were recovered from durable state or
+provided by another service, but it blocks new bundled OS apps such as Directed
+Evolution from being installed or reconciled after the code is merged.
+
+## Decision
+
+The Temper runtime image will include the repository `os-apps/` directory under
+`/opt/temper-os-apps` and set `TEMPER_OS_APPS_DIR=/opt/temper-os-apps`.
+
+This keeps app discovery explicit and uses the existing first-priority app
+catalog path. The server remains responsible for deciding which apps to install
+per tenant; the image only makes the app bundles available.
+
+## Rollout Plan
+
+1. **Phase 0 (Immediate)** - Copy `os-apps/` into the runtime image and set
+   `TEMPER_OS_APPS_DIR`.
+2. **Phase 1 (Production deploy)** - Redeploy the Railway `temper-server`
+   service and verify the Directed Evolution entity sets can be installed or
+   recovered from the bundled source.
+3. **Phase 2 (Follow-up)** - If image size becomes a problem, split runtime
+   app packaging into a curated bundle manifest rather than copying every app.
+
+## Readiness Gates
+
+- Production logs show app catalog discovery from `/opt/temper-os-apps`.
+- Directed Evolution app sources are available to the deployed server.
+- Existing tenant/app recovery still boots without requiring the working
+  directory to contain source files.
+
+## Consequences
+
+### Positive
+
+- New repository-bundled OS apps are deployable without a second artifact store.
+- Runtime behavior matches local development more closely.
+- Directed Evolution can be installed into a production tenant after merge.
+
+### Negative
+
+- Runtime images are larger because all bundled OS app sources and WASM
+  artifacts are copied.
+
+### Risks
+
+- Copying every app may include source-only app material that is not needed at
+  runtime. The mitigation is to keep app installation governed and add a
+  manifest-based curated copy if size or exposure becomes an operational issue.
+
+### DST Compliance
+
+This changes only container packaging and startup configuration. No
+simulation-visible runtime code changes.
+
+## Non-Goals
+
+- Auto-installing all OS apps for all tenants.
+- Changing app discovery precedence.
+- Replacing Genesis-published app bundles.
+
+## Alternatives Considered
+
+1. **Install Directed Evolution manually from a local path after deploy** -
+   rejected because it would not survive normal production redeploys.
+2. **Add a Directed Evolution-specific copy path** - rejected because the same
+   deployment gap applies to future bundled OS apps.
+3. **Publish app bundles to Genesis first** - useful long term, but it does not
+   solve the existing Temper runtime image failing to include its own bundled
+   apps.
+
+## Rollback Policy
+
+Remove the `TEMPER_OS_APPS_DIR` environment variable and the `COPY
+--from=builder /app/os-apps /opt/temper-os-apps` line from the Dockerfile, then
+redeploy. Existing persisted app state remains in the platform store.

--- a/docs/adrs/0121-bundled-os-apps-in-runtime-image.md
+++ b/docs/adrs/0121-bundled-os-apps-in-runtime-image.md
@@ -7,6 +7,7 @@
   - ADR-0027: OS App Catalog
   - ADR-0120: Directed Evolution Control Plane
   - `Dockerfile`
+  - `railway.toml`
   - `crates/temper-platform/src/os_apps/app_catalog.rs`
 
 ## Context
@@ -33,13 +34,18 @@ This keeps app discovery explicit and uses the existing first-priority app
 catalog path. The server remains responsible for deciding which apps to install
 per tenant; the image only makes the app bundles available.
 
+The production Railway start command will explicitly pass
+`--app directed-evolution`. This installs or reconciles the bundled Directed
+Evolution app for the `default` tenant on boot using the normal governed app
+installer, rather than requiring an ad-hoc post-deploy mutation endpoint.
+
 ## Rollout Plan
 
 1. **Phase 0 (Immediate)** - Copy `os-apps/` into the runtime image and set
    `TEMPER_OS_APPS_DIR`.
 2. **Phase 1 (Production deploy)** - Redeploy the Railway `temper-server`
-   service and verify the Directed Evolution entity sets can be installed or
-   recovered from the bundled source.
+   service with `--app directed-evolution` and verify the Directed Evolution
+   entity sets are installed or recovered from the bundled source.
 3. **Phase 2 (Follow-up)** - If image size becomes a problem, split runtime
    app packaging into a curated bundle manifest rather than copying every app.
 
@@ -47,6 +53,8 @@ per tenant; the image only makes the app bundles available.
 
 - Production logs show app catalog discovery from `/opt/temper-os-apps`.
 - Directed Evolution app sources are available to the deployed server.
+- `GET /tdata/Directions` for the production tenant no longer returns
+  `EntitySetNotFound`.
 - Existing tenant/app recovery still boots without requiring the working
   directory to contain source files.
 
@@ -56,12 +64,15 @@ per tenant; the image only makes the app bundles available.
 
 - New repository-bundled OS apps are deployable without a second artifact store.
 - Runtime behavior matches local development more closely.
-- Directed Evolution can be installed into a production tenant after merge.
+- Directed Evolution is installed into the production `default` tenant during
+  the normal boot sequence after merge.
 
 ### Negative
 
 - Runtime images are larger because all bundled OS app sources and WASM
   artifacts are copied.
+- The production boot surface now includes Directed Evolution by default for the
+  `default` tenant.
 
 ### Risks
 
@@ -77,6 +88,7 @@ simulation-visible runtime code changes.
 ## Non-Goals
 
 - Auto-installing all OS apps for all tenants.
+- Installing Directed Evolution into every tenant.
 - Changing app discovery precedence.
 - Replacing Genesis-published app bundles.
 
@@ -93,5 +105,6 @@ simulation-visible runtime code changes.
 ## Rollback Policy
 
 Remove the `TEMPER_OS_APPS_DIR` environment variable and the `COPY
---from=builder /app/os-apps /opt/temper-os-apps` line from the Dockerfile, then
-redeploy. Existing persisted app state remains in the platform store.
+--from=builder /app/os-apps /opt/temper-os-apps` line from the Dockerfile, drop
+the `--app directed-evolution` start-command argument, then redeploy. Existing
+persisted app state remains in the platform store.

--- a/railway.toml
+++ b/railway.toml
@@ -2,7 +2,7 @@
 dockerfilePath = "Dockerfile"
 
 [deploy]
-startCommand = "sh -c 'temper serve --port $PORT'"
+startCommand = "sh -c 'temper serve --port $PORT --app directed-evolution'"
 healthcheckPath = "/healthz"
 healthcheckTimeout = 300
 restartPolicyType = "ON_FAILURE"


### PR DESCRIPTION
## Summary
- copy bundled os-apps into the Temper runtime image
- set TEMPER_OS_APPS_DIR so deployed servers can discover merged OS app bundles
- start Railway temper-server with `--app directed-evolution` so the bundled app is installed/reconciled for the default production tenant at boot
- add ADR-0121 for the deployment packaging and boot-install decision

## Verification
- git diff --check
- cargo test -p temper-cli railway_start_command_does_not_pin_turso
- verified os-apps/directed-evolution app.toml and WASM artifacts are present in the branch
- earlier pre-push cargo fmt, clippy, and readability gates passed locally
- earlier local full-suite pre-push was blocked by Testcontainers Postgres startup timeouts in temper-actor-runtime integration tests (CreateContainer RequestTimeoutError), unrelated to this Dockerfile/ADR/railway.toml change

This is the production packaging follow-up needed after Directed Evolution landed: the current Railway image boots without os-app sources and without a default-tenant app install, so the deployed server cannot expose the new control-plane entity sets.