### PR TITLE
fix(os-apps): reconcile missing active policies

### DIFF
--- a/crates/temper-platform/src/os_apps/mod_test.rs
+++ b/crates/temper-platform/src/os_apps/mod_test.rs
@@ -252,7 +252,8 @@ fn test_reconcile_plan_for_wasm_only_digest_skips_unrelated_phases() {
         status: "installed".to_string(),
     };
 
-    let plan = reconcile::plan_reconcile_from_installed_record(&installed, &current, true, true);
+    let plan =
+        reconcile::plan_reconcile_from_installed_record(&installed, &current, true, true, true);
 
     assert_eq!(
         plan,
@@ -290,6 +291,84 @@ async fn test_reconcile_os_app_skips_unchanged_bundle_digest() {
     assert!(
         matches!(result, OsAppReconcileResult::Skipped { .. }),
         "unchanged app should skip hot reinstall, got {result:?}"
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(format!("{db_path}-wal"));
+    let _ = std::fs::remove_file(format!("{db_path}-shm"));
+}
+
+#[tokio::test]
+async fn test_reconcile_os_app_repairs_missing_active_policies_for_unchanged_bundle() {
+    let db_path = format!(
+        "/tmp/temper-test-policy-reconcile-{}.db",
+        uuid::Uuid::new_v4()
+    );
+    let db_url = format!("file:{db_path}");
+    let tenant = "test-policy-reconcile";
+
+    let turso = temper_store_turso::TursoEventStore::new(&db_url, None)
+        .await
+        .unwrap();
+    let mut state = PlatformState::new(None);
+    state
+        .server
+        .set_storage_stack(temper_server::StorageStack::from_turso(turso));
+
+    install_os_app(&state, tenant, "project-management")
+        .await
+        .expect("initial install should succeed");
+
+    {
+        let mut policies = state.server.tenant_policies.write().unwrap(); // ci-ok: infallible lock
+        policies.remove(tenant);
+    }
+    state
+        .server
+        .authz
+        .reload_tenant_policies(tenant, "")
+        .expect("empty tenant policy should load");
+
+    let admin_ctx = SecurityContext::from_headers(&[
+        ("X-Temper-Principal-Id".to_string(), "admin-1".to_string()),
+        ("X-Temper-Principal-Kind".to_string(), "admin".to_string()),
+    ]);
+    let mut issue_attrs = HashMap::new();
+    issue_attrs.insert("id".to_string(), serde_json::json!("issue-1"));
+
+    let denied_before_reconcile = state.server.authz.authorize_for_tenant(
+        tenant,
+        &admin_ctx,
+        "MoveToTodo",
+        "Issue",
+        &issue_attrs,
+    );
+    assert!(
+        !denied_before_reconcile.is_allowed(),
+        "test setup should remove active app policies before reconcile"
+    );
+
+    let result = reconcile_os_app(&state, tenant, "project-management")
+        .await
+        .expect("unchanged reconcile should repair missing active policies");
+
+    let OsAppReconcileResult::Installed { install, .. } = result else {
+        panic!("missing active policies should force a policies-only reconcile");
+    };
+    assert!(install.added.is_empty());
+    assert!(install.updated.is_empty());
+    assert!(install.skipped.is_empty());
+
+    let allowed_after_reconcile = state.server.authz.authorize_for_tenant(
+        tenant,
+        &admin_ctx,
+        "MoveToTodo",
+        "Issue",
+        &issue_attrs,
+    );
+    assert!(
+        allowed_after_reconcile.is_allowed(),
+        "reconcile should reload the app Cedar policies when active memory lost them: {allowed_after_reconcile:?}"
     );
 
     let _ = std::fs::remove_file(&db_path);

--- a/crates/temper-platform/src/os_apps/reconcile.rs
+++ b/crates/temper-platform/src/os_apps/reconcile.rs
@@ -230,14 +230,37 @@ pub(super) fn plan_reconcile_from_installed_record(
     digest: &OsAppBundleDigest,
     specs_ready: bool,
     wasm_registered: bool,
+    policies_active: bool,
 ) -> OsAppInstallPlan {
     OsAppInstallPlan {
         specs: record.spec_digest != digest.spec_digest || !specs_ready,
-        policies: record.policy_digest != digest.policy_digest,
+        policies: record.policy_digest != digest.policy_digest || !policies_active,
         wasm: record.wasm_digest != digest.wasm_digest || !wasm_registered,
         content: record.content_digest != digest.content_digest,
         seed: record.seed_digest != digest.seed_digest,
     }
+}
+
+fn tenant_has_active_policies_for_bundle(
+    state: &PlatformState,
+    tenant: &str,
+    bundle: &AppBundle,
+) -> bool {
+    if bundle.cedar_policies.is_empty() {
+        return true;
+    }
+
+    let Ok(policies) = state.server.tenant_policies.read() else {
+        return false;
+    };
+    let Some(active_text) = policies.get(tenant) else {
+        return false;
+    };
+
+    bundle.cedar_policies.iter().all(|policy| {
+        let policy = policy.trim();
+        policy.is_empty() || active_text.contains(policy)
+    })
 }
 
 fn tenant_has_registered_wasm_for_bundle(
@@ -338,6 +361,7 @@ pub async fn reconcile_os_app(
             Ok(Some(record)) => {
                 let mut specs_ready = tenant_has_ready_app_specs_for_bundle(state, tenant, &bundle);
                 let wasm_registered = tenant_has_registered_wasm_for_bundle(state, tenant, &bundle);
+                let policies_active = tenant_has_active_policies_for_bundle(state, tenant, &bundle);
 
                 if record.bundle_digest == digest.bundle_digest && !specs_ready {
                     specs_ready = restore_app_specs_from_matching_digest(
@@ -350,7 +374,11 @@ pub async fn reconcile_os_app(
                     .await;
                 }
 
-                if record.bundle_digest == digest.bundle_digest && specs_ready && wasm_registered {
+                if record.bundle_digest == digest.bundle_digest
+                    && specs_ready
+                    && wasm_registered
+                    && policies_active
+                {
                     tracing::info!(
                         tenant,
                         app = %app_name,
@@ -378,6 +406,7 @@ pub async fn reconcile_os_app(
                     &digest,
                     specs_ready,
                     wasm_registered,
+                    policies_active,
                 );
 
                 tracing::info!(


### PR DESCRIPTION
## Summary
- Treat active Cedar policy text as part of OS app reconcile readiness.
- Force a policies-only reconcile when the installed bundle digest matches but the live tenant policy cache is missing the app policies.
- Add a regression that clears active policies after install and proves unchanged reconcile restores authorization.

## Production RCA
Katagami palette synthesis was not stuck in routing anymore. The live workers reached PaletteSystem/TasteRule operations, but TemperPaw denied them with no matching Cedar permit. The platform reconcile path could skip or run spec/WASM-only deltas based on stored digests without checking whether the app policies were actually active in memory, so unchanged policies could stay absent after restart/reconcile.

## Verification
- cargo test -p temper-platform test_reconcile_os_app_repairs_missing_active_policies_for_unchanged_bundle -- --nocapture
- cargo test -p temper-platform reconcile_os_app -- --nocapture
- cargo test -p temper-platform
- cargo clippy -p temper-platform -- -D warnings
- git push pre-push gates: cargo fmt --check, cargo clippy --workspace -- -D warnings, readability ratchet, cargo test --workspace
