### PR TITLE
Fix Git route params for exact endpoints

### DIFF
--- a/crates/temper-server/src/router.rs
+++ b/crates/temper-server/src/router.rs
@@ -321,6 +321,11 @@ async fn dispatch_matched_route(
                 .map(|s| (k.as_str().to_string(), s.to_string()))
         })
         .collect();
+    let route_params = git_route_params_for_http_dispatch(
+        &route.route.integration_module,
+        uri.path(),
+        route.params.clone(),
+    );
     let ctx = WasmInvocationContext {
         tenant: tenant_id.as_str().to_string(),
         entity_type: "HttpEndpoint".to_string(),
@@ -344,7 +349,7 @@ async fn dispatch_matched_route(
                 Some(q) => format!("{}?{}", uri.path(), q),
                 None => uri.path().to_string(),
             },
-            params: route.params.clone(),
+            params: route_params.clone(),
             headers: header_pairs,
             principal_id: None,
             request_body_handle: guest_request_body.0,
@@ -425,7 +430,7 @@ async fn dispatch_matched_route(
             state,
             tenant_id,
             headers,
-            route.params,
+            route_params,
             route.route.requires_auth,
             action_bridge,
             result,
@@ -651,6 +656,47 @@ fn bridge_action_params(callback_params: &serde_json::Value) -> serde_json::Valu
         map.remove("bridge_response");
     }
     fallback
+}
+
+fn git_route_params_for_http_dispatch(
+    integration_module: &str,
+    request_path: &str,
+    mut params: std::collections::BTreeMap<String, String>,
+) -> std::collections::BTreeMap<String, String> {
+    if params.get("owner").is_some_and(|v| !v.is_empty())
+        && params.get("repo").is_some_and(|v| !v.is_empty())
+    {
+        return params;
+    }
+    if !matches!(
+        integration_module,
+        "git_refs_advertise" | "git_upload_pack" | "git_receive_pack"
+    ) {
+        return params;
+    }
+
+    let trimmed = request_path.trim_start_matches('/');
+    let Some((owner, rest)) = trimmed.split_once('/') else {
+        return params;
+    };
+    let repo = rest
+        .strip_suffix(".git/info/refs")
+        .or_else(|| rest.strip_suffix(".git/git-upload-pack"))
+        .or_else(|| rest.strip_suffix(".git/git-receive-pack"));
+    let Some(repo) = repo else {
+        return params;
+    };
+    if owner.is_empty() || repo.is_empty() {
+        return params;
+    }
+
+    params
+        .entry("owner".to_string())
+        .or_insert_with(|| owner.to_string());
+    params
+        .entry("repo".to_string())
+        .or_insert_with(|| repo.to_string());
+    params
 }
 
 /// Adapter short-circuit response for action-bridge routes (ADR-0138).

--- a/crates/temper-server/src/router_test.rs
+++ b/crates/temper-server/src/router_test.rs
@@ -2127,6 +2127,45 @@ fn bridge_action_params_fallback_strips_control_keys() {
 }
 
 #[test]
+fn git_route_params_fall_back_to_smart_http_path_when_exact_endpoint_has_no_captures() {
+    let params = git_route_params_for_http_dispatch(
+        "git_refs_advertise",
+        "/temperpaw/paw-agent.git/info/refs",
+        std::collections::BTreeMap::new(),
+    );
+
+    assert_eq!(params.get("owner").map(String::as_str), Some("temperpaw"));
+    assert_eq!(params.get("repo").map(String::as_str), Some("paw-agent"));
+}
+
+#[test]
+fn git_route_params_keep_captured_values() {
+    let mut captured = std::collections::BTreeMap::new();
+    captured.insert("owner".to_string(), "captured".to_string());
+    captured.insert("repo".to_string(), "repo".to_string());
+
+    let params = git_route_params_for_http_dispatch(
+        "git_receive_pack",
+        "/temperpaw/paw-agent.git/git-receive-pack",
+        captured,
+    );
+
+    assert_eq!(params.get("owner").map(String::as_str), Some("captured"));
+    assert_eq!(params.get("repo").map(String::as_str), Some("repo"));
+}
+
+#[test]
+fn route_param_inference_ignores_non_git_modules() {
+    let params = git_route_params_for_http_dispatch(
+        "some_json_endpoint",
+        "/temperpaw/paw-agent.git/info/refs",
+        std::collections::BTreeMap::new(),
+    );
+
+    assert!(params.is_empty());
+}
+
+#[test]
 fn bridge_response_requires_structured_action_params() {
     // Same passthrough guard as bridge_principal: never honored
     // verbatim, never falls through to dispatch.


### PR DESCRIPTION
## Summary
- infer Git owner/repo route params from Smart HTTP paths when a legacy exact endpoint has no captures
- pass the inferred params to the WASM dispatch context and action bridge
- add regression coverage for exact endpoint fallback, captured-param preservation, and non-Git route safety

## Tests
- cargo test -p temper-server router::tests:: -- --nocapture

## ADR
This is a narrow production bug fix for existing HTTP endpoint dispatch behavior. No new architecture primitive is introduced; the PR notes record that ADR judgement.