### PR TITLE
Require runtime policies before app recovery ready

### DIFF
--- a/crates/temper-platform/src/os_apps/mod.rs
+++ b/crates/temper-platform/src/os_apps/mod.rs
@@ -37,6 +37,9 @@ pub use closure_bootstrap::{
     startup_os_app_closure,
 };
 pub use reconcile::{os_app_bundle_digest, reconcile_os_app, resolve_os_app_install_order};
+pub(crate) use reconcile::{
+    tenant_has_active_policies_for_bundle, tenant_has_registered_wasm_for_bundle,
+};
 pub(crate) use runtime_heal::{
     restore_app_specs_from_matching_digest, tenant_has_ready_app_specs_for_bundle,
 };

--- a/crates/temper-platform/src/os_apps/mod_test.rs
+++ b/crates/temper-platform/src/os_apps/mod_test.rs
@@ -477,6 +477,71 @@ async fn test_reconcile_os_app_repairs_missing_authz_engine_policies_despite_tex
 }
 
 #[tokio::test]
+async fn test_runtime_recovery_requires_active_policies_for_ready_outcome() {
+    let db_path = format!(
+        "/tmp/temper-test-runtime-policy-readiness-{}.db",
+        uuid::Uuid::new_v4()
+    );
+    let db_url = format!("file:{db_path}");
+    let tenant = "test-runtime-policy-readiness";
+
+    let turso = temper_store_turso::TursoEventStore::new(&db_url, None)
+        .await
+        .unwrap();
+    let mut state = PlatformState::new(None);
+    state
+        .server
+        .set_storage_stack(temper_server::StorageStack::from_turso(turso));
+
+    install_os_app(&state, tenant, "project-management")
+        .await
+        .expect("initial install should succeed");
+
+    let turso_ref = state.server.platform_turso_store().unwrap();
+    let cached_policy_text = {
+        let policies = state.server.tenant_policies.read().unwrap(); // ci-ok: infallible lock
+        policies
+            .get(tenant)
+            .cloned()
+            .expect("initial install should cache app policies")
+    };
+    state
+        .server
+        .authz
+        .reload_tenant_policies(tenant, "")
+        .expect("empty tenant policy should load");
+
+    let outcome = crate::recovery::recover_installed_app_runtime_state(
+        &state,
+        &turso_ref,
+        tenant,
+        "project-management",
+    )
+    .await;
+
+    assert_eq!(
+        outcome,
+        crate::recovery::InstalledAppRuntimeRecoveryOutcome::NeedsReconcile,
+        "runtime recovery must not mark an unchanged app ready when active Cedar policies are missing"
+    );
+    assert_eq!(
+        state
+            .server
+            .tenant_policies
+            .read()
+            .unwrap()
+            .get(tenant)
+            .map(String::as_str),
+        Some(cached_policy_text.as_str()),
+        "test setup should preserve cached policy text while active authz is empty"
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(format!("{db_path}-wal"));
+    let _ = std::fs::remove_file(format!("{db_path}-shm"));
+}
+
+#[tokio::test]
 async fn test_install_plan_without_spec_phase_does_not_reclassify_specs() {
     let state = PlatformState::new(None);
     let tenant = "test-install-plan-skip-specs";

--- a/crates/temper-platform/src/os_apps/reconcile.rs
+++ b/crates/temper-platform/src/os_apps/reconcile.rs
@@ -241,7 +241,7 @@ pub(super) fn plan_reconcile_from_installed_record(
     }
 }
 
-fn tenant_has_active_policies_for_bundle(
+pub(crate) fn tenant_has_active_policies_for_bundle(
     state: &PlatformState,
     tenant: &str,
     bundle: &AppBundle,
@@ -264,7 +264,7 @@ fn bundle_policies_present(active_text: &str, cedar_policies: &[String]) -> bool
     })
 }
 
-fn tenant_has_registered_wasm_for_bundle(
+pub(crate) fn tenant_has_registered_wasm_for_bundle(
     state: &PlatformState,
     tenant: &str,
     bundle: &AppBundle,

--- a/crates/temper-platform/src/recovery.rs
+++ b/crates/temper-platform/src/recovery.rs
@@ -250,7 +250,11 @@ pub async fn recover_installed_app_runtime_state(
         return InstalledAppRuntimeRecoveryOutcome::MissingBundle;
     };
 
-    if os_apps::tenant_has_ready_app_specs_for_bundle(state, tenant, &bundle) {
+    let specs_ready = os_apps::tenant_has_ready_app_specs_for_bundle(state, tenant, &bundle);
+    let policies_active = os_apps::tenant_has_active_policies_for_bundle(state, tenant, &bundle);
+    let wasm_registered = os_apps::tenant_has_registered_wasm_for_bundle(state, tenant, &bundle);
+
+    if specs_ready && policies_active && wasm_registered {
         return InstalledAppRuntimeRecoveryOutcome::Ready;
     }
 
@@ -260,9 +264,12 @@ pub async fn recover_installed_app_runtime_state(
 
     match ps.get_installed_app(tenant, app_name).await {
         Ok(Some(record)) if record.bundle_digest == digest.bundle_digest => {
-            if os_apps::restore_app_specs_from_matching_digest(state, ps, tenant, app_name, &bundle)
-                .await
-            {
+            let specs_ready = specs_ready
+                || os_apps::restore_app_specs_from_matching_digest(
+                    state, ps, tenant, app_name, &bundle,
+                )
+                .await;
+            if specs_ready && policies_active && wasm_registered {
                 InstalledAppRuntimeRecoveryOutcome::Healed
             } else {
                 InstalledAppRuntimeRecoveryOutcome::NeedsReconcile


### PR DESCRIPTION
## Summary
- make installed-app runtime recovery require active Cedar policies and registered WASM before returning Ready
- force NeedsReconcile for matching-digest apps whose active runtime policy state is missing
- add regression coverage for active authz loss with cached policy text still present

## Verification
- cargo test -p temper-platform test_runtime_recovery_requires_active_policies_for_ready_outcome -- --nocapture
- cargo test -p temper-platform test_reconcile_os_app_repairs_missing_authz_engine_policies_despite_text_cache -- --nocapture
- cargo test -p temper-platform test_reconcile_os_app_repairs_missing_active_policies_for_unchanged_bundle -- --nocapture
- cargo test -p temper-platform
- cargo clippy -p temper-platform -- -D warnings
- cargo fmt --check
- git diff --check
