### PR TITLE
Fix bounded route lookup platform fallbacks

### DIFF
--- a/crates/temper-server/src/observe/specs/load_inline.rs
+++ b/crates/temper-server/src/observe/specs/load_inline.rs
@@ -252,10 +252,7 @@ pub(crate) async fn handle_load_inline(
             // Update the in-memory text cache.
             if let Ok(mut policies) = state.tenant_policies.write() {
                 let entry = policies.entry(tenant.clone()).or_default();
-                if !entry.is_empty() {
-                    entry.push('\n');
-                }
-                entry.push_str(cedar_text);
+                *entry = merge_inline_cedar_policy_text(entry, cedar_text);
             }
             // Reload the per-tenant Cedar policy set.
             let full_text = state
@@ -392,6 +389,19 @@ fn resolve_inline_specs_root(
     } else {
         tmp_dir.join(relative_root)
     })
+}
+
+fn merge_inline_cedar_policy_text(existing: &str, incoming: &str) -> String {
+    let mut policy_text = existing.trim_end().to_string();
+    let incoming = incoming.trim();
+    if incoming.is_empty() || policy_text.contains(incoming) {
+        return policy_text;
+    }
+    if !policy_text.is_empty() {
+        policy_text.push('\n');
+    }
+    policy_text.push_str(incoming);
+    policy_text
 }
 
 fn adr_candidate_paths(app_name: Option<&str>, namespaces: &[String]) -> Vec<String> {
@@ -537,7 +547,10 @@ async fn find_existing_adr_paths(
 
 #[cfg(test)]
 mod tests {
-    use super::{adr_candidate_paths, namespace_to_app_candidates, normalize_app_slug};
+    use super::{
+        adr_candidate_paths, merge_inline_cedar_policy_text, namespace_to_app_candidates,
+        normalize_app_slug,
+    };
 
     #[test]
     fn normalize_app_slug_kebab_cases_namespaces() {
@@ -567,5 +580,25 @@ mod tests {
             adr_candidate_paths(Some("llm-wiki"), &["Temper.ProjectManagement".to_string()]);
         assert!(paths.contains(&"/apps/llm-wiki/adrs/".to_string()));
         assert!(paths.contains(&"/apps/project-management/adrs/".to_string()));
+    }
+
+    #[test]
+    fn inline_cedar_policy_merge_deduplicates_repeated_bundle_text() {
+        let policy = "permit(principal, action, resource);";
+        let merged_once = merge_inline_cedar_policy_text("", policy);
+        let merged_twice = merge_inline_cedar_policy_text(&merged_once, policy);
+
+        assert_eq!(merged_twice, policy);
+    }
+
+    #[test]
+    fn inline_cedar_policy_merge_preserves_distinct_existing_policy() {
+        let existing = "permit(principal, action == Action::\"read\", resource);";
+        let incoming = "permit(principal, action == Action::\"write\", resource);";
+
+        assert_eq!(
+            merge_inline_cedar_policy_text(existing, incoming),
+            format!("{existing}\n{incoming}")
+        );
     }
 }

--- a/crates/temper-server/src/odata/query_plane_read/mod.rs
+++ b/crates/temper-server/src/odata/query_plane_read/mod.rs
@@ -11,8 +11,11 @@ pub(in crate::odata) use types::{
 
 use super::authz::{LIST_ACTION, authorize_read};
 use super::read_support::missing_catalog_entity_ids;
-use scan::{native_candidate_page_plan, read_from_source_cursor, try_native_page_read};
-use types::{QueryPlaneCoverageReport, QueryPlaneFallbackReason};
+use scan::{
+    ScanCounters, budget_rejection, native_candidate_page_plan, read_from_source_cursor,
+    try_native_page_read,
+};
+use types::{QueryPlaneCoverageReport, QueryPlaneFallbackReason, QueryPlaneReadStrategy};
 
 fn should_try_native_before_catalog_coverage(
     request: &QueryPlaneReadRequest<'_>,
@@ -29,6 +32,13 @@ fn should_try_lazy_catalog_repair_after_native_result(
     indexed_entity_ids.is_empty()
         && result.entities.is_empty()
         && request.budget.requested_top(request.query_options) > 0
+}
+
+fn should_check_source_cursor_catalog_coverage(
+    candidate_count: usize,
+    budget: QueryPlaneReadBudget,
+) -> bool {
+    candidate_count <= budget.scan_candidate_budget()
 }
 
 async fn catalog_coverage_report(
@@ -124,6 +134,24 @@ pub(in crate::odata) async fn read_entity_set_from_query_plane(
         .state
         .list_entity_ids_lazy(request.tenant, request.entity_type)
         .await;
+    let needs_full_proof = request.query_options.filter.is_some()
+        || request.query_options.orderby.is_some()
+        || request.query_options.count == Some(true);
+    if needs_full_proof
+        && !should_check_source_cursor_catalog_coverage(all_entity_ids.len(), request.budget)
+    {
+        return Err(budget_rejection(
+            &request,
+            QueryPlaneReadStrategy::ReadSourceCursor,
+            false,
+            request.state.query_plane_store().is_some(),
+            QueryPlaneCoverageReport::default(),
+            ScanCounters {
+                candidate_count: all_entity_ids.len(),
+                ..ScanCounters::empty()
+            },
+        ));
+    }
     let (coverage, missing_ids) = catalog_coverage_report(&request, &all_entity_ids).await;
 
     if coverage.missing == 0

--- a/crates/temper-server/src/odata/query_plane_read/tests.rs
+++ b/crates/temper-server/src/odata/query_plane_read/tests.rs
@@ -185,6 +185,23 @@ fn native_catalog_coverage_short_circuit_requires_pushdown_without_count() {
     ));
 }
 
+#[test]
+fn source_cursor_catalog_coverage_is_skipped_when_candidate_set_exceeds_budget() {
+    let budget = QueryPlaneReadBudget {
+        default_page_size: 1,
+        max_entities: 1,
+    };
+
+    assert!(should_check_source_cursor_catalog_coverage(
+        budget.scan_candidate_budget(),
+        budget
+    ));
+    assert!(!should_check_source_cursor_catalog_coverage(
+        budget.scan_candidate_budget() + 1,
+        budget
+    ));
+}
+
 #[tokio::test]
 async fn row_authorized_count_over_budget_returns_413() {
     let state = build_order_state("query-plane-budget-count");

--- a/docs/adrs/0143-bounded-source-cursor-coverage.md
+++ b/docs/adrs/0143-bounded-source-cursor-coverage.md
@@ -1,0 +1,34 @@
+# ADR-0143: Reject Oversized Source-Cursor Proofs Before Catalog Coverage
+
+## Status
+
+Accepted
+
+## Context
+
+Filtered OData reads can fall back from native query-plane pages to a
+source-cursor proof. Full-proof reads (`$filter`, `$orderby`, or `$count=true`)
+must evaluate the candidate set to prove correctness. The source-cursor code
+already rejected candidate sets above the bounded scan budget, but the caller
+performed catalog coverage first. On large entity sets that meant a query could
+load tens of thousands of catalog rows only to reject the read afterward.
+
+## Decision
+
+Before requesting catalog coverage for a source-cursor full-proof read, compare
+the source candidate count with the query-plane scan budget. If it exceeds the
+budget, return `QueryTooLarge` immediately with `FallbackCandidateBudget`
+telemetry.
+
+Unfiltered first-page reads keep their streaming behavior: they can still stop
+after proving the requested page and do not need to reject solely because the
+total source cursor is large.
+
+## Consequences
+
+- Oversized filtered reads fail fast instead of issuing broad catalog coverage
+  materialization queries.
+- Callers that need large filtered reads must use native pushdown, a narrower
+  filter, or a smaller entity set.
+- The query-plane budget remains the single bound for fallback proofs; coverage
+  checks no longer bypass it.

--- a/docs/adrs/0144-idempotent-inline-cedar-loads.md
+++ b/docs/adrs/0144-idempotent-inline-cedar-loads.md
@@ -1,0 +1,30 @@
+# ADR-0144: Inline Cedar Policy Loads Are Idempotent
+
+## Status
+
+Accepted
+
+## Context
+
+`/api/specs/load-inline` can submit bundled Cedar policy text alongside inline
+specs. The loader appended that text to the tenant's in-memory policy bundle on
+every successful load. Repeated app reconcile or server restart cycles could
+therefore duplicate the same policy text many times, increasing Cedar parse and
+authorization cost without adding new policy semantics.
+
+OS app install already treats bundled policies as idempotent by skipping policy
+text that is already present. Inline spec loading needs the same contract.
+
+## Decision
+
+When inline Cedar text is valid and non-empty, merge it into the tenant policy
+text only if the exact trimmed bundle is not already present. Preserve existing
+distinct policy text and separate newly-added policy bundles with one newline.
+
+## Consequences
+
+- Repeated inline app/spec loads no longer grow tenant policy text with duplicate
+  policy bundles.
+- Existing distinct tenant policy text is preserved.
+- This is an in-memory idempotence guard for the inline endpoint; durable
+  granular policy row storage remains the preferred long-term app-policy model.


### PR DESCRIPTION
## Summary
- make inline Cedar policy loads idempotent to stop repeated bundled-policy bloat
- reject oversized full-proof OData source-cursor reads before catalog coverage materialization
- add ADRs for both platform behavior changes

## Tests
- cargo fmt --check
- cargo test -p temper-server odata::query_plane_read::tests
- cargo test -p temper-server --features observe inline_cedar_policy_merge
- cargo check -p temper-server --features observe
- git diff --check