### PR TITLE
Opt out structure LLM spans from Datadog LLMObs conversion

### DIFF
--- a/crates/temper-server/src/state/dispatch/wasm.rs
+++ b/crates/temper-server/src/state/dispatch/wasm.rs
@@ -1773,6 +1773,7 @@ fn build_llm_root_span(
         wasm.module = %module_name,
         gen_ai.system = %provider,
         gen_ai.provider.name = %provider,
+        dd_llmobs_enabled = false,
         gen_ai.system_instructions = tracing::field::Empty,
         gen_ai.request.model = %model,
         gen_ai.operation.name = "chat",
@@ -2227,7 +2228,7 @@ mod tests {
                 .trace_id()
                 .to_string()
         });
-        let llm_trace_id = parent.in_scope(|| {
+        let (llm_trace_id, has_llmobs_auto_conversion_opt_out) = parent.in_scope(|| {
             let ctx = WasmDispatchCtx {
                 entity_ref: WasmEntityRef {
                     tenant: &tenant,
@@ -2240,10 +2241,26 @@ mod tests {
                 mode: WasmDispatchMode::Inline,
             };
             let span = build_llm_root_span(&ctx, &integration, &entity_state, "provider_caller");
-            span.context().span().span_context().trace_id().to_string()
+            let has_opt_out = span
+                .metadata()
+                .map(|metadata| {
+                    metadata
+                        .fields()
+                        .iter()
+                        .any(|field| field.name() == "dd_llmobs_enabled")
+                })
+                .unwrap_or(false);
+            (
+                span.context().span().span_context().trace_id().to_string(),
+                has_opt_out,
+            )
         });
 
         assert_eq!(llm_trace_id, expected_trace_id);
+        assert!(
+            has_llmobs_auto_conversion_opt_out,
+            "root LLM OTel span must opt out of Datadog auto LLMObs conversion"
+        );
     }
 
     #[test]

--- a/crates/temper-wasm/src/engine/guest_spans.rs
+++ b/crates/temper-wasm/src/engine/guest_spans.rs
@@ -159,6 +159,7 @@ impl GuestSpanRegistry {
             workflow_run_id = self.context.workflow_run_id.as_deref().unwrap_or(""),
             observability_event = "wasm_guest.span",
             wasm_guest_span_id = id,
+            dd_llmobs_enabled = tracing::field::Empty,
             action_name = tracing::field::Empty,
             managed_session_id = tracing::field::Empty,
             inner_session_id = tracing::field::Empty,

--- a/crates/temper-wasm/src/engine/guest_spans_test.rs
+++ b/crates/temper-wasm/src/engine/guest_spans_test.rs
@@ -78,6 +78,7 @@ fn protects_reserved_observability_fields() {
     assert!(!guest_span_attribute_allowed("trace_id"));
     assert!(!guest_span_attribute_allowed("dd.span_id"));
     assert!(!guest_span_attribute_allowed("_otel.parent_trace_id"));
+    assert!(guest_span_attribute_allowed("dd_llmobs_enabled"));
     assert!(guest_span_attribute_allowed("tool.name"));
     assert!(guest_span_attribute_allowed("gen_ai.operation.name"));
 }

--- a/crates/temper-wasm/src/host_trait.rs
+++ b/crates/temper-wasm/src/host_trait.rs
@@ -814,6 +814,7 @@ impl WasmHost for ProductionWasmHost {
             workflow_root_entity_type = tracing::field::Empty,
             workflow_root_entity_id = tracing::field::Empty,
             workflow_run_id = tracing::field::Empty,
+            dd_llmobs_enabled = tracing::field::Empty,
             tool.name = tracing::field::Empty,
             tool.call_id = tracing::field::Empty,
             gen_ai.operation.name = tracing::field::Empty,
@@ -1041,6 +1042,7 @@ impl WasmHost for ProductionWasmHost {
             workflow_root_entity_type = tracing::field::Empty,
             workflow_root_entity_id = tracing::field::Empty,
             workflow_run_id = tracing::field::Empty,
+            dd_llmobs_enabled = tracing::field::Empty,
             tool.name = tracing::field::Empty,
             tool.call_id = tracing::field::Empty,
             gen_ai.operation.name = tracing::field::Empty,
@@ -1239,6 +1241,7 @@ impl WasmHost for ProductionWasmHost {
             workflow_root_entity_type = tracing::field::Empty,
             workflow_root_entity_id = tracing::field::Empty,
             workflow_run_id = tracing::field::Empty,
+            dd_llmobs_enabled = tracing::field::Empty,
         );
         record_invocation_context_on_span(&span, self.invocation_context.as_ref(), "connect_call");
         apply_span_hints(&span, &span_hints);
@@ -1322,6 +1325,7 @@ impl WasmHost for ProductionWasmHost {
             workflow_root_entity_type = tracing::field::Empty,
             workflow_root_entity_id = tracing::field::Empty,
             workflow_run_id = tracing::field::Empty,
+            dd_llmobs_enabled = tracing::field::Empty,
             error.type = tracing::field::Empty,
             error.message = tracing::field::Empty,
         );
@@ -1379,6 +1383,7 @@ impl WasmHost for ProductionWasmHost {
             workflow_root_entity_type = tracing::field::Empty,
             workflow_root_entity_id = tracing::field::Empty,
             workflow_run_id = tracing::field::Empty,
+            dd_llmobs_enabled = tracing::field::Empty,
             error.type = tracing::field::Empty,
             error.message = tracing::field::Empty,
         );
@@ -1629,6 +1634,7 @@ impl WasmHost for ProductionWasmHost {
             workflow_root_entity_type = tracing::field::Empty,
             workflow_root_entity_id = tracing::field::Empty,
             workflow_run_id = tracing::field::Empty,
+            dd_llmobs_enabled = tracing::field::Empty,
             tool.name = tracing::field::Empty,
             tool.call_id = tracing::field::Empty,
             gen_ai.operation.name = tracing::field::Empty,

--- a/crates/temper-wasm/src/host_trait/span_hints.rs
+++ b/crates/temper-wasm/src/host_trait/span_hints.rs
@@ -119,6 +119,7 @@ pub(crate) fn datadog_visible_span_hint_field(attr_key: &str) -> Option<&'static
         "workflow_root_entity_type" => Some("workflow_root_entity_type"),
         "workflow_root_entity_id" => Some("workflow_root_entity_id"),
         "workflow_run_id" => Some("workflow_run_id"),
+        "dd_llmobs_enabled" => Some("dd_llmobs_enabled"),
         "tool.name" => Some("tool.name"),
         "tool.call_id" => Some("tool.call_id"),
         "gen_ai.operation.name" => Some("gen_ai.operation.name"),

--- a/crates/temper-wasm/src/host_trait/tests/span_hint_tests.rs
+++ b/crates/temper-wasm/src/host_trait/tests/span_hint_tests.rs
@@ -98,6 +98,7 @@ fn common_session_tool_and_llm_span_hints_are_datadog_visible_fields() {
         "workflow_root_entity_type",
         "workflow_root_entity_id",
         "workflow_run_id",
+        "dd_llmobs_enabled",
         "tool.name",
         "tool.call_id",
         "gen_ai.operation.name",

--- a/docs/adrs/0137-datadog-llmobs-auto-conversion-opt-out.md
+++ b/docs/adrs/0137-datadog-llmobs-auto-conversion-opt-out.md
@@ -1,0 +1,101 @@
+# ADR-0137: Datadog LLMObs Auto-Conversion Opt-Out
+
+- Status: Accepted
+- Date: 2026-06-09
+- Deciders: Temper core maintainers
+- Related:
+  - ADR-0136: Guest Span LLMObs Content Fields
+  - `crates/temper-server/src/state/dispatch/wasm.rs`
+  - `crates/temper-wasm/src/engine/guest_spans.rs`
+  - `crates/temper-wasm/src/host_trait.rs`
+
+## Context
+
+ADR-0136 made LLM content attributes visible on Datadog-rendered guest spans.
+That fixed spans where TemperPaw intentionally exported content, but production
+also emits root OTel GenAI spans and provider-call helper spans whose purpose is
+trace structure and provider metadata, not LLMObs transcript rendering.
+
+Datadog can auto-convert GenAI OTel spans into LLMObs rows. When those
+structure-only spans do not contain input or output content, the LLMObs UI
+renders them as empty `No content` rows even though the span itself is valid
+trace telemetry. Environment-level resource attributes are not sufficient for
+this path because the opt-out attribute must be present on the spans Datadog is
+evaluating.
+
+## Decision
+
+Temper root LLM spans and Datadog-visible WASM guest/host span hint surfaces
+must support the `dd_llmobs_enabled` attribute.
+
+The server records `dd_llmobs_enabled = false` on the root LLM span created for
+provider-caller integrations. The WASM host declares `dd_llmobs_enabled` as a
+static tracing field on guest spans and host spans that accept guest span hints,
+and maps the corresponding `X-Temper-Span-Attr-dd_llmobs_enabled` hint to that
+field.
+
+Provider integrations that emit OTel GenAI helper spans can now set
+`dd_llmobs_enabled=false` on those spans while still exporting normal trace
+metadata. Integrations that intentionally emit complete LLMObs transcript spans
+can continue to send content-bearing fields.
+
+## Rollout Plan
+
+1. **Phase 0 (Immediate)** - Ship the platform field and root-span opt-out,
+   then repin TemperPaw so provider-caller spans send the new hint.
+2. **Phase 1 (Production proof)** - Query Datadog after deploy and confirm new
+   LLM span exports no longer include empty auto-converted rows.
+
+## Consequences
+
+### Positive
+
+- Structure-only GenAI spans remain useful in traces without polluting LLMObs
+  content tables.
+- The opt-out follows the span instead of relying on process-wide environment
+  metadata that may not be copied onto Datadog's auto-conversion input.
+- The existing span-hint API shape remains unchanged.
+
+### Negative
+
+- Datadog-specific behavior is now represented in the platform span field
+  surface.
+- Callers must still choose intentionally whether a span is a transcript span
+  or a structure-only helper span.
+
+### Risks
+
+- If a future Datadog exporter changes the opt-out attribute name, this field
+  will need a compatibility update.
+- A caller can still create empty LLMObs rows by emitting GenAI content spans
+  without setting the opt-out or actual content.
+
+### DST Compliance
+
+- Changes touch `temper-server` and `temper-wasm`, but add only static span
+  fields and deterministic attribute mapping.
+- No wall-clock access, randomness, filesystem access, network I/O, or
+  background scheduling is introduced.
+
+## Non-Goals
+
+- This does not disable Datadog tracing or APM ingestion.
+- This does not remove content-bearing LLMObs spans that callers intentionally
+  emit.
+- This does not add a separate LLM observability bridge.
+
+## Alternatives Considered
+
+1. **Only use `OTEL_RESOURCE_ATTRIBUTES`** - Rejected because production spans
+   continued to auto-convert without the opt-out appearing on the relevant
+   spans.
+2. **Remove GenAI attributes from helper spans** - Rejected because provider,
+   model, token, and operation metadata are still useful trace context.
+3. **Disable LLM observability globally** - Rejected because transcript-bearing
+   spans should remain possible for integrations that provide complete bounded
+   content.
+
+## Rollback Policy
+
+Remove the static field mapping and root-span opt-out, then repin downstream
+applications to the rollback commit.


### PR DESCRIPTION
## Summary
- record dd_llmobs_enabled=false on structure-only root LLM spans
- allow guest and host span hints to record dd_llmobs_enabled as a Datadog-visible static field
- document the Datadog auto-conversion decision in ADR-0137

## Verification
- cargo test -p temper-wasm common_session_tool_and_llm_span_hints_are_datadog_visible_fields
- cargo test -p temper-wasm protects_reserved_observability_fields
- cargo test -p temper-server llm_root_span_stays_on_active_trace
- pre-push full pipeline: rustfmt, clippy, readability ratchet, cargo test --workspace