### PR TITLE
fix(dispatch): acknowledge an action only after its query projection lands (ADR-0142)

### DIFF
--- a/crates/temper-server/src/state/dispatch/effects.rs
+++ b/crates/temper-server/src/state/dispatch/effects.rs
@@ -31,7 +31,14 @@ pub(crate) struct PostDispatchContext<'a> {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum QueryProjectionUpdateMode {
-    Background,
+    /// The dispatch response is returned only after the query-plane
+    /// projection row reflects the dispatch (ADR-0142). An acknowledged
+    /// action is immediately readable: OData point-reads serve from the
+    /// projection, and callers — including WASM integrations that
+    /// read-after-write (e.g. a PR number assigned by one dispatch and
+    /// rendered by the next read) — must see their own writes. The
+    /// store's `sequence_nr <=` guard keeps concurrent writers safe.
+    Inline,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -40,7 +47,7 @@ enum DispatchTrajectoryPersistenceMode {
 }
 
 fn query_projection_update_mode() -> QueryProjectionUpdateMode {
-    QueryProjectionUpdateMode::Background
+    QueryProjectionUpdateMode::Inline
 }
 
 fn dispatch_trajectory_persistence_mode() -> DispatchTrajectoryPersistenceMode {
@@ -56,14 +63,14 @@ impl crate::state::ServerState {
         self.enqueue_trajectory_entry(entry);
     }
 
-    fn enqueue_query_projection_update(
+    async fn apply_query_projection_update(
         &self,
         ctx: &PostDispatchContext<'_>,
         response: &EntityResponse,
     ) {
         debug_assert_eq!(
             query_projection_update_mode(),
-            QueryProjectionUpdateMode::Background
+            QueryProjectionUpdateMode::Inline
         );
         let Some(query_plane) = self.query_plane_store() else {
             return;
@@ -83,7 +90,7 @@ impl crate::state::ServerState {
             "upsert"
         }
         .to_string();
-        let source = "background_dispatch".to_string();
+        let source = "inline_dispatch".to_string();
         let enqueued_at = Instant::now(); // determinism-ok: production-only projection queue metric
 
         crate::query_projection_metrics::record_update_enqueued(
@@ -102,7 +109,12 @@ impl crate::state::ServerState {
             operation = %operation,
         );
 
-        spawn_post_dispatch_effect(
+        // Boxed so the update does not inflate every dispatch future: the
+        // dispatch state machine nests through reactions and callbacks, and
+        // embedding this future inline overflowed the stack where the
+        // previous tokio::spawn had heap-allocated it. Box::pin keeps that
+        // heap allocation while preserving awaited-before-response order.
+        Box::pin(
             async move {
                 let started_at = Instant::now(); // determinism-ok: production-only projection duration metric
                 crate::query_projection_metrics::record_update_started(
@@ -160,13 +172,19 @@ impl crate::state::ServerState {
                         &operation,
                         &source,
                     );
-                    tracing::warn!(
+                    // The action is committed and non-idempotent, so the
+                    // dispatch is still acknowledged — but the projection now
+                    // serves a stale row until shadow/parity repair. Loud by
+                    // convention (entity_ops create/patch fail their request
+                    // on this same error); the ack-vs-fail tradeoff for
+                    // dispatch is recorded in ADR-0142.
+                    tracing::error!(
                         error = %e,
                         tenant = %tenant,
                         entity_type = %entity_type,
                         entity_id = %entity_id,
                         operation = %operation,
-                        "failed to update query projection"
+                        "failed to update query projection for an acknowledged dispatch"
                     );
                 } else {
                     crate::query_projection_metrics::record_update_applied_sequence(
@@ -179,7 +197,8 @@ impl crate::state::ServerState {
                 }
             }
             .instrument(span),
-        );
+        )
+        .await;
     }
 
     /// Record a trajectory entry for a completed dispatch (success or guard failure).
@@ -699,10 +718,15 @@ impl crate::state::ServerState {
         // cancellation ensures stale timers become no-ops.
         self.arm_state_timeouts_if_needed(ctx, &response);
 
-        // 8. Update the durable query plane for collection reads. This must not
-        // sit on the action-dispatch critical path; the entity transition is
-        // already durable, and projection lag is tracked by explicit metrics.
-        self.enqueue_query_projection_update(ctx, &response);
+        // 8. Update the durable query plane before acknowledging the
+        // dispatch (ADR-0142). The response is the caller's signal that the
+        // action happened; OData point-reads serve from the projection, so
+        // returning before the row lands lets an acknowledged write be read
+        // back stale (a PR number assigned by one dispatch and rendered as 0
+        // by the very next read — a ~40% race in the workflow round-trip).
+        // Cost is one sequence-guarded row upsert on the same store that
+        // already persisted the event; lag metrics remain in place.
+        self.apply_query_projection_update(ctx, &response).await;
 
         response
     }
@@ -713,10 +737,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn query_projection_updates_are_not_on_the_dispatch_critical_path() {
+    fn query_projection_updates_land_before_the_dispatch_response_is_returned() {
+        // ADR-0142: an acknowledged dispatch must be readable. The previous
+        // background mode let a caller read its own committed write back
+        // stale from the query plane.
         assert_eq!(
             query_projection_update_mode(),
-            QueryProjectionUpdateMode::Background
+            QueryProjectionUpdateMode::Inline
         );
     }
 

--- a/docs/adrs/0142-dispatch-acknowledges-after-projection.md
+++ b/docs/adrs/0142-dispatch-acknowledges-after-projection.md
@@ -1,0 +1,67 @@
+# ADR-0142: A Dispatch Is Acknowledged Only After Its Query Projection Lands
+
+## Status
+
+Accepted
+
+## Context
+
+OData point-reads (`/tdata/Entity('id')`) are served from the durable
+query-plane projection (`entity_catalog`); only a *missing* row falls back to
+the entity actor. The projection row, however, was written by a **spawned
+background task** after the action committed — a deliberate choice ("must not
+sit on the action-dispatch critical path") pinned by a unit test and tracked
+with queue-lag metrics.
+
+That combination is unsound: a dispatch returns 200 with the new state, the
+caller reads the entity back, and the read races the background upsert. The
+system's own modules read-after-write — `scm_assign_pr_number` dispatches
+`PullRequest.AssignNumber` (acknowledged 200), then `github_rest_pulls` reads
+the row to render the response. In the Genesis workflow round-trip this lost
+the race ~40% of the time (2/5 local runs, 2/2 CI runs on one day): the commit
+log showed `AssignNumber … succeeded` 7 ms *before* the response rendered
+`"number": 0`. Retrying reads in callers would be a band-aid in every consumer
+of an API whose acknowledgement lies.
+
+## Decision
+
+`run_post_dispatch_effects` applies the query-projection upsert (or remove)
+**inline** and only then returns the dispatch response
+(`apply_query_projection_update`, mode `Inline`). An acknowledged action is
+immediately readable.
+
+Safety with concurrent writers is preserved by the store guard: projection
+writes carry the entity `sequence_nr` and the SQL refuses to regress a row
+(`sequence_nr <= new`), so in-flight background writers (boot backfill,
+on-read repair, reconcilers — which stay asynchronous) cannot overwrite a
+newer inline row.
+
+## Consequences
+
+- **Read-your-writes on the successful path for every dispatch caller** —
+  HTTP, OData, WASM integrations, composite reactions. The Genesis workflow
+  round-trip went from ~40% flake to stable (5/5 local) with this change.
+- **Residual: a projection-write *failure* still acknowledges the dispatch.**
+  The action is committed and non-idempotent, so failing the response would
+  lie in the other direction; the row stays stale until shadow/parity repair
+  (stale rows are not repaired on read — only missing ones are). This is
+  logged at `error` and counted by `record_update_error`. Whether a dispatch
+  should instead surface a degraded acknowledgement on projection failure is
+  an open tradeoff deliberately left for review, not silently decided here.
+- **Latency:** each dispatch pays one sequence-guarded row upsert on the same
+  store that already persisted the event synchronously, behind the
+  `WritePriority::Low` gate (timeout-bounded at 30 s, so worst case under
+  contention is a bounded stall, never a hang; gate waits ≥100 ms already
+  log). Production impact pending re-measurement by the Genesis
+  benchmark (docs/PERFORMANCE.md there) after this ships — pre-change,
+  REST PR open/merge had ~2× headroom over github.com.
+- **Amends ADR-0082 Sub-Decision 3:** the dispatch-path metrics source label
+  changes `background_dispatch` → `inline_dispatch`, and
+  `record_update_queue_wait` now measures ~0 for this source (enqueue and
+  start are the same task). Dashboards or monitors filtered on
+  `source:background_dispatch` must be updated.
+- If a workload ever needs the background mode back, it must come with a
+  read path that does not serve acknowledged-stale rows (e.g. actor
+  read-through), not by reintroducing the race.
+- Trajectory persistence (audit log) stays background — nothing reads it
+  synchronously.


### PR DESCRIPTION
Root-causes the Genesis CI workflow-gate flake (PR responses rendering `"number": 0`): the dispatch path wrote its query-plane projection row in a **background task after returning the response**, so an acknowledged action could be read back stale. Server logs showed `AssignNumber … succeeded` 7 ms *before* the stale read; the race lost ~40% of runs (2/5 local, 2/2 CI on the genesis#27 gate).

**Change:** `run_post_dispatch_effects` applies the projection upsert inline and only then returns (ADR-0142). Entity create/patch already behaved this way — dispatch was the only backgrounded writer. Store `sequence_nr` guards (turso + postgres, independently verified) make concurrent background writers safe.

**Evidence:** workflow smoke loop 3/5 → **5/5**; lib dispatch tests 74/74; clippy/fmt clean. Two-pass independent code review to PASS (panic-safety of the inlined body, no lock across the await, 30s-bounded write gate, other effects still backgrounded — each verified, not assumed).

**Tradeoff for review (deliberately not decided silently):** when the projection write itself *fails*, the dispatch is still acknowledged (the action is committed and non-idempotent) and the row stays stale until shadow/parity repair — now logged at `error`. The alternative — failing/flagging the response — is recorded as an open option in ADR-0142's Consequences. Also amends ADR-0082 sub-decision 3: metrics source label `background_dispatch` → `inline_dispatch`; dashboards filtered on the old label need updating.

After merge: genesis submodule bump + Railway redeploy + production smoke re-run; the genesis benchmark re-measures dispatch latency impact (pre-change, REST PR ops had ~2× headroom over github.com).

🤖 Generated with [Claude Code](https://claude.com/claude-code)