### PR TITLE
fix: heal os-app wasm durable drift

### DIFF
--- a/crates/temper-platform/src/os_apps/mod.rs
+++ b/crates/temper-platform/src/os_apps/mod.rs
@@ -10,9 +10,11 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
+use chrono::{DateTime, NaiveDateTime, Utc};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use temper_runtime::tenant::TenantId;
+use temper_server::state::WasmModuleSource;
 use temper_spec::automaton;
 use temper_spec::csdl::{emit_csdl_xml, merge_csdl, parse_csdl};
 
@@ -1117,10 +1119,10 @@ pub(super) async fn install_os_app_with_plan(
         state.server.enable_commons_guardrails(tenant);
     }
     let tenant_id = TenantId::new(tenant);
-    let replace_uploaded_wasm = if plan.wasm && !bundle.wasm_modules.is_empty() {
-        should_replace_uploaded_wasm_for_bundle_reconcile(state, tenant, app_name, &bundle).await
+    let upload_replacement = if plan.wasm && !bundle.wasm_modules.is_empty() {
+        uploaded_wasm_replacement_context(state, tenant, app_name, &bundle).await
     } else {
-        false
+        UploadedWasmReplacementContext::default()
     };
 
     if bundle.adrs.is_empty() {
@@ -1385,9 +1387,8 @@ pub(super) async fn install_os_app_with_plan(
     //
     // Source-aware preservation: if a (tenant, module) row in the durable store
     // has source='upload' (i.e., a hot upload from `POST /api/wasm/modules/{name}`),
-    // preserve it across same-bundle restarts. When the installed app metadata
-    // says the bundled WASM digest changed, the bundle is a newer deployment and
-    // must replace stale uploads so production executes the shipped module.
+    // preserve uploads newer than the installed app record. Replace uploads when
+    // the bundle digest changed or durable metadata predates the app record.
     let mut wasm_registered = Vec::new();
     let mut wasm_skipped = Vec::new();
     let mut wasm_failures = Vec::new();
@@ -1409,24 +1410,29 @@ pub(super) async fn install_os_app_with_plan(
             let module_config = bundle.wasm_module_configs.get(module_name);
             let hash = temper_wasm::WasmEngine::hash_module(wasm_bytes);
 
-            if let Some((existing_hash, existing_source)) = existing_sources.get(module_name)
-                && existing_source == "upload"
-                && existing_hash != &hash
+            let replace_uploaded_module = existing_sources
+                .get(module_name)
+                .map(|existing| upload_replacement.should_replace(existing))
+                .unwrap_or(false);
+
+            if let Some(existing) = existing_sources.get(module_name)
+                && existing.source == "upload"
+                && existing.sha256_hash != hash
             {
-                if replace_uploaded_wasm {
+                if replace_uploaded_module {
                     tracing::info!(
                         tenant,
                         module = %module_name,
                         bundled_hash = %hash,
-                        upload_hash = %existing_hash,
-                        "Replacing hot-uploaded WASM module: bundled app WASM digest changed"
+                        upload_hash = %existing.sha256_hash,
+                        "Replacing stale hot-uploaded WASM module during os-app reconcile"
                     );
                 } else {
                     tracing::info!(
                         tenant,
                         module = %module_name,
                         bundled_hash = %hash,
-                        upload_hash = %existing_hash,
+                        upload_hash = %existing.sha256_hash,
                         "Skipping bundled install: hot-uploaded module preserved"
                     );
                     wasm_skipped.push(module_name.clone());
@@ -1434,7 +1440,7 @@ pub(super) async fn install_os_app_with_plan(
                 }
             }
 
-            let upsert_result = if replace_uploaded_wasm {
+            let upsert_result = if replace_uploaded_module {
                 state
                     .server
                     .upsert_bundled_wasm_module_replacing_upload(
@@ -1579,24 +1585,68 @@ pub(super) async fn install_os_app_with_plan(
     })
 }
 
-async fn should_replace_uploaded_wasm_for_bundle_reconcile(
+#[derive(Debug, Clone, Default)]
+struct UploadedWasmReplacementContext {
+    bundle_wasm_digest_changed: bool,
+    app_recorded_at: Option<DateTime<Utc>>,
+}
+
+impl UploadedWasmReplacementContext {
+    fn should_replace(&self, existing: &WasmModuleSource) -> bool {
+        if existing.source != "upload" {
+            return false;
+        }
+        if self.bundle_wasm_digest_changed {
+            return true;
+        }
+        let Some(app_recorded_at) = self.app_recorded_at else {
+            return false;
+        };
+        let Some(updated_at) = existing
+            .updated_at
+            .as_deref()
+            .and_then(parse_persisted_timestamp)
+        else {
+            return false;
+        };
+        updated_at < app_recorded_at
+    }
+}
+
+fn parse_persisted_timestamp(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|dt| dt.with_timezone(&Utc))
+        .or_else(|_| {
+            NaiveDateTime::parse_from_str(value, "%Y-%m-%d %H:%M:%S").map(|dt| dt.and_utc())
+        })
+        .ok()
+}
+
+async fn uploaded_wasm_replacement_context(
     state: &PlatformState,
     tenant: &str,
     app_name: &str,
     bundle: &AppBundle,
-) -> bool {
+) -> UploadedWasmReplacementContext {
     let Some(ps) = state
         .server
         .storage_stack
         .as_ref()
         .and_then(|stack| stack.platform.clone())
     else {
-        return false;
+        return UploadedWasmReplacementContext::default();
     };
     let digest = reconcile::digest_app_bundle(app_name, bundle);
     match ps.get_installed_app(tenant, app_name).await {
-        Ok(Some(record)) => record.wasm_digest != digest.wasm_digest,
-        Ok(None) => false,
+        Ok(Some(record)) => UploadedWasmReplacementContext {
+            bundle_wasm_digest_changed: record.wasm_digest != digest.wasm_digest,
+            app_recorded_at: record
+                .last_reconciled_at
+                .as_deref()
+                .or(record.installed_at.as_deref())
+                .and_then(parse_persisted_timestamp),
+        },
+        Ok(None) => UploadedWasmReplacementContext::default(),
         Err(error) => {
             tracing::warn!(
                 tenant,
@@ -1604,7 +1654,7 @@ async fn should_replace_uploaded_wasm_for_bundle_reconcile(
                 error = %error,
                 "Failed to read OS app metadata while deciding WASM hot-upload replacement"
             );
-            false
+            UploadedWasmReplacementContext::default()
         }
     }
 }

--- a/crates/temper-platform/src/os_apps/mod_test.rs
+++ b/crates/temper-platform/src/os_apps/mod_test.rs
@@ -2040,10 +2040,9 @@ startup_loading = "lazy"
         .load_wasm_module_sources(tenant_name)
         .await
         .expect("load wasm module sources");
-    assert_eq!(
-        module_sources.get("echo"),
-        Some(&(expected_bundled_hash, "bundled".to_string()))
-    );
+    let echo_source = module_sources.get("echo").expect("echo module source");
+    assert_eq!(echo_source.sha256_hash.as_str(), expected_bundled_hash);
+    assert_eq!(echo_source.source.as_str(), "bundled");
 
     let _ = fs::remove_dir_all(&app_root);
     let _ = fs::remove_dir_all(&state.server.data_dir);
@@ -2157,10 +2156,161 @@ startup_loading = "lazy"
         .load_wasm_module_sources(tenant_name)
         .await
         .expect("load wasm module sources");
-    assert_eq!(
-        module_sources.get("echo"),
-        Some(&(uploaded_hash, "upload".to_string()))
-    );
+    let echo_source = module_sources.get("echo").expect("echo module source");
+    assert_eq!(echo_source.sha256_hash.as_str(), uploaded_hash);
+    assert_eq!(echo_source.source.as_str(), "upload");
+
+    let _ = fs::remove_dir_all(&app_root);
+    let _ = fs::remove_dir_all(&state.server.data_dir);
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(format!("{db_path}-wal"));
+    let _ = std::fs::remove_file(format!("{db_path}-shm"));
+}
+
+#[tokio::test]
+async fn test_reconcile_os_app_replaces_stale_upload_when_app_metadata_matches_bundle() {
+    use temper_store_turso::TursoEventStore;
+
+    let app_root = std::env::temp_dir().join(format!(
+        "temper-os-apps-wasm-durable-drift-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let app_dir = app_root.join("wasm-durable-drift-app");
+    let module_dir = app_dir
+        .join("wasm")
+        .join("echo")
+        .join("target")
+        .join("wasm32-unknown-unknown")
+        .join("release");
+    fs::create_dir_all(&module_dir).unwrap();
+    fs::write(
+        app_dir.join("app.toml"),
+        r#"name = "wasm-durable-drift-app"
+description = "Temporary WASM durable drift test app"
+version = "0.1.0"
+
+[[wasm_modules]]
+name = "echo"
+criticality = "app-required"
+startup_loading = "lazy"
+"#,
+    )
+    .unwrap();
+    fs::write(
+        app_dir.join("APP.md"),
+        "# WASM Durable Drift App\n\nTemporary WASM durable drift test app.\n",
+    )
+    .unwrap();
+
+    let echo_wasm = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../temper-wasm/tests/fixtures/echo_integration.wasm");
+    fs::copy(&echo_wasm, module_dir.join("echo.wasm")).unwrap();
+    add_os_apps_dir(app_root.clone());
+
+    let db_path = format!("/tmp/temper-wasm-durable-drift-{}.db", uuid::Uuid::new_v4());
+    let db_url = format!("file:{db_path}");
+    let turso = TursoEventStore::new(&db_url, None).await.unwrap();
+    let mut state = PlatformState::new(None);
+    state
+        .server
+        .set_storage_stack(temper_server::StorageStack::from_turso(turso));
+    state.server.data_dir = std::path::PathBuf::from(format!(
+        "/tmp/temper-wasm-durable-drift-{}-data",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&state.server.data_dir).unwrap();
+    let tenant_name = "test-wasm-durable-drift";
+    let tenant = TenantId::new(tenant_name);
+
+    add_os_apps_dir(app_root.clone());
+    install_os_app(&state, tenant_name, "wasm-durable-drift-app")
+        .await
+        .expect("initial app install should succeed");
+
+    let expected_bundled_bytes = fs::read(module_dir.join("echo.wasm")).unwrap();
+    let expected_bundled_hash = temper_wasm::WasmEngine::hash_module(&expected_bundled_bytes);
+    let current = os_app_bundle_digest("wasm-durable-drift-app").expect("durable drift app digest");
+    let ps = state
+        .server
+        .storage_stack
+        .as_ref()
+        .and_then(|stack| stack.platform.clone())
+        .expect("platform store");
+
+    let uploaded_bytes = b"stale upload left behind by partial rollout".to_vec();
+    let uploaded_hash = temper_wasm::WasmEngine::hash_module(&uploaded_bytes);
+    state
+        .server
+        .upsert_wasm_module(
+            tenant_name,
+            "echo",
+            &uploaded_bytes,
+            &uploaded_hash,
+            "upload",
+        )
+        .await
+        .expect("stale upload should persist");
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    ps.record_installed_app_metadata(&InstalledAppRecord {
+        tenant: tenant_name.to_string(),
+        app_name: current.app_name.clone(),
+        source_kind: "local".to_string(),
+        app_ref: String::new(),
+        version_hash: String::new(),
+        pinned_version_hash: String::new(),
+        current_version_hash: String::new(),
+        follow_policy: "pinned".to_string(),
+        closure_id: String::new(),
+        registry_url: String::new(),
+        registry_tenant: String::new(),
+        app_version: current.app_version.clone(),
+        bundle_digest: current.bundle_digest.clone(),
+        spec_digest: current.spec_digest.clone(),
+        policy_digest: current.policy_digest.clone(),
+        wasm_digest: current.wasm_digest.clone(),
+        content_digest: current.content_digest.clone(),
+        seed_digest: current.seed_digest.clone(),
+        installed_at: None,
+        last_reconciled_at: None,
+        status: "installed".to_string(),
+    })
+    .await
+    .expect("installed app metadata should match bundle");
+
+    state
+        .server
+        .wasm_module_registry
+        .write()
+        .unwrap()
+        .register(&tenant, "echo", &uploaded_hash);
+
+    add_os_apps_dir(app_root.clone());
+    let result = reconcile_os_app(&state, tenant_name, "wasm-durable-drift-app")
+        .await
+        .expect("reconcile should succeed");
+    let OsAppReconcileResult::Installed { install, .. } = result else {
+        panic!("durable WASM drift should run delta install");
+    };
+    assert_eq!(install.wasm_modules, vec!["echo".to_string()]);
+    assert!(install.wasm_skipped.is_empty());
+
+    {
+        let registry = state.server.wasm_module_registry.read().unwrap();
+        assert_eq!(
+            registry.get_hash(&tenant, "echo"),
+            Some(expected_bundled_hash.as_str())
+        );
+    }
+
+    let module_sources = state
+        .server
+        .load_wasm_module_sources(tenant_name)
+        .await
+        .expect("load wasm module sources");
+    let echo_source = module_sources.get("echo").expect("echo module source");
+    assert_eq!(echo_source.sha256_hash.as_str(), expected_bundled_hash);
+    assert_eq!(echo_source.source.as_str(), "bundled");
 
     let _ = fs::remove_dir_all(&app_root);
     let _ = fs::remove_dir_all(&state.server.data_dir);

--- a/crates/temper-platform/src/os_apps/reconcile.rs
+++ b/crates/temper-platform/src/os_apps/reconcile.rs
@@ -285,6 +285,34 @@ pub(crate) fn tenant_has_registered_wasm_for_bundle(
     })
 }
 
+pub(crate) async fn tenant_has_durable_wasm_for_bundle(
+    state: &PlatformState,
+    tenant: &str,
+    bundle: &AppBundle,
+) -> bool {
+    if bundle.wasm_modules.is_empty() {
+        return true;
+    }
+    let sources = match state.server.load_wasm_module_sources(tenant).await {
+        Ok(sources) => sources,
+        Err(error) => {
+            tracing::warn!(
+                tenant,
+                error = %error,
+                "Failed to load durable WASM module metadata during os-app reconcile"
+            );
+            return false;
+        }
+    };
+    bundle.wasm_modules.iter().all(|(module_name, wasm_bytes)| {
+        let hash = temper_wasm::WasmEngine::hash_module(wasm_bytes);
+        sources
+            .get(module_name)
+            .map(|source| source.sha256_hash.as_str())
+            == Some(hash.as_str())
+    })
+}
+
 async fn record_app_install_metadata(
     state: &PlatformState,
     tenant: &str,
@@ -366,6 +394,9 @@ pub async fn reconcile_os_app(
             Ok(Some(record)) => {
                 let mut specs_ready = tenant_has_ready_app_specs_for_bundle(state, tenant, &bundle);
                 let wasm_registered = tenant_has_registered_wasm_for_bundle(state, tenant, &bundle);
+                let durable_wasm_ready =
+                    tenant_has_durable_wasm_for_bundle(state, tenant, &bundle).await;
+                let wasm_ready = wasm_registered && durable_wasm_ready;
                 let policies_active = tenant_has_active_policies_for_bundle(state, tenant, &bundle);
 
                 if record.bundle_digest == digest.bundle_digest && !specs_ready {
@@ -381,7 +412,7 @@ pub async fn reconcile_os_app(
 
                 if record.bundle_digest == digest.bundle_digest
                     && specs_ready
-                    && wasm_registered
+                    && wasm_ready
                     && policies_active
                 {
                     tracing::info!(
@@ -410,7 +441,7 @@ pub async fn reconcile_os_app(
                     &record,
                     &digest,
                     specs_ready,
-                    wasm_registered,
+                    wasm_ready,
                     policies_active,
                 );
 

--- a/crates/temper-server/src/state/mod.rs
+++ b/crates/temper-server/src/state/mod.rs
@@ -33,6 +33,7 @@ pub use pending_decisions::{
     ActionScope, DecisionStatus, DurationScope, PendingDecision, PolicyScopeMatrix, PrincipalScope,
     ResourceScope,
 };
+pub use persistence::WasmModuleSource;
 pub use policy_suggestions::PolicySuggestionEngine;
 pub use published_artifacts::PublishFileArtifactRequest;
 pub use trajectory::{TrajectoryEntry, TrajectorySource};

--- a/crates/temper-server/src/state/persistence/mod.rs
+++ b/crates/temper-server/src/state/persistence/mod.rs
@@ -23,6 +23,17 @@ mod spec_metadata;
 
 const BUNDLED_REPLACE_UPLOAD_SOURCE: &str = "bundled-replace-upload";
 
+/// Durable provenance for a persisted WASM module row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WasmModuleSource {
+    /// SHA-256 hash of the persisted WASM bytes.
+    pub sha256_hash: String,
+    /// Provenance: `"bundled"` or `"upload"`.
+    pub source: String,
+    /// Backend timestamp for the last module byte/hash update.
+    pub updated_at: Option<String>,
+}
+
 impl ServerState {
     fn redis_ephemeral_error(operation: &str) -> String {
         format!(
@@ -154,29 +165,40 @@ impl ServerState {
         .await
     }
 
-    /// Return `(module_name -> (sha256_hash, source))` for every WASM module
-    /// currently persisted for `tenant`. Used by the os-apps install pipeline
-    /// to decide whether hot-uploaded modules should be preserved or replaced.
+    /// Return durable source metadata for every WASM module currently persisted
+    /// for `tenant`. Used by the os-apps install pipeline to decide whether
+    /// hot-uploaded modules should be preserved or replaced.
     pub async fn load_wasm_module_sources(
         &self,
         tenant: &str,
-    ) -> Result<std::collections::BTreeMap<String, (String, String)>, String> {
+    ) -> Result<std::collections::BTreeMap<String, WasmModuleSource>, String> {
         let Some(backend) = self.tenant_metadata_backend(tenant).await else {
             return Ok(std::collections::BTreeMap::new());
         };
 
         match backend {
             TenantMetadataBackend::Postgres(pool) => {
-                let rows = sqlx::query_as::<_, (String, String, String)>(
-                    "SELECT module_name, sha256_hash, source FROM wasm_modules WHERE tenant = $1",
-                )
-                .bind(tenant)
-                .fetch_all(&pool)
-                .await
-                .map_err(|e| format!("failed to load WASM module sources for {tenant}: {e}"))?;
+                let rows =
+                    sqlx::query_as::<_, (String, String, String, chrono::DateTime<chrono::Utc>)>(
+                        "SELECT module_name, sha256_hash, source, updated_at \
+                         FROM wasm_modules WHERE tenant = $1",
+                    )
+                    .bind(tenant)
+                    .fetch_all(&pool)
+                    .await
+                    .map_err(|e| format!("failed to load WASM module sources for {tenant}: {e}"))?;
                 Ok(rows
                     .into_iter()
-                    .map(|(name, hash, source)| (name, (hash, source)))
+                    .map(|(name, hash, source, updated_at)| {
+                        (
+                            name,
+                            WasmModuleSource {
+                                sha256_hash: hash,
+                                source,
+                                updated_at: Some(updated_at.to_rfc3339()),
+                            },
+                        )
+                    })
                     .collect())
             }
             TenantMetadataBackend::Turso(turso) => {
@@ -186,10 +208,19 @@ impl ServerState {
                     .map_err(|e| format!("failed to load WASM module sources for {tenant}: {e}"))?;
                 Ok(rows
                     .into_iter()
-                    .map(|r| (r.module_name, (r.sha256_hash, r.source)))
+                    .map(|r| {
+                        (
+                            r.module_name,
+                            WasmModuleSource {
+                                sha256_hash: r.sha256_hash,
+                                source: r.source,
+                                updated_at: Some(r.updated_at),
+                            },
+                        )
+                    })
                     .collect())
             }
-            TenantMetadataBackend::Redis => Ok(std::collections::BTreeMap::new()),
+            TenantMetadataBackend::Redis => Err(Self::redis_ephemeral_error("WASM module sources")),
         }
     }
 

--- a/docs/adrs/0145-os-app-wasm-durable-drift-recovery.md
+++ b/docs/adrs/0145-os-app-wasm-durable-drift-recovery.md
@@ -1,0 +1,49 @@
+# ADR-0145: OS App WASM Reconcile Heals Durable Drift
+
+## Status
+
+Accepted
+
+## Context
+
+OS app reconcile stores a bundle digest in `tenant_installed_apps` and each
+WASM module body in `wasm_modules`. Hot-uploaded modules are preserved across
+same-bundle restarts, but a failed or partial rollout can leave those two stores
+split: the installed app record says the current bundle is installed while the
+durable module row is still an older `source='upload'` body.
+
+After restart, the in-memory WASM registry is empty. Reconcile therefore must
+reload bundled bytes when the durable module row does not match the bundle,
+even if the app digest metadata already matches.
+
+## Decision
+
+OS app reconcile treats the bundled WASM phase as needed whenever either the
+in-memory registry is missing the bundled hashes or durable `wasm_modules`
+contains a different hash/source for any bundled module.
+
+The replacement check for `source='upload'` modules uses durable module
+comparison, not only installed app digest comparison. If the app WASM digest
+changed, the bundled module replaces the upload. If the digest matches, the
+bundled module replaces the upload only when the upload's `updated_at` predates
+the installed app record's `last_reconciled_at` timestamp, falling back to
+`installed_at` for older records.
+
+## Consequences
+
+- Restart recovery heals split-brain app installs where metadata is current but
+  durable WASM bytes are stale.
+- Same-bundle hot uploads are still preserved while the in-memory registry
+  points at the uploaded hash.
+- Bundle rollout no longer depends on `tenant_installed_apps.wasm_digest` being
+  the only signal for WASM replacement.
+
+## Non-Goals
+
+- This does not add a new public upload API or change upload authorization.
+- This does not remove hot-upload preservation for development workflows.
+
+## Rollback Policy
+
+Revert this ADR and the reconcile comparison change. Systems that have stale
+uploaded WASM rows would then require a manual upload or row repair to recover.


### PR DESCRIPTION
## Summary
- add ADR-0145 for os-app WASM durable drift recovery
- make os-app reconcile consider durable wasm_modules hashes, not only the in-memory registry
- replace stale source=upload rows when they predate the current app record, while preserving newer hot uploads
- add regression coverage for current app metadata with a stale durable upload row

## Validation
- cargo test -p temper-platform test_reconcile_os_app_ -- --nocapture
- cargo test -p temper-server -p temper-platform
- cargo clippy -p temper-server -p temper-platform -- -D warnings
- pre-push gates 1-3 passed: cargo fmt --check, cargo clippy --workspace -- -D warnings, readability ratchet

## Pre-push note
- Gate 4 cargo test --workspace was started and passed through the affected crates plus many workspace suites, but failed in crates/temper-actor-runtime/tests/integration.rs because Docker/Postgres container creation timed out: Client(CreateContainer(RequestTimeoutError)). Docker CLI probes also hung locally, so this is recorded as an infrastructure failure rather than a code failure.
