### PR TITLE
Require packaged WASM artifacts for reconcile readiness

### DIFF
--- a/crates/temper-platform/src/os_apps/mod.rs
+++ b/crates/temper-platform/src/os_apps/mod.rs
@@ -346,8 +346,8 @@ fn effective_app_deployment_mode(manifest: &AppManifest) -> AppDeploymentMode {
 
 /// Find compiled WASM module binaries in an app directory.
 ///
-/// Scans manifest-selected target outputs, common WASM release outputs, and
-/// packaged artifacts copied next to the module after Docker target pruning.
+/// Scans packaged artifacts copied next to the module first, then falls back
+/// to manifest-selected target outputs and common WASM release outputs.
 fn find_wasm_modules(
     app_dir: &Path,
     module_configs: &BTreeMap<String, WasmModuleManifest>,
@@ -369,16 +369,18 @@ fn find_wasm_modules(
         if !module_dir.is_dir() {
             continue;
         }
-        // When the manifest declares a specific compilation target, search
-        // only that target's release directory — avoids picking up a stale
-        // build from the wrong target (e.g. wasm32-unknown-unknown when the
-        // module requires wasm32-wasip1). Fall back to bundled artifacts
-        // copied after compilation.
+        // Prefer packaged sibling artifacts because they are the deployable
+        // copy left after Docker target pruning. Target output remains a local
+        // development fallback.
         let dashed_name = module_name.replace('_', "-");
         let candidates: Vec<PathBuf> = if let Some(config) = module_configs.get(&module_name)
             && let Some(ref target) = config.target
         {
             vec![
+                module_dir.join(format!("{module_name}.wasm")),
+                module_dir.join(format!("{dashed_name}.wasm")),
+                wasm_dir.join(format!("{module_name}.wasm")),
+                wasm_dir.join(format!("{dashed_name}.wasm")),
                 module_dir
                     .join("target")
                     .join(target)
@@ -389,37 +391,33 @@ fn find_wasm_modules(
                     .join(target)
                     .join("release")
                     .join(format!("{dashed_name}.wasm")),
-                module_dir.join(format!("{module_name}.wasm")),
-                module_dir.join(format!("{dashed_name}.wasm")),
-                wasm_dir.join(format!("{module_name}.wasm")),
-                wasm_dir.join(format!("{dashed_name}.wasm")),
             ]
         } else {
             vec![
-                module_dir
-                    .join("target")
-                    .join("wasm32-unknown-unknown")
-                    .join("release")
-                    .join(format!("{module_name}.wasm")),
-                module_dir
-                    .join("target")
-                    .join("wasm32-wasip1")
-                    .join("release")
-                    .join(format!("{module_name}.wasm")),
-                module_dir
-                    .join("target")
-                    .join("wasm32-unknown-unknown")
-                    .join("release")
-                    .join(format!("{dashed_name}.wasm")),
-                module_dir
-                    .join("target")
-                    .join("wasm32-wasip1")
-                    .join("release")
-                    .join(format!("{dashed_name}.wasm")),
                 module_dir.join(format!("{module_name}.wasm")),
                 module_dir.join(format!("{dashed_name}.wasm")),
                 wasm_dir.join(format!("{module_name}.wasm")),
                 wasm_dir.join(format!("{dashed_name}.wasm")),
+                module_dir
+                    .join("target")
+                    .join("wasm32-unknown-unknown")
+                    .join("release")
+                    .join(format!("{module_name}.wasm")),
+                module_dir
+                    .join("target")
+                    .join("wasm32-wasip1")
+                    .join("release")
+                    .join(format!("{module_name}.wasm")),
+                module_dir
+                    .join("target")
+                    .join("wasm32-unknown-unknown")
+                    .join("release")
+                    .join(format!("{dashed_name}.wasm")),
+                module_dir
+                    .join("target")
+                    .join("wasm32-wasip1")
+                    .join("release")
+                    .join(format!("{dashed_name}.wasm")),
             ]
         };
 

--- a/crates/temper-platform/src/os_apps/mod_test.rs
+++ b/crates/temper-platform/src/os_apps/mod_test.rs
@@ -2474,6 +2474,43 @@ startup_loading = "lazy"
 }
 
 #[test]
+fn test_required_wasm_config_without_artifact_is_not_registered_ready() {
+    let mut configs = BTreeMap::new();
+    configs.insert(
+        "echo".to_string(),
+        WasmModuleManifest {
+            name: "echo".to_string(),
+            target: None,
+            criticality: WasmModuleCriticality::AppRequired,
+            startup_loading: WasmStartupLoading::Lazy,
+            provenance: None,
+            import_class: None,
+        },
+    );
+    let bundle = AppBundle {
+        deployment_mode: AppDeploymentMode::Operator,
+        specs: Vec::new(),
+        csdl: None,
+        cross_invariants_toml: None,
+        cedar_policies: Vec::new(),
+        cedar_policy_sources: Vec::new(),
+        wasm_modules: BTreeMap::new(),
+        wasm_module_configs: configs,
+        agents: Vec::new(),
+        skills: Vec::new(),
+        adrs: Vec::new(),
+        system_files: Vec::new(),
+        seed_instances: Vec::new(),
+    };
+    let state = PlatformState::new(None);
+
+    assert!(
+        !tenant_has_registered_wasm_for_bundle(&state, "test-required-missing-artifact", &bundle),
+        "configured required WASM modules without bundled bytes must not be treated as ready"
+    );
+}
+
+#[test]
 fn test_load_app_bundle_rejects_legacy_reactions_file() {
     let temp_dir = std::env::temp_dir().join(format!(
         "temper-legacy-reactions-bundle-test-{}",
@@ -2564,6 +2601,49 @@ fn test_find_wasm_modules_respects_manifest_target() {
     assert_eq!(
         modules["echo"], correct_bytes,
         "should pick the wasip1 binary, not wasm32-unknown-unknown"
+    );
+
+    let _ = fs::remove_dir_all(&temp_dir);
+}
+
+#[test]
+fn test_find_wasm_modules_prefers_packaged_sibling_over_target_output() {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "temper-wasm-packaged-test-{}",
+        uuid::Uuid::new_v4()
+    ));
+
+    let target_dir = temp_dir
+        .join("wasm")
+        .join("echo")
+        .join("target")
+        .join("wasm32-wasip1")
+        .join("release");
+    let module_dir = temp_dir.join("wasm").join("echo");
+    fs::create_dir_all(&target_dir).unwrap();
+
+    let stale_target_bytes = b"stale-target-output";
+    let packaged_bytes = b"packaged-sibling-artifact";
+    fs::write(target_dir.join("echo.wasm"), stale_target_bytes).unwrap();
+    fs::write(module_dir.join("echo.wasm"), packaged_bytes).unwrap();
+
+    let mut configs = BTreeMap::new();
+    configs.insert(
+        "echo".to_string(),
+        WasmModuleManifest {
+            name: "echo".to_string(),
+            target: Some("wasm32-wasip1".to_string()),
+            criticality: WasmModuleCriticality::AppRequired,
+            startup_loading: WasmStartupLoading::default(),
+            provenance: None,
+            import_class: None,
+        },
+    );
+
+    let modules = find_wasm_modules(&temp_dir, &configs);
+    assert_eq!(
+        modules["echo"], packaged_bytes,
+        "packaged sibling artifact should win over target output"
     );
 
     let _ = fs::remove_dir_all(&temp_dir);

--- a/crates/temper-platform/src/os_apps/reconcile.rs
+++ b/crates/temper-platform/src/os_apps/reconcile.rs
@@ -268,11 +268,23 @@ fn bundle_policies_present(active_text: &str, cedar_policies: &[String]) -> bool
     })
 }
 
+fn bundle_required_wasm_artifacts_present(bundle: &AppBundle) -> bool {
+    bundle
+        .wasm_module_configs
+        .iter()
+        .all(|(module_name, config)| {
+            !config.is_required() || bundle.wasm_modules.contains_key(module_name)
+        })
+}
+
 pub(crate) fn tenant_has_registered_wasm_for_bundle(
     state: &PlatformState,
     tenant: &str,
     bundle: &AppBundle,
 ) -> bool {
+    if !bundle_required_wasm_artifacts_present(bundle) {
+        return false;
+    }
     let tenant_id = TenantId::new(tenant);
     let registry = state
         .server
@@ -290,6 +302,9 @@ pub(crate) async fn tenant_has_durable_wasm_for_bundle(
     tenant: &str,
     bundle: &AppBundle,
 ) -> bool {
+    if !bundle_required_wasm_artifacts_present(bundle) {
+        return false;
+    }
     if bundle.wasm_modules.is_empty() {
         return true;
     }

--- a/docs/adrs/0147-required-wasm-packaged-artifact-readiness.md
+++ b/docs/adrs/0147-required-wasm-packaged-artifact-readiness.md
@@ -1,0 +1,23 @@
+# ADR-0147: Required WASM Packaged Artifact Readiness
+
+## Status
+
+Accepted
+
+## Context
+
+OS app reconcile compares the installed app digest with the currently loaded bundle and skips when specs, policies, and WASM appear ready. Required WASM modules declared in `app.toml` were only checked after artifacts were discovered. If discovery found no bytes for a configured required module, readiness over the empty discovered set could incorrectly pass and leave an older durable or in-memory module active.
+
+WASM discovery also preferred `target/` build outputs before the packaged sibling `.wasm` copied next to each module for deployment. That made local/deploy verification less direct when both a stale target output and a packaged artifact existed.
+
+## Decision
+
+Required manifest-declared WASM modules must have bundled artifact bytes before registry or durable WASM readiness can pass. Missing optional artifacts remain skippable.
+
+WASM discovery now prefers packaged sibling artifacts before falling back to target release outputs. Target output remains a local development fallback when no packaged artifact exists.
+
+## Consequences
+
+Reconcile will run instead of silently skipping when a required module artifact is missing. The install step already records required missing artifacts as WASM failures, so operators see an explicit failure instead of stale module reuse.
+
+Packaged `.wasm` files are the deploy source of truth for bundle hashing and install, matching Docker target-pruning behavior and CI package verification.


### PR DESCRIPTION
## Summary
- prefer packaged sibling WASM artifacts over target outputs during OS-app discovery
- treat missing required manifest-declared WASM artifacts as not ready for registry/durable reconcile checks
- add regression coverage and ADR-0147

## Verification
- RED: cargo test -p temper-platform test_required_wasm_config_without_artifact_is_not_registered_ready --quiet
- RED: cargo test -p temper-platform test_find_wasm_modules_prefers_packaged_sibling_over_target_output --quiet
- cargo test -p temper-platform test_required_wasm_config_without_artifact_is_not_registered_ready --quiet
- cargo test -p temper-platform test_find_wasm_modules_prefers_packaged_sibling_over_target_output --quiet
- cargo test -p temper-platform os_apps::mod_test --quiet
- cargo fmt --all --check
- git diff --check
- bash scripts/readability-ratchet.sh check .ci/readability-baseline.env

Note: local pre-push full suite was blocked by Docker/Postgres CreateContainer(RequestTimeoutError) in temper-actor-runtime integration tests; targeted tests and readability passed, and CI should run on a clean environment.