### PR TITLE
Persist large composite sub-write fields

### DIFF
--- a/crates/temper-platform/src/genesis_install.rs
+++ b/crates/temper-platform/src/genesis_install.rs
@@ -1805,6 +1805,44 @@ async fn materialize_tree(
     Ok(())
 }
 
+/// Recompute the durable entity id Genesis assigns to a git object.
+///
+/// Git objects are persisted keyed by `{sanitized_repository_id}-{git_sha}`.
+/// This MUST stay byte-identical to `object_entity_id`, the writer, in the
+/// genesis app bundle at `wasm/scm_ingest_pack/src/lib.rs` (arni-labs/genesis);
+/// any divergence makes the keyed lookup miss and reintroduces the bundle 404.
+/// The contract is exercised end-to-end by the genesis repo's
+/// `scripts/live-genesis-install-e2e-smoke.sh` push→bundle round-trip.
+fn genesis_object_entity_id(repository_id: &str, git_sha: &str) -> String {
+    let mut repo = String::with_capacity(repository_id.len());
+    let mut last_dash = false;
+    for ch in repository_id.chars() {
+        if ch.is_ascii_alphanumeric() {
+            repo.push(ch.to_ascii_lowercase());
+            last_dash = false;
+        } else if !last_dash {
+            repo.push('-');
+            last_dash = true;
+        }
+    }
+    let repo = repo.trim_matches('-');
+    if repo.is_empty() {
+        format!("obj-{git_sha}")
+    } else {
+        format!("{repo}-{git_sha}")
+    }
+}
+
+/// Resolve a git object (Commit/Tree/Blob) by its durable entity key.
+///
+/// Objects are content-addressed under `{repository_id}-{git_sha}`, so we load
+/// that key directly (hydrating from the event store when the actor is cold).
+/// A bare-sha fallback covers any legacy object stored before the composite-key
+/// scheme. The previous implementation looked up the bare sha — which is never
+/// the real key — and then scanned `list_entity_ids_lazy`, whose partially
+/// populated in-memory index could omit durable objects; that made the Genesis
+/// bundle export 404 with "blob not found" for objects that existed and cloned
+/// cleanly. Keyed lookup is both correct and O(1) instead of O(objects).
 async fn load_genesis_object(
     state: &ServerState,
     tenant: &TenantId,
@@ -1812,33 +1850,54 @@ async fn load_genesis_object(
     repository_id: &str,
     git_sha: &str,
 ) -> Result<Option<temper_server::EntityResponse>, String> {
-    if state.entity_exists(tenant, entity_type, git_sha)
-        && let Ok(found) = state
-            .get_tenant_entity_state(tenant, entity_type, git_sha)
-            .await
+    debug_assert!(!git_sha.is_empty(), "git object sha must not be empty");
+
+    let composite_id = genesis_object_entity_id(repository_id, git_sha);
+    if let Some(found) =
+        load_genesis_object_by_key(state, tenant, entity_type, repository_id, git_sha, &composite_id)
+            .await?
     {
-        let fields = &found.state.fields;
-        let object_repo = string_field(fields, "RepositoryId").unwrap_or_default();
-        let object_sha = string_field(fields, "Id").unwrap_or_default();
-        if object_repo == repository_id && object_sha == git_sha {
-            return Ok(Some(found));
-        }
+        return Ok(Some(found));
     }
 
-    let ids = state.list_entity_ids_lazy(tenant, entity_type).await;
-    for entity_id in ids {
-        let candidate = state
-            .get_tenant_entity_state(tenant, entity_type, &entity_id)
-            .await
-            .map_err(|e| format!("read Genesis {entity_type} {entity_id}: {e}"))?;
-        let fields = &candidate.state.fields;
-        let object_repo = string_field(fields, "RepositoryId").unwrap_or_default();
-        let object_sha = string_field(fields, "Id").unwrap_or_default();
-        if object_repo == repository_id && object_sha == git_sha {
-            return Ok(Some(candidate));
-        }
+    // Legacy objects predating the composite-key scheme were keyed by bare sha.
+    // `composite_id` is `{repo}-{sha}` or `obj-{sha}`, so it never equals a
+    // non-empty bare sha; the guard only avoids a redundant duplicate lookup.
+    if composite_id != git_sha
+        && let Some(found) =
+            load_genesis_object_by_key(state, tenant, entity_type, repository_id, git_sha, git_sha)
+                .await?
+    {
+        return Ok(Some(found));
     }
+
     Ok(None)
+}
+
+/// Load one candidate entity id and confirm it is the requested git object.
+async fn load_genesis_object_by_key(
+    state: &ServerState,
+    tenant: &TenantId,
+    entity_type: &str,
+    repository_id: &str,
+    git_sha: &str,
+    entity_id: &str,
+) -> Result<Option<temper_server::EntityResponse>, String> {
+    if !state.ensure_entity_loaded(tenant, entity_type, entity_id).await {
+        return Ok(None);
+    }
+    let found = state
+        .get_tenant_entity_state(tenant, entity_type, entity_id)
+        .await
+        .map_err(|e| format!("read Genesis {entity_type} {entity_id}: {e}"))?;
+    let fields = &found.state.fields;
+    let object_repo = string_field(fields, "RepositoryId").unwrap_or_default();
+    let object_sha = string_field(fields, "Id").unwrap_or_default();
+    if object_repo == repository_id && object_sha == git_sha {
+        Ok(Some(found))
+    } else {
+        Ok(None)
+    }
 }
 
 #[derive(Debug)]
@@ -2039,6 +2098,33 @@ mod tests {
     use base64::Engine as _;
 
     use super::*;
+
+    #[test]
+    fn genesis_object_entity_id_matches_ingest_scheme() {
+        // Byte-identical to scm_ingest_pack::object_entity_id, the writer of
+        // these keys. Real durable ids observed in prod Genesis:
+        assert_eq!(
+            genesis_object_entity_id(
+                "rp-katagami-katagami-curation",
+                "5a7ae8c0224769fdfc27106329f21a8fcb7b8441"
+            ),
+            "rp-katagami-katagami-curation-5a7ae8c0224769fdfc27106329f21a8fcb7b8441"
+        );
+        // Already-canonical repository ids round-trip unchanged (idempotent).
+        assert_eq!(
+            genesis_object_entity_id("rp-temperpaw-paw-foresight", "013224e7"),
+            "rp-temperpaw-paw-foresight-013224e7"
+        );
+        // Non-canonical input is sanitized: lowercased, non-alphanumeric runs
+        // collapse to a single dash, leading/trailing dashes trimmed.
+        assert_eq!(
+            genesis_object_entity_id("Katagami/Katagami Curation", "abc"),
+            "katagami-katagami-curation-abc"
+        );
+        // Empty repository id falls back to the `obj-` prefix, never bare sha.
+        assert_eq!(genesis_object_entity_id("", "abc"), "obj-abc");
+        assert_ne!(genesis_object_entity_id("rp-x", "abc"), "abc");
+    }
 
     #[test]
     fn parses_git_tree_entries() {

--- a/crates/temper-platform/src/genesis_install.rs
+++ b/crates/temper-platform/src/genesis_install.rs
@@ -1853,9 +1853,15 @@ async fn load_genesis_object(
     debug_assert!(!git_sha.is_empty(), "git object sha must not be empty");
 
     let composite_id = genesis_object_entity_id(repository_id, git_sha);
-    if let Some(found) =
-        load_genesis_object_by_key(state, tenant, entity_type, repository_id, git_sha, &composite_id)
-            .await?
+    if let Some(found) = load_genesis_object_by_key(
+        state,
+        tenant,
+        entity_type,
+        repository_id,
+        git_sha,
+        &composite_id,
+    )
+    .await?
     {
         return Ok(Some(found));
     }
@@ -1883,7 +1889,10 @@ async fn load_genesis_object_by_key(
     git_sha: &str,
     entity_id: &str,
 ) -> Result<Option<temper_server::EntityResponse>, String> {
-    if !state.ensure_entity_loaded(tenant, entity_type, entity_id).await {
+    if !state
+        .ensure_entity_loaded(tenant, entity_type, entity_id)
+        .await
+    {
         return Ok(None);
     }
     let found = state

--- a/crates/temper-server/src/router.rs
+++ b/crates/temper-server/src/router.rs
@@ -321,6 +321,11 @@ async fn dispatch_matched_route(
                 .map(|s| (k.as_str().to_string(), s.to_string()))
         })
         .collect();
+    let route_params = git_route_params_for_http_dispatch(
+        &route.route.integration_module,
+        uri.path(),
+        route.params.clone(),
+    );
     let ctx = WasmInvocationContext {
         tenant: tenant_id.as_str().to_string(),
         entity_type: "HttpEndpoint".to_string(),
@@ -344,7 +349,7 @@ async fn dispatch_matched_route(
                 Some(q) => format!("{}?{}", uri.path(), q),
                 None => uri.path().to_string(),
             },
-            params: route.params.clone(),
+            params: route_params.clone(),
             headers: header_pairs,
             principal_id: None,
             request_body_handle: guest_request_body.0,
@@ -425,7 +430,7 @@ async fn dispatch_matched_route(
             state,
             tenant_id,
             headers,
-            route.params,
+            route_params,
             route.route.requires_auth,
             action_bridge,
             result,
@@ -651,6 +656,47 @@ fn bridge_action_params(callback_params: &serde_json::Value) -> serde_json::Valu
         map.remove("bridge_response");
     }
     fallback
+}
+
+fn git_route_params_for_http_dispatch(
+    integration_module: &str,
+    request_path: &str,
+    mut params: std::collections::BTreeMap<String, String>,
+) -> std::collections::BTreeMap<String, String> {
+    if params.get("owner").is_some_and(|v| !v.is_empty())
+        && params.get("repo").is_some_and(|v| !v.is_empty())
+    {
+        return params;
+    }
+    if !matches!(
+        integration_module,
+        "git_refs_advertise" | "git_upload_pack" | "git_receive_pack"
+    ) {
+        return params;
+    }
+
+    let trimmed = request_path.trim_start_matches('/');
+    let Some((owner, rest)) = trimmed.split_once('/') else {
+        return params;
+    };
+    let repo = rest
+        .strip_suffix(".git/info/refs")
+        .or_else(|| rest.strip_suffix(".git/git-upload-pack"))
+        .or_else(|| rest.strip_suffix(".git/git-receive-pack"));
+    let Some(repo) = repo else {
+        return params;
+    };
+    if owner.is_empty() || repo.is_empty() {
+        return params;
+    }
+
+    params
+        .entry("owner".to_string())
+        .or_insert_with(|| owner.to_string());
+    params
+        .entry("repo".to_string())
+        .or_insert_with(|| repo.to_string());
+    params
 }
 
 /// Adapter short-circuit response for action-bridge routes (ADR-0138).

--- a/crates/temper-server/src/router_test.rs
+++ b/crates/temper-server/src/router_test.rs
@@ -2127,6 +2127,45 @@ fn bridge_action_params_fallback_strips_control_keys() {
 }
 
 #[test]
+fn git_route_params_fall_back_to_smart_http_path_when_exact_endpoint_has_no_captures() {
+    let params = git_route_params_for_http_dispatch(
+        "git_refs_advertise",
+        "/temperpaw/paw-agent.git/info/refs",
+        std::collections::BTreeMap::new(),
+    );
+
+    assert_eq!(params.get("owner").map(String::as_str), Some("temperpaw"));
+    assert_eq!(params.get("repo").map(String::as_str), Some("paw-agent"));
+}
+
+#[test]
+fn git_route_params_keep_captured_values() {
+    let mut captured = std::collections::BTreeMap::new();
+    captured.insert("owner".to_string(), "captured".to_string());
+    captured.insert("repo".to_string(), "repo".to_string());
+
+    let params = git_route_params_for_http_dispatch(
+        "git_receive_pack",
+        "/temperpaw/paw-agent.git/git-receive-pack",
+        captured,
+    );
+
+    assert_eq!(params.get("owner").map(String::as_str), Some("captured"));
+    assert_eq!(params.get("repo").map(String::as_str), Some("repo"));
+}
+
+#[test]
+fn route_param_inference_ignores_non_git_modules() {
+    let params = git_route_params_for_http_dispatch(
+        "some_json_endpoint",
+        "/temperpaw/paw-agent.git/info/refs",
+        std::collections::BTreeMap::new(),
+    );
+
+    assert!(params.is_empty());
+}
+
+#[test]
 fn bridge_response_requires_structured_action_params() {
     // Same passthrough guard as bridge_principal: never honored
     // verbatim, never falls through to dispatch.

--- a/crates/temper-server/src/state/dispatch/composite_test.rs
+++ b/crates/temper-server/src/state/dispatch/composite_test.rs
@@ -1413,6 +1413,73 @@ async fn composite_atomic_batch_allows_existing_sub_write_to_delete_target() {
 
 #[cfg(feature = "sim")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn composite_ingest_pack_large_blob_sub_write_persists_overflow_fields() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = SimEventStore::no_faults(44);
+    let mut state = composite_test_state_with_store(store.clone());
+    state.data_dir = dir.path().to_path_buf();
+    let tenant = TenantId::default();
+    let agent = AgentContext::for_service("composite-test");
+    let canonical_bytes = "W".repeat(512 * 1024);
+
+    let applied = state
+        .apply_composite_integration_result(
+            &tenant,
+            "Parent",
+            "repo-large-blob",
+            "IngestPack",
+            &json!({
+                "sub_writes": [{
+                    "entity_type": "Blob",
+                    "entity_id": "blob-large-1",
+                    "action": "Create",
+                    "params": {
+                        "RepositoryId": "repo-large-blob",
+                        "CanonicalBytes": canonical_bytes
+                    }
+                }]
+            }),
+            &agent,
+        )
+        .await
+        .expect("large Blob sub-write should persist through field-overflow");
+    assert!(applied);
+
+    let blob = state
+        .get_tenant_entity_state(&tenant, "Blob", "blob-large-1")
+        .await
+        .expect("large blob entity should be readable");
+    let canonical_field = blob
+        .state
+        .fields
+        .get("CanonicalBytes")
+        .expect("CanonicalBytes field should be present");
+    let blob_key = canonical_field
+        .get(crate::blobs::FIELD_OVERFLOW_REF_KEY)
+        .and_then(serde_json::Value::as_str)
+        .expect("large CanonicalBytes should be stored as a field-overflow blob ref");
+    let bytes = state
+        .get_blob_with_legacy_fallback(&tenant, blob_key)
+        .await
+        .expect("field-overflow blob read should succeed")
+        .expect("field-overflow blob should exist");
+    let restored: serde_json::Value =
+        serde_json::from_slice(&bytes).expect("field-overflow blob should contain JSON");
+    assert_eq!(
+        restored.as_str().map(str::len),
+        Some(512 * 1024),
+        "field-overflow blob should preserve the full large field"
+    );
+
+    let blob_journal = store.dump_journal("default:Blob:blob-large-1");
+    assert!(
+        blob_journal.iter().any(|event| event.event_type == "Create"),
+        "atomic composite batch should persist the Blob.Create event"
+    );
+}
+
+#[cfg(feature = "sim")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn composite_atomic_batch_handles_concurrent_multi_entity_results() {
     const COMPOSITES: usize = 12;
     const CHILDREN_PER_COMPOSITE: usize = 3;

--- a/crates/temper-server/src/state/dispatch/composite_test.rs
+++ b/crates/temper-server/src/state/dispatch/composite_test.rs
@@ -1473,7 +1473,9 @@ async fn composite_ingest_pack_large_blob_sub_write_persists_overflow_fields() {
 
     let blob_journal = store.dump_journal("default:Blob:blob-large-1");
     assert!(
-        blob_journal.iter().any(|event| event.event_type == "Create"),
+        blob_journal
+            .iter()
+            .any(|event| event.event_type == "Create"),
         "atomic composite batch should persist the Blob.Create event"
     );
 }

--- a/crates/temper-server/src/state/entity_ops.rs
+++ b/crates/temper-server/src/state/entity_ops.rs
@@ -282,6 +282,24 @@ impl ServerState {
         })
     }
 
+    /// Mark every entity type observed in `entities` as fully hydrated from the
+    /// durable store, so `list_entity_ids_lazy` serves it from the in-memory
+    /// index without a redundant store scan. Used by the paths that load the
+    /// authoritative set for a tenant (full and eager hydration).
+    fn mark_types_hydrated(&self, tenant: &TenantId, entities: &[(String, String)]) {
+        let keys: std::collections::BTreeSet<String> = entities
+            .iter()
+            .map(|(entity_type, _entity_id)| format!("{tenant}:{entity_type}"))
+            .collect();
+        if keys.is_empty() {
+            return;
+        }
+        self.entity_index_hydrated
+            .write()
+            .expect("entity index hydrated lock poisoned")
+            .extend(keys);
+    }
+
     /// Populate `entity_index` from the event store without spawning actors.
     ///
     /// This is the memory-safe startup/list path: we discover persisted
@@ -307,6 +325,8 @@ impl ServerState {
                             .insert(entity_id.clone());
                     }
                 } // write lock dropped before metrics call
+                // A full-store scan is authoritative for every type it observed.
+                self.mark_types_hydrated(tenant, &entities);
                 tracing::info!(
                     tenant = %tenant,
                     count = entities.len(),
@@ -356,6 +376,12 @@ impl ServerState {
                         ids.insert(entity_id);
                     }
                 }
+                // The store scan is authoritative for this type: mark it fully
+                // hydrated so `list_entity_ids_lazy` can serve from the index.
+                self.entity_index_hydrated
+                    .write()
+                    .expect("entity index hydrated lock poisoned")
+                    .insert(format!("{tenant}:{entity_type}"));
                 tracing::info!(
                     tenant = %tenant,
                     entity_type,
@@ -439,6 +465,10 @@ impl ServerState {
                             hydrated = hydrated.saturating_add(1);
                         }
                     }
+                    // Eager hydration loaded every durable entity, so each
+                    // observed type's index is complete — mark it hydrated so
+                    // the first lazy list does not re-scan the store.
+                    self.mark_types_hydrated(tenant, &entities);
                     tracing::info!(
                         tenant = %tenant,
                         count = hydrated,
@@ -1368,21 +1398,36 @@ impl ServerState {
         }
     }
 
-    /// List entity IDs from in-memory index, lazily hydrating from the event
-    /// store if the index is cold.
+    /// List entity IDs for a type, guaranteeing completeness against the
+    /// durable event store.
+    ///
+    /// The in-memory index is served only once the type has been fully
+    /// hydrated from the store. A non-empty index is NOT sufficient: lazily
+    /// spawning a single actor inserts just that id, so trusting "non-empty
+    /// means complete" lets a partial index hide durable entities, and a
+    /// collection query then silently returns a partial set. When the type is
+    /// not yet hydrated we scan the store once (which marks it complete) and
+    /// then serve from the index on subsequent calls.
     #[instrument(skip_all, fields(otel.name = "entity.list_entity_ids_lazy", tenant = %tenant, entity_type))]
     pub async fn list_entity_ids_lazy(&self, tenant: &TenantId, entity_type: &str) -> Vec<String> {
-        let ids = self.list_entity_ids(tenant, entity_type);
-        if !ids.is_empty() {
-            return ids;
+        let index_key = format!("{tenant}:{entity_type}");
+        let already_hydrated = self
+            .entity_index_hydrated
+            .read()
+            .expect("entity index hydrated lock poisoned")
+            .contains(&index_key);
+        if already_hydrated {
+            return self.list_entity_ids(tenant, entity_type);
         }
 
+        // No durable journal to reconcile against: the in-memory index is all
+        // there is, so return it as-is.
         if self.event_journal().is_none() {
-            return ids;
+            return self.list_entity_ids(tenant, entity_type);
         }
+
         self.populate_index_from_store_by_type(tenant, entity_type)
             .await;
-
         self.list_entity_ids(tenant, entity_type)
     }
 

--- a/crates/temper-server/src/state/mod.rs
+++ b/crates/temper-server/src/state/mod.rs
@@ -378,6 +378,13 @@ pub struct ServerState {
     pub registry: Arc<RwLock<SpecRegistry>>,
     /// Index of entity IDs per (tenant:entity_type) for collection queries.
     pub entity_index: Arc<RwLock<BTreeMap<String, BTreeSet<String>>>>,
+    /// `{tenant}:{entity_type}` keys whose `entity_index` entry has been fully
+    /// hydrated from the durable event store. A type is only complete once a
+    /// store scan has run for it; lazily spawning a single actor must NOT mark
+    /// it complete, or a partial index can hide durable entities from
+    /// collection queries (a consumer would read present, durable entities as
+    /// "not found").
+    pub entity_index_hydrated: Arc<RwLock<BTreeSet<String>>>,
     /// Broadcast channel for entity state change events (SSE subscriptions).
     pub event_tx: Arc<tokio::sync::broadcast::Sender<EntityStateChange>>,
     /// Broadcast channel for replayable per-entity lifecycle and progress events.
@@ -622,6 +629,7 @@ impl ServerState {
             authz: Arc::new(AuthzEngine::permissive()),
             registry: Arc::new(RwLock::new(SpecRegistry::new())),
             entity_index: Arc::new(RwLock::new(BTreeMap::new())),
+            entity_index_hydrated: Arc::new(RwLock::new(BTreeSet::new())),
             event_tx: Arc::new(event_tx),
             entity_observe_tx: Arc::new(entity_observe_tx),
             start_time: sim_now(),
@@ -864,6 +872,7 @@ impl ServerState {
             authz: Arc::new(AuthzEngine::permissive()),
             registry,
             entity_index: Arc::new(RwLock::new(BTreeMap::new())),
+            entity_index_hydrated: Arc::new(RwLock::new(BTreeSet::new())),
             event_tx: Arc::new(event_tx),
             entity_observe_tx: Arc::new(entity_observe_tx),
             start_time: sim_now(),

--- a/crates/temper-server/tests/ensure_entity_loaded.rs
+++ b/crates/temper-server/tests/ensure_entity_loaded.rs
@@ -362,3 +362,61 @@ async fn ensure_entity_loaded_returns_false_for_deleted_entity() {
 
     let _ = std::fs::remove_file(db_path);
 }
+
+/// Regression: a partially populated in-memory index (one resident actor) must
+/// not hide other durable entities of the same type from `list_entity_ids_lazy`.
+/// Previously a non-empty index short-circuited the store scan, so collection
+/// queries returned only the resident subset, reading present durable entities
+/// as "not found".
+#[tokio::test]
+async fn list_entity_ids_lazy_surfaces_durable_entities_missing_from_partial_index() {
+    let db_path = std::env::temp_dir().join(format!(
+        "temper-lazy-list-partial-{}.db",
+        uuid::Uuid::new_v4()
+    ));
+    let db_url = format!("file:{}", db_path.display());
+    let store = TursoEventStore::new(&db_url, None)
+        .await
+        .expect("create local turso db");
+
+    let tenant = TenantId::new("tenant-a");
+
+    // Persist two durable Order entities through the normal create path.
+    let writer = build_state_with_turso("test-lazy-list-partial-writer", store.clone());
+    for id in ["ord-1", "ord-2"] {
+        writer
+            .get_or_create_tenant_entity(
+                &tenant,
+                "Order",
+                id,
+                serde_json::json!({"Title": id}),
+            )
+            .await
+            .expect("create durable order");
+    }
+
+    // Fresh process: empty in-memory index (simulates a server restart).
+    let state = build_state_with_turso("test-lazy-list-partial-reader", store);
+
+    // Touch exactly one entity so the index holds ONLY ord-1 (partial index).
+    assert!(
+        state.ensure_entity_loaded(&tenant, "Order", "ord-1").await,
+        "ord-1 should hydrate from the durable store"
+    );
+    assert_eq!(
+        state.list_entity_ids(&tenant, "Order"),
+        vec!["ord-1".to_string()],
+        "precondition: in-memory index is partial (only the touched entity)"
+    );
+
+    // Lazy listing must reconcile against the store and return BOTH entities.
+    let mut ids = state.list_entity_ids_lazy(&tenant, "Order").await;
+    ids.sort();
+    assert_eq!(
+        ids,
+        vec!["ord-1".to_string(), "ord-2".to_string()],
+        "lazy listing must surface durable entities absent from the partial index"
+    );
+
+    let _ = std::fs::remove_file(db_path);
+}

--- a/crates/temper-server/tests/ensure_entity_loaded.rs
+++ b/crates/temper-server/tests/ensure_entity_loaded.rs
@@ -385,12 +385,7 @@ async fn list_entity_ids_lazy_surfaces_durable_entities_missing_from_partial_ind
     let writer = build_state_with_turso("test-lazy-list-partial-writer", store.clone());
     for id in ["ord-1", "ord-2"] {
         writer
-            .get_or_create_tenant_entity(
-                &tenant,
-                "Order",
-                id,
-                serde_json::json!({"Title": id}),
-            )
+            .get_or_create_tenant_entity(&tenant, "Order", id, serde_json::json!({"Title": id}))
             .await
             .expect("create durable order");
     }


### PR DESCRIPTION
## Summary
- Add regression coverage that large composite sub-write fields persist via overflow storage instead of failing inline field limits.
- Supports Genesis thin-pack/upload-pack large object sync work.

## Verification
- cargo test -p temper-server --features sim composite_ingest_pack_large_blob_sub_write_persists_overflow_fields -- --nocapture