### PR TITLE
Avoid global OData coverage sweep for filtered reads

### DIFF
--- a/crates/temper-server/src/odata/query_plane_read/mod.rs
+++ b/crates/temper-server/src/odata/query_plane_read/mod.rs
@@ -14,6 +14,23 @@ use super::read_support::missing_catalog_entity_ids;
 use scan::{native_candidate_page_plan, read_from_source_cursor, try_native_page_read};
 use types::{QueryPlaneCoverageReport, QueryPlaneFallbackReason};
 
+fn should_try_native_before_catalog_coverage(
+    request: &QueryPlaneReadRequest<'_>,
+    plan: &scan::NativeCandidatePagePlan,
+) -> bool {
+    plan.filter_pushdown && request.query_options.count != Some(true)
+}
+
+fn should_try_lazy_catalog_repair_after_native_result(
+    request: &QueryPlaneReadRequest<'_>,
+    indexed_entity_ids: &[String],
+    result: &scan::CandidateScanResult,
+) -> bool {
+    indexed_entity_ids.is_empty()
+        && result.entities.is_empty()
+        && request.budget.requested_top(request.query_options) > 0
+}
+
 async fn catalog_coverage_report(
     request: &QueryPlaneReadRequest<'_>,
     all_entity_ids: &[String],
@@ -50,12 +67,64 @@ pub(in crate::odata) async fn read_entity_set_from_query_plane(
         return Err(QueryPlaneReadError::AuthorizationDenied(response));
     }
 
+    let native_plan = native_candidate_page_plan(&request);
+    if let Some(plan) = native_plan.clone()
+        && should_try_native_before_catalog_coverage(&request, &plan)
+    {
+        let indexed_entity_ids = request
+            .state
+            .list_entity_ids(request.tenant, request.entity_type);
+        let can_repair_with_bounded_coverage = !indexed_entity_ids.is_empty()
+            && indexed_entity_ids.len() <= request.budget.scan_candidate_budget();
+        if can_repair_with_bounded_coverage {
+            let (coverage, missing_ids) =
+                catalog_coverage_report(&request, &indexed_entity_ids).await;
+            if coverage.missing == 0 {
+                if let Some(result) = try_native_page_read(&request, plan, coverage).await {
+                    return result.map(|result| QueryPlaneReadResult {
+                        entities: result.entities,
+                        count: result.count,
+                        telemetry: result.telemetry,
+                    });
+                }
+            } else {
+                let result = read_from_source_cursor(
+                    &request,
+                    &indexed_entity_ids,
+                    coverage,
+                    &missing_ids,
+                    QueryPlaneFallbackReason::CatalogCoverageGap,
+                )
+                .await?;
+                return Ok(QueryPlaneReadResult {
+                    entities: result.entities,
+                    count: result.count,
+                    telemetry: result.telemetry,
+                });
+            }
+        } else if let Some(result) =
+            try_native_page_read(&request, plan, QueryPlaneCoverageReport::default()).await
+        {
+            let result = result?;
+            if !should_try_lazy_catalog_repair_after_native_result(
+                &request,
+                &indexed_entity_ids,
+                &result,
+            ) {
+                return Ok(QueryPlaneReadResult {
+                    entities: result.entities,
+                    count: result.count,
+                    telemetry: result.telemetry,
+                });
+            }
+        }
+    }
+
     let all_entity_ids = request
         .state
         .list_entity_ids_lazy(request.tenant, request.entity_type)
         .await;
     let (coverage, missing_ids) = catalog_coverage_report(&request, &all_entity_ids).await;
-    let native_plan = native_candidate_page_plan(&request);
 
     if coverage.missing == 0
         && let Some(plan) = native_plan.clone()

--- a/crates/temper-server/src/odata/query_plane_read/tests.rs
+++ b/crates/temper-server/src/odata/query_plane_read/tests.rs
@@ -121,6 +121,70 @@ fn scan_candidate_budget_matches_existing_odata_cap() {
     assert_eq!(large_default.scan_candidate_budget(), 20_000);
 }
 
+#[test]
+fn native_catalog_coverage_short_circuit_requires_pushdown_without_count() {
+    let state = build_order_state("query-plane-native-coverage-short-circuit");
+    let tenant = TenantId::default();
+    let security_ctx = SecurityContext::system();
+    let filtered_options = QueryOptions {
+        filter: Some(FilterExpr::BinaryOp {
+            left: Box::new(FilterExpr::Property("Id".to_string())),
+            op: BinaryOperator::Eq,
+            right: Box::new(FilterExpr::Literal(ODataValue::String(
+                "ord-01".to_string(),
+            ))),
+        }),
+        top: Some(1),
+        ..QueryOptions::default()
+    };
+    let filtered_request = QueryPlaneReadRequest {
+        state: &state,
+        tenant: &tenant,
+        security_ctx: &security_ctx,
+        entity_type: "Order",
+        entity_set_name: "Orders",
+        query_options: &filtered_options,
+        budget: QueryPlaneReadBudget {
+            default_page_size: 1,
+            max_entities: 10,
+        },
+    };
+    let filtered_plan = native_candidate_page_plan(&filtered_request).expect("native plan");
+
+    assert!(should_try_native_before_catalog_coverage(
+        &filtered_request,
+        &filtered_plan
+    ));
+
+    let count_options = QueryOptions {
+        count: Some(true),
+        ..filtered_options.clone()
+    };
+    let count_request = QueryPlaneReadRequest {
+        query_options: &count_options,
+        ..filtered_request
+    };
+    let count_plan = native_candidate_page_plan(&count_request).expect("native count plan");
+    assert!(!should_try_native_before_catalog_coverage(
+        &count_request,
+        &count_plan
+    ));
+
+    let unfiltered_options = QueryOptions {
+        top: Some(1),
+        ..QueryOptions::default()
+    };
+    let unfiltered_request = QueryPlaneReadRequest {
+        query_options: &unfiltered_options,
+        ..count_request
+    };
+    let unfiltered_plan = native_candidate_page_plan(&unfiltered_request).expect("native plan");
+    assert!(!should_try_native_before_catalog_coverage(
+        &unfiltered_request,
+        &unfiltered_plan
+    ));
+}
+
 #[tokio::test]
 async fn row_authorized_count_over_budget_returns_413() {
     let state = build_order_state("query-plane-budget-count");


### PR DESCRIPTION
## Summary
- route pushdown-filtered, non-count OData reads through the native query-plane page reader before any large global catalog coverage sweep
- keep conservative catalog coverage/repair for small indexed entity sets, counts, unfiltered reads, non-pushdown filters, and fallback reads
- add unit coverage for the native-before-coverage eligibility rules and preserve the missing-catalog repair contract

## Root cause
Paul/Paw context preparation timed out before the model was reached. Datadog and Railway logs showed `context_preparer step=load_messages` failing after about 120s while a selected-catalog SQL query stalled for 119.531s. The read path was sweeping catalog coverage across all `SessionEntry` rows before applying `SessionId eq ...`, so one thread context load could pay for tens of thousands of unrelated rows.

## Validation
- `cargo test -p temper-server --test odata_read filtered_entity_set_repairs_missing_catalog_rows_before_trusting_pushdown`
- `cargo test -p temper-server odata::query_plane_read --lib`
- `cargo test -p temper-server --test odata_read`
- full pre-push hook passed rustfmt, clippy, readability, workspace tests, and doctests

## Live impact
This removes the global coverage sweep from the hot path Paul hit. The live OpenPaw deployment will still be vulnerable until this PR is merged and TemperPaw is rebuilt/deployed against this Temper commit.