### PR TITLE
Bound Temper derived DB writes off Foresight hot path

### DIFF
--- a/crates/temper-mcp/src/runtime.rs
+++ b/crates/temper-mcp/src/runtime.rs
@@ -4,6 +4,7 @@ use anyhow::{Result, bail};
 use monty::MontyObject;
 use serde_json::Value;
 use std::collections::BTreeMap;
+use std::time::Duration;
 use temper_ots::{
     DecisionType, MessageRole, OTSChoice, OTSConsequence, OTSContext, OTSDecision, OTSMessage,
     OTSMessageContent, OTSMetadata, OutcomeType, TrajectoryBuilder,
@@ -13,6 +14,9 @@ use tokio::io::{self, AsyncBufReadExt, AsyncWriteExt, BufReader};
 
 use super::McpConfig;
 use super::protocol::dispatch_json_line;
+
+const OTS_UPLOAD_MAX_ATTEMPTS: u32 = 3;
+const OTS_UPLOAD_RETRY_DELAY_MS: u64 = 100;
 
 /// Client identity received from the MCP `initialize` handshake.
 #[derive(Clone, Debug, Default)]
@@ -246,34 +250,9 @@ impl RuntimeContext {
         let trajectory_id = trajectory.trajectory_id.clone();
         let json = serde_json::to_string(&trajectory)?;
 
-        let url = format!("{}/api/ots/trajectories", self.base_url);
-        let mut request = self
-            .http
-            .post(&url)
-            .body(json)
-            .header("Content-Type", "application/json")
-            .header("X-Tenant-Id", self.primary_tenant());
-
-        if let Some(primary_entity_type) = self.primary_entity_type() {
-            request = request.header("X-Entity-Type", primary_entity_type);
-        }
-        if let Some(ref agent_id) = self.agent_id {
-            request = request.header("X-Agent-Id", agent_id);
-        }
-        if let Some(ref session_id) = self.session_id {
-            request = request.header("X-Session-Id", session_id);
-        }
-        if let Some(ref api_key) = self.api_key {
-            request = request.header("Authorization", format!("Bearer {api_key}"));
-        }
-
-        let resp = request.send().await?;
-        if resp.status().is_success() {
-            tracing::info!("ots.trajectory.flushed");
-            Ok(trajectory_id)
-        } else {
-            bail!("flush failed: HTTP {}", resp.status());
-        }
+        self.upload_trajectory_json(json).await?;
+        tracing::info!("ots.trajectory.flushed");
+        Ok(trajectory_id)
     }
 
     /// Finalize and POST the trajectory to the server.
@@ -291,6 +270,55 @@ impl RuntimeContext {
             }
         };
 
+        match self.upload_trajectory_json(json).await {
+            Ok(()) => {
+                tracing::info!("ots.trajectory.uploaded");
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "ots.trajectory.upload_failed");
+            }
+        }
+    }
+
+    async fn upload_trajectory_json(&self, json: String) -> Result<()> {
+        let max_attempts = std::env::var("TEMPER_MCP_OTS_UPLOAD_MAX_ATTEMPTS")
+            .ok()
+            .and_then(|value| value.trim().parse::<u32>().ok())
+            .filter(|attempts| *attempts > 0)
+            .unwrap_or(OTS_UPLOAD_MAX_ATTEMPTS); // determinism-ok: MCP client runtime config
+        let retry_delay = Duration::from_millis(
+            std::env::var("TEMPER_MCP_OTS_UPLOAD_RETRY_DELAY_MS")
+                .ok()
+                .and_then(|value| value.trim().parse::<u64>().ok())
+                .unwrap_or(OTS_UPLOAD_RETRY_DELAY_MS),
+        ); // determinism-ok: MCP client runtime config
+
+        let mut last_error = None;
+        for attempt in 1..=max_attempts {
+            match self.send_trajectory_json(json.clone()).await {
+                Ok(()) => return Ok(()),
+                Err(error) if attempt < max_attempts && error.retryable => {
+                    tracing::warn!(
+                        attempt,
+                        max_attempts,
+                        error = %error.message,
+                        "ots.trajectory.upload_retry"
+                    );
+                    last_error = Some(error.message);
+                    tokio::time::sleep(retry_delay).await;
+                }
+                Err(error) => {
+                    return Err(anyhow::anyhow!(error.message));
+                }
+            }
+        }
+
+        Err(anyhow::anyhow!(last_error.unwrap_or_else(|| {
+            "OTS trajectory upload failed".to_string()
+        })))
+    }
+
+    async fn send_trajectory_json(&self, json: String) -> Result<(), TrajectoryUploadError> {
         let url = format!("{}/api/ots/trajectories", self.base_url);
         let mut request = self
             .http
@@ -302,7 +330,6 @@ impl RuntimeContext {
         if let Some(primary_entity_type) = self.primary_entity_type() {
             request = request.header("X-Entity-Type", primary_entity_type);
         }
-
         if let Some(ref agent_id) = self.agent_id {
             request = request.header("X-Agent-Id", agent_id);
         }
@@ -314,18 +341,22 @@ impl RuntimeContext {
         }
 
         match request.send().await {
-            Ok(resp) if resp.status().is_success() => {
-                tracing::info!("ots.trajectory.uploaded");
-            }
+            Ok(resp) if resp.status().is_success() => Ok(()),
             Ok(resp) => {
-                tracing::warn!(
-                    status = resp.status().as_u16(),
-                    "ots.trajectory.upload_failed"
-                );
+                let status = resp.status();
+                Err(TrajectoryUploadError {
+                    message: format!("HTTP {status}"),
+                    retryable: status.as_u16() == 503
+                        || status.as_u16() == 408
+                        || status.as_u16() == 425
+                        || status.as_u16() == 429
+                        || status.is_server_error(),
+                })
             }
-            Err(e) => {
-                tracing::warn!(error = %e, "ots.trajectory.upload_failed");
-            }
+            Err(error) => Err(TrajectoryUploadError {
+                message: error.to_string(),
+                retryable: true,
+            }),
         }
     }
 
@@ -415,6 +446,11 @@ impl RuntimeContext {
             )
             .await
     }
+}
+
+struct TrajectoryUploadError {
+    message: String,
+    retryable: bool,
 }
 
 fn extract_trajectory_actions_from_code(code: &str) -> Vec<Value> {
@@ -837,6 +873,11 @@ pub async fn run_stdio_server(config: McpConfig) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::{Router, extract::State, http::StatusCode, routing::post};
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
 
     #[test]
     fn extract_trajectory_actions_from_temper_action_calls() {
@@ -890,5 +931,48 @@ await temper.create("tenant-b", "Task", {"Title": "x"})
             }),
             "expected tenant-b/Task metadata"
         );
+    }
+
+    #[tokio::test]
+    async fn finalize_trajectory_retries_retryable_ots_upload_failure() {
+        async fn handler(State(attempts): State<Arc<AtomicUsize>>) -> StatusCode {
+            let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+            if attempt == 0 {
+                StatusCode::SERVICE_UNAVAILABLE
+            } else {
+                StatusCode::ACCEPTED
+            }
+        }
+
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let app = Router::new()
+            .route("/api/ots/trajectories", post(handler))
+            .with_state(attempts.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let addr = listener.local_addr().expect("test server addr");
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve test server");
+        });
+
+        let mut ctx = RuntimeContext {
+            base_url: format!("http://{addr}"),
+            http: reqwest::Client::new(),
+            agent_id: Some("agent".to_string()),
+            agent_type: Some("test-agent".to_string()),
+            session_id: Some("session".to_string()),
+            api_key: None,
+            identity_tenant: "tenant".to_string(),
+            sandbox: temper_sandbox::runner::PersistentSandbox::new(&[("temper", "Temper", 1)]),
+            trajectory: None,
+            tenants_seen: BTreeMap::new(),
+            entity_types_seen: BTreeMap::new(),
+        };
+        ctx.init_trajectory();
+
+        ctx.finalize_trajectory().await;
+
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
     }
 }

--- a/crates/temper-server/src/entity_actor/actor.rs
+++ b/crates/temper-server/src/entity_actor/actor.rs
@@ -39,6 +39,7 @@ use super::effects::{
     FieldSyncMode, build_eval_context_with_xref, process_action_with_xref_and_field_mode,
     prune_transient_action_fields_from_state,
 };
+use super::snapshot_queue::{SnapshotEnqueueOutcome, SnapshotWriteQueue};
 use super::types::{
     EntityEvent, EntityMsg, EntityResponse, EntityState, MAX_EVENTS_SINCE_SNAPSHOT,
     MAX_ITEMS_PER_ENTITY,
@@ -104,6 +105,8 @@ pub struct EntityActor {
     initial_fields: serde_json::Value,
     /// Optional event journal for persistence. None = in-memory only.
     event_journal: Option<BoxedEventStore>,
+    /// Optional async snapshot writer. Event appends remain synchronous.
+    snapshot_queue: Option<Arc<SnapshotWriteQueue>>,
     /// Persistence backend label used for metrics and backend-specific field sync.
     event_backend: Option<BackendLabel>,
     /// Trace ID for correlating all events from this actor.
@@ -231,6 +234,7 @@ impl EntityActor {
             table,
             initial_fields,
             event_journal: None,
+            snapshot_queue: None,
             event_backend: None,
             trace_id: sim_uuid().to_string(),
             idempotency_cache: None,
@@ -254,6 +258,7 @@ impl EntityActor {
             table,
             initial_fields,
             event_journal: Some(store),
+            snapshot_queue: None,
             event_backend: Some(backend),
             trace_id: sim_uuid().to_string(),
             idempotency_cache: None,
@@ -264,6 +269,12 @@ impl EntityActor {
     /// Set the tenant for this actor (must be called before spawning).
     pub fn with_tenant(mut self, tenant: impl Into<String>) -> Self {
         self.tenant = tenant.into();
+        self
+    }
+
+    /// Attach the background snapshot writer for this actor's event journal.
+    pub(crate) fn with_snapshot_queue(mut self, queue: Option<Arc<SnapshotWriteQueue>>) -> Self {
+        self.snapshot_queue = queue;
         self
     }
 
@@ -367,18 +378,49 @@ impl EntityActor {
     /// Save a snapshot when the configured interval is reached.
     async fn maybe_save_snapshot(
         store: &BoxedEventStore,
+        snapshot_queue: Option<&Arc<SnapshotWriteQueue>>,
         persistence_id: &str,
         state: &mut EntityState,
     ) -> Result<(), PersistenceError> {
         if state.sequence_nr == 0 {
             return Ok(());
         }
+        if let Some(queue) = snapshot_queue
+            && let Some(applied_sequence) = queue.applied_sequence(persistence_id)
+            && applied_sequence > state.last_snapshot_sequence_nr
+        {
+            let applied_sequence = applied_sequence.min(state.sequence_nr);
+            state.last_snapshot_sequence_nr = applied_sequence;
+            state.events_since_snapshot =
+                state.sequence_nr.saturating_sub(applied_sequence) as usize;
+        }
+
         let interval = Self::snapshot_interval();
-        if !state.sequence_nr.is_multiple_of(interval) {
+        let pending_sequence = snapshot_queue
+            .and_then(|queue| queue.pending_sequence(persistence_id))
+            .unwrap_or(0);
+        let latest_snapshot_boundary = state.last_snapshot_sequence_nr.max(pending_sequence);
+        if state.sequence_nr.saturating_sub(latest_snapshot_boundary) < interval {
             return Ok(());
         }
 
         let snapshot = Self::serialize_snapshot_state(state)?;
+        if let Some(queue) = snapshot_queue {
+            match queue.enqueue(persistence_id.to_string(), state.sequence_nr, snapshot) {
+                SnapshotEnqueueOutcome::Enqueued
+                | SnapshotEnqueueOutcome::Coalesced
+                | SnapshotEnqueueOutcome::StaleSkipped => return Ok(()),
+                SnapshotEnqueueOutcome::Full => {
+                    tracing::warn!(
+                        entity = %state.entity_id,
+                        seq = state.sequence_nr,
+                        "snapshot write queue full; keeping replay tail open"
+                    );
+                    return Ok(());
+                }
+            }
+        }
+
         store
             .save_snapshot(persistence_id, state.sequence_nr, &snapshot)
             .await?;
@@ -1162,9 +1204,15 @@ impl Actor for EntityActor {
 
                     state.push_event_bounded(event);
 
+                    let persistence_id = self.persistence_id();
                     if let Some(ref store) = self.event_journal
-                        && let Err(e) =
-                            Self::maybe_save_snapshot(store, &self.persistence_id(), state).await
+                        && let Err(e) = Self::maybe_save_snapshot(
+                            store,
+                            self.snapshot_queue.as_ref(),
+                            &persistence_id,
+                            state,
+                        )
+                        .await
                     {
                         tracing::warn!(
                             entity = %state.entity_id,

--- a/crates/temper-server/src/entity_actor/actor_test.rs
+++ b/crates/temper-server/src/entity_actor/actor_test.rs
@@ -79,6 +79,72 @@ fn event_budget_workspace_id_uses_workspace_entity_id_or_field() {
     assert_eq!(event_budget_workspace_id(&file_state), "ws-2");
 }
 
+#[cfg(feature = "sim")]
+#[tokio::test]
+async fn queued_snapshot_only_advances_replay_boundary_after_write_applies() {
+    use temper_store_sim::SimEventStore;
+
+    let store = Arc::new(SimEventStore::no_faults(43));
+    let boxed_store = crate::storage::BoxedEventStore::from_arc(store);
+    let snapshot_queue = SnapshotWriteQueue::start(boxed_store.clone());
+    let persistence_id = "default:Order:queued-snapshot-1";
+    let mut state = EntityState {
+        entity_type: "Order".to_string(),
+        entity_id: "queued-snapshot-1".to_string(),
+        status: "Draft".to_string(),
+        item_count: 0,
+        counters: BTreeMap::new(),
+        booleans: BTreeMap::new(),
+        lists: BTreeMap::new(),
+        fields: serde_json::json!({
+            "Id": "queued-snapshot-1",
+            "Status": "Draft"
+        }),
+        events: std::collections::VecDeque::new(),
+        total_event_count: 100,
+        events_since_snapshot: 100,
+        last_snapshot_sequence_nr: 0,
+        sequence_nr: 100,
+        processed_idempotency_keys: BTreeMap::new(),
+    };
+
+    EntityActor::maybe_save_snapshot(
+        &boxed_store,
+        Some(&snapshot_queue),
+        persistence_id,
+        &mut state,
+    )
+    .await
+    .expect("snapshot enqueue should succeed");
+
+    assert_eq!(snapshot_queue.pending_sequence(persistence_id), Some(100));
+    assert_eq!(state.last_snapshot_sequence_nr, 0);
+    assert_eq!(state.events_since_snapshot, 100);
+
+    for _ in 0..20 {
+        if snapshot_queue.applied_sequence(persistence_id) == Some(100) {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert_eq!(snapshot_queue.applied_sequence(persistence_id), Some(100));
+
+    state.sequence_nr = 101;
+    state.total_event_count = 101;
+    state.events_since_snapshot = 101;
+    EntityActor::maybe_save_snapshot(
+        &boxed_store,
+        Some(&snapshot_queue),
+        persistence_id,
+        &mut state,
+    )
+    .await
+    .expect("snapshot boundary observation should succeed");
+
+    assert_eq!(state.last_snapshot_sequence_nr, 100);
+    assert_eq!(state.events_since_snapshot, 1);
+}
+
 // =============================================
 // DST-FIRST: Test the actor through the runtime
 // =============================================

--- a/crates/temper-server/src/entity_actor/mod.rs
+++ b/crates/temper-server/src/entity_actor/mod.rs
@@ -7,6 +7,7 @@
 mod actor;
 pub mod effects;
 pub mod sim_handler;
+mod snapshot_queue;
 pub mod types;
 
 pub use actor::EntityActor;
@@ -16,4 +17,5 @@ pub use effects::{
     process_action, sync_fields,
 };
 pub use sim_handler::EntityActorHandler;
+pub(crate) use snapshot_queue::SnapshotWriteQueue;
 pub use types::{EntityEvent, EntityMsg, EntityResponse, EntityState};

--- a/crates/temper-server/src/entity_actor/snapshot_queue.rs
+++ b/crates/temper-server/src/entity_actor/snapshot_queue.rs
@@ -1,0 +1,406 @@
+//! Bounded, coalescing snapshot writer for entity actors.
+//!
+//! The event journal append remains synchronous. Snapshot rows are derived
+//! recovery accelerators, so this queue moves their writes off the actor hot
+//! path while preserving the latest accepted sequence per persistence stream.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use tokio::sync::Notify;
+use tracing::Instrument;
+
+use crate::storage::BoxedEventStore;
+
+const DEFAULT_SNAPSHOT_QUEUE_CAPACITY: usize = 20_000;
+const DEFAULT_SNAPSHOT_DRAIN_BATCH: usize = 256;
+
+#[derive(Clone, Debug)]
+struct QueuedSnapshotWrite {
+    persistence_id: String,
+    sequence_nr: u64,
+    snapshot: Vec<u8>,
+    enqueued_at: Instant,
+}
+
+#[derive(Debug, Default)]
+struct PendingSnapshotWrites {
+    writes: BTreeMap<String, QueuedSnapshotWrite>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum SnapshotEnqueueOutcome {
+    Enqueued,
+    Coalesced,
+    StaleSkipped,
+    Full,
+}
+
+/// Background snapshot writer shared by all entity actors for one storage stack.
+pub(crate) struct SnapshotWriteQueue {
+    store: BoxedEventStore,
+    pending: Arc<Mutex<PendingSnapshotWrites>>,
+    applied_sequences: Arc<Mutex<BTreeMap<String, u64>>>,
+    notify: Arc<Notify>,
+    capacity: usize,
+    drain_batch: usize,
+}
+
+impl SnapshotWriteQueue {
+    pub(crate) fn start(store: BoxedEventStore) -> Arc<Self> {
+        let queue = Arc::new(Self {
+            store,
+            pending: Arc::new(Mutex::new(PendingSnapshotWrites::default())),
+            applied_sequences: Arc::new(Mutex::new(BTreeMap::new())),
+            notify: Arc::new(Notify::new()),
+            capacity: snapshot_queue_capacity(),
+            drain_batch: snapshot_drain_batch(),
+        });
+        queue.spawn_worker();
+        queue
+    }
+
+    #[cfg(test)]
+    fn new_for_test(store: BoxedEventStore, capacity: usize, drain_batch: usize) -> Self {
+        Self {
+            store,
+            pending: Arc::new(Mutex::new(PendingSnapshotWrites::default())),
+            applied_sequences: Arc::new(Mutex::new(BTreeMap::new())),
+            notify: Arc::new(Notify::new()),
+            capacity,
+            drain_batch,
+        }
+    }
+
+    pub(crate) fn enqueue(
+        &self,
+        persistence_id: String,
+        sequence_nr: u64,
+        snapshot: Vec<u8>,
+    ) -> SnapshotEnqueueOutcome {
+        let mut pending = self.pending.lock().expect("snapshot queue mutex poisoned");
+        let existing = pending.writes.get(&persistence_id);
+        if existing.is_some_and(|existing| existing.sequence_nr >= sequence_nr) {
+            crate::runtime_metrics::record_snapshot_write_stale_skipped();
+            return SnapshotEnqueueOutcome::StaleSkipped;
+        }
+
+        if existing.is_none() && pending.writes.len() >= self.capacity {
+            crate::runtime_metrics::record_snapshot_write_dropped();
+            return SnapshotEnqueueOutcome::Full;
+        }
+
+        let outcome = if existing.is_some() {
+            SnapshotEnqueueOutcome::Coalesced
+        } else {
+            SnapshotEnqueueOutcome::Enqueued
+        };
+        if outcome == SnapshotEnqueueOutcome::Coalesced {
+            crate::runtime_metrics::record_snapshot_write_coalesced();
+        }
+
+        pending.writes.insert(
+            persistence_id.clone(),
+            QueuedSnapshotWrite {
+                persistence_id,
+                sequence_nr,
+                snapshot,
+                enqueued_at: Instant::now(),
+            },
+        );
+        crate::runtime_metrics::record_snapshot_write_queue_depth(pending.writes.len() as u64);
+        drop(pending);
+
+        self.notify.notify_one();
+        outcome
+    }
+
+    pub(crate) fn applied_sequence(&self, persistence_id: &str) -> Option<u64> {
+        self.applied_sequences
+            .lock()
+            .expect("snapshot applied sequence mutex poisoned")
+            .get(persistence_id)
+            .copied()
+    }
+
+    pub(crate) fn pending_sequence(&self, persistence_id: &str) -> Option<u64> {
+        self.pending
+            .lock()
+            .expect("snapshot queue mutex poisoned")
+            .writes
+            .get(persistence_id)
+            .map(|write| write.sequence_nr)
+    }
+
+    fn spawn_worker(self: &Arc<Self>) {
+        let queue = Arc::clone(self);
+        tokio::spawn(async move {
+            queue.run().await;
+        });
+    }
+
+    async fn run(self: Arc<Self>) {
+        loop {
+            let writes = self.take_batch();
+            if writes.is_empty() {
+                self.notify.notified().await;
+                continue;
+            }
+
+            for write in writes {
+                self.apply(write).await;
+            }
+        }
+    }
+
+    fn take_batch(&self) -> Vec<QueuedSnapshotWrite> {
+        let mut pending = self.pending.lock().expect("snapshot queue mutex poisoned");
+        let mut writes = Vec::with_capacity(self.drain_batch.min(pending.writes.len()));
+        for _ in 0..self.drain_batch {
+            let Some((_, write)) = pending.writes.pop_first() else {
+                break;
+            };
+            writes.push(write);
+        }
+        crate::runtime_metrics::record_snapshot_write_queue_depth(pending.writes.len() as u64);
+        writes
+    }
+
+    async fn apply(&self, write: QueuedSnapshotWrite) {
+        let span = tracing::info_span!(
+            "dispatch.phase.snapshot.queued",
+            otel.name = "dispatch.phase.snapshot.queued",
+            persistence_id = %write.persistence_id,
+            sequence_nr = write.sequence_nr,
+        );
+
+        async move {
+            let started_at = Instant::now();
+            crate::runtime_metrics::record_snapshot_write_started();
+            crate::runtime_metrics::record_snapshot_write_queue_wait(
+                started_at.duration_since(write.enqueued_at),
+            );
+            let result = self
+                .store
+                .save_snapshot(&write.persistence_id, write.sequence_nr, &write.snapshot)
+                .await;
+            let result_label = if result.is_ok() { "ok" } else { "error" };
+            crate::runtime_metrics::record_snapshot_write_duration(
+                result_label,
+                started_at.elapsed(),
+            );
+            crate::runtime_metrics::record_snapshot_write_end_to_end_duration(
+                result_label,
+                write.enqueued_at.elapsed(),
+            );
+
+            match result {
+                Ok(()) => {
+                    crate::runtime_metrics::record_snapshot_write_applied_sequence(
+                        write.sequence_nr,
+                    );
+                    self.record_applied_sequence(&write.persistence_id, write.sequence_nr);
+                }
+                Err(e) => {
+                    crate::runtime_metrics::record_snapshot_write_error();
+                    tracing::error!(
+                        error = %e,
+                        persistence_id = %write.persistence_id,
+                        sequence_nr = write.sequence_nr,
+                        "failed to persist queued snapshot"
+                    );
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    self.requeue_failed_write(write);
+                }
+            }
+        }
+        .instrument(span)
+        .await;
+    }
+
+    fn record_applied_sequence(&self, persistence_id: &str, sequence_nr: u64) {
+        let mut applied = self
+            .applied_sequences
+            .lock()
+            .expect("snapshot applied sequence mutex poisoned");
+        let entry = applied.entry(persistence_id.to_string()).or_insert(0);
+        if sequence_nr > *entry {
+            *entry = sequence_nr;
+        }
+    }
+
+    fn requeue_failed_write(&self, write: QueuedSnapshotWrite) {
+        let mut pending = self.pending.lock().expect("snapshot queue mutex poisoned");
+        if pending
+            .writes
+            .get(&write.persistence_id)
+            .is_some_and(|existing| existing.sequence_nr >= write.sequence_nr)
+        {
+            crate::runtime_metrics::record_snapshot_write_queue_depth(pending.writes.len() as u64);
+            return;
+        }
+        pending.writes.insert(write.persistence_id.clone(), write);
+        crate::runtime_metrics::record_snapshot_write_queue_depth(pending.writes.len() as u64);
+        drop(pending);
+        self.notify.notify_one();
+    }
+}
+
+fn snapshot_queue_capacity() -> usize {
+    std::env::var("TEMPER_SNAPSHOT_QUEUE_CAPACITY") // determinism-ok: production side-effect queue sizing
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_SNAPSHOT_QUEUE_CAPACITY)
+}
+
+fn snapshot_drain_batch() -> usize {
+    std::env::var("TEMPER_SNAPSHOT_DRAIN_BATCH") // determinism-ok: production side-effect queue sizing
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_SNAPSHOT_DRAIN_BATCH)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use temper_runtime::persistence::{
+        EventStore, PersistenceAppend, PersistenceAppendResult, PersistenceEnvelope,
+        PersistenceError,
+    };
+
+    #[derive(Default)]
+    struct RecordingEventStore {
+        saves: AtomicUsize,
+    }
+
+    impl EventStore for RecordingEventStore {
+        async fn append(
+            &self,
+            _persistence_id: &str,
+            expected_sequence: u64,
+            events: &[PersistenceEnvelope],
+        ) -> Result<u64, PersistenceError> {
+            Ok(expected_sequence + events.len() as u64)
+        }
+
+        async fn append_batch(
+            &self,
+            appends: &[PersistenceAppend],
+        ) -> Result<Vec<PersistenceAppendResult>, PersistenceError> {
+            Ok(appends
+                .iter()
+                .map(|append| PersistenceAppendResult {
+                    persistence_id: append.persistence_id.clone(),
+                    sequence_nr: append.expected_sequence + append.events.len() as u64,
+                })
+                .collect())
+        }
+
+        async fn read_events(
+            &self,
+            _persistence_id: &str,
+            _from_sequence: u64,
+        ) -> Result<Vec<PersistenceEnvelope>, PersistenceError> {
+            Ok(Vec::new())
+        }
+
+        async fn save_snapshot(
+            &self,
+            _persistence_id: &str,
+            _sequence_nr: u64,
+            _snapshot: &[u8],
+        ) -> Result<(), PersistenceError> {
+            self.saves.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn load_snapshot(
+            &self,
+            _persistence_id: &str,
+        ) -> Result<Option<(u64, Vec<u8>)>, PersistenceError> {
+            Ok(None)
+        }
+
+        async fn list_entity_ids(
+            &self,
+            _tenant: &str,
+        ) -> Result<Vec<(String, String)>, PersistenceError> {
+            Ok(Vec::new())
+        }
+
+        async fn list_entity_ids_by_type(
+            &self,
+            _tenant: &str,
+            _entity_type: &str,
+        ) -> Result<Vec<String>, PersistenceError> {
+            Ok(Vec::new())
+        }
+    }
+
+    #[test]
+    fn enqueue_coalesces_newer_snapshot_for_same_stream() {
+        let queue = SnapshotWriteQueue::new_for_test(
+            BoxedEventStore::new(RecordingEventStore::default()),
+            10,
+            10,
+        );
+
+        assert_eq!(
+            queue.enqueue("tenant:Session:s-1".to_string(), 1, vec![1]),
+            SnapshotEnqueueOutcome::Enqueued
+        );
+        assert_eq!(
+            queue.enqueue("tenant:Session:s-1".to_string(), 2, vec![2]),
+            SnapshotEnqueueOutcome::Coalesced
+        );
+
+        let writes = queue.take_batch();
+        assert_eq!(writes.len(), 1);
+        assert_eq!(writes[0].sequence_nr, 2);
+        assert_eq!(writes[0].snapshot, vec![2]);
+    }
+
+    #[test]
+    fn enqueue_skips_stale_snapshot_before_store_access() {
+        let queue = SnapshotWriteQueue::new_for_test(
+            BoxedEventStore::new(RecordingEventStore::default()),
+            10,
+            10,
+        );
+
+        assert_eq!(
+            queue.enqueue("tenant:Session:s-1".to_string(), 3, vec![3]),
+            SnapshotEnqueueOutcome::Enqueued
+        );
+        assert_eq!(
+            queue.enqueue("tenant:Session:s-1".to_string(), 2, vec![2]),
+            SnapshotEnqueueOutcome::StaleSkipped
+        );
+
+        let writes = queue.take_batch();
+        assert_eq!(writes.len(), 1);
+        assert_eq!(writes[0].sequence_nr, 3);
+    }
+
+    #[test]
+    fn enqueue_rejects_new_stream_when_capacity_is_exhausted() {
+        let queue = SnapshotWriteQueue::new_for_test(
+            BoxedEventStore::new(RecordingEventStore::default()),
+            1,
+            10,
+        );
+
+        assert_eq!(
+            queue.enqueue("tenant:Session:s-1".to_string(), 1, vec![1]),
+            SnapshotEnqueueOutcome::Enqueued
+        );
+        assert_eq!(
+            queue.enqueue("tenant:Session:s-2".to_string(), 1, vec![1]),
+            SnapshotEnqueueOutcome::Full
+        );
+    }
+}

--- a/crates/temper-server/src/lib.rs
+++ b/crates/temper-server/src/lib.rs
@@ -24,6 +24,7 @@ pub mod identity;
 #[cfg(feature = "observe")]
 pub mod observe;
 pub mod odata;
+pub(crate) mod ots_trajectory_outbox;
 pub mod platform_store;
 pub mod profiling;
 mod query_eval;

--- a/crates/temper-server/src/observe/evolution/trajectories.rs
+++ b/crates/temper-server/src/observe/evolution/trajectories.rs
@@ -295,7 +295,10 @@ pub(crate) async fn handle_post_ots_trajectory(
         data: body,
     };
 
-    match outbox.try_enqueue_metadata_store(backend, store, write) {
+    match outbox
+        .try_enqueue_metadata_store(backend, store, write)
+        .await
+    {
         Ok(()) => {
             tracing::info!(
                 tenant = %tenant,

--- a/crates/temper-server/src/observe/evolution/trajectories.rs
+++ b/crates/temper-server/src/observe/evolution/trajectories.rs
@@ -6,6 +6,7 @@ use temper_runtime::scheduler::{sim_now, sim_uuid};
 use tracing::instrument;
 
 use crate::authz::{observe_tenant_scope, require_observe_auth};
+use crate::ots_trajectory_outbox::{OtsTrajectoryEnqueueError, OtsTrajectoryWrite};
 use crate::state::{ServerState, TrajectoryEntry, TrajectorySource};
 
 /// Query parameters for the trajectory aggregation endpoint.
@@ -264,40 +265,57 @@ pub(crate) async fn handle_post_ots_trajectory(
         .and_then(|v| v.to_str().ok())
         .unwrap_or("default");
 
-    if let Some(store) = state.metadata_store_for_tenant(tenant).await {
-        store
-            .persist_ots_trajectory(&temper_store_turso::OtsTrajectoryParams {
-                trajectory_id: &trajectory_id,
-                tenant,
-                agent_id,
-                session_id,
-                outcome,
-                turn_count,
-                data: &body,
-            })
-            .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("failed to persist OTS trajectory: {e}"),
-                )
-            })?;
-
-        tracing::info!(
-            trajectory_id = %trajectory_id,
-            agent_id = %agent_id,
-            turn_count = turn_count,
-            outcome = %outcome,
-            "ots.trajectory.persisted"
-        );
-    } else {
+    let Some(store) = state.metadata_store_for_tenant(tenant).await else {
         tracing::warn!(
             tenant = %tenant,
             "no persistent store — OTS trajectory not persisted"
         );
-    }
+        return Ok(StatusCode::CREATED);
+    };
 
-    Ok(StatusCode::CREATED)
+    let Some((backend, outbox)) = state.ots_trajectory_outbox() else {
+        tracing::error!(
+            tenant = %tenant,
+            trajectory_id = %trajectory_id,
+            "OTS trajectory outbox unavailable despite configured metadata store"
+        );
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            "OTS trajectory persistence queue unavailable; retry upload".to_string(),
+        ));
+    };
+
+    let write = OtsTrajectoryWrite {
+        trajectory_id,
+        tenant: tenant.to_string(),
+        agent_id: agent_id.to_string(),
+        session_id: session_id.to_string(),
+        outcome: outcome.to_string(),
+        turn_count,
+        data: body,
+    };
+
+    match outbox.try_enqueue_metadata_store(backend, store, write) {
+        Ok(()) => {
+            tracing::info!(
+                tenant = %tenant,
+                agent_id = %agent_id,
+                session_id = %session_id,
+                turn_count = turn_count,
+                outcome = %outcome,
+                "ots.trajectory.queued"
+            );
+            Ok(StatusCode::ACCEPTED)
+        }
+        Err(OtsTrajectoryEnqueueError::Full) => Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            "OTS trajectory persistence queue full; retry upload".to_string(),
+        )),
+        Err(OtsTrajectoryEnqueueError::Closed) => Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            "OTS trajectory persistence queue closed; retry upload".to_string(),
+        )),
+    }
 }
 
 /// GET /api/ots/trajectories — list OTS trajectories with optional filters.

--- a/crates/temper-server/src/odata/query_plane_read/tests.rs
+++ b/crates/temper-server/src/odata/query_plane_read/tests.rs
@@ -5,6 +5,7 @@ use super::types::{
 use super::*;
 use crate::registry::SpecRegistry;
 use crate::request_context::AgentContext;
+use crate::storage::{CatalogRowsLoad, load_catalog_rows_by_id};
 use crate::{ServerState, StorageStack};
 use temper_authz::SecurityContext;
 use temper_odata::query::types::{
@@ -281,6 +282,79 @@ async fn row_authorized_first_page_can_stop_after_proof() {
         result.telemetry.strategy,
         QueryPlaneReadStrategy::ReadSourceCursor
     );
+}
+
+#[tokio::test]
+async fn projection_lagged_actor_write_repairs_missing_catalog_row() {
+    let db_path =
+        std::env::temp_dir().join(format!("temper-query-plane-lag-repair-{}.db", sim_uuid()));
+    let _ = std::fs::remove_file(&db_path);
+    let db_url = format!("file:{}", db_path.display());
+    let store = TursoEventStore::new(&db_url, None)
+        .await
+        .expect("create local turso db");
+    let mut state = build_order_state("query-plane-lag-repair");
+    create_orders(&state, 1).await;
+    state.set_storage_stack(StorageStack::from_turso(store.clone()));
+    let tenant = TenantId::default();
+
+    let security_ctx = SecurityContext::system();
+    let query_options = QueryOptions {
+        filter: Some(FilterExpr::BinaryOp {
+            left: Box::new(FilterExpr::Property("Id".to_string())),
+            op: BinaryOperator::Eq,
+            right: Box::new(FilterExpr::Literal(ODataValue::String(
+                "ord-00".to_string(),
+            ))),
+        }),
+        top: Some(1),
+        select: Some(vec!["Id".to_string(), "Status".to_string()]),
+        ..QueryOptions::default()
+    };
+
+    let result = match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+        state: &state,
+        tenant: &tenant,
+        security_ctx: &security_ctx,
+        entity_type: "Order",
+        entity_set_name: "Orders",
+        query_options: &query_options,
+        budget: QueryPlaneReadBudget {
+            default_page_size: 1,
+            max_entities: 10,
+        },
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => panic!("lagged projection should fall back to actor and repair"),
+    };
+
+    assert_eq!(result.entities.len(), 1);
+    assert_eq!(result.entities[0]["Id"].as_str(), Some("ord-00"));
+    assert_eq!(
+        result.telemetry.strategy,
+        QueryPlaneReadStrategy::ReadSourceCursor
+    );
+    assert_eq!(
+        result.telemetry.fallback_reason,
+        QueryPlaneFallbackReason::CatalogCoverageGap
+    );
+    assert_eq!(result.telemetry.coverage.missing, 1);
+
+    let ids = vec!["ord-00".to_string()];
+    let query_plane = state
+        .query_plane_store()
+        .expect("query-plane store should be configured");
+    let repaired = load_catalog_rows_by_id(&query_plane, tenant.as_str(), "Order", &ids)
+        .await
+        .expect("load repaired catalog row");
+    let CatalogRowsLoad::Available(rows) = repaired else {
+        panic!("turso catalog row load should be supported");
+    };
+    assert!(rows.contains_key("ord-00"));
+
+    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]

--- a/crates/temper-server/src/odata/query_plane_read/tests/proof.rs
+++ b/crates/temper-server/src/odata/query_plane_read/tests/proof.rs
@@ -157,6 +157,89 @@ async fn nullable_scalar_order_uses_read_source_full_proof() {
 }
 
 #[tokio::test]
+async fn context_prep_shaped_filter_with_huge_top_uses_bounded_native_page() {
+    let db_path = std::env::temp_dir().join(format!(
+        "temper-query-plane-session-filter-{}.db",
+        sim_uuid()
+    ));
+    let _ = std::fs::remove_file(&db_path);
+    let db_url = format!("file:{}", db_path.display());
+    let store = TursoEventStore::new(&db_url, None)
+        .await
+        .expect("create local turso db");
+    let mut state = build_order_state("query-plane-session-filter");
+    state.set_storage_stack(StorageStack::from_turso(store.clone()));
+    let tenant = TenantId::default();
+
+    for index in 0usize..1200 {
+        upsert_order_projection(
+            &store,
+            &tenant,
+            &format!("entry-{index:04}"),
+            serde_json::json!({
+                "SessionId": "session-hot",
+                "ParentEntryId": format!("entry-{:04}", index.saturating_sub(1)),
+            }),
+            index as u64 + 1,
+        )
+        .await;
+    }
+    upsert_order_projection(
+        &store,
+        &tenant,
+        "entry-other",
+        serde_json::json!({ "SessionId": "session-cold" }),
+        2000,
+    )
+    .await;
+
+    let security_ctx = SecurityContext::system();
+    let query_options = QueryOptions {
+        filter: Some(FilterExpr::BinaryOp {
+            left: Box::new(FilterExpr::Property("SessionId".to_string())),
+            op: BinaryOperator::Eq,
+            right: Box::new(FilterExpr::Literal(ODataValue::String(
+                "session-hot".to_string(),
+            ))),
+        }),
+        top: Some(10_000),
+        select: Some(vec!["Id".to_string(), "SessionId".to_string()]),
+        ..QueryOptions::default()
+    };
+
+    let result = match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+        state: &state,
+        tenant: &tenant,
+        security_ctx: &security_ctx,
+        entity_type: "Order",
+        entity_set_name: "Orders",
+        query_options: &query_options,
+        budget: QueryPlaneReadBudget {
+            default_page_size: 100,
+            max_entities: 1000,
+        },
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => panic!("context-prep shaped filtered read should use native page pushdown"),
+    };
+
+    assert_eq!(result.entities.len(), 1000);
+    assert_eq!(
+        result.telemetry.strategy,
+        QueryPlaneReadStrategy::NativePagePushdown
+    );
+    assert!(result.telemetry.filter_pushdown);
+    assert_eq!(result.telemetry.candidate_count, 1000);
+    assert_eq!(result.telemetry.materialized_count, 1000);
+    assert_eq!(result.telemetry.pushdown_page_count, 1000);
+    assert_eq!(result.telemetry.returned_count, 1000);
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
 async fn unsafe_order_uses_read_source_full_proof() {
     let db_path =
         std::env::temp_dir().join(format!("temper-query-plane-order-proof-{}.db", sim_uuid()));

--- a/crates/temper-server/src/odata/query_plane_read/tests/proof.rs
+++ b/crates/temper-server/src/odata/query_plane_read/tests/proof.rs
@@ -240,6 +240,156 @@ async fn context_prep_shaped_filter_with_huge_top_uses_bounded_native_page() {
 }
 
 #[tokio::test]
+async fn session_entry_chain_parent_lookup_uses_bounded_native_page() {
+    let db_dir = tempfile::tempdir().expect("create isolated query-plane db dir");
+    let db_path = db_dir.path().join("session-parent.db");
+    let db_url = format!("file:{}", db_path.display());
+    let store = TursoEventStore::new(&db_url, None)
+        .await
+        .expect("create local turso db");
+    let mut state = build_order_state("query-plane-session-parent");
+    state.set_storage_stack(StorageStack::from_turso(store.clone()));
+    let tenant = TenantId::default();
+
+    for index in 0usize..1200 {
+        upsert_order_projection(
+            &store,
+            &tenant,
+            &format!("entry-{index:04}"),
+            serde_json::json!({
+                "SessionId": "session-hot",
+                "ParentEntryId": format!("entry-{:04}", index.saturating_sub(1)),
+            }),
+            index as u64 + 1,
+        )
+        .await;
+    }
+
+    let security_ctx = SecurityContext::system();
+    let query_options = QueryOptions {
+        filter: Some(FilterExpr::BinaryOp {
+            left: Box::new(FilterExpr::Property("ParentEntryId".to_string())),
+            op: BinaryOperator::Eq,
+            right: Box::new(FilterExpr::Literal(ODataValue::String(
+                "entry-1198".to_string(),
+            ))),
+        }),
+        top: Some(1),
+        select: Some(vec![
+            "Id".to_string(),
+            "SessionId".to_string(),
+            "ParentEntryId".to_string(),
+        ]),
+        ..QueryOptions::default()
+    };
+
+    let result = match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+        state: &state,
+        tenant: &tenant,
+        security_ctx: &security_ctx,
+        entity_type: "Order",
+        entity_set_name: "Orders",
+        query_options: &query_options,
+        budget: QueryPlaneReadBudget {
+            default_page_size: 100,
+            max_entities: 1000,
+        },
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => panic!("SessionEntry parent lookup should use native page pushdown"),
+    };
+
+    assert_eq!(result.entities.len(), 1);
+    assert_eq!(result.entities[0]["Id"].as_str(), Some("entry-1199"));
+    assert_eq!(
+        result.entities[0]["ParentEntryId"].as_str(),
+        Some("entry-1198")
+    );
+    assert_eq!(
+        result.telemetry.strategy,
+        QueryPlaneReadStrategy::NativePagePushdown
+    );
+    assert!(result.telemetry.filter_pushdown);
+    assert_eq!(result.telemetry.candidate_count, 1);
+    assert_eq!(result.telemetry.pushdown_page_count, 1);
+}
+
+#[tokio::test]
+async fn session_entry_leaf_id_lookup_uses_bounded_native_page() {
+    let db_dir = tempfile::tempdir().expect("create isolated query-plane db dir");
+    let db_path = db_dir.path().join("session-leaf.db");
+    let db_url = format!("file:{}", db_path.display());
+    let store = TursoEventStore::new(&db_url, None)
+        .await
+        .expect("create local turso db");
+    let mut state = build_order_state("query-plane-session-leaf");
+    state.set_storage_stack(StorageStack::from_turso(store.clone()));
+    let tenant = TenantId::default();
+
+    for index in 0usize..1200 {
+        upsert_order_projection(
+            &store,
+            &tenant,
+            &format!("entry-{index:04}"),
+            serde_json::json!({
+                "SessionId": "session-hot",
+                "ParentEntryId": format!("entry-{:04}", index.saturating_sub(1)),
+            }),
+            index as u64 + 1,
+        )
+        .await;
+    }
+
+    let security_ctx = SecurityContext::system();
+    let query_options = QueryOptions {
+        filter: Some(FilterExpr::BinaryOp {
+            left: Box::new(FilterExpr::Property("Id".to_string())),
+            op: BinaryOperator::Eq,
+            right: Box::new(FilterExpr::Literal(ODataValue::String(
+                "entry-1199".to_string(),
+            ))),
+        }),
+        top: Some(1),
+        select: Some(vec![
+            "Id".to_string(),
+            "SessionId".to_string(),
+            "ParentEntryId".to_string(),
+        ]),
+        ..QueryOptions::default()
+    };
+
+    let result = match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+        state: &state,
+        tenant: &tenant,
+        security_ctx: &security_ctx,
+        entity_type: "Order",
+        entity_set_name: "Orders",
+        query_options: &query_options,
+        budget: QueryPlaneReadBudget {
+            default_page_size: 100,
+            max_entities: 1000,
+        },
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => panic!("SessionEntry leaf id lookup should use native page pushdown"),
+    };
+
+    assert_eq!(result.entities.len(), 1);
+    assert_eq!(result.entities[0]["Id"].as_str(), Some("entry-1199"));
+    assert_eq!(
+        result.telemetry.strategy,
+        QueryPlaneReadStrategy::NativePagePushdown
+    );
+    assert!(result.telemetry.filter_pushdown);
+    assert_eq!(result.telemetry.candidate_count, 1);
+    assert_eq!(result.telemetry.pushdown_page_count, 1);
+}
+
+#[tokio::test]
 async fn unsafe_order_uses_read_source_full_proof() {
     let db_path =
         std::env::temp_dir().join(format!("temper-query-plane-order-proof-{}.db", sim_uuid()));

--- a/crates/temper-server/src/ots_trajectory_outbox.rs
+++ b/crates/temper-server/src/ots_trajectory_outbox.rs
@@ -2,168 +2,26 @@
 #![cfg_attr(not(feature = "observe"), allow(dead_code))]
 
 use std::sync::{
-    Arc, OnceLock,
+    Arc,
     atomic::{AtomicU64, AtomicUsize, Ordering},
 };
 use std::time::{Duration, Instant};
 
-use opentelemetry::{
-    KeyValue, global,
-    metrics::{Counter, Gauge, Histogram},
-};
 use temper_runtime::persistence::PersistenceError;
 use temper_store_turso::OtsTrajectoryParams;
 use tokio::sync::mpsc;
 use tracing::Instrument;
 
-use crate::storage::{MetadataStore, OtsStore};
+use crate::storage::{MetadataStore, MetadataStoreProvider, OtsStore};
 
-const DEFAULT_CAPACITY: usize = 512;
-const DEFAULT_DRAIN_BATCH: usize = 16;
-const DEFAULT_MAX_ATTEMPTS: u32 = 5;
-const DEFAULT_RETRY_DELAY_MS: u64 = 100;
+mod config;
+mod metrics;
 
-struct OtsOutboxMetrics {
-    depth: Gauge<u64>,
-    capacity: Gauge<u64>,
-    enqueued_total: Counter<u64>,
-    rejected_total: Counter<u64>,
-    retry_total: Counter<u64>,
-    persisted_total: Counter<u64>,
-    failed_total: Counter<u64>,
-    persist_latency_ms: Histogram<f64>,
-}
-
-fn metrics() -> &'static OtsOutboxMetrics {
-    static METRICS: OnceLock<OtsOutboxMetrics> = OnceLock::new();
-    METRICS.get_or_init(|| {
-        let meter = global::meter("temper.runtime");
-        OtsOutboxMetrics {
-            depth: meter
-                .u64_gauge("temper_ots_trajectory_outbox_depth")
-                .with_description("Current number of OTS trajectory artifacts pending persistence.")
-                .build(),
-            capacity: meter
-                .u64_gauge("temper_ots_trajectory_outbox_capacity")
-                .with_description("Configured OTS trajectory persistence outbox capacity.")
-                .build(),
-            enqueued_total: meter
-                .u64_counter("temper_ots_trajectory_outbox_enqueued_total")
-                .with_description("OTS trajectory artifacts accepted by the persistence outbox.")
-                .build(),
-            rejected_total: meter
-                .u64_counter("temper_ots_trajectory_outbox_rejected_total")
-                .with_description("OTS trajectory artifacts rejected because the outbox was full.")
-                .build(),
-            retry_total: meter
-                .u64_counter("temper_ots_trajectory_outbox_retry_total")
-                .with_description("OTS trajectory persistence attempts scheduled for retry.")
-                .build(),
-            persisted_total: meter
-                .u64_counter("temper_ots_trajectory_outbox_persisted_total")
-                .with_description("OTS trajectory artifacts persisted by the outbox.")
-                .build(),
-            failed_total: meter
-                .u64_counter("temper_ots_trajectory_outbox_failed_total")
-                .with_description("OTS trajectory artifacts that exhausted outbox retries.")
-                .build(),
-            persist_latency_ms: meter
-                .f64_histogram("temper_ots_trajectory_outbox_persist_latency_ms")
-                .with_unit("ms")
-                .with_description("Wall time for one OTS trajectory persistence attempt.")
-                .build(),
-        }
-    })
-}
-
-fn env_usize(name: &str, default: usize) -> usize {
-    std::env::var(name) // determinism-ok: observe persistence queue config read at startup
-        .ok()
-        .and_then(|value| value.trim().parse::<usize>().ok())
-        .filter(|value| *value > 0)
-        .unwrap_or(default)
-}
-
-fn env_u32(name: &str, default: u32) -> u32 {
-    std::env::var(name) // determinism-ok: observe persistence queue config read at startup
-        .ok()
-        .and_then(|value| value.trim().parse::<u32>().ok())
-        .filter(|value| *value > 0)
-        .unwrap_or(default)
-}
-
-fn env_u64(name: &str, default: u64) -> u64 {
-    std::env::var(name) // determinism-ok: observe persistence queue config read at startup
-        .ok()
-        .and_then(|value| value.trim().parse::<u64>().ok())
-        .filter(|value| *value > 0)
-        .unwrap_or(default)
-}
-
-fn outbox_config() -> OtsTrajectoryOutboxConfig {
-    OtsTrajectoryOutboxConfig {
-        capacity: env_usize("TEMPER_OTS_TRAJECTORY_OUTBOX_CAPACITY", DEFAULT_CAPACITY),
-        drain_batch: env_usize("TEMPER_OTS_TRAJECTORY_DRAIN_BATCH", DEFAULT_DRAIN_BATCH),
-        max_attempts: env_u32("TEMPER_OTS_TRAJECTORY_MAX_ATTEMPTS", DEFAULT_MAX_ATTEMPTS),
-        retry_delay: Duration::from_millis(env_u64(
-            "TEMPER_OTS_TRAJECTORY_RETRY_DELAY_MS",
-            DEFAULT_RETRY_DELAY_MS,
-        )),
-    }
-}
-
-fn attrs(item: &OtsTrajectoryWrite, backend: &'static str) -> [KeyValue; 3] {
-    [
-        KeyValue::new("tenant", item.tenant.clone()),
-        KeyValue::new("outcome", item.outcome.clone()),
-        KeyValue::new("backend", backend.to_string()),
-    ]
-}
-
-fn record_depth(depth: usize) {
-    metrics().depth.record(depth as u64, &[]);
-}
-
-fn record_capacity(capacity: usize) {
-    metrics().capacity.record(capacity as u64, &[]);
-}
-
-fn record_enqueue(item: &OtsTrajectoryWrite, backend: &'static str) {
-    metrics().enqueued_total.add(1, &attrs(item, backend));
-}
-
-fn record_rejected(item: &OtsTrajectoryWrite, backend: &'static str) {
-    metrics().rejected_total.add(1, &attrs(item, backend));
-}
-
-fn record_retry(item: &OtsTrajectoryWrite, backend: &'static str) {
-    metrics().retry_total.add(1, &attrs(item, backend));
-}
-
-fn record_persisted(item: &OtsTrajectoryWrite, backend: &'static str) {
-    metrics().persisted_total.add(1, &attrs(item, backend));
-}
-
-fn record_failed(item: &OtsTrajectoryWrite, backend: &'static str) {
-    metrics().failed_total.add(1, &attrs(item, backend));
-}
-
-fn record_persist_latency(
-    item: &OtsTrajectoryWrite,
-    backend: &'static str,
-    result: &str,
-    duration: Duration,
-) {
-    let attrs = [
-        KeyValue::new("tenant", item.tenant.clone()),
-        KeyValue::new("outcome", item.outcome.clone()),
-        KeyValue::new("backend", backend.to_string()),
-        KeyValue::new("result", result.to_string()),
-    ];
-    metrics()
-        .persist_latency_ms
-        .record(duration.as_secs_f64() * 1000.0, &attrs);
-}
+use config::outbox_config;
+use metrics::{
+    record_capacity, record_depth, record_enqueue, record_failed, record_persist_latency,
+    record_persisted, record_rejected, record_retry,
+};
 
 #[derive(Clone)]
 struct OtsTrajectoryOutboxConfig {
@@ -246,13 +104,85 @@ impl OtsTrajectoryOutbox {
         outbox
     }
 
-    pub(crate) fn try_enqueue_metadata_store(
+    pub(crate) async fn try_enqueue_metadata_store(
         &self,
         backend: &'static str,
         store: Arc<dyn MetadataStore>,
         item: OtsTrajectoryWrite,
     ) -> Result<(), OtsTrajectoryEnqueueError> {
-        self.try_enqueue(backend, Arc::new(MetadataOtsStore { inner: store }), item)
+        let store = Arc::new(MetadataOtsStore { inner: store });
+        store
+            .enqueue_ots_trajectory(&item.params())
+            .await
+            .map_err(|error| {
+                tracing::warn!(
+                    tenant = %item.tenant,
+                    trajectory_id = %item.trajectory_id,
+                    error = %error,
+                    "failed to durably enqueue OTS trajectory"
+                );
+                OtsTrajectoryEnqueueError::Closed
+            })?;
+        self.try_enqueue(backend, store, item)
+    }
+
+    pub(crate) fn recover_queued_metadata_stores(
+        self: &Arc<Self>,
+        backend: &'static str,
+        provider: Arc<dyn MetadataStoreProvider>,
+    ) {
+        let outbox = Arc::clone(self);
+        tokio::spawn(async move { outbox.recover_queued(backend, provider).await }); // determinism-ok: external observe persistence recovery
+    }
+
+    async fn recover_queued(
+        self: Arc<Self>,
+        backend: &'static str,
+        provider: Arc<dyn MetadataStoreProvider>,
+    ) {
+        let stores = provider.all_stores().await;
+        for store in stores {
+            let rows = match store.list_queued_ots_trajectories(1024).await {
+                Ok(rows) => rows,
+                Err(error) => {
+                    tracing::warn!(error = %error, "failed to load queued OTS trajectories for recovery");
+                    continue;
+                }
+            };
+            for row in rows {
+                let item = OtsTrajectoryWrite {
+                    trajectory_id: row.trajectory_id,
+                    tenant: row.tenant,
+                    agent_id: row.agent_id,
+                    session_id: row.session_id,
+                    outcome: row.outcome,
+                    turn_count: row.turn_count,
+                    data: row.data,
+                };
+                if let Err(error) = self.try_enqueue_recovered(
+                    backend,
+                    Arc::new(MetadataOtsStore {
+                        inner: store.clone(),
+                    }),
+                    item,
+                ) {
+                    tracing::warn!(
+                        ?error,
+                        "OTS trajectory recovery queue full or closed; row remains durable"
+                    );
+                    break;
+                }
+            }
+        }
+    }
+
+    fn try_enqueue_recovered(
+        &self,
+        backend: &'static str,
+        store: Arc<dyn OtsStore>,
+        item: OtsTrajectoryWrite,
+    ) -> Result<(), OtsTrajectoryEnqueueError> {
+        self.try_enqueue(backend, store, item)
     }
 
     fn try_enqueue(
@@ -343,6 +273,19 @@ impl OtsTrajectoryOutbox {
     ) -> Result<(), OtsTrajectoryEnqueueError> {
         self.try_enqueue("test", store, item)
     }
+
+    #[cfg(test)]
+    async fn try_enqueue_durable_for_tests(
+        &self,
+        store: Arc<dyn OtsStore>,
+        item: OtsTrajectoryWrite,
+    ) -> Result<(), OtsTrajectoryEnqueueError> {
+        store
+            .enqueue_ots_trajectory(&item.params())
+            .await
+            .map_err(|_| OtsTrajectoryEnqueueError::Closed)?;
+        self.try_enqueue("test", store, item)
+    }
 }
 
 async fn run_worker(
@@ -387,7 +330,7 @@ async fn persist_with_retries(
             let started_at = Instant::now();
             match queued
                 .store
-                .persist_ots_trajectory(&queued.item.params())
+                .mark_ots_trajectory_persisted(&queued.item.trajectory_id)
                 .await
             {
                 Ok(()) => {
@@ -434,6 +377,16 @@ async fn persist_with_retries(
                     );
                     record_failed(&queued.item, queued.backend);
                     failed_total.fetch_add(1, Ordering::Relaxed);
+                    if let Err(mark_error) = queued
+                        .store
+                        .mark_ots_trajectory_failed(&queued.item.trajectory_id, &error.to_string())
+                        .await
+                    {
+                        tracing::error!(
+                            error = %mark_error,
+                            "failed to mark OTS trajectory outbox row as failed"
+                        );
+                    }
                     tracing::error!(
                         error = %error,
                         attempts = attempt,
@@ -459,6 +412,39 @@ impl OtsStore for MetadataOtsStore {
         params: &OtsTrajectoryParams<'_>,
     ) -> Result<(), PersistenceError> {
         self.inner.persist_ots_trajectory(params).await
+    }
+
+    async fn enqueue_ots_trajectory(
+        &self,
+        params: &OtsTrajectoryParams<'_>,
+    ) -> Result<(), PersistenceError> {
+        self.inner.enqueue_ots_trajectory(params).await
+    }
+
+    async fn mark_ots_trajectory_persisted(
+        &self,
+        trajectory_id: &str,
+    ) -> Result<(), PersistenceError> {
+        self.inner
+            .mark_ots_trajectory_persisted(trajectory_id)
+            .await
+    }
+
+    async fn mark_ots_trajectory_failed(
+        &self,
+        trajectory_id: &str,
+        error: &str,
+    ) -> Result<(), PersistenceError> {
+        self.inner
+            .mark_ots_trajectory_failed(trajectory_id, error)
+            .await
+    }
+
+    async fn list_queued_ots_trajectories(
+        &self,
+        limit: i64,
+    ) -> Result<Vec<temper_store_turso::OtsQueuedTrajectoryRow>, PersistenceError> {
+        self.inner.list_queued_ots_trajectories(limit).await
     }
 
     async fn list_ots_trajectories(

--- a/crates/temper-server/src/ots_trajectory_outbox.rs
+++ b/crates/temper-server/src/ots_trajectory_outbox.rs
@@ -1,0 +1,485 @@
+//! Bounded, retrying background persistence for full OTS trajectory artifacts.
+#![cfg_attr(not(feature = "observe"), allow(dead_code))]
+
+use std::sync::{
+    Arc, OnceLock,
+    atomic::{AtomicU64, AtomicUsize, Ordering},
+};
+use std::time::{Duration, Instant};
+
+use opentelemetry::{
+    KeyValue, global,
+    metrics::{Counter, Gauge, Histogram},
+};
+use temper_runtime::persistence::PersistenceError;
+use temper_store_turso::OtsTrajectoryParams;
+use tokio::sync::mpsc;
+use tracing::Instrument;
+
+use crate::storage::{MetadataStore, OtsStore};
+
+const DEFAULT_CAPACITY: usize = 512;
+const DEFAULT_DRAIN_BATCH: usize = 16;
+const DEFAULT_MAX_ATTEMPTS: u32 = 5;
+const DEFAULT_RETRY_DELAY_MS: u64 = 100;
+
+struct OtsOutboxMetrics {
+    depth: Gauge<u64>,
+    capacity: Gauge<u64>,
+    enqueued_total: Counter<u64>,
+    rejected_total: Counter<u64>,
+    retry_total: Counter<u64>,
+    persisted_total: Counter<u64>,
+    failed_total: Counter<u64>,
+    persist_latency_ms: Histogram<f64>,
+}
+
+fn metrics() -> &'static OtsOutboxMetrics {
+    static METRICS: OnceLock<OtsOutboxMetrics> = OnceLock::new();
+    METRICS.get_or_init(|| {
+        let meter = global::meter("temper.runtime");
+        OtsOutboxMetrics {
+            depth: meter
+                .u64_gauge("temper_ots_trajectory_outbox_depth")
+                .with_description("Current number of OTS trajectory artifacts pending persistence.")
+                .build(),
+            capacity: meter
+                .u64_gauge("temper_ots_trajectory_outbox_capacity")
+                .with_description("Configured OTS trajectory persistence outbox capacity.")
+                .build(),
+            enqueued_total: meter
+                .u64_counter("temper_ots_trajectory_outbox_enqueued_total")
+                .with_description("OTS trajectory artifacts accepted by the persistence outbox.")
+                .build(),
+            rejected_total: meter
+                .u64_counter("temper_ots_trajectory_outbox_rejected_total")
+                .with_description("OTS trajectory artifacts rejected because the outbox was full.")
+                .build(),
+            retry_total: meter
+                .u64_counter("temper_ots_trajectory_outbox_retry_total")
+                .with_description("OTS trajectory persistence attempts scheduled for retry.")
+                .build(),
+            persisted_total: meter
+                .u64_counter("temper_ots_trajectory_outbox_persisted_total")
+                .with_description("OTS trajectory artifacts persisted by the outbox.")
+                .build(),
+            failed_total: meter
+                .u64_counter("temper_ots_trajectory_outbox_failed_total")
+                .with_description("OTS trajectory artifacts that exhausted outbox retries.")
+                .build(),
+            persist_latency_ms: meter
+                .f64_histogram("temper_ots_trajectory_outbox_persist_latency_ms")
+                .with_unit("ms")
+                .with_description("Wall time for one OTS trajectory persistence attempt.")
+                .build(),
+        }
+    })
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name) // determinism-ok: observe persistence queue config read at startup
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(default)
+}
+
+fn env_u32(name: &str, default: u32) -> u32 {
+    std::env::var(name) // determinism-ok: observe persistence queue config read at startup
+        .ok()
+        .and_then(|value| value.trim().parse::<u32>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(default)
+}
+
+fn env_u64(name: &str, default: u64) -> u64 {
+    std::env::var(name) // determinism-ok: observe persistence queue config read at startup
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(default)
+}
+
+fn outbox_config() -> OtsTrajectoryOutboxConfig {
+    OtsTrajectoryOutboxConfig {
+        capacity: env_usize("TEMPER_OTS_TRAJECTORY_OUTBOX_CAPACITY", DEFAULT_CAPACITY),
+        drain_batch: env_usize("TEMPER_OTS_TRAJECTORY_DRAIN_BATCH", DEFAULT_DRAIN_BATCH),
+        max_attempts: env_u32("TEMPER_OTS_TRAJECTORY_MAX_ATTEMPTS", DEFAULT_MAX_ATTEMPTS),
+        retry_delay: Duration::from_millis(env_u64(
+            "TEMPER_OTS_TRAJECTORY_RETRY_DELAY_MS",
+            DEFAULT_RETRY_DELAY_MS,
+        )),
+    }
+}
+
+fn attrs(item: &OtsTrajectoryWrite, backend: &'static str) -> [KeyValue; 3] {
+    [
+        KeyValue::new("tenant", item.tenant.clone()),
+        KeyValue::new("outcome", item.outcome.clone()),
+        KeyValue::new("backend", backend.to_string()),
+    ]
+}
+
+fn record_depth(depth: usize) {
+    metrics().depth.record(depth as u64, &[]);
+}
+
+fn record_capacity(capacity: usize) {
+    metrics().capacity.record(capacity as u64, &[]);
+}
+
+fn record_enqueue(item: &OtsTrajectoryWrite, backend: &'static str) {
+    metrics().enqueued_total.add(1, &attrs(item, backend));
+}
+
+fn record_rejected(item: &OtsTrajectoryWrite, backend: &'static str) {
+    metrics().rejected_total.add(1, &attrs(item, backend));
+}
+
+fn record_retry(item: &OtsTrajectoryWrite, backend: &'static str) {
+    metrics().retry_total.add(1, &attrs(item, backend));
+}
+
+fn record_persisted(item: &OtsTrajectoryWrite, backend: &'static str) {
+    metrics().persisted_total.add(1, &attrs(item, backend));
+}
+
+fn record_failed(item: &OtsTrajectoryWrite, backend: &'static str) {
+    metrics().failed_total.add(1, &attrs(item, backend));
+}
+
+fn record_persist_latency(
+    item: &OtsTrajectoryWrite,
+    backend: &'static str,
+    result: &str,
+    duration: Duration,
+) {
+    let attrs = [
+        KeyValue::new("tenant", item.tenant.clone()),
+        KeyValue::new("outcome", item.outcome.clone()),
+        KeyValue::new("backend", backend.to_string()),
+        KeyValue::new("result", result.to_string()),
+    ];
+    metrics()
+        .persist_latency_ms
+        .record(duration.as_secs_f64() * 1000.0, &attrs);
+}
+
+#[derive(Clone)]
+struct OtsTrajectoryOutboxConfig {
+    capacity: usize,
+    drain_batch: usize,
+    max_attempts: u32,
+    retry_delay: Duration,
+}
+
+/// Owned OTS trajectory artifact ready for background persistence.
+#[derive(Clone, Debug)]
+pub(crate) struct OtsTrajectoryWrite {
+    pub trajectory_id: String,
+    pub tenant: String,
+    pub agent_id: String,
+    pub session_id: String,
+    pub outcome: String,
+    pub turn_count: i64,
+    pub data: String,
+}
+
+impl OtsTrajectoryWrite {
+    fn params(&self) -> OtsTrajectoryParams<'_> {
+        OtsTrajectoryParams {
+            trajectory_id: &self.trajectory_id,
+            tenant: &self.tenant,
+            agent_id: &self.agent_id,
+            session_id: &self.session_id,
+            outcome: &self.outcome,
+            turn_count: self.turn_count,
+            data: &self.data,
+        }
+    }
+}
+
+struct QueuedOtsTrajectory {
+    store: Arc<dyn OtsStore>,
+    backend: &'static str,
+    item: OtsTrajectoryWrite,
+}
+
+/// Bounded queue for OTS trajectory artifacts.
+pub(crate) struct OtsTrajectoryOutbox {
+    sender: mpsc::Sender<QueuedOtsTrajectory>,
+    config: OtsTrajectoryOutboxConfig,
+    depth: Arc<AtomicUsize>,
+    rejected_total: Arc<AtomicU64>,
+    #[cfg(test)]
+    failed_total: Arc<AtomicU64>,
+}
+
+/// Rejection reason for OTS trajectory enqueue attempts.
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum OtsTrajectoryEnqueueError {
+    Full,
+    Closed,
+}
+
+impl OtsTrajectoryOutbox {
+    /// Start the OTS outbox with production configuration.
+    pub(crate) fn start() -> Arc<Self> {
+        Self::start_with_config(outbox_config())
+    }
+
+    fn start_with_config(config: OtsTrajectoryOutboxConfig) -> Arc<Self> {
+        let (sender, receiver) = mpsc::channel(config.capacity);
+        let depth = Arc::new(AtomicUsize::new(0));
+        let failed_total = Arc::new(AtomicU64::new(0));
+        let outbox = Arc::new(Self {
+            sender,
+            config: config.clone(),
+            depth: Arc::clone(&depth),
+            rejected_total: Arc::new(AtomicU64::new(0)),
+            #[cfg(test)]
+            failed_total: Arc::clone(&failed_total),
+        });
+        record_capacity(config.capacity);
+        record_depth(0);
+        tokio::spawn(run_worker(receiver, depth, failed_total, config)); // determinism-ok: external observe persistence
+        outbox
+    }
+
+    pub(crate) fn try_enqueue_metadata_store(
+        &self,
+        backend: &'static str,
+        store: Arc<dyn MetadataStore>,
+        item: OtsTrajectoryWrite,
+    ) -> Result<(), OtsTrajectoryEnqueueError> {
+        self.try_enqueue(backend, Arc::new(MetadataOtsStore { inner: store }), item)
+    }
+
+    fn try_enqueue(
+        &self,
+        backend: &'static str,
+        store: Arc<dyn OtsStore>,
+        item: OtsTrajectoryWrite,
+    ) -> Result<(), OtsTrajectoryEnqueueError> {
+        let prev = self.depth.fetch_add(1, Ordering::Relaxed);
+        if prev >= self.config.capacity {
+            self.depth.fetch_sub(1, Ordering::Relaxed);
+            self.rejected_total.fetch_add(1, Ordering::Relaxed);
+            record_depth(self.depth.load(Ordering::Relaxed));
+            record_rejected(&item, backend);
+            tracing::warn!(
+                tenant = %item.tenant,
+                trajectory_id = %item.trajectory_id,
+                agent_id = %item.agent_id,
+                session_id = %item.session_id,
+                "OTS trajectory outbox full; rejecting upload for retry"
+            );
+            return Err(OtsTrajectoryEnqueueError::Full);
+        }
+
+        let metric_item = item.clone();
+        let queued = QueuedOtsTrajectory {
+            store,
+            backend,
+            item,
+        };
+        match self.sender.try_send(queued) {
+            Ok(()) => {
+                record_enqueue(&metric_item, backend);
+                record_depth(self.depth.load(Ordering::Relaxed));
+                Ok(())
+            }
+            Err(mpsc::error::TrySendError::Full(queued)) => {
+                self.depth.fetch_sub(1, Ordering::Relaxed);
+                self.rejected_total.fetch_add(1, Ordering::Relaxed);
+                record_rejected(&queued.item, backend);
+                record_depth(self.depth.load(Ordering::Relaxed));
+                Err(OtsTrajectoryEnqueueError::Full)
+            }
+            Err(mpsc::error::TrySendError::Closed(queued)) => {
+                self.depth.fetch_sub(1, Ordering::Relaxed);
+                record_failed(&queued.item, backend);
+                record_depth(self.depth.load(Ordering::Relaxed));
+                Err(OtsTrajectoryEnqueueError::Closed)
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn depth(&self) -> usize {
+        self.depth.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    fn rejected_total(&self) -> u64 {
+        self.rejected_total.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    fn failed_total(&self) -> u64 {
+        self.failed_total.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    fn start_for_tests(
+        capacity: usize,
+        drain_batch: usize,
+        max_attempts: u32,
+        retry_delay: Duration,
+    ) -> Arc<Self> {
+        Self::start_with_config(OtsTrajectoryOutboxConfig {
+            capacity,
+            drain_batch,
+            max_attempts,
+            retry_delay,
+        })
+    }
+
+    #[cfg(test)]
+    fn try_enqueue_for_tests(
+        &self,
+        store: Arc<dyn OtsStore>,
+        item: OtsTrajectoryWrite,
+    ) -> Result<(), OtsTrajectoryEnqueueError> {
+        self.try_enqueue("test", store, item)
+    }
+}
+
+async fn run_worker(
+    mut receiver: mpsc::Receiver<QueuedOtsTrajectory>,
+    depth: Arc<AtomicUsize>,
+    failed_total: Arc<AtomicU64>,
+    config: OtsTrajectoryOutboxConfig,
+) {
+    while let Some(first) = receiver.recv().await {
+        let mut batch = Vec::with_capacity(config.drain_batch);
+        batch.push(first);
+        while batch.len() < config.drain_batch {
+            match receiver.try_recv() {
+                Ok(item) => batch.push(item),
+                Err(_) => break,
+            }
+        }
+        for item in batch {
+            persist_with_retries(item, &config, &failed_total).await;
+            depth.fetch_sub(1, Ordering::Relaxed);
+            record_depth(depth.load(Ordering::Relaxed));
+        }
+    }
+}
+
+async fn persist_with_retries(
+    queued: QueuedOtsTrajectory,
+    config: &OtsTrajectoryOutboxConfig,
+    failed_total: &AtomicU64,
+) {
+    let span = tracing::info_span!(
+        "ots_trajectory_outbox.persist",
+        tenant = %queued.item.tenant,
+        trajectory_id = %queued.item.trajectory_id,
+        agent_id = %queued.item.agent_id,
+        session_id = %queued.item.session_id,
+        backend = queued.backend,
+    );
+    async move {
+        let mut attempt = 1;
+        loop {
+            let started_at = Instant::now();
+            match queued
+                .store
+                .persist_ots_trajectory(&queued.item.params())
+                .await
+            {
+                Ok(()) => {
+                    record_persist_latency(
+                        &queued.item,
+                        queued.backend,
+                        "ok",
+                        started_at.elapsed(),
+                    );
+                    record_persisted(&queued.item, queued.backend);
+                    tracing::info!(
+                        trajectory_id = %queued.item.trajectory_id,
+                        agent_id = %queued.item.agent_id,
+                        turn_count = queued.item.turn_count,
+                        outcome = %queued.item.outcome,
+                        attempts = attempt,
+                        "ots.trajectory.persisted"
+                    );
+                    return;
+                }
+                Err(error) if attempt < config.max_attempts => {
+                    record_persist_latency(
+                        &queued.item,
+                        queued.backend,
+                        "retry",
+                        started_at.elapsed(),
+                    );
+                    record_retry(&queued.item, queued.backend);
+                    tracing::warn!(
+                        error = %error,
+                        attempt = attempt,
+                        max_attempts = config.max_attempts,
+                        "OTS trajectory persistence failed; retrying"
+                    );
+                    attempt += 1;
+                    tokio::time::sleep(config.retry_delay).await;
+                }
+                Err(error) => {
+                    record_persist_latency(
+                        &queued.item,
+                        queued.backend,
+                        "failed",
+                        started_at.elapsed(),
+                    );
+                    record_failed(&queued.item, queued.backend);
+                    failed_total.fetch_add(1, Ordering::Relaxed);
+                    tracing::error!(
+                        error = %error,
+                        attempts = attempt,
+                        "OTS trajectory persistence exhausted retries"
+                    );
+                    return;
+                }
+            }
+        }
+    }
+    .instrument(span)
+    .await;
+}
+
+struct MetadataOtsStore {
+    inner: Arc<dyn MetadataStore>,
+}
+
+#[async_trait::async_trait]
+impl OtsStore for MetadataOtsStore {
+    async fn persist_ots_trajectory(
+        &self,
+        params: &OtsTrajectoryParams<'_>,
+    ) -> Result<(), PersistenceError> {
+        self.inner.persist_ots_trajectory(params).await
+    }
+
+    async fn list_ots_trajectories(
+        &self,
+        tenant: &str,
+        agent_id: Option<&str>,
+        outcome: Option<&str>,
+        limit: i64,
+    ) -> Result<Vec<temper_store_turso::OtsTrajectoryRow>, PersistenceError> {
+        self.inner
+            .list_ots_trajectories(tenant, agent_id, outcome, limit)
+            .await
+    }
+
+    async fn get_ots_trajectory(
+        &self,
+        trajectory_id: &str,
+    ) -> Result<Option<String>, PersistenceError> {
+        self.inner.get_ots_trajectory(trajectory_id).await
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/temper-server/src/ots_trajectory_outbox/config.rs
+++ b/crates/temper-server/src/ots_trajectory_outbox/config.rs
@@ -1,0 +1,44 @@
+use std::time::Duration;
+
+use super::OtsTrajectoryOutboxConfig;
+
+const DEFAULT_CAPACITY: usize = 512;
+const DEFAULT_DRAIN_BATCH: usize = 16;
+const DEFAULT_MAX_ATTEMPTS: u32 = 5;
+const DEFAULT_RETRY_DELAY_MS: u64 = 100;
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name) // determinism-ok: observe persistence queue config read at startup
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(default)
+}
+
+fn env_u32(name: &str, default: u32) -> u32 {
+    std::env::var(name) // determinism-ok: observe persistence queue config read at startup
+        .ok()
+        .and_then(|value| value.trim().parse::<u32>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(default)
+}
+
+fn env_u64(name: &str, default: u64) -> u64 {
+    std::env::var(name) // determinism-ok: observe persistence queue config read at startup
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(default)
+}
+
+pub(super) fn outbox_config() -> OtsTrajectoryOutboxConfig {
+    OtsTrajectoryOutboxConfig {
+        capacity: env_usize("TEMPER_OTS_TRAJECTORY_OUTBOX_CAPACITY", DEFAULT_CAPACITY),
+        drain_batch: env_usize("TEMPER_OTS_TRAJECTORY_DRAIN_BATCH", DEFAULT_DRAIN_BATCH),
+        max_attempts: env_u32("TEMPER_OTS_TRAJECTORY_MAX_ATTEMPTS", DEFAULT_MAX_ATTEMPTS),
+        retry_delay: Duration::from_millis(env_u64(
+            "TEMPER_OTS_TRAJECTORY_RETRY_DELAY_MS",
+            DEFAULT_RETRY_DELAY_MS,
+        )),
+    }
+}

--- a/crates/temper-server/src/ots_trajectory_outbox/metrics.rs
+++ b/crates/temper-server/src/ots_trajectory_outbox/metrics.rs
@@ -1,0 +1,115 @@
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use opentelemetry::{
+    KeyValue, global,
+    metrics::{Counter, Gauge, Histogram},
+};
+
+use super::OtsTrajectoryWrite;
+
+struct OtsOutboxMetrics {
+    depth: Gauge<u64>,
+    capacity: Gauge<u64>,
+    enqueued_total: Counter<u64>,
+    rejected_total: Counter<u64>,
+    retry_total: Counter<u64>,
+    persisted_total: Counter<u64>,
+    failed_total: Counter<u64>,
+    persist_latency_ms: Histogram<f64>,
+}
+
+fn metrics() -> &'static OtsOutboxMetrics {
+    static METRICS: OnceLock<OtsOutboxMetrics> = OnceLock::new();
+    METRICS.get_or_init(|| {
+        let meter = global::meter("temper.runtime");
+        OtsOutboxMetrics {
+            depth: meter
+                .u64_gauge("temper_ots_trajectory_outbox_depth")
+                .with_description("Current number of OTS trajectory artifacts pending persistence.")
+                .build(),
+            capacity: meter
+                .u64_gauge("temper_ots_trajectory_outbox_capacity")
+                .with_description("Configured OTS trajectory persistence outbox capacity.")
+                .build(),
+            enqueued_total: meter
+                .u64_counter("temper_ots_trajectory_outbox_enqueued_total")
+                .with_description("OTS trajectory artifacts accepted by the persistence outbox.")
+                .build(),
+            rejected_total: meter
+                .u64_counter("temper_ots_trajectory_outbox_rejected_total")
+                .with_description("OTS trajectory artifacts rejected because the outbox was full.")
+                .build(),
+            retry_total: meter
+                .u64_counter("temper_ots_trajectory_outbox_retry_total")
+                .with_description("OTS trajectory persistence attempts scheduled for retry.")
+                .build(),
+            persisted_total: meter
+                .u64_counter("temper_ots_trajectory_outbox_persisted_total")
+                .with_description("OTS trajectory artifacts persisted by the outbox.")
+                .build(),
+            failed_total: meter
+                .u64_counter("temper_ots_trajectory_outbox_failed_total")
+                .with_description("OTS trajectory artifacts that exhausted outbox retries.")
+                .build(),
+            persist_latency_ms: meter
+                .f64_histogram("temper_ots_trajectory_outbox_persist_latency_ms")
+                .with_unit("ms")
+                .with_description("Wall time for one OTS trajectory persistence attempt.")
+                .build(),
+        }
+    })
+}
+
+fn attrs(item: &OtsTrajectoryWrite, backend: &'static str) -> [KeyValue; 3] {
+    [
+        KeyValue::new("tenant", item.tenant.clone()),
+        KeyValue::new("outcome", item.outcome.clone()),
+        KeyValue::new("backend", backend.to_string()),
+    ]
+}
+
+pub(super) fn record_depth(depth: usize) {
+    metrics().depth.record(depth as u64, &[]);
+}
+
+pub(super) fn record_capacity(capacity: usize) {
+    metrics().capacity.record(capacity as u64, &[]);
+}
+
+pub(super) fn record_enqueue(item: &OtsTrajectoryWrite, backend: &'static str) {
+    metrics().enqueued_total.add(1, &attrs(item, backend));
+}
+
+pub(super) fn record_rejected(item: &OtsTrajectoryWrite, backend: &'static str) {
+    metrics().rejected_total.add(1, &attrs(item, backend));
+}
+
+pub(super) fn record_retry(item: &OtsTrajectoryWrite, backend: &'static str) {
+    metrics().retry_total.add(1, &attrs(item, backend));
+}
+
+pub(super) fn record_persisted(item: &OtsTrajectoryWrite, backend: &'static str) {
+    metrics().persisted_total.add(1, &attrs(item, backend));
+}
+
+pub(super) fn record_failed(item: &OtsTrajectoryWrite, backend: &'static str) {
+    metrics().failed_total.add(1, &attrs(item, backend));
+}
+
+pub(super) fn record_persist_latency(
+    item: &OtsTrajectoryWrite,
+    backend: &'static str,
+    result: &str,
+    duration: Duration,
+) {
+    let attrs = [
+        KeyValue::new("tenant", item.tenant.clone()),
+        KeyValue::new("outcome", item.outcome.clone()),
+        KeyValue::new("backend", backend.to_string()),
+        KeyValue::new("result", result.to_string()),
+    ];
+    metrics()
+        .persist_latency_ms
+        .record(duration.as_secs_f64() * 1000.0, &attrs);
+}

--- a/crates/temper-server/src/ots_trajectory_outbox/tests.rs
+++ b/crates/temper-server/src/ots_trajectory_outbox/tests.rs
@@ -1,4 +1,6 @@
 use super::*;
+use std::collections::BTreeMap;
+use std::sync::Mutex;
 use std::sync::atomic::AtomicBool;
 use tokio::sync::Notify;
 
@@ -6,6 +8,10 @@ use tokio::sync::Notify;
 struct FakeOtsStore {
     attempts: AtomicU64,
     fail_attempts: AtomicU64,
+    enqueue_attempts: AtomicU64,
+    mark_persisted_attempts: AtomicU64,
+    mark_failed_attempts: AtomicU64,
+    status: Mutex<BTreeMap<String, String>>,
     persist_started: Notify,
     allow_persist: Notify,
     block_first_persist: AtomicBool,
@@ -31,6 +37,61 @@ impl OtsStore for FakeOtsStore {
         Ok(())
     }
 
+    async fn enqueue_ots_trajectory(
+        &self,
+        params: &OtsTrajectoryParams<'_>,
+    ) -> Result<(), PersistenceError> {
+        self.enqueue_attempts.fetch_add(1, Ordering::Relaxed);
+        self.status
+            .lock()
+            .expect("fake status mutex poisoned")
+            .insert(params.trajectory_id.to_string(), "queued".to_string());
+        Ok(())
+    }
+
+    async fn mark_ots_trajectory_persisted(
+        &self,
+        trajectory_id: &str,
+    ) -> Result<(), PersistenceError> {
+        self.attempts.fetch_add(1, Ordering::Relaxed);
+        self.mark_persisted_attempts.fetch_add(1, Ordering::Relaxed);
+        self.persist_started.notify_waiters();
+        if self.block_first_persist.swap(false, Ordering::Relaxed) {
+            self.allow_persist.notified().await;
+        }
+        if self.fail_attempts.load(Ordering::Relaxed) > 0 {
+            self.fail_attempts.fetch_sub(1, Ordering::Relaxed);
+            return Err(PersistenceError::Storage(
+                "temporary OTS failure".to_string(),
+            ));
+        }
+        self.status
+            .lock()
+            .expect("fake status mutex poisoned")
+            .insert(trajectory_id.to_string(), "persisted".to_string());
+        Ok(())
+    }
+
+    async fn mark_ots_trajectory_failed(
+        &self,
+        trajectory_id: &str,
+        _error: &str,
+    ) -> Result<(), PersistenceError> {
+        self.mark_failed_attempts.fetch_add(1, Ordering::Relaxed);
+        self.status
+            .lock()
+            .expect("fake status mutex poisoned")
+            .insert(trajectory_id.to_string(), "failed".to_string());
+        Ok(())
+    }
+
+    async fn list_queued_ots_trajectories(
+        &self,
+        _limit: i64,
+    ) -> Result<Vec<temper_store_turso::OtsQueuedTrajectoryRow>, PersistenceError> {
+        Ok(Vec::new())
+    }
+
     async fn list_ots_trajectories(
         &self,
         _tenant: &str,
@@ -47,6 +108,15 @@ impl OtsStore for FakeOtsStore {
     ) -> Result<Option<String>, PersistenceError> {
         Ok(None)
     }
+}
+
+fn status(store: &FakeOtsStore, id: &str) -> Option<String> {
+    store
+        .status
+        .lock()
+        .expect("fake status mutex poisoned")
+        .get(id)
+        .cloned()
 }
 
 fn item(id: &str) -> OtsTrajectoryWrite {
@@ -98,6 +168,24 @@ async fn enqueue_does_not_wait_for_slow_persistence() {
 }
 
 #[tokio::test]
+async fn durable_admission_records_queued_before_enqueue_ack() {
+    let store = Arc::new(FakeOtsStore {
+        block_first_persist: AtomicBool::new(true),
+        ..FakeOtsStore::default()
+    });
+    let outbox = OtsTrajectoryOutbox::start_for_tests(2, 1, 2, Duration::from_millis(1));
+
+    outbox
+        .try_enqueue_durable_for_tests(store.clone(), item("traj-durable"))
+        .await
+        .expect("durable enqueue should accept artifact");
+
+    assert_eq!(store.enqueue_attempts.load(Ordering::Relaxed), 1);
+    assert_eq!(status(&store, "traj-durable").as_deref(), Some("queued"));
+    store.allow_persist.notify_waiters();
+}
+
+#[tokio::test]
 async fn failed_persistence_is_retried() {
     let store = Arc::new(FakeOtsStore {
         fail_attempts: AtomicU64::new(1),
@@ -118,6 +206,7 @@ async fn failed_persistence_is_retried() {
     .expect("retry should eventually persist");
     assert_eq!(store.attempts.load(Ordering::Relaxed), 2);
     assert_eq!(outbox.failed_total(), 0);
+    assert_eq!(status(&store, "traj-retry").as_deref(), Some("persisted"));
 }
 
 #[tokio::test]
@@ -141,6 +230,8 @@ async fn exhausted_retries_are_visible() {
     .expect("terminal failure should release queue depth");
     assert_eq!(store.attempts.load(Ordering::Relaxed), 2);
     assert_eq!(outbox.failed_total(), 1);
+    assert_eq!(store.mark_failed_attempts.load(Ordering::Relaxed), 1);
+    assert_eq!(status(&store, "traj-fail").as_deref(), Some("failed"));
 }
 
 #[tokio::test]

--- a/crates/temper-server/src/ots_trajectory_outbox/tests.rs
+++ b/crates/temper-server/src/ots_trajectory_outbox/tests.rs
@@ -1,0 +1,163 @@
+use super::*;
+use std::sync::atomic::AtomicBool;
+use tokio::sync::Notify;
+
+#[derive(Default)]
+struct FakeOtsStore {
+    attempts: AtomicU64,
+    fail_attempts: AtomicU64,
+    persist_started: Notify,
+    allow_persist: Notify,
+    block_first_persist: AtomicBool,
+}
+
+#[async_trait::async_trait]
+impl OtsStore for FakeOtsStore {
+    async fn persist_ots_trajectory(
+        &self,
+        _params: &OtsTrajectoryParams<'_>,
+    ) -> Result<(), PersistenceError> {
+        self.attempts.fetch_add(1, Ordering::Relaxed);
+        self.persist_started.notify_waiters();
+        if self.block_first_persist.swap(false, Ordering::Relaxed) {
+            self.allow_persist.notified().await;
+        }
+        if self.fail_attempts.load(Ordering::Relaxed) > 0 {
+            self.fail_attempts.fetch_sub(1, Ordering::Relaxed);
+            return Err(PersistenceError::Storage(
+                "temporary OTS failure".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    async fn list_ots_trajectories(
+        &self,
+        _tenant: &str,
+        _agent_id: Option<&str>,
+        _outcome: Option<&str>,
+        _limit: i64,
+    ) -> Result<Vec<temper_store_turso::OtsTrajectoryRow>, PersistenceError> {
+        Ok(Vec::new())
+    }
+
+    async fn get_ots_trajectory(
+        &self,
+        _trajectory_id: &str,
+    ) -> Result<Option<String>, PersistenceError> {
+        Ok(None)
+    }
+}
+
+fn item(id: &str) -> OtsTrajectoryWrite {
+    OtsTrajectoryWrite {
+        trajectory_id: id.to_string(),
+        tenant: "tenant".to_string(),
+        agent_id: "agent".to_string(),
+        session_id: "session".to_string(),
+        outcome: "success".to_string(),
+        turn_count: 1,
+        data: serde_json::json!({
+            "metadata": {
+                "trajectory_id": id,
+                "agent_id": "agent",
+                "outcome": "success"
+            },
+            "turns": []
+        })
+        .to_string(),
+    }
+}
+
+#[tokio::test]
+async fn enqueue_does_not_wait_for_slow_persistence() {
+    let store = Arc::new(FakeOtsStore {
+        block_first_persist: AtomicBool::new(true),
+        ..FakeOtsStore::default()
+    });
+    let outbox = OtsTrajectoryOutbox::start_for_tests(2, 1, 2, Duration::from_millis(1));
+
+    outbox
+        .try_enqueue_for_tests(store.clone(), item("traj-slow"))
+        .expect("enqueue should accept slow persistence");
+
+    tokio::time::timeout(Duration::from_millis(100), store.persist_started.notified())
+        .await
+        .expect("background worker should start persistence");
+    assert_eq!(outbox.depth(), 1);
+    assert_eq!(store.attempts.load(Ordering::Relaxed), 1);
+
+    store.allow_persist.notify_waiters();
+    tokio::time::timeout(Duration::from_millis(100), async {
+        while outbox.depth() != 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("outbox should drain after the store unblocks");
+}
+
+#[tokio::test]
+async fn failed_persistence_is_retried() {
+    let store = Arc::new(FakeOtsStore {
+        fail_attempts: AtomicU64::new(1),
+        ..FakeOtsStore::default()
+    });
+    let outbox = OtsTrajectoryOutbox::start_for_tests(2, 1, 3, Duration::from_millis(1));
+
+    outbox
+        .try_enqueue_for_tests(store.clone(), item("traj-retry"))
+        .expect("enqueue should accept retryable persistence");
+
+    tokio::time::timeout(Duration::from_millis(200), async {
+        while outbox.depth() != 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("retry should eventually persist");
+    assert_eq!(store.attempts.load(Ordering::Relaxed), 2);
+    assert_eq!(outbox.failed_total(), 0);
+}
+
+#[tokio::test]
+async fn exhausted_retries_are_visible() {
+    let store = Arc::new(FakeOtsStore {
+        fail_attempts: AtomicU64::new(3),
+        ..FakeOtsStore::default()
+    });
+    let outbox = OtsTrajectoryOutbox::start_for_tests(2, 1, 2, Duration::from_millis(1));
+
+    outbox
+        .try_enqueue_for_tests(store.clone(), item("traj-fail"))
+        .expect("enqueue should accept artifact before retries exhaust");
+
+    tokio::time::timeout(Duration::from_millis(200), async {
+        while outbox.depth() != 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("terminal failure should release queue depth");
+    assert_eq!(store.attempts.load(Ordering::Relaxed), 2);
+    assert_eq!(outbox.failed_total(), 1);
+}
+
+#[tokio::test]
+async fn full_outbox_rejects_for_caller_retry() {
+    let store = Arc::new(FakeOtsStore {
+        block_first_persist: AtomicBool::new(true),
+        ..FakeOtsStore::default()
+    });
+    let outbox = OtsTrajectoryOutbox::start_for_tests(1, 1, 2, Duration::from_millis(1));
+
+    outbox
+        .try_enqueue_for_tests(store, item("traj-one"))
+        .expect("first enqueue should fit");
+    assert_eq!(
+        outbox.try_enqueue_for_tests(Arc::new(FakeOtsStore::default()), item("traj-two")),
+        Err(OtsTrajectoryEnqueueError::Full)
+    );
+    assert_eq!(outbox.rejected_total(), 1);
+    assert_eq!(outbox.depth(), 1);
+}

--- a/crates/temper-server/src/query_projection_metrics.rs
+++ b/crates/temper-server/src/query_projection_metrics.rs
@@ -16,6 +16,10 @@ struct QueryProjectionMetrics {
     update_duration_ms: Histogram<f64>,
     update_end_to_end_duration_ms: Histogram<f64>,
     update_applied_sequence_nr: Gauge<u64>,
+    update_coalesced_total: Counter<u64>,
+    update_stale_skipped_total: Counter<u64>,
+    update_dropped_total: Counter<u64>,
+    update_queue_depth: Gauge<u64>,
     backfill_entities_total: Counter<u64>,
     backfill_duration_ms: Histogram<f64>,
     backfill_replay_events: Histogram<u64>,
@@ -78,6 +82,28 @@ fn metrics() -> &'static QueryProjectionMetrics {
                 .with_description(
                     "Latest authoritative entity sequence number applied to the durable query projection.",
                 )
+                .build(),
+            update_coalesced_total: meter
+                .u64_counter("temper_query_projection_update_coalesced_total")
+                .with_description(
+                    "Durable query-plane projection updates replaced by a newer pending sequence before DB access.",
+                )
+                .build(),
+            update_stale_skipped_total: meter
+                .u64_counter("temper_query_projection_update_stale_skipped_total")
+                .with_description(
+                    "Durable query-plane projection updates skipped before DB access because a newer sequence is pending.",
+                )
+                .build(),
+            update_dropped_total: meter
+                .u64_counter("temper_query_projection_update_dropped_total")
+                .with_description(
+                    "Durable query-plane projection updates rejected because the bounded queue was full.",
+                )
+                .build(),
+            update_queue_depth: meter
+                .u64_gauge("temper_query_projection_update_queue_depth")
+                .with_description("Current pending durable query-plane projection updates.")
                 .build(),
             backfill_entities_total: meter
                 .u64_counter("temper_query_projection_backfill_entities_total")
@@ -275,6 +301,43 @@ pub(crate) fn record_update_error(tenant: &str, entity_type: &str, operation: &s
         .add(1, &projection_attrs(tenant, entity_type, operation, source));
 }
 
+pub(crate) fn record_update_coalesced(
+    tenant: &str,
+    entity_type: &str,
+    operation: &str,
+    source: &str,
+) {
+    metrics()
+        .update_coalesced_total
+        .add(1, &projection_attrs(tenant, entity_type, operation, source));
+}
+
+pub(crate) fn record_update_stale_skipped(
+    tenant: &str,
+    entity_type: &str,
+    operation: &str,
+    source: &str,
+) {
+    metrics()
+        .update_stale_skipped_total
+        .add(1, &projection_attrs(tenant, entity_type, operation, source));
+}
+
+pub(crate) fn record_update_dropped(
+    tenant: &str,
+    entity_type: &str,
+    operation: &str,
+    source: &str,
+) {
+    metrics()
+        .update_dropped_total
+        .add(1, &projection_attrs(tenant, entity_type, operation, source));
+}
+
+pub(crate) fn record_update_queue_depth(depth: u64) {
+    metrics().update_queue_depth.record(depth, &[]);
+}
+
 pub(crate) fn record_backfill_entities(
     tenant: &str,
     entity_type: &str,
@@ -405,75 +468,4 @@ pub(crate) fn record_replay_parity_run(
 }
 
 #[cfg(test)]
-mod tests {
-    use std::time::Duration;
-
-    #[test]
-    fn projection_metrics_record_all_observability_slices() {
-        super::record_update_enqueued("tenant", "Session", "upsert", "background_dispatch");
-        super::record_update_started("tenant", "Session", "upsert", "background_dispatch");
-        super::record_update_queue_wait(
-            "tenant",
-            "Session",
-            "upsert",
-            "background_dispatch",
-            Duration::from_millis(2),
-        );
-        super::record_update_duration(
-            "tenant",
-            "Session",
-            "upsert",
-            "background_dispatch",
-            "ok",
-            Duration::from_millis(3),
-        );
-        super::record_update_end_to_end_duration(
-            "tenant",
-            "Session",
-            "upsert",
-            "background_dispatch",
-            "ok",
-            Duration::from_millis(5),
-        );
-        super::record_update_applied_sequence(
-            "tenant",
-            "Session",
-            "upsert",
-            "background_dispatch",
-            42,
-        );
-        super::record_update_error("tenant", "Session", "upsert", "background_dispatch");
-        super::record_backfill_entities("tenant", "Session", "backfill_snapshot", "ok", 3);
-        super::record_backfill_duration("tenant", "overall", Duration::from_millis(8));
-        super::record_backfill_replay_events("tenant", "Session", "ok", 12);
-        super::record_shadow_check(
-            "tenant",
-            "Session",
-            "drift",
-            "fields",
-            "catalog_behind",
-            2,
-            Duration::from_millis(13),
-        );
-        super::record_replay_parity_check(
-            "tenant",
-            "Session",
-            "drift",
-            "sequence",
-            "catalog_behind",
-            2,
-            Duration::from_millis(21),
-        );
-        super::record_replay_parity_run(
-            "tenant",
-            "Session",
-            "observe_probe",
-            "drift",
-            10,
-            1,
-            0,
-            0,
-            Duration::from_millis(34),
-        );
-    }
-}
+mod tests;

--- a/crates/temper-server/src/query_projection_metrics/tests.rs
+++ b/crates/temper-server/src/query_projection_metrics/tests.rs
@@ -1,0 +1,64 @@
+use std::time::Duration;
+
+#[test]
+fn projection_metrics_record_all_observability_slices() {
+    super::record_update_enqueued("tenant", "Session", "upsert", "background_dispatch");
+    super::record_update_started("tenant", "Session", "upsert", "background_dispatch");
+    super::record_update_queue_wait(
+        "tenant",
+        "Session",
+        "upsert",
+        "background_dispatch",
+        Duration::from_millis(2),
+    );
+    super::record_update_duration(
+        "tenant",
+        "Session",
+        "upsert",
+        "background_dispatch",
+        "ok",
+        Duration::from_millis(3),
+    );
+    super::record_update_end_to_end_duration(
+        "tenant",
+        "Session",
+        "upsert",
+        "background_dispatch",
+        "ok",
+        Duration::from_millis(5),
+    );
+    super::record_update_applied_sequence("tenant", "Session", "upsert", "background_dispatch", 42);
+    super::record_update_error("tenant", "Session", "upsert", "background_dispatch");
+    super::record_backfill_entities("tenant", "Session", "backfill_snapshot", "ok", 3);
+    super::record_backfill_duration("tenant", "overall", Duration::from_millis(8));
+    super::record_backfill_replay_events("tenant", "Session", "ok", 12);
+    super::record_shadow_check(
+        "tenant",
+        "Session",
+        "drift",
+        "fields",
+        "catalog_behind",
+        2,
+        Duration::from_millis(13),
+    );
+    super::record_replay_parity_check(
+        "tenant",
+        "Session",
+        "drift",
+        "sequence",
+        "catalog_behind",
+        2,
+        Duration::from_millis(21),
+    );
+    super::record_replay_parity_run(
+        "tenant",
+        "Session",
+        "observe_probe",
+        "drift",
+        10,
+        1,
+        0,
+        0,
+        Duration::from_millis(34),
+    );
+}

--- a/crates/temper-server/src/runtime_metrics.rs
+++ b/crates/temper-server/src/runtime_metrics.rs
@@ -14,6 +14,10 @@ use opentelemetry::{KeyValue, global};
 use crate::state::ServerState;
 
 pub(crate) mod blob_transport;
+mod handler_deadlines;
+mod snapshot_writes;
+pub use handler_deadlines::*;
+pub use snapshot_writes::*;
 
 struct RuntimeMetrics {
     process_resident_memory_bytes: Gauge<u64>,
@@ -61,6 +65,16 @@ struct RuntimeMetrics {
     actor_registry_lock_wait_ms: Histogram<f64>,
     actor_cold_start_duration_ms: Histogram<f64>,
     event_store_append_wait_ms: Histogram<f64>,
+    snapshot_write_started_total: Counter<u64>,
+    snapshot_write_error_total: Counter<u64>,
+    snapshot_write_coalesced_total: Counter<u64>,
+    snapshot_write_stale_skipped_total: Counter<u64>,
+    snapshot_write_dropped_total: Counter<u64>,
+    snapshot_write_queue_depth: Gauge<u64>,
+    snapshot_write_queue_wait_ms: Histogram<f64>,
+    snapshot_write_duration_ms: Histogram<f64>,
+    snapshot_write_end_to_end_duration_ms: Histogram<f64>,
+    snapshot_write_applied_sequence: Gauge<u64>,
     // cedar_eval_duration is emitted from temper-authz (existing
     // temper_cedar_evaluation_duration histogram) — no duplicate here.
     // --- Handler-deadline primitive (W3 / temper#147 — reserved) ---------
@@ -294,6 +308,55 @@ fn metrics() -> &'static RuntimeMetrics {
                      writer-lock or fsync serialization. High p95 points at storage as a \
                      cold-start bottleneck. See temper#146.",
                 )
+                .build(),
+            snapshot_write_started_total: meter
+                .u64_counter("temper_snapshot_write_started_total")
+                .with_description("Queued snapshot writes started by the background worker.")
+                .build(),
+            snapshot_write_error_total: meter
+                .u64_counter("temper_snapshot_write_error_total")
+                .with_description("Queued snapshot writes that failed in the event store.")
+                .build(),
+            snapshot_write_coalesced_total: meter
+                .u64_counter("temper_snapshot_write_coalesced_total")
+                .with_description(
+                    "Snapshot enqueue attempts coalesced behind a newer pending write for the same stream.",
+                )
+                .build(),
+            snapshot_write_stale_skipped_total: meter
+                .u64_counter("temper_snapshot_write_stale_skipped_total")
+                .with_description(
+                    "Snapshot enqueue attempts skipped before storage because a same-stream newer sequence was already pending.",
+                )
+                .build(),
+            snapshot_write_dropped_total: meter
+                .u64_counter("temper_snapshot_write_dropped_total")
+                .with_description(
+                    "Snapshot enqueue attempts rejected because the bounded queue was full.",
+                )
+                .build(),
+            snapshot_write_queue_depth: meter
+                .u64_gauge("temper_snapshot_write_queue_depth")
+                .with_description("Pending queued snapshot writes after enqueue or drain.")
+                .build(),
+            snapshot_write_queue_wait_ms: meter
+                .f64_histogram("temper_snapshot_write_queue_wait_ms")
+                .with_unit("ms")
+                .with_description("Time a snapshot write spent queued before storage began.")
+                .build(),
+            snapshot_write_duration_ms: meter
+                .f64_histogram("temper_snapshot_write_duration_ms")
+                .with_unit("ms")
+                .with_description("Storage duration for a queued snapshot write.")
+                .build(),
+            snapshot_write_end_to_end_duration_ms: meter
+                .f64_histogram("temper_snapshot_write_end_to_end_duration_ms")
+                .with_unit("ms")
+                .with_description("End-to-end snapshot lag from enqueue to write completion.")
+                .build(),
+            snapshot_write_applied_sequence: meter
+                .u64_gauge("temper_snapshot_write_applied_sequence")
+                .with_description("Latest snapshot sequence successfully written by the queue.")
                 .build(),
             handler_deadline_remaining_ms: meter
                 .u64_gauge("temper_handler_deadline_remaining_ms")
@@ -854,58 +917,6 @@ pub fn record_event_store_append_wait(backend: &str, operation: &str, elapsed: D
 
 // Cedar evaluation duration is emitted from the temper-authz crate via the
 // existing `record_cedar_evaluation` helper. No duplicate metric here.
-
-// ============================================================================
-// W3 reserved (temper#147): handler-deadline primitive helpers.
-// ============================================================================
-//
-// These functions are the call-site surface the handler-deadline
-// implementation will use. They are public now so dashboards, monitors,
-// and tests can reference the metric names; the primitive wires them on
-// when epoch-interruption lands.
-
-/// Record the deadline headroom (budget remaining) at WASM dispatch start.
-pub fn record_handler_deadline_remaining(entity_type: &str, action: &str, remaining: Duration) {
-    metrics().handler_deadline_remaining_ms.record(
-        (remaining.as_secs_f64() * 1000.0).max(0.0) as u64,
-        &[
-            KeyValue::new("entity_type", entity_type.to_string()),
-            KeyValue::new("action", action.to_string()),
-        ],
-    );
-}
-
-/// Record a handler killed for exceeding its deadline.
-///
-/// `dying_span` identifies which host function was running when the guest
-/// was terminated (e.g. `wasm.web_search`, `wasm.provider_call`). It is
-/// mandatory: without it the metric cannot be used to identify hang
-/// sources.
-pub fn record_handler_deadline_exceeded(entity_type: &str, action: &str, dying_span: &'static str) {
-    metrics().handler_deadline_exceeded_total.add(
-        1,
-        &[
-            KeyValue::new("entity_type", entity_type.to_string()),
-            KeyValue::new("action", action.to_string()),
-            KeyValue::new("dying_span", dying_span),
-        ],
-    );
-}
-
-/// Record the observed interval between Wasmtime epoch ticks.
-pub fn record_wasm_epoch_tick_interval(elapsed: Duration) {
-    metrics()
-        .wasm_epoch_tick_interval_ms
-        .record(elapsed.as_secs_f64() * 1000.0, &[]);
-}
-
-/// Record the time from deadline breach to guest exit completion.
-pub fn record_handler_kill_latency(entity_type: &str, elapsed: Duration) {
-    metrics().handler_kill_latency_ms.record(
-        elapsed.as_secs_f64() * 1000.0,
-        &[KeyValue::new("entity_type", entity_type.to_string())],
-    );
-}
 
 // ============================================================================
 // Katagami.

--- a/crates/temper-server/src/runtime_metrics/handler_deadlines.rs
+++ b/crates/temper-server/src/runtime_metrics/handler_deadlines.rs
@@ -1,0 +1,46 @@
+use std::time::Duration;
+
+use opentelemetry::KeyValue;
+
+use super::metrics;
+
+/// Record the deadline headroom (budget remaining) at WASM dispatch start.
+pub fn record_handler_deadline_remaining(entity_type: &str, action: &str, remaining: Duration) {
+    metrics().handler_deadline_remaining_ms.record(
+        (remaining.as_secs_f64() * 1000.0).max(0.0) as u64,
+        &[
+            KeyValue::new("entity_type", entity_type.to_string()),
+            KeyValue::new("action", action.to_string()),
+        ],
+    );
+}
+
+/// Record a handler killed for exceeding its deadline.
+///
+/// `dying_span` identifies which host function was running when the guest
+/// was terminated, such as `wasm.web_search` or `wasm.provider_call`.
+pub fn record_handler_deadline_exceeded(entity_type: &str, action: &str, dying_span: &'static str) {
+    metrics().handler_deadline_exceeded_total.add(
+        1,
+        &[
+            KeyValue::new("entity_type", entity_type.to_string()),
+            KeyValue::new("action", action.to_string()),
+            KeyValue::new("dying_span", dying_span),
+        ],
+    );
+}
+
+/// Record the observed interval between Wasmtime epoch ticks.
+pub fn record_wasm_epoch_tick_interval(elapsed: Duration) {
+    metrics()
+        .wasm_epoch_tick_interval_ms
+        .record(elapsed.as_secs_f64() * 1000.0, &[]);
+}
+
+/// Record the time from deadline breach to guest exit completion.
+pub fn record_handler_kill_latency(entity_type: &str, elapsed: Duration) {
+    metrics().handler_kill_latency_ms.record(
+        elapsed.as_secs_f64() * 1000.0,
+        &[KeyValue::new("entity_type", entity_type.to_string())],
+    );
+}

--- a/crates/temper-server/src/runtime_metrics/snapshot_writes.rs
+++ b/crates/temper-server/src/runtime_metrics/snapshot_writes.rs
@@ -1,0 +1,65 @@
+use std::time::Duration;
+
+use opentelemetry::KeyValue;
+
+use super::metrics;
+
+/// Record a queued snapshot write that the background worker started.
+pub fn record_snapshot_write_started() {
+    metrics().snapshot_write_started_total.add(1, &[]);
+}
+
+/// Record a queued snapshot write failure.
+pub fn record_snapshot_write_error() {
+    metrics().snapshot_write_error_total.add(1, &[]);
+}
+
+/// Record a snapshot enqueue coalesced by stream before storage access.
+pub fn record_snapshot_write_coalesced() {
+    metrics().snapshot_write_coalesced_total.add(1, &[]);
+}
+
+/// Record a stale snapshot enqueue skipped before storage access.
+pub fn record_snapshot_write_stale_skipped() {
+    metrics().snapshot_write_stale_skipped_total.add(1, &[]);
+}
+
+/// Record a snapshot enqueue rejected by bounded queue capacity.
+pub fn record_snapshot_write_dropped() {
+    metrics().snapshot_write_dropped_total.add(1, &[]);
+}
+
+/// Record pending snapshot queue depth.
+pub fn record_snapshot_write_queue_depth(depth: u64) {
+    metrics().snapshot_write_queue_depth.record(depth, &[]);
+}
+
+/// Record how long a snapshot waited before the worker opened storage.
+pub fn record_snapshot_write_queue_wait(elapsed: Duration) {
+    metrics()
+        .snapshot_write_queue_wait_ms
+        .record(elapsed.as_secs_f64() * 1000.0, &[]);
+}
+
+/// Record storage duration for a queued snapshot write.
+pub fn record_snapshot_write_duration(result: &str, elapsed: Duration) {
+    metrics().snapshot_write_duration_ms.record(
+        elapsed.as_secs_f64() * 1000.0,
+        &[KeyValue::new("result", result.to_string())],
+    );
+}
+
+/// Record end-to-end lag from enqueue to snapshot write completion.
+pub fn record_snapshot_write_end_to_end_duration(result: &str, elapsed: Duration) {
+    metrics().snapshot_write_end_to_end_duration_ms.record(
+        elapsed.as_secs_f64() * 1000.0,
+        &[KeyValue::new("result", result.to_string())],
+    );
+}
+
+/// Record the latest snapshot sequence written by the queue.
+pub fn record_snapshot_write_applied_sequence(sequence_nr: u64) {
+    metrics()
+        .snapshot_write_applied_sequence
+        .record(sequence_nr, &[]);
+}

--- a/crates/temper-server/src/state/dispatch/composite.rs
+++ b/crates/temper-server/src/state/dispatch/composite.rs
@@ -21,11 +21,12 @@ use crate::request_context::AgentContext;
 use crate::state::account_verification::CommonsAccountVerificationError;
 use crate::state::app_uniqueness::CommonsAppUniquenessError;
 use crate::state::storage_caps::{CommonsStorageCapError, CommonsStorageWrite};
-use crate::storage::{BackendLabel, QueryProjectionUpsert};
+use crate::storage::BackendLabel;
 
 use super::DispatchError;
 
 mod helpers;
+mod projection;
 use helpers::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -394,59 +395,12 @@ impl crate::state::ServerState {
         let append_ms = append_started_at.map(|started| started.elapsed().as_millis() as u64);
 
         let projection_collect_started_at = timing_enabled.then(std::time::Instant::now);
-        let query_plane = self.query_plane_store();
-        let mut projection_upserts = Vec::new();
-        for stream in streams.values() {
-            if stream.events.is_empty() {
-                continue;
-            }
-            self.cache_entity_status(
-                format!("{tenant}:{}:{}", stream.entity_type, stream.entity_id),
-                stream.state.status.clone(),
-            );
-            {
-                let index_key = format!("{tenant}:{}", stream.entity_type);
-                let mut index = self.entity_index.write().map_err(|_| {
-                    DispatchError::Internal(
-                        "entity index lock poisoned after composite batch".to_string(),
-                    )
-                })?;
-                index
-                    .entry(index_key)
-                    .or_default()
-                    .insert(stream.entity_id.clone());
-            }
-            self.clear_commons_storage_projection_cache_for_entity(&stream.entity_type);
-            if query_plane.is_some() {
-                let fields = stream.state.fields.clone();
-                let indexed_fields =
-                    self.query_projection_fields(tenant, &stream.entity_type, &fields);
-                projection_upserts.push(QueryProjectionUpsert {
-                    entity_type: stream.entity_type.clone(),
-                    entity_id: stream.entity_id.clone(),
-                    status: stream.state.status.clone(),
-                    fields,
-                    state: self.query_projection_state(&stream.state),
-                    indexed_fields,
-                    sequence_nr: stream.state.sequence_nr,
-                    known_new: !stream.target_existed,
-                });
-            }
-        }
+        self.update_composite_query_projections(tenant, &streams)
+            .await?;
         let projection_collect_ms =
             projection_collect_started_at.map(|started| started.elapsed().as_millis() as u64);
 
         let projection_write_started_at = timing_enabled.then(std::time::Instant::now);
-        if let Some(query_plane) = query_plane {
-            query_plane
-                .upsert_projections(tenant.as_str(), &projection_upserts)
-                .await
-                .map_err(|e| {
-                    DispatchError::Internal(format!(
-                        "query projection write failed after composite batch: {e}"
-                    ))
-                })?;
-        }
         let projection_write_ms =
             projection_write_started_at.map(|started| started.elapsed().as_millis() as u64);
 

--- a/crates/temper-server/src/state/dispatch/composite/projection.rs
+++ b/crates/temper-server/src/state/dispatch/composite/projection.rs
@@ -1,0 +1,136 @@
+use std::collections::BTreeMap;
+
+use temper_runtime::tenant::TenantId;
+
+use crate::state::{ProjectionEnqueueOutcome, ServerState};
+use crate::storage::QueryProjectionUpsert;
+
+use super::{AtomicCompositeStream, DispatchError};
+
+impl ServerState {
+    pub(super) async fn update_composite_query_projections(
+        &self,
+        tenant: &TenantId,
+        streams: &BTreeMap<String, AtomicCompositeStream>,
+    ) -> Result<(), DispatchError> {
+        let query_plane = self.query_plane_store();
+        let projection_queue = self
+            .query_projection_queue
+            .lock()
+            .ok()
+            .and_then(|slot| slot.clone());
+        let mut projection_upserts = Vec::new();
+
+        for stream in streams.values().filter(|stream| !stream.events.is_empty()) {
+            self.cache_entity_status(
+                format!("{tenant}:{}:{}", stream.entity_type, stream.entity_id),
+                stream.state.status.clone(),
+            );
+            self.index_composite_stream(tenant, stream)?;
+            self.clear_commons_storage_projection_cache_for_entity(&stream.entity_type);
+
+            if query_plane.is_some() {
+                self.queue_or_stage_projection(
+                    tenant,
+                    stream,
+                    projection_queue.as_ref(),
+                    &mut projection_upserts,
+                );
+            }
+        }
+
+        if let Some(query_plane) = query_plane
+            && !projection_upserts.is_empty()
+        {
+            query_plane
+                .upsert_projections(tenant.as_str(), &projection_upserts)
+                .await
+                .map_err(|e| {
+                    DispatchError::Internal(format!(
+                        "query projection write failed after composite batch: {e}"
+                    ))
+                })?;
+        }
+
+        Ok(())
+    }
+
+    fn index_composite_stream(
+        &self,
+        tenant: &TenantId,
+        stream: &AtomicCompositeStream,
+    ) -> Result<(), DispatchError> {
+        let index_key = format!("{tenant}:{}", stream.entity_type);
+        let mut index = self.entity_index.write().map_err(|_| {
+            DispatchError::Internal("entity index lock poisoned after composite batch".to_string())
+        })?;
+        index
+            .entry(index_key)
+            .or_default()
+            .insert(stream.entity_id.clone());
+        Ok(())
+    }
+
+    fn queue_or_stage_projection(
+        &self,
+        tenant: &TenantId,
+        stream: &AtomicCompositeStream,
+        projection_queue: Option<&std::sync::Arc<crate::state::QueryProjectionWriteQueue>>,
+        projection_upserts: &mut Vec<QueryProjectionUpsert>,
+    ) {
+        let fields = stream.state.fields.clone();
+        let projected_state = self.query_projection_state(&stream.state);
+        if let Some(queue) = projection_queue {
+            let outcome = queue.enqueue_upsert(
+                tenant.to_string(),
+                stream.entity_type.clone(),
+                stream.entity_id.clone(),
+                stream.state.status.clone(),
+                fields,
+                projected_state,
+                stream.state.sequence_nr,
+                "queued_composite",
+            );
+            record_composite_projection_enqueue(tenant, stream, outcome);
+        } else {
+            let indexed_fields = self.query_projection_fields(tenant, &stream.entity_type, &fields);
+            projection_upserts.push(QueryProjectionUpsert {
+                entity_type: stream.entity_type.clone(),
+                entity_id: stream.entity_id.clone(),
+                status: stream.state.status.clone(),
+                fields,
+                state: projected_state,
+                indexed_fields,
+                sequence_nr: stream.state.sequence_nr,
+                known_new: !stream.target_existed,
+            });
+        }
+    }
+}
+
+fn record_composite_projection_enqueue(
+    tenant: &TenantId,
+    stream: &AtomicCompositeStream,
+    outcome: ProjectionEnqueueOutcome,
+) {
+    match outcome {
+        ProjectionEnqueueOutcome::Enqueued | ProjectionEnqueueOutcome::Coalesced => {
+            crate::query_projection_metrics::record_update_enqueued(
+                tenant.as_str(),
+                &stream.entity_type,
+                "upsert",
+                "queued_composite",
+            );
+        }
+        ProjectionEnqueueOutcome::StaleSkipped => {}
+        ProjectionEnqueueOutcome::Full => {
+            tracing::error!(
+                tenant = %tenant,
+                entity_type = %stream.entity_type,
+                entity_id = %stream.entity_id,
+                sequence_nr = stream.state.sequence_nr,
+                "bounded query projection queue full after composite batch"
+            );
+        }
+    }
+}

--- a/crates/temper-server/src/state/dispatch/effects.rs
+++ b/crates/temper-server/src/state/dispatch/effects.rs
@@ -13,6 +13,7 @@ use tracing::Instrument;
 use crate::entity_actor::{EntityResponse, effects::ScheduledAction};
 use crate::events::EntityStateChange;
 use crate::request_context::AgentContext;
+use crate::state::ProjectionEnqueueOutcome;
 use crate::state::trajectory::{TrajectoryEntry, TrajectorySource};
 use temper_runtime::scheduler::sim_now;
 use temper_runtime::tenant::TenantId;
@@ -31,14 +32,11 @@ pub(crate) struct PostDispatchContext<'a> {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum QueryProjectionUpdateMode {
-    /// The dispatch response is returned only after the query-plane
-    /// projection row reflects the dispatch (ADR-0142). An acknowledged
-    /// action is immediately readable: OData point-reads serve from the
-    /// projection, and callers — including WASM integrations that
-    /// read-after-write (e.g. a PR number assigned by one dispatch and
-    /// rendered by the next read) — must see their own writes. The
-    /// store's `sequence_nr <=` guard keeps concurrent writers safe.
-    Inline,
+    /// The dispatch response is returned after the journal append and after a
+    /// bounded, coalescing projection update is accepted. The projection row
+    /// may lag the journal, but stale pending writes are skipped before DB
+    /// access and lag is observable (ADR-0148).
+    Queued,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -47,7 +45,7 @@ enum DispatchTrajectoryPersistenceMode {
 }
 
 fn query_projection_update_mode() -> QueryProjectionUpdateMode {
-    QueryProjectionUpdateMode::Inline
+    QueryProjectionUpdateMode::Queued
 }
 
 fn dispatch_trajectory_persistence_mode() -> DispatchTrajectoryPersistenceMode {
@@ -70,7 +68,7 @@ impl crate::state::ServerState {
     ) {
         debug_assert_eq!(
             query_projection_update_mode(),
-            QueryProjectionUpdateMode::Inline
+            QueryProjectionUpdateMode::Queued
         );
         let Some(query_plane) = self.query_plane_store() else {
             return;
@@ -90,15 +88,66 @@ impl crate::state::ServerState {
             "upsert"
         }
         .to_string();
-        let source = "inline_dispatch".to_string();
+        let source = "queued_dispatch".to_string();
         let enqueued_at = Instant::now(); // determinism-ok: production-only projection queue metric
-
-        crate::query_projection_metrics::record_update_enqueued(
-            &tenant,
-            &entity_type,
-            &operation,
-            &source,
-        );
+        let queue = self
+            .query_projection_queue
+            .lock()
+            .ok()
+            .and_then(|slot| slot.clone());
+        if let Some(queue) = queue {
+            let outcome = if status == "Deleted" {
+                queue.enqueue_remove(
+                    tenant.clone(),
+                    entity_type.clone(),
+                    entity_id.clone(),
+                    sequence_nr,
+                    "queued_dispatch",
+                )
+            } else {
+                queue.enqueue_upsert(
+                    tenant.clone(),
+                    entity_type.clone(),
+                    entity_id.clone(),
+                    status.clone(),
+                    fields,
+                    projected_state,
+                    sequence_nr,
+                    "queued_dispatch",
+                )
+            };
+            match outcome {
+                ProjectionEnqueueOutcome::Enqueued | ProjectionEnqueueOutcome::Coalesced => {
+                    crate::query_projection_metrics::record_update_enqueued(
+                        &tenant,
+                        &entity_type,
+                        &operation,
+                        &source,
+                    );
+                }
+                ProjectionEnqueueOutcome::StaleSkipped => {
+                    tracing::debug!(
+                        tenant = %tenant,
+                        entity_type = %entity_type,
+                        entity_id = %entity_id,
+                        sequence_nr,
+                        operation = %operation,
+                        "skipped stale queued query projection update"
+                    );
+                }
+                ProjectionEnqueueOutcome::Full => {
+                    tracing::error!(
+                        tenant = %tenant,
+                        entity_type = %entity_type,
+                        entity_id = %entity_id,
+                        sequence_nr,
+                        operation = %operation,
+                        "bounded query projection queue full; acknowledged dispatch will rely on repair/backfill"
+                    );
+                }
+            }
+            return;
+        }
 
         let span = tracing::info_span!(
             "dispatch.phase.query_projection",
@@ -117,17 +166,23 @@ impl crate::state::ServerState {
         Box::pin(
             async move {
                 let started_at = Instant::now(); // determinism-ok: production-only projection duration metric
+                crate::query_projection_metrics::record_update_enqueued(
+                    &tenant,
+                    &entity_type,
+                    &operation,
+                    "inline_dispatch_fallback",
+                );
                 crate::query_projection_metrics::record_update_started(
                     &tenant,
                     &entity_type,
                     &operation,
-                    &source,
+                    "inline_dispatch_fallback",
                 );
                 crate::query_projection_metrics::record_update_queue_wait(
                     &tenant,
                     &entity_type,
                     &operation,
-                    &source,
+                    "inline_dispatch_fallback",
                     started_at.duration_since(enqueued_at),
                 );
                 let result = if status == "Deleted" {
@@ -152,7 +207,7 @@ impl crate::state::ServerState {
                     &tenant,
                     &entity_type,
                     &operation,
-                    &source,
+                    "inline_dispatch_fallback",
                     result_label,
                     started_at.elapsed(),
                 );
@@ -160,7 +215,7 @@ impl crate::state::ServerState {
                     &tenant,
                     &entity_type,
                     &operation,
-                    &source,
+                    "inline_dispatch_fallback",
                     result_label,
                     enqueued_at.elapsed(),
                 );
@@ -170,7 +225,7 @@ impl crate::state::ServerState {
                         &tenant,
                         &entity_type,
                         &operation,
-                        &source,
+                        "inline_dispatch_fallback",
                     );
                     // The action is committed and non-idempotent, so the
                     // dispatch is still acknowledged — but the projection now
@@ -191,7 +246,7 @@ impl crate::state::ServerState {
                         &tenant,
                         &entity_type,
                         &operation,
-                        &source,
+                        "inline_dispatch_fallback",
                         sequence_nr,
                     );
                 }
@@ -718,14 +773,9 @@ impl crate::state::ServerState {
         // cancellation ensures stale timers become no-ops.
         self.arm_state_timeouts_if_needed(ctx, &response);
 
-        // 8. Update the durable query plane before acknowledging the
-        // dispatch (ADR-0142). The response is the caller's signal that the
-        // action happened; OData point-reads serve from the projection, so
-        // returning before the row lands lets an acknowledged write be read
-        // back stale (a PR number assigned by one dispatch and rendered as 0
-        // by the very next read — a ~40% race in the workflow round-trip).
-        // Cost is one sequence-guarded row upsert on the same store that
-        // already persisted the event; lag metrics remain in place.
+        // 8. Enqueue durable query-plane maintenance (ADR-0148). The journal
+        // append is already durable; projection writes are derived rows and
+        // are coalesced by entity/sequence before DB access.
         self.apply_query_projection_update(ctx, &response).await;
 
         response
@@ -737,13 +787,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn query_projection_updates_land_before_the_dispatch_response_is_returned() {
-        // ADR-0142: an acknowledged dispatch must be readable. The previous
-        // background mode let a caller read its own committed write back
-        // stale from the query plane.
+    fn query_projection_updates_are_queued_after_journal_commit() {
+        // ADR-0148: dispatch waits for the event journal, then accepts derived
+        // projection maintenance into a bounded coalescing queue.
         assert_eq!(
             query_projection_update_mode(),
-            QueryProjectionUpdateMode::Inline
+            QueryProjectionUpdateMode::Queued
         );
     }
 

--- a/crates/temper-server/src/state/entity_ops.rs
+++ b/crates/temper-server/src/state/entity_ops.rs
@@ -552,6 +552,11 @@ impl ServerState {
         // ADR-0048 sub-decision 5: every actor gets the shared idempotency
         // cache so it can dedupe duplicate asks produced by retry storms.
         let tenant_blob_store = self.blob_store_for_tenant(tenant).ok();
+        let snapshot_queue = self
+            .snapshot_write_queue
+            .lock()
+            .ok()
+            .and_then(|slot| slot.clone());
         let actor = match self.event_journal() {
             Some((store, backend)) => EntityActor::with_persistence(
                 entity_type,
@@ -562,6 +567,7 @@ impl ServerState {
                 backend,
             )
             .with_tenant(tenant.as_str())
+            .with_snapshot_queue(snapshot_queue)
             .with_idempotency_cache(self.idempotency_cache.clone())
             .with_blob_store(tenant_blob_store.clone()),
             None => EntityActor::new(entity_type, entity_id, table, initial_fields)

--- a/crates/temper-server/src/state/mod.rs
+++ b/crates/temper-server/src/state/mod.rs
@@ -63,6 +63,7 @@ use crate::adapters::AdapterRegistry;
 use crate::entity_actor::{EntityMsg, SnapshotWriteQueue};
 use crate::events::EntityStateChange;
 use crate::idempotency::IdempotencyCache;
+use crate::ots_trajectory_outbox::OtsTrajectoryOutbox;
 use crate::registry::SpecRegistry;
 use crate::secrets::vault::SecretsVault;
 use crate::storage::{
@@ -375,6 +376,8 @@ pub struct ServerState {
     pub(crate) query_projection_queue: Arc<Mutex<Option<Arc<QueryProjectionWriteQueue>>>>,
     /// Bounded background writer for durable actor recovery snapshots.
     pub(crate) snapshot_write_queue: Arc<Mutex<Option<Arc<SnapshotWriteQueue>>>>,
+    /// Bounded background writer for full OTS trajectory artifacts.
+    pub(crate) ots_trajectory_outbox: Arc<Mutex<Option<Arc<OtsTrajectoryOutbox>>>>,
     /// Runtime data directory for persisted local metadata (e.g. specs registry).
     pub data_dir: std::path::PathBuf,
     /// Agent hints learned from trajectory analysis, keyed by action name.
@@ -566,6 +569,12 @@ impl ServerState {
                 *slot = Some(queue);
             }
         }
+        if stack.metadata.is_some() {
+            let queue = OtsTrajectoryOutbox::start();
+            if let Ok(mut slot) = self.ots_trajectory_outbox.lock() {
+                *slot = Some(queue);
+            }
+        }
         self.storage_stack = Some(stack);
     }
 
@@ -608,6 +617,14 @@ impl ServerState {
         None
     }
 
+    /// Return the OTS trajectory artifact outbox plus backend label.
+    #[cfg_attr(not(feature = "observe"), allow(dead_code))]
+    pub(crate) fn ots_trajectory_outbox(&self) -> Option<(&'static str, Arc<OtsTrajectoryOutbox>)> {
+        let backend = self.storage_stack.as_ref()?.backend.as_str();
+        let queue = self.ots_trajectory_outbox.lock().ok()?.clone()?;
+        Some((backend, queue))
+    }
+
     /// Create ServerState from CSDL XML and optional specification sources.
     pub fn new(system: ActorSystem, csdl: CsdlDocument, csdl_xml: String) -> Self {
         install_liveness_metrics_reporter_once();
@@ -644,6 +661,7 @@ impl ServerState {
             storage_stack: None,
             query_projection_queue: Arc::new(Mutex::new(None)),
             snapshot_write_queue: Arc::new(Mutex::new(None)),
+            ots_trajectory_outbox: Arc::new(Mutex::new(None)),
             data_dir: std::path::PathBuf::new(),
             agent_hints: Arc::new(RwLock::new(BTreeMap::new())),
             authz: Arc::new(AuthzEngine::permissive()),
@@ -889,6 +907,7 @@ impl ServerState {
             storage_stack: None,
             query_projection_queue: Arc::new(Mutex::new(None)),
             snapshot_write_queue: Arc::new(Mutex::new(None)),
+            ots_trajectory_outbox: Arc::new(Mutex::new(None)),
             data_dir: std::path::PathBuf::new(),
             agent_hints: Arc::new(RwLock::new(BTreeMap::new())),
             authz: Arc::new(AuthzEngine::permissive()),

--- a/crates/temper-server/src/state/mod.rs
+++ b/crates/temper-server/src/state/mod.rs
@@ -569,8 +569,9 @@ impl ServerState {
                 *slot = Some(queue);
             }
         }
-        if stack.metadata.is_some() {
+        if let Some(metadata) = stack.metadata.clone() {
             let queue = OtsTrajectoryOutbox::start();
+            queue.recover_queued_metadata_stores(stack.backend.as_str(), metadata);
             if let Ok(mut slot) = self.ots_trajectory_outbox.lock() {
                 *slot = Some(queue);
             }

--- a/crates/temper-server/src/state/mod.rs
+++ b/crates/temper-server/src/state/mod.rs
@@ -17,6 +17,7 @@ mod persistence;
 pub mod policy_suggestions;
 mod projection_backfill;
 mod published_artifacts;
+mod query_projection_queue;
 pub(crate) mod rate_limit;
 mod runtime_metrics;
 pub(crate) mod storage_caps;
@@ -36,6 +37,7 @@ pub use pending_decisions::{
 pub use persistence::WasmModuleSource;
 pub use policy_suggestions::PolicySuggestionEngine;
 pub use published_artifacts::PublishFileArtifactRequest;
+pub(crate) use query_projection_queue::{ProjectionEnqueueOutcome, QueryProjectionWriteQueue};
 pub use trajectory::{TrajectoryEntry, TrajectorySource};
 pub use wasm_invocation_log::WasmInvocationEntry;
 
@@ -58,7 +60,7 @@ use temper_spec::csdl::CsdlDocument;
 use temper_store_postgres::PostgresEventStore;
 
 use crate::adapters::AdapterRegistry;
-use crate::entity_actor::EntityMsg;
+use crate::entity_actor::{EntityMsg, SnapshotWriteQueue};
 use crate::events::EntityStateChange;
 use crate::idempotency::IdempotencyCache;
 use crate::registry::SpecRegistry;
@@ -369,6 +371,10 @@ pub struct ServerState {
     pub last_accessed: Arc<RwLock<BTreeMap<String, chrono::DateTime<chrono::Utc>>>>,
     /// First-class storage capabilities selected for this runtime.
     pub storage_stack: Option<Arc<StorageStack>>,
+    /// Bounded background writer for derived query-plane projection rows.
+    pub(crate) query_projection_queue: Arc<Mutex<Option<Arc<QueryProjectionWriteQueue>>>>,
+    /// Bounded background writer for durable actor recovery snapshots.
+    pub(crate) snapshot_write_queue: Arc<Mutex<Option<Arc<SnapshotWriteQueue>>>>,
     /// Runtime data directory for persisted local metadata (e.g. specs registry).
     pub data_dir: std::path::PathBuf,
     /// Agent hints learned from trajectory analysis, keyed by action name.
@@ -549,7 +555,18 @@ impl ServerState {
 
     /// Attach the composed runtime storage stack.
     pub fn set_storage_stack(&mut self, stack: StorageStack) {
-        self.storage_stack = Some(Arc::new(stack));
+        let stack = Arc::new(stack);
+        let snapshot_queue = SnapshotWriteQueue::start(stack.events.clone());
+        if let Ok(mut slot) = self.snapshot_write_queue.lock() {
+            *slot = Some(snapshot_queue);
+        }
+        if let Some(query_plane) = stack.query_plane.clone() {
+            let queue = QueryProjectionWriteQueue::start(query_plane);
+            if let Ok(mut slot) = self.query_projection_queue.lock() {
+                *slot = Some(queue);
+            }
+        }
+        self.storage_stack = Some(stack);
     }
 
     /// Return the durable query-plane capability for projection reads/writes.
@@ -625,6 +642,8 @@ impl ServerState {
             actor_registry: Arc::new(RwLock::new(BTreeMap::new())),
             last_accessed: Arc::new(RwLock::new(BTreeMap::new())),
             storage_stack: None,
+            query_projection_queue: Arc::new(Mutex::new(None)),
+            snapshot_write_queue: Arc::new(Mutex::new(None)),
             data_dir: std::path::PathBuf::new(),
             agent_hints: Arc::new(RwLock::new(BTreeMap::new())),
             authz: Arc::new(AuthzEngine::permissive()),
@@ -868,6 +887,8 @@ impl ServerState {
             actor_registry: Arc::new(RwLock::new(BTreeMap::new())),
             last_accessed: Arc::new(RwLock::new(BTreeMap::new())),
             storage_stack: None,
+            query_projection_queue: Arc::new(Mutex::new(None)),
+            snapshot_write_queue: Arc::new(Mutex::new(None)),
             data_dir: std::path::PathBuf::new(),
             agent_hints: Arc::new(RwLock::new(BTreeMap::new())),
             authz: Arc::new(AuthzEngine::permissive()),

--- a/crates/temper-server/src/state/query_projection_queue.rs
+++ b/crates/temper-server/src/state/query_projection_queue.rs
@@ -1,0 +1,365 @@
+//! Bounded, coalescing query-projection writer.
+//!
+//! The event journal remains the synchronous commit point. This worker keeps
+//! derived query-plane rows off the dispatch critical path while preserving a
+//! per-entity latest-sequence contract before opening a storage connection.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use tokio::sync::Notify;
+use tracing::Instrument;
+
+use crate::storage::QueryPlaneStore;
+
+const DEFAULT_PROJECTION_QUEUE_CAPACITY: usize = 20_000;
+const DEFAULT_PROJECTION_DRAIN_BATCH: usize = 256;
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+struct ProjectionKey {
+    tenant: String,
+    entity_type: String,
+    entity_id: String,
+}
+
+#[derive(Clone, Debug)]
+enum ProjectionOperation {
+    Upsert {
+        status: String,
+        fields: serde_json::Value,
+        state: serde_json::Value,
+    },
+    Remove,
+}
+
+#[derive(Clone, Debug)]
+struct QueuedProjectionUpdate {
+    key: ProjectionKey,
+    operation: ProjectionOperation,
+    sequence_nr: u64,
+    enqueued_at: Instant,
+    source: &'static str,
+}
+
+#[derive(Debug, Default)]
+struct PendingProjectionUpdates {
+    updates: BTreeMap<ProjectionKey, QueuedProjectionUpdate>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum ProjectionEnqueueOutcome {
+    Enqueued,
+    Coalesced,
+    StaleSkipped,
+    Full,
+}
+
+/// Background projection writer shared by all `ServerState` clones.
+pub(crate) struct QueryProjectionWriteQueue {
+    store: Arc<dyn QueryPlaneStore>,
+    pending: Arc<Mutex<PendingProjectionUpdates>>,
+    notify: Arc<Notify>,
+    capacity: usize,
+    drain_batch: usize,
+}
+
+impl QueryProjectionWriteQueue {
+    pub(crate) fn start(store: Arc<dyn QueryPlaneStore>) -> Arc<Self> {
+        let queue = Arc::new(Self {
+            store,
+            pending: Arc::new(Mutex::new(PendingProjectionUpdates::default())),
+            notify: Arc::new(Notify::new()),
+            capacity: projection_queue_capacity(),
+            drain_batch: projection_drain_batch(),
+        });
+        queue.spawn_worker();
+        queue
+    }
+
+    #[cfg(test)]
+    fn new_for_test(store: Arc<dyn QueryPlaneStore>, capacity: usize, drain_batch: usize) -> Self {
+        Self {
+            store,
+            pending: Arc::new(Mutex::new(PendingProjectionUpdates::default())),
+            notify: Arc::new(Notify::new()),
+            capacity,
+            drain_batch,
+        }
+    }
+
+    #[expect(clippy::too_many_arguments, reason = "projection enqueue boundary")]
+    pub(crate) fn enqueue_upsert(
+        &self,
+        tenant: String,
+        entity_type: String,
+        entity_id: String,
+        status: String,
+        fields: serde_json::Value,
+        state: serde_json::Value,
+        sequence_nr: u64,
+        source: &'static str,
+    ) -> ProjectionEnqueueOutcome {
+        self.enqueue(QueuedProjectionUpdate {
+            key: ProjectionKey {
+                tenant,
+                entity_type,
+                entity_id,
+            },
+            operation: ProjectionOperation::Upsert {
+                status,
+                fields,
+                state,
+            },
+            sequence_nr,
+            enqueued_at: Instant::now(),
+            source,
+        })
+    }
+
+    pub(crate) fn enqueue_remove(
+        &self,
+        tenant: String,
+        entity_type: String,
+        entity_id: String,
+        sequence_nr: u64,
+        source: &'static str,
+    ) -> ProjectionEnqueueOutcome {
+        self.enqueue(QueuedProjectionUpdate {
+            key: ProjectionKey {
+                tenant,
+                entity_type,
+                entity_id,
+            },
+            operation: ProjectionOperation::Remove,
+            sequence_nr,
+            enqueued_at: Instant::now(),
+            source,
+        })
+    }
+
+    fn enqueue(&self, update: QueuedProjectionUpdate) -> ProjectionEnqueueOutcome {
+        let mut pending = self
+            .pending
+            .lock()
+            .expect("query projection queue mutex poisoned");
+        let existing = pending.updates.get(&update.key);
+        if existing.is_some_and(|existing| existing.sequence_nr >= update.sequence_nr) {
+            crate::query_projection_metrics::record_update_stale_skipped(
+                &update.key.tenant,
+                &update.key.entity_type,
+                update.operation.label(),
+                update.source,
+            );
+            return ProjectionEnqueueOutcome::StaleSkipped;
+        }
+
+        if existing.is_none() && pending.updates.len() >= self.capacity {
+            crate::query_projection_metrics::record_update_dropped(
+                &update.key.tenant,
+                &update.key.entity_type,
+                update.operation.label(),
+                update.source,
+            );
+            return ProjectionEnqueueOutcome::Full;
+        }
+
+        let outcome = if existing.is_some() {
+            ProjectionEnqueueOutcome::Coalesced
+        } else {
+            ProjectionEnqueueOutcome::Enqueued
+        };
+        match outcome {
+            ProjectionEnqueueOutcome::Coalesced => {
+                crate::query_projection_metrics::record_update_coalesced(
+                    &update.key.tenant,
+                    &update.key.entity_type,
+                    update.operation.label(),
+                    update.source,
+                )
+            }
+            ProjectionEnqueueOutcome::Enqueued
+            | ProjectionEnqueueOutcome::StaleSkipped
+            | ProjectionEnqueueOutcome::Full => {}
+        }
+        pending.updates.insert(update.key.clone(), update);
+        crate::query_projection_metrics::record_update_queue_depth(pending.updates.len() as u64);
+        drop(pending);
+
+        self.notify.notify_one();
+        outcome
+    }
+
+    fn spawn_worker(self: &Arc<Self>) {
+        let queue = Arc::clone(self);
+        tokio::spawn(async move {
+            queue.run().await;
+        });
+    }
+
+    async fn run(self: Arc<Self>) {
+        loop {
+            let updates = self.take_batch();
+            if updates.is_empty() {
+                self.notify.notified().await;
+                continue;
+            }
+
+            for update in updates {
+                self.apply(update).await;
+            }
+        }
+    }
+
+    fn take_batch(&self) -> Vec<QueuedProjectionUpdate> {
+        let mut pending = self
+            .pending
+            .lock()
+            .expect("query projection queue mutex poisoned");
+        let mut updates = Vec::with_capacity(self.drain_batch.min(pending.updates.len()));
+        for _ in 0..self.drain_batch {
+            let Some((_, update)) = pending.updates.pop_first() else {
+                break;
+            };
+            updates.push(update);
+        }
+        crate::query_projection_metrics::record_update_queue_depth(pending.updates.len() as u64);
+        updates
+    }
+
+    async fn apply(&self, update: QueuedProjectionUpdate) {
+        let operation = match update.operation {
+            ProjectionOperation::Upsert { .. } => "upsert",
+            ProjectionOperation::Remove => "remove",
+        };
+        let source = update.source;
+        let span = tracing::info_span!(
+            "dispatch.phase.query_projection.queued",
+            otel.name = "dispatch.phase.query_projection.queued",
+            tenant = %update.key.tenant,
+            entity_type = %update.key.entity_type,
+            entity_id = %update.key.entity_id,
+            operation,
+            sequence_nr = update.sequence_nr,
+        );
+
+        async move {
+            let started_at = Instant::now();
+            crate::query_projection_metrics::record_update_started(
+                &update.key.tenant,
+                &update.key.entity_type,
+                operation,
+                source,
+            );
+            crate::query_projection_metrics::record_update_queue_wait(
+                &update.key.tenant,
+                &update.key.entity_type,
+                operation,
+                source,
+                started_at.duration_since(update.enqueued_at),
+            );
+
+            let result = match update.operation {
+                ProjectionOperation::Upsert {
+                    status,
+                    fields,
+                    state,
+                } => {
+                    self.store
+                        .upsert_projection(
+                            &update.key.tenant,
+                            &update.key.entity_type,
+                            &update.key.entity_id,
+                            &status,
+                            &fields,
+                            &state,
+                            update.sequence_nr,
+                        )
+                        .await
+                }
+                ProjectionOperation::Remove => {
+                    self.store
+                        .remove_projection(
+                            &update.key.tenant,
+                            &update.key.entity_type,
+                            &update.key.entity_id,
+                        )
+                        .await
+                }
+            };
+            let result_label = if result.is_ok() { "ok" } else { "error" };
+            crate::query_projection_metrics::record_update_duration(
+                &update.key.tenant,
+                &update.key.entity_type,
+                operation,
+                source,
+                result_label,
+                started_at.elapsed(),
+            );
+            crate::query_projection_metrics::record_update_end_to_end_duration(
+                &update.key.tenant,
+                &update.key.entity_type,
+                operation,
+                source,
+                result_label,
+                update.enqueued_at.elapsed(),
+            );
+
+            if let Err(e) = result {
+                crate::query_projection_metrics::record_update_error(
+                    &update.key.tenant,
+                    &update.key.entity_type,
+                    operation,
+                    source,
+                );
+                tracing::error!(
+                    error = %e,
+                    tenant = %update.key.tenant,
+                    entity_type = %update.key.entity_type,
+                    entity_id = %update.key.entity_id,
+                    operation,
+                    sequence_nr = update.sequence_nr,
+                    "failed to update queued query projection"
+                );
+            } else {
+                crate::query_projection_metrics::record_update_applied_sequence(
+                    &update.key.tenant,
+                    &update.key.entity_type,
+                    operation,
+                    source,
+                    update.sequence_nr,
+                );
+            }
+        }
+        .instrument(span)
+        .await;
+    }
+}
+
+impl ProjectionOperation {
+    fn label(&self) -> &'static str {
+        match self {
+            ProjectionOperation::Upsert { .. } => "upsert",
+            ProjectionOperation::Remove => "remove",
+        }
+    }
+}
+
+fn projection_queue_capacity() -> usize {
+    std::env::var("TEMPER_QUERY_PROJECTION_QUEUE_CAPACITY") // determinism-ok: production side-effect queue sizing
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_PROJECTION_QUEUE_CAPACITY)
+}
+
+fn projection_drain_batch() -> usize {
+    std::env::var("TEMPER_QUERY_PROJECTION_DRAIN_BATCH") // determinism-ok: production side-effect queue sizing
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_PROJECTION_DRAIN_BATCH)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/temper-server/src/state/query_projection_queue.rs
+++ b/crates/temper-server/src/state/query_projection_queue.rs
@@ -6,7 +6,7 @@
 
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use tokio::sync::Notify;
 use tracing::Instrument;
@@ -15,6 +15,8 @@ use crate::storage::QueryPlaneStore;
 
 const DEFAULT_PROJECTION_QUEUE_CAPACITY: usize = 20_000;
 const DEFAULT_PROJECTION_DRAIN_BATCH: usize = 256;
+const DEFAULT_PROJECTION_MAX_ATTEMPTS: u32 = 5;
+const DEFAULT_PROJECTION_RETRY_DELAY_MS: u64 = 100;
 
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 struct ProjectionKey {
@@ -62,6 +64,8 @@ pub(crate) struct QueryProjectionWriteQueue {
     notify: Arc<Notify>,
     capacity: usize,
     drain_batch: usize,
+    max_attempts: u32,
+    retry_delay: Duration,
 }
 
 impl QueryProjectionWriteQueue {
@@ -72,6 +76,8 @@ impl QueryProjectionWriteQueue {
             notify: Arc::new(Notify::new()),
             capacity: projection_queue_capacity(),
             drain_batch: projection_drain_batch(),
+            max_attempts: projection_max_attempts(),
+            retry_delay: projection_retry_delay(),
         });
         queue.spawn_worker();
         queue
@@ -85,6 +91,27 @@ impl QueryProjectionWriteQueue {
             notify: Arc::new(Notify::new()),
             capacity,
             drain_batch,
+            max_attempts: DEFAULT_PROJECTION_MAX_ATTEMPTS,
+            retry_delay: Duration::from_millis(1),
+        }
+    }
+
+    #[cfg(test)]
+    fn new_for_test_with_retry(
+        store: Arc<dyn QueryPlaneStore>,
+        capacity: usize,
+        drain_batch: usize,
+        max_attempts: u32,
+        retry_delay: Duration,
+    ) -> Self {
+        Self {
+            store,
+            pending: Arc::new(Mutex::new(PendingProjectionUpdates::default())),
+            notify: Arc::new(Notify::new()),
+            capacity,
+            drain_batch,
+            max_attempts,
+            retry_delay,
         }
     }
 
@@ -227,11 +254,19 @@ impl QueryProjectionWriteQueue {
         updates
     }
 
+    fn has_newer_pending(&self, update: &QueuedProjectionUpdate) -> bool {
+        let pending = self
+            .pending
+            .lock()
+            .expect("query projection queue mutex poisoned");
+        pending
+            .updates
+            .get(&update.key)
+            .is_some_and(|pending| pending.sequence_nr >= update.sequence_nr)
+    }
+
     async fn apply(&self, update: QueuedProjectionUpdate) {
-        let operation = match update.operation {
-            ProjectionOperation::Upsert { .. } => "upsert",
-            ProjectionOperation::Remove => "remove",
-        };
+        let operation = update.operation.label();
         let source = update.source;
         let span = tracing::info_span!(
             "dispatch.phase.query_projection.queued",
@@ -244,91 +279,128 @@ impl QueryProjectionWriteQueue {
         );
 
         async move {
-            let started_at = Instant::now();
-            crate::query_projection_metrics::record_update_started(
-                &update.key.tenant,
-                &update.key.entity_type,
-                operation,
-                source,
-            );
-            crate::query_projection_metrics::record_update_queue_wait(
-                &update.key.tenant,
-                &update.key.entity_type,
-                operation,
-                source,
-                started_at.duration_since(update.enqueued_at),
-            );
+            let mut attempt = 1;
+            loop {
+                let started_at = Instant::now();
+                crate::query_projection_metrics::record_update_started(
+                    &update.key.tenant,
+                    &update.key.entity_type,
+                    operation,
+                    source,
+                );
+                crate::query_projection_metrics::record_update_queue_wait(
+                    &update.key.tenant,
+                    &update.key.entity_type,
+                    operation,
+                    source,
+                    started_at.duration_since(update.enqueued_at),
+                );
 
-            let result = match update.operation {
-                ProjectionOperation::Upsert {
-                    status,
-                    fields,
-                    state,
-                } => {
-                    self.store
-                        .upsert_projection(
+                let result = match &update.operation {
+                    ProjectionOperation::Upsert {
+                        status,
+                        fields,
+                        state,
+                    } => {
+                        self.store
+                            .upsert_projection(
+                                &update.key.tenant,
+                                &update.key.entity_type,
+                                &update.key.entity_id,
+                                status,
+                                fields,
+                                state,
+                                update.sequence_nr,
+                            )
+                            .await
+                    }
+                    ProjectionOperation::Remove => {
+                        self.store
+                            .remove_projection(
+                                &update.key.tenant,
+                                &update.key.entity_type,
+                                &update.key.entity_id,
+                            )
+                            .await
+                    }
+                };
+                let result_label = if result.is_ok() { "ok" } else { "error" };
+                crate::query_projection_metrics::record_update_duration(
+                    &update.key.tenant,
+                    &update.key.entity_type,
+                    operation,
+                    source,
+                    result_label,
+                    started_at.elapsed(),
+                );
+                crate::query_projection_metrics::record_update_end_to_end_duration(
+                    &update.key.tenant,
+                    &update.key.entity_type,
+                    operation,
+                    source,
+                    result_label,
+                    update.enqueued_at.elapsed(),
+                );
+
+                match result {
+                    Ok(()) => {
+                        crate::query_projection_metrics::record_update_applied_sequence(
                             &update.key.tenant,
                             &update.key.entity_type,
-                            &update.key.entity_id,
-                            &status,
-                            &fields,
-                            &state,
+                            operation,
+                            source,
                             update.sequence_nr,
-                        )
-                        .await
-                }
-                ProjectionOperation::Remove => {
-                    self.store
-                        .remove_projection(
+                        );
+                        return;
+                    }
+                    Err(e) => {
+                        crate::query_projection_metrics::record_update_error(
                             &update.key.tenant,
                             &update.key.entity_type,
-                            &update.key.entity_id,
-                        )
-                        .await
+                            operation,
+                            source,
+                        );
+                        if self.has_newer_pending(&update) {
+                            tracing::warn!(
+                                error = %e,
+                                tenant = %update.key.tenant,
+                                entity_type = %update.key.entity_type,
+                                entity_id = %update.key.entity_id,
+                                operation,
+                                sequence_nr = update.sequence_nr,
+                                attempt,
+                                "skipping failed query projection retry because a newer update is queued"
+                            );
+                            return;
+                        }
+                        if attempt >= self.max_attempts {
+                            tracing::error!(
+                                error = %e,
+                                tenant = %update.key.tenant,
+                                entity_type = %update.key.entity_type,
+                                entity_id = %update.key.entity_id,
+                                operation,
+                                sequence_nr = update.sequence_nr,
+                                attempts = attempt,
+                                "failed to update queued query projection after retries"
+                            );
+                            return;
+                        }
+                        tracing::warn!(
+                            error = %e,
+                            tenant = %update.key.tenant,
+                            entity_type = %update.key.entity_type,
+                            entity_id = %update.key.entity_id,
+                            operation,
+                            sequence_nr = update.sequence_nr,
+                            attempt,
+                            max_attempts = self.max_attempts,
+                            "failed to update queued query projection; retrying"
+                        );
+                        attempt += 1;
+                        tokio::time::sleep(self.retry_delay).await; // determinism-ok: production side-effect retry backoff
+                    }
                 }
-            };
-            let result_label = if result.is_ok() { "ok" } else { "error" };
-            crate::query_projection_metrics::record_update_duration(
-                &update.key.tenant,
-                &update.key.entity_type,
-                operation,
-                source,
-                result_label,
-                started_at.elapsed(),
-            );
-            crate::query_projection_metrics::record_update_end_to_end_duration(
-                &update.key.tenant,
-                &update.key.entity_type,
-                operation,
-                source,
-                result_label,
-                update.enqueued_at.elapsed(),
-            );
-
-            if let Err(e) = result {
-                crate::query_projection_metrics::record_update_error(
-                    &update.key.tenant,
-                    &update.key.entity_type,
-                    operation,
-                    source,
-                );
-                tracing::error!(
-                    error = %e,
-                    tenant = %update.key.tenant,
-                    entity_type = %update.key.entity_type,
-                    entity_id = %update.key.entity_id,
-                    operation,
-                    sequence_nr = update.sequence_nr,
-                    "failed to update queued query projection"
-                );
-            } else {
-                crate::query_projection_metrics::record_update_applied_sequence(
-                    &update.key.tenant,
-                    &update.key.entity_type,
-                    operation,
-                    source,
-                    update.sequence_nr,
-                );
             }
         }
         .instrument(span)
@@ -359,6 +431,22 @@ fn projection_drain_batch() -> usize {
         .and_then(|value| value.trim().parse::<usize>().ok())
         .filter(|value| *value > 0)
         .unwrap_or(DEFAULT_PROJECTION_DRAIN_BATCH)
+}
+
+fn projection_max_attempts() -> u32 {
+    std::env::var("TEMPER_QUERY_PROJECTION_MAX_ATTEMPTS") // determinism-ok: production side-effect queue sizing
+        .ok()
+        .and_then(|value| value.trim().parse::<u32>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_PROJECTION_MAX_ATTEMPTS)
+}
+
+fn projection_retry_delay() -> Duration {
+    let millis = std::env::var("TEMPER_QUERY_PROJECTION_RETRY_DELAY_MS") // determinism-ok: production side-effect queue sizing
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_PROJECTION_RETRY_DELAY_MS);
+    Duration::from_millis(millis)
 }
 
 #[cfg(test)]

--- a/crates/temper-server/src/state/query_projection_queue/tests.rs
+++ b/crates/temper-server/src/state/query_projection_queue/tests.rs
@@ -4,11 +4,13 @@ use crate::storage::{
 };
 use async_trait::async_trait;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 use temper_runtime::persistence::PersistenceError;
 
 #[derive(Default)]
 struct RecordingQueryPlane {
     upserts: AtomicUsize,
+    fail_upserts: AtomicUsize,
 }
 
 #[async_trait]
@@ -24,6 +26,12 @@ impl QueryPlaneStore for RecordingQueryPlane {
         _sequence_nr: u64,
     ) -> Result<(), PersistenceError> {
         self.upserts.fetch_add(1, Ordering::SeqCst);
+        if self.fail_upserts.load(Ordering::SeqCst) > 0 {
+            self.fail_upserts.fetch_sub(1, Ordering::SeqCst);
+            return Err(PersistenceError::Storage(
+                "transient projection failure".to_string(),
+            ));
+        }
         Ok(())
     }
 
@@ -185,4 +193,40 @@ fn enqueue_rejects_new_entity_when_capacity_is_exhausted() {
         ),
         ProjectionEnqueueOutcome::Full
     );
+}
+
+#[tokio::test]
+async fn failed_projection_write_is_retried_before_drop() {
+    let store = Arc::new(RecordingQueryPlane {
+        fail_upserts: AtomicUsize::new(1),
+        ..RecordingQueryPlane::default()
+    });
+    let queue = QueryProjectionWriteQueue::new_for_test_with_retry(
+        store.clone(),
+        10,
+        10,
+        2,
+        Duration::from_millis(1),
+    );
+
+    assert_eq!(
+        queue.enqueue_upsert(
+            "tenant".to_string(),
+            "Session".to_string(),
+            "s-1".to_string(),
+            "Idle".to_string(),
+            serde_json::json!({"Title": "retry"}),
+            serde_json::json!({"sequence_nr": 4}),
+            4,
+            "test",
+        ),
+        ProjectionEnqueueOutcome::Enqueued
+    );
+    let mut batch = queue.take_batch();
+    assert_eq!(batch.len(), 1);
+
+    queue.apply(batch.pop().expect("queued update")).await;
+
+    assert_eq!(store.upserts.load(Ordering::SeqCst), 2);
+    assert_eq!(store.fail_upserts.load(Ordering::SeqCst), 0);
 }

--- a/crates/temper-server/src/state/query_projection_queue/tests.rs
+++ b/crates/temper-server/src/state/query_projection_queue/tests.rs
@@ -1,0 +1,188 @@
+use super::*;
+use crate::storage::{
+    EntityCatalogRow, QueryFieldIndexOrder, QueryFieldIndexPage, QueryProjectionFieldsRow,
+};
+use async_trait::async_trait;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use temper_runtime::persistence::PersistenceError;
+
+#[derive(Default)]
+struct RecordingQueryPlane {
+    upserts: AtomicUsize,
+}
+
+#[async_trait]
+impl QueryPlaneStore for RecordingQueryPlane {
+    async fn upsert_projection(
+        &self,
+        _tenant: &str,
+        _entity_type: &str,
+        _entity_id: &str,
+        _status: &str,
+        _fields: &serde_json::Value,
+        _state: &serde_json::Value,
+        _sequence_nr: u64,
+    ) -> Result<(), PersistenceError> {
+        self.upserts.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn remove_projection(
+        &self,
+        _tenant: &str,
+        _entity_type: &str,
+        _entity_id: &str,
+    ) -> Result<(), PersistenceError> {
+        Ok(())
+    }
+
+    async fn query_field_index(
+        &self,
+        _tenant: &str,
+        _entity_type: &str,
+        _where_clause: &str,
+        _params: Vec<String>,
+    ) -> Result<Option<Vec<String>>, PersistenceError> {
+        Ok(None)
+    }
+
+    async fn query_field_index_page(
+        &self,
+        _tenant: &str,
+        _entity_type: &str,
+        _where_clause: &str,
+        _params: Vec<String>,
+        _order_by: &[QueryFieldIndexOrder],
+        _skip: usize,
+        _top: usize,
+        _include_count: bool,
+    ) -> Result<Option<QueryFieldIndexPage>, PersistenceError> {
+        Ok(None)
+    }
+
+    async fn load_projection_fields_many(
+        &self,
+        _tenant: &str,
+        _entity_type: &str,
+        _entity_ids: &[String],
+        _field_names: &[&str],
+    ) -> Result<Option<Vec<QueryProjectionFieldsRow>>, PersistenceError> {
+        Ok(None)
+    }
+
+    async fn load_entity_catalog_rows(
+        &self,
+        _tenant: &str,
+        _entity_type: &str,
+        _entity_ids: &[String],
+    ) -> Result<Option<Vec<EntityCatalogRow>>, PersistenceError> {
+        Ok(None)
+    }
+
+    async fn projected_entity_counts_by_tenant(
+        &self,
+    ) -> Result<Option<Vec<(String, u64)>>, PersistenceError> {
+        Ok(None)
+    }
+}
+
+#[test]
+fn enqueue_coalesces_newer_entity_update() {
+    let store = Arc::new(RecordingQueryPlane::default());
+    let queue = QueryProjectionWriteQueue::new_for_test(store, 10, 10);
+
+    assert_eq!(
+        queue.enqueue_upsert(
+            "tenant".to_string(),
+            "Session".to_string(),
+            "s-1".to_string(),
+            "Running".to_string(),
+            serde_json::json!({"Title": "old"}),
+            serde_json::json!({"sequence_nr": 1}),
+            1,
+            "test",
+        ),
+        ProjectionEnqueueOutcome::Enqueued
+    );
+    assert_eq!(
+        queue.enqueue_upsert(
+            "tenant".to_string(),
+            "Session".to_string(),
+            "s-1".to_string(),
+            "Idle".to_string(),
+            serde_json::json!({"Title": "new"}),
+            serde_json::json!({"sequence_nr": 2}),
+            2,
+            "test",
+        ),
+        ProjectionEnqueueOutcome::Coalesced
+    );
+
+    let batch = queue.take_batch();
+    assert_eq!(batch.len(), 1);
+    assert_eq!(batch[0].sequence_nr, 2);
+}
+
+#[test]
+fn enqueue_skips_stale_update_before_store_access() {
+    let store = Arc::new(RecordingQueryPlane::default());
+    let queue = QueryProjectionWriteQueue::new_for_test(store, 10, 10);
+
+    assert_eq!(
+        queue.enqueue_upsert(
+            "tenant".to_string(),
+            "Session".to_string(),
+            "s-1".to_string(),
+            "Idle".to_string(),
+            serde_json::json!({}),
+            serde_json::json!({"sequence_nr": 3}),
+            3,
+            "test",
+        ),
+        ProjectionEnqueueOutcome::Enqueued
+    );
+    assert_eq!(
+        queue.enqueue_upsert(
+            "tenant".to_string(),
+            "Session".to_string(),
+            "s-1".to_string(),
+            "Running".to_string(),
+            serde_json::json!({}),
+            serde_json::json!({"sequence_nr": 2}),
+            2,
+            "test",
+        ),
+        ProjectionEnqueueOutcome::StaleSkipped
+    );
+
+    let batch = queue.take_batch();
+    assert_eq!(batch.len(), 1);
+    assert_eq!(batch[0].sequence_nr, 3);
+}
+
+#[test]
+fn enqueue_rejects_new_entity_when_capacity_is_exhausted() {
+    let store = Arc::new(RecordingQueryPlane::default());
+    let queue = QueryProjectionWriteQueue::new_for_test(store, 1, 10);
+
+    assert_eq!(
+        queue.enqueue_remove(
+            "tenant".to_string(),
+            "Session".to_string(),
+            "s-1".to_string(),
+            1,
+            "test",
+        ),
+        ProjectionEnqueueOutcome::Enqueued
+    );
+    assert_eq!(
+        queue.enqueue_remove(
+            "tenant".to_string(),
+            "Session".to_string(),
+            "s-2".to_string(),
+            1,
+            "test",
+        ),
+        ProjectionEnqueueOutcome::Full
+    );
+}

--- a/crates/temper-server/src/storage/mod.rs
+++ b/crates/temper-server/src/storage/mod.rs
@@ -23,10 +23,10 @@ use temper_runtime::persistence::{
 use temper_store_postgres::{PostgresEventStore, PostgresPolicyRow, PostgresTrajectoryInsert};
 use temper_store_turso::{
     ActionStats, AgentSummary, DesignTimeEventRow, EvolutionRecordRow, FeatureRequestRow,
-    OtsTrajectoryParams, OtsTrajectoryRow, PolicyDenialPatternRow, PolicyRow as TursoPolicyRow,
-    TenantStoreRouter, TenantUserRow, TursoEventStore, TursoTrajectoryInsert, TursoTrajectoryRow,
-    TursoWasmInvocationInsert, TursoWasmInvocationRow, TursoWasmModuleMetadataRow,
-    UnmetIntentAggRow, store::TrajectoryStats,
+    OtsQueuedTrajectoryRow, OtsTrajectoryParams, OtsTrajectoryRow, PolicyDenialPatternRow,
+    PolicyRow as TursoPolicyRow, TenantStoreRouter, TenantUserRow, TursoEventStore,
+    TursoTrajectoryInsert, TursoTrajectoryRow, TursoWasmInvocationInsert, TursoWasmInvocationRow,
+    TursoWasmModuleMetadataRow, UnmetIntentAggRow, store::TrajectoryStats,
 };
 
 use crate::platform_store::PlatformStore;
@@ -545,6 +545,27 @@ pub trait OtsStore: Send + Sync {
         &self,
         params: &OtsTrajectoryParams<'_>,
     ) -> Result<(), PersistenceError>;
+
+    async fn enqueue_ots_trajectory(
+        &self,
+        params: &OtsTrajectoryParams<'_>,
+    ) -> Result<(), PersistenceError>;
+
+    async fn mark_ots_trajectory_persisted(
+        &self,
+        trajectory_id: &str,
+    ) -> Result<(), PersistenceError>;
+
+    async fn mark_ots_trajectory_failed(
+        &self,
+        trajectory_id: &str,
+        error: &str,
+    ) -> Result<(), PersistenceError>;
+
+    async fn list_queued_ots_trajectories(
+        &self,
+        limit: i64,
+    ) -> Result<Vec<OtsQueuedTrajectoryRow>, PersistenceError>;
 
     async fn list_ots_trajectories(
         &self,
@@ -1688,6 +1709,46 @@ impl OtsStore for PostgresEventStore {
         .await
     }
 
+    async fn enqueue_ots_trajectory(
+        &self,
+        params: &OtsTrajectoryParams<'_>,
+    ) -> Result<(), PersistenceError> {
+        self.enqueue_ots_trajectory(&temper_store_postgres::PostgresOtsTrajectoryParams {
+            trajectory_id: params.trajectory_id,
+            tenant: params.tenant,
+            agent_id: params.agent_id,
+            session_id: params.session_id,
+            outcome: params.outcome,
+            turn_count: params.turn_count,
+            data: params.data,
+        })
+        .await
+    }
+
+    async fn mark_ots_trajectory_persisted(
+        &self,
+        trajectory_id: &str,
+    ) -> Result<(), PersistenceError> {
+        self.mark_ots_trajectory_persisted(trajectory_id).await
+    }
+
+    async fn mark_ots_trajectory_failed(
+        &self,
+        trajectory_id: &str,
+        error: &str,
+    ) -> Result<(), PersistenceError> {
+        self.mark_ots_trajectory_failed(trajectory_id, error).await
+    }
+
+    async fn list_queued_ots_trajectories(
+        &self,
+        limit: i64,
+    ) -> Result<Vec<OtsQueuedTrajectoryRow>, PersistenceError> {
+        self.list_queued_ots_trajectories(limit)
+            .await
+            .map(|rows| rows.into_iter().map(pg_queued_ots_to_turso).collect())
+    }
+
     async fn list_ots_trajectories(
         &self,
         tenant: &str,
@@ -1715,6 +1776,35 @@ impl OtsStore for TursoEventStore {
         params: &OtsTrajectoryParams<'_>,
     ) -> Result<(), PersistenceError> {
         self.persist_ots_trajectory(params).await
+    }
+
+    async fn enqueue_ots_trajectory(
+        &self,
+        params: &OtsTrajectoryParams<'_>,
+    ) -> Result<(), PersistenceError> {
+        self.enqueue_ots_trajectory(params).await
+    }
+
+    async fn mark_ots_trajectory_persisted(
+        &self,
+        trajectory_id: &str,
+    ) -> Result<(), PersistenceError> {
+        self.mark_ots_trajectory_persisted(trajectory_id).await
+    }
+
+    async fn mark_ots_trajectory_failed(
+        &self,
+        trajectory_id: &str,
+        error: &str,
+    ) -> Result<(), PersistenceError> {
+        self.mark_ots_trajectory_failed(trajectory_id, error).await
+    }
+
+    async fn list_queued_ots_trajectories(
+        &self,
+        limit: i64,
+    ) -> Result<Vec<OtsQueuedTrajectoryRow>, PersistenceError> {
+        self.list_queued_ots_trajectories(limit).await
     }
 
     async fn list_ots_trajectories(
@@ -2104,7 +2194,26 @@ fn pg_ots_to_turso(row: temper_store_postgres::PostgresOtsTrajectoryRow) -> OtsT
         session_id: row.session_id,
         outcome: row.outcome,
         turn_count: row.turn_count,
+        persistence_status: row.persistence_status,
+        persist_attempts: row.persist_attempts,
+        last_error: row.last_error,
         created_at: row.created_at,
+        updated_at: row.updated_at,
+    }
+}
+
+fn pg_queued_ots_to_turso(
+    row: temper_store_postgres::PostgresQueuedOtsTrajectoryRow,
+) -> OtsQueuedTrajectoryRow {
+    OtsQueuedTrajectoryRow {
+        trajectory_id: row.trajectory_id,
+        tenant: row.tenant,
+        agent_id: row.agent_id,
+        session_id: row.session_id,
+        outcome: row.outcome,
+        turn_count: row.turn_count,
+        data: row.data,
+        persist_attempts: row.persist_attempts,
     }
 }
 

--- a/crates/temper-store-postgres/migrations/0008_ots_trajectory_outbox_status.sql
+++ b/crates/temper-store-postgres/migrations/0008_ots_trajectory_outbox_status.sql
@@ -1,0 +1,14 @@
+ALTER TABLE ots_trajectories
+    ADD COLUMN IF NOT EXISTS persistence_status TEXT NOT NULL DEFAULT 'persisted';
+
+ALTER TABLE ots_trajectories
+    ADD COLUMN IF NOT EXISTS persist_attempts BIGINT NOT NULL DEFAULT 0;
+
+ALTER TABLE ots_trajectories
+    ADD COLUMN IF NOT EXISTS last_error TEXT;
+
+ALTER TABLE ots_trajectories
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+CREATE INDEX IF NOT EXISTS idx_ots_trajectories_status
+    ON ots_trajectories (persistence_status, updated_at);

--- a/crates/temper-store-postgres/src/lib.rs
+++ b/crates/temper-store-postgres/src/lib.rs
@@ -30,9 +30,10 @@ pub use platform::{
     PostgresEvolutionRecordRow, PostgresFeatureRequestRow, PostgresInstalledAppRow,
     PostgresOtsTrajectoryParams, PostgresOtsTrajectoryRow, PostgresPolicyDenialPatternRow,
     PostgresPolicyRow, PostgresProjectedEntityFieldsRow, PostgresPublishedArtifactRow,
-    PostgresPublishedArtifactUpsert, PostgresSecretRow, PostgresSpecRow,
-    PostgresSpecVerificationUpdate, PostgresTrajectoryInsert, PostgresTrajectoryRow,
-    PostgresTrajectoryStats, PostgresUnmetIntentAggRow, PostgresWasmInvocationInsert,
-    PostgresWasmInvocationRow, PostgresWasmModuleMetadataRow, PostgresWasmModuleRow,
+    PostgresPublishedArtifactUpsert, PostgresQueuedOtsTrajectoryRow, PostgresSecretRow,
+    PostgresSpecRow, PostgresSpecVerificationUpdate, PostgresTrajectoryInsert,
+    PostgresTrajectoryRow, PostgresTrajectoryStats, PostgresUnmetIntentAggRow,
+    PostgresWasmInvocationInsert, PostgresWasmInvocationRow, PostgresWasmModuleMetadataRow,
+    PostgresWasmModuleRow,
 };
 pub use store::PostgresEventStore;

--- a/crates/temper-store-postgres/src/migration.rs
+++ b/crates/temper-store-postgres/src/migration.rs
@@ -36,6 +36,7 @@ mod tests {
             include_str!("../migrations/0005_installed_app_genesis_provenance.sql"),
             include_str!("../migrations/0006_segmented_event_history.sql"),
             include_str!("../migrations/0007_installed_app_follow_policy.sql"),
+            include_str!("../migrations/0008_ots_trajectory_outbox_status.sql"),
         ]
         .join("\n")
         .to_lowercase();
@@ -51,6 +52,7 @@ mod tests {
             "published_artifacts",
             "event_segments",
             "snapshot_history",
+            "ots_trajectories",
         ] {
             assert!(
                 migration.contains(&format!("create table if not exists {table}")),
@@ -68,6 +70,10 @@ mod tests {
         assert!(
             migration.contains("add column if not exists state jsonb"),
             "versioned migration must add entity catalog state metadata"
+        );
+        assert!(
+            migration.contains("persistence_status"),
+            "versioned migration must add OTS outbox status metadata"
         );
     }
 

--- a/crates/temper-store-postgres/src/platform.rs
+++ b/crates/temper-store-postgres/src/platform.rs
@@ -393,7 +393,23 @@ pub struct PostgresOtsTrajectoryRow {
     pub session_id: String,
     pub outcome: String,
     pub turn_count: i64,
+    pub persistence_status: String,
+    pub persist_attempts: i64,
+    pub last_error: Option<String>,
     pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct PostgresQueuedOtsTrajectoryRow {
+    pub trajectory_id: String,
+    pub tenant: String,
+    pub agent_id: String,
+    pub session_id: String,
+    pub outcome: String,
+    pub turn_count: i64,
+    pub data: String,
+    pub persist_attempts: i64,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -1965,11 +1981,12 @@ impl PostgresEventStore {
         let data = parse_json(p.data)?;
         crate::dbm::postgres_query!(
             "INSERT INTO ots_trajectories \
-             (trajectory_id, tenant, agent_id, session_id, outcome, turn_count, data, created_at) \
-             VALUES ($1, $2, $3, $4, $5, $6, $7, now()) \
+             (trajectory_id, tenant, agent_id, session_id, outcome, turn_count, data, persistence_status, persist_attempts, last_error, created_at, updated_at) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, 'persisted', 0, NULL, now(), now()) \
              ON CONFLICT (trajectory_id) DO UPDATE SET \
                  tenant = EXCLUDED.tenant, agent_id = EXCLUDED.agent_id, session_id = EXCLUDED.session_id, \
-                 outcome = EXCLUDED.outcome, turn_count = EXCLUDED.turn_count, data = EXCLUDED.data, created_at = now()",
+                 outcome = EXCLUDED.outcome, turn_count = EXCLUDED.turn_count, data = EXCLUDED.data, \
+                 persistence_status = 'persisted', persist_attempts = 0, last_error = NULL, updated_at = now()",
         )
         .bind(p.trajectory_id)
         .bind(p.tenant)
@@ -1984,6 +2001,85 @@ impl PostgresEventStore {
         Ok(())
     }
 
+    pub async fn enqueue_ots_trajectory(
+        &self,
+        p: &PostgresOtsTrajectoryParams<'_>,
+    ) -> Result<(), PersistenceError> {
+        let data = parse_json(p.data)?;
+        crate::dbm::postgres_query!(
+            "INSERT INTO ots_trajectories \
+             (trajectory_id, tenant, agent_id, session_id, outcome, turn_count, data, persistence_status, persist_attempts, last_error, created_at, updated_at) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, 'queued', 0, NULL, now(), now()) \
+             ON CONFLICT (trajectory_id) DO UPDATE SET \
+                 tenant = EXCLUDED.tenant, agent_id = EXCLUDED.agent_id, session_id = EXCLUDED.session_id, \
+                 outcome = EXCLUDED.outcome, turn_count = EXCLUDED.turn_count, data = EXCLUDED.data, \
+                 persistence_status = 'queued', last_error = NULL, updated_at = now()",
+        )
+        .bind(p.trajectory_id)
+        .bind(p.tenant)
+        .bind(p.agent_id)
+        .bind(p.session_id)
+        .bind(p.outcome)
+        .bind(p.turn_count)
+        .bind(data)
+        .execute(self.pool())
+        .await
+        .map_err(storage_error)?;
+        Ok(())
+    }
+
+    pub async fn mark_ots_trajectory_persisted(
+        &self,
+        trajectory_id: &str,
+    ) -> Result<(), PersistenceError> {
+        crate::dbm::postgres_query!(
+            "UPDATE ots_trajectories \
+             SET persistence_status = 'persisted', last_error = NULL, updated_at = now() \
+             WHERE trajectory_id = $1",
+        )
+        .bind(trajectory_id)
+        .execute(self.pool())
+        .await
+        .map_err(storage_error)?;
+        Ok(())
+    }
+
+    pub async fn mark_ots_trajectory_failed(
+        &self,
+        trajectory_id: &str,
+        error: &str,
+    ) -> Result<(), PersistenceError> {
+        crate::dbm::postgres_query!(
+            "UPDATE ots_trajectories \
+             SET persistence_status = 'failed', persist_attempts = persist_attempts + 1, last_error = $2, updated_at = now() \
+             WHERE trajectory_id = $1",
+        )
+        .bind(trajectory_id)
+        .bind(error)
+        .execute(self.pool())
+        .await
+        .map_err(storage_error)?;
+        Ok(())
+    }
+
+    pub async fn list_queued_ots_trajectories(
+        &self,
+        limit: i64,
+    ) -> Result<Vec<PostgresQueuedOtsTrajectoryRow>, PersistenceError> {
+        let rows = crate::dbm::postgres_query!(
+            "SELECT trajectory_id, tenant, agent_id, COALESCE(session_id, '') AS session_id, outcome, turn_count, data, persist_attempts \
+             FROM ots_trajectories \
+             WHERE persistence_status = 'queued' \
+             ORDER BY updated_at ASC, created_at ASC \
+             LIMIT $1",
+        )
+        .bind(limit)
+        .fetch_all(self.pool())
+        .await
+        .map_err(storage_error)?;
+        Ok(rows.into_iter().map(row_to_queued_ots_trajectory).collect())
+    }
+
     pub async fn list_ots_trajectories(
         &self,
         tenant: &str,
@@ -1992,7 +2088,7 @@ impl PostgresEventStore {
         limit: i64,
     ) -> Result<Vec<PostgresOtsTrajectoryRow>, PersistenceError> {
         let rows = crate::dbm::postgres_query!(
-            "SELECT trajectory_id, tenant, agent_id, COALESCE(session_id, '') AS session_id, outcome, turn_count, created_at \
+            "SELECT trajectory_id, tenant, agent_id, COALESCE(session_id, '') AS session_id, outcome, turn_count, persistence_status, persist_attempts, last_error, created_at, updated_at \
              FROM ots_trajectories \
              WHERE tenant = $1 \
                AND ($2::text IS NULL OR agent_id = $2) \

--- a/crates/temper-store-postgres/src/platform/rows.rs
+++ b/crates/temper-store-postgres/src/platform/rows.rs
@@ -236,6 +236,7 @@ pub(super) fn row_to_design_time_event(row: sqlx::postgres::PgRow) -> PostgresDe
 
 pub(super) fn row_to_ots_trajectory(row: sqlx::postgres::PgRow) -> PostgresOtsTrajectoryRow {
     let created_at: chrono::DateTime<chrono::Utc> = row.get("created_at");
+    let updated_at: chrono::DateTime<chrono::Utc> = row.get("updated_at");
     PostgresOtsTrajectoryRow {
         trajectory_id: row.get("trajectory_id"),
         tenant: row.get("tenant"),
@@ -243,7 +244,27 @@ pub(super) fn row_to_ots_trajectory(row: sqlx::postgres::PgRow) -> PostgresOtsTr
         session_id: row.get("session_id"),
         outcome: row.get("outcome"),
         turn_count: row.get("turn_count"),
+        persistence_status: row.get("persistence_status"),
+        persist_attempts: row.get("persist_attempts"),
+        last_error: row.get("last_error"),
         created_at: created_at.to_rfc3339(),
+        updated_at: updated_at.to_rfc3339(),
+    }
+}
+
+pub(super) fn row_to_queued_ots_trajectory(
+    row: sqlx::postgres::PgRow,
+) -> PostgresQueuedOtsTrajectoryRow {
+    let data: serde_json::Value = row.get("data");
+    PostgresQueuedOtsTrajectoryRow {
+        trajectory_id: row.get("trajectory_id"),
+        tenant: row.get("tenant"),
+        agent_id: row.get("agent_id"),
+        session_id: row.get("session_id"),
+        outcome: row.get("outcome"),
+        turn_count: row.get("turn_count"),
+        data: data.to_string(),
+        persist_attempts: row.get("persist_attempts"),
     }
 }
 

--- a/crates/temper-store-postgres/src/query_page.rs
+++ b/crates/temper-store-postgres/src/query_page.rs
@@ -29,14 +29,29 @@ impl PostgresEventStore {
         let order_sql = postgres_query_field_order_sql(order_by);
         let limit_param = params.len() + 3;
         let offset_param = params.len() + 4;
-        let sql = format!(
-            "SELECT entity_id, COUNT(*) OVER() AS total_count \
-             FROM entity_catalog \
-             WHERE tenant = $1 AND entity_type = $2 AND ({clause}) \
-             ORDER BY {order_sql} \
-             LIMIT ${limit_param} OFFSET ${offset_param}"
+        let sql = postgres_query_field_page_sql(
+            &clause,
+            &order_sql,
+            limit_param,
+            offset_param,
+            include_count,
         );
         let tagged_sql = crate::dbm::tag_sql(&sql);
+        if !include_count {
+            let mut query = sqlx::query_scalar::<_, String>(tagged_sql.as_ref())
+                .bind(tenant)
+                .bind(entity_type);
+            for param in params.iter().cloned() {
+                query = query.bind(param);
+            }
+            query = query
+                .bind(top.min(i64::MAX as usize) as i64)
+                .bind(skip.min(i64::MAX as usize) as i64);
+
+            let entity_ids = query.fetch_all(self.pool()).await.map_err(storage_error)?;
+            return Ok((entity_ids, None));
+        }
+
         let mut query = sqlx::query_as::<_, (String, i64)>(tagged_sql.as_ref())
             .bind(tenant)
             .bind(entity_type);
@@ -91,6 +106,27 @@ impl PostgresEventStore {
     }
 }
 
+fn postgres_query_field_page_sql(
+    clause: &str,
+    order_sql: &str,
+    limit_param: usize,
+    offset_param: usize,
+    include_count: bool,
+) -> String {
+    let select = if include_count {
+        "entity_id, COUNT(*) OVER() AS total_count"
+    } else {
+        "entity_id"
+    };
+    format!(
+        "SELECT {select} \
+         FROM entity_catalog \
+         WHERE tenant = $1 AND entity_type = $2 AND ({clause}) \
+         ORDER BY {order_sql} \
+         LIMIT ${limit_param} OFFSET ${offset_param}"
+    )
+}
+
 fn postgres_query_field_order_sql(order_by: &[(String, bool)]) -> String {
     let mut clauses = Vec::new();
     for (field_name, descending) in order_by {
@@ -122,4 +158,24 @@ fn postgres_query_field_order_sql(order_by: &[(String, bool)]) -> String {
 
 fn postgres_string_literal(value: &str) -> String {
     format!("'{}'", value.replace('\'', "''"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_count_page_sql_does_not_compute_window_count() {
+        let sql = postgres_query_field_page_sql("entity_id = $3", "entity_id ASC", 4, 5, false);
+
+        assert!(sql.starts_with("SELECT entity_id FROM entity_catalog"));
+        assert!(!sql.contains("COUNT(*) OVER()"));
+    }
+
+    #[test]
+    fn count_page_sql_computes_count_only_when_requested() {
+        let sql = postgres_query_field_page_sql("entity_id = $3", "entity_id ASC", 4, 5, true);
+
+        assert!(sql.contains("COUNT(*) OVER() AS total_count"));
+    }
 }

--- a/crates/temper-store-postgres/src/schema.rs
+++ b/crates/temper-store-postgres/src/schema.rs
@@ -415,8 +415,28 @@ CREATE TABLE IF NOT EXISTS ots_trajectories (
     entity_type   TEXT,
     turn_count    BIGINT       NOT NULL DEFAULT 0,
     data          JSONB        NOT NULL,
-    created_at    TIMESTAMPTZ  NOT NULL DEFAULT now()
+    persistence_status TEXT    NOT NULL DEFAULT 'persisted',
+    persist_attempts BIGINT    NOT NULL DEFAULT 0,
+    last_error    TEXT,
+    created_at    TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at    TIMESTAMPTZ  NOT NULL DEFAULT now()
 );";
+
+/// Add durable outbox status to existing OTS trajectory tables.
+pub const ALTER_OTS_TRAJECTORIES_ADD_PERSISTENCE_STATUS: &str = "\
+ALTER TABLE ots_trajectories ADD COLUMN IF NOT EXISTS persistence_status TEXT NOT NULL DEFAULT 'persisted';";
+
+/// Add durable outbox attempt count to existing OTS trajectory tables.
+pub const ALTER_OTS_TRAJECTORIES_ADD_PERSIST_ATTEMPTS: &str = "\
+ALTER TABLE ots_trajectories ADD COLUMN IF NOT EXISTS persist_attempts BIGINT NOT NULL DEFAULT 0;";
+
+/// Add durable outbox error details to existing OTS trajectory tables.
+pub const ALTER_OTS_TRAJECTORIES_ADD_LAST_ERROR: &str = "\
+ALTER TABLE ots_trajectories ADD COLUMN IF NOT EXISTS last_error TEXT;";
+
+/// Add durable outbox update timestamp to existing OTS trajectory tables.
+pub const ALTER_OTS_TRAJECTORIES_ADD_UPDATED_AT: &str = "\
+ALTER TABLE ots_trajectories ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT now();";
 
 /// CREATE INDEX for OTS lookup by agent.
 pub const CREATE_OTS_TRAJECTORIES_AGENT_INDEX: &str = "\
@@ -432,6 +452,11 @@ CREATE INDEX IF NOT EXISTS idx_ots_trajectories_tenant
 pub const CREATE_OTS_TRAJECTORIES_OUTCOME_INDEX: &str = "\
 CREATE INDEX IF NOT EXISTS idx_ots_trajectories_outcome
     ON ots_trajectories (outcome);";
+
+/// CREATE INDEX for OTS durable outbox recovery.
+pub const CREATE_OTS_TRAJECTORIES_STATUS_INDEX: &str = "\
+CREATE INDEX IF NOT EXISTS idx_ots_trajectories_status
+    ON ots_trajectories (persistence_status, updated_at);";
 
 /// Content-addressed blob storage for development/local deployments.
 pub const CREATE_BLOBS_TABLE: &str = "\

--- a/crates/temper-store-postgres/src/store_projection_test.rs
+++ b/crates/temper-store-postgres/src/store_projection_test.rs
@@ -263,6 +263,25 @@ fn query_field_index_page_orders_and_limits_inside_postgres() {
         assert_eq!(ids, vec!["entry-10".to_string()]);
         assert_eq!(count, Some(3));
 
+        let (ids, count) = store
+            .query_field_index_page(
+                &tenant,
+                entity_type,
+                "entity_id IN (SELECT entity_id FROM entity_field_index \
+                 WHERE tenant = ?1 AND entity_type = ?2 \
+                 AND field_name = ?3 AND field_value = ?4)",
+                vec!["SessionId".to_string(), "ss-bounded".to_string()],
+                &[("Sequence".to_string(), true)],
+                0,
+                1,
+                false,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(ids, vec!["entry-10".to_string()]);
+        assert_eq!(count, None);
+
         let missing_sequence_id = "entry-missing-sequence";
         let missing_sequence_fields = serde_json::json!({
             "SessionId": "ss-bounded",

--- a/crates/temper-store-turso/src/lib.rs
+++ b/crates/temper-store-turso/src/lib.rs
@@ -77,5 +77,5 @@ pub use store::{
     QueryProjectionUpsert, TursoBlobRow, TursoEventStore, TursoInstalledAppRow,
     TursoQueryProjectionRow, TursoSpecRow, TursoTenantConstraintRow, TursoTrajectoryRow,
     TursoWasmInvocationRow, TursoWasmModuleMetadataRow, TursoWasmModuleRow, UnmetIntentAggRow,
-    ots::{OtsTrajectoryParams, OtsTrajectoryRow},
+    ots::{OtsQueuedTrajectoryRow, OtsTrajectoryParams, OtsTrajectoryRow},
 };

--- a/crates/temper-store-turso/src/schema.rs
+++ b/crates/temper-store-turso/src/schema.rs
@@ -455,8 +455,24 @@ CREATE TABLE IF NOT EXISTS ots_trajectories (
     entity_type TEXT,
     turn_count INTEGER NOT NULL DEFAULT 0,
     data TEXT NOT NULL,
-    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    persistence_status TEXT NOT NULL DEFAULT 'persisted',
+    persist_attempts INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );";
+
+pub const ALTER_OTS_TRAJECTORIES_ADD_PERSISTENCE_STATUS: &str = "\
+ALTER TABLE ots_trajectories ADD COLUMN persistence_status TEXT NOT NULL DEFAULT 'persisted';";
+
+pub const ALTER_OTS_TRAJECTORIES_ADD_PERSIST_ATTEMPTS: &str = "\
+ALTER TABLE ots_trajectories ADD COLUMN persist_attempts INTEGER NOT NULL DEFAULT 0;";
+
+pub const ALTER_OTS_TRAJECTORIES_ADD_LAST_ERROR: &str = "\
+ALTER TABLE ots_trajectories ADD COLUMN last_error TEXT;";
+
+pub const ALTER_OTS_TRAJECTORIES_ADD_UPDATED_AT: &str = "\
+ALTER TABLE ots_trajectories ADD COLUMN updated_at TEXT NOT NULL DEFAULT (datetime('now'));";
 
 pub const CREATE_OTS_TRAJECTORIES_AGENT_INDEX: &str = "\
 CREATE INDEX IF NOT EXISTS idx_ots_trajectories_agent
@@ -469,6 +485,10 @@ CREATE INDEX IF NOT EXISTS idx_ots_trajectories_tenant
 pub const CREATE_OTS_TRAJECTORIES_OUTCOME_INDEX: &str = "\
 CREATE INDEX IF NOT EXISTS idx_ots_trajectories_outcome
     ON ots_trajectories(outcome);";
+
+pub const CREATE_OTS_TRAJECTORIES_STATUS_INDEX: &str = "\
+CREATE INDEX IF NOT EXISTS idx_ots_trajectories_status
+    ON ots_trajectories(persistence_status, updated_at);";
 
 #[cfg(test)]
 #[path = "schema_test.rs"]

--- a/crates/temper-store-turso/src/store/mod.rs
+++ b/crates/temper-store-turso/src/store/mod.rs
@@ -312,6 +312,14 @@ impl TursoEventStore {
         conn.execute(schema::CREATE_OTS_TRAJECTORIES_TABLE, ())
             .await
             .map_err(storage_error)?;
+        for stmt in [
+            schema::ALTER_OTS_TRAJECTORIES_ADD_PERSISTENCE_STATUS,
+            schema::ALTER_OTS_TRAJECTORIES_ADD_PERSIST_ATTEMPTS,
+            schema::ALTER_OTS_TRAJECTORIES_ADD_LAST_ERROR,
+            schema::ALTER_OTS_TRAJECTORIES_ADD_UPDATED_AT,
+        ] {
+            let _ = conn.execute(stmt, ()).await;
+        }
         conn.execute(schema::CREATE_OTS_TRAJECTORIES_AGENT_INDEX, ())
             .await
             .map_err(storage_error)?;
@@ -319,6 +327,9 @@ impl TursoEventStore {
             .await
             .map_err(storage_error)?;
         conn.execute(schema::CREATE_OTS_TRAJECTORIES_OUTCOME_INDEX, ())
+            .await
+            .map_err(storage_error)?;
+        conn.execute(schema::CREATE_OTS_TRAJECTORIES_STATUS_INDEX, ())
             .await
             .map_err(storage_error)?;
 

--- a/crates/temper-store-turso/src/store/ots.rs
+++ b/crates/temper-store-turso/src/store/ots.rs
@@ -16,7 +16,24 @@ pub struct OtsTrajectoryRow {
     pub session_id: String,
     pub outcome: String,
     pub turn_count: i64,
+    pub persistence_status: String,
+    pub persist_attempts: i64,
+    pub last_error: Option<String>,
     pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Durable queued OTS trajectory row ready for outbox replay.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct OtsQueuedTrajectoryRow {
+    pub trajectory_id: String,
+    pub tenant: String,
+    pub agent_id: String,
+    pub session_id: String,
+    pub outcome: String,
+    pub turn_count: i64,
+    pub data: String,
+    pub persist_attempts: i64,
 }
 
 /// Parameters for persisting an OTS trajectory.
@@ -44,7 +61,9 @@ impl TursoEventStore {
         let _timer = TursoQueryTimer::start("turso.persist_ots_trajectory");
         let conn = self.connection()?;
         conn.execute(
-            "INSERT OR REPLACE INTO ots_trajectories (trajectory_id, tenant, agent_id, session_id, outcome, turn_count, data, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, datetime('now'))",
+            "INSERT OR REPLACE INTO ots_trajectories \
+             (trajectory_id, tenant, agent_id, session_id, outcome, turn_count, data, persistence_status, persist_attempts, last_error, created_at, updated_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'persisted', 0, NULL, datetime('now'), datetime('now'))",
             params![
                 p.trajectory_id.to_string(),
                 p.tenant.to_string(),
@@ -58,6 +77,113 @@ impl TursoEventStore {
         .await
         .map_err(storage_error)?;
         Ok(())
+    }
+
+    /// Durably admit an OTS trajectory artifact for background status advancement.
+    #[instrument(skip_all, fields(
+        otel.name = "turso.enqueue_ots_trajectory",
+        trajectory_id = %p.trajectory_id,
+        agent_id = %p.agent_id,
+    ))]
+    pub async fn enqueue_ots_trajectory(
+        &self,
+        p: &OtsTrajectoryParams<'_>,
+    ) -> Result<(), PersistenceError> {
+        let _timer = TursoQueryTimer::start("turso.enqueue_ots_trajectory");
+        let conn = self.connection()?;
+        conn.execute(
+            "INSERT INTO ots_trajectories \
+             (trajectory_id, tenant, agent_id, session_id, outcome, turn_count, data, persistence_status, persist_attempts, last_error, created_at, updated_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'queued', 0, NULL, datetime('now'), datetime('now')) \
+             ON CONFLICT(trajectory_id) DO UPDATE SET \
+                tenant = excluded.tenant, agent_id = excluded.agent_id, session_id = excluded.session_id, \
+                outcome = excluded.outcome, turn_count = excluded.turn_count, data = excluded.data, \
+                persistence_status = 'queued', last_error = NULL, updated_at = datetime('now')",
+            params![
+                p.trajectory_id.to_string(),
+                p.tenant.to_string(),
+                p.agent_id.to_string(),
+                p.session_id.to_string(),
+                p.outcome.to_string(),
+                p.turn_count,
+                p.data.to_string(),
+            ],
+        )
+        .await
+        .map_err(storage_error)?;
+        Ok(())
+    }
+
+    /// Mark a queued OTS trajectory as persisted.
+    pub async fn mark_ots_trajectory_persisted(
+        &self,
+        trajectory_id: &str,
+    ) -> Result<(), PersistenceError> {
+        let _timer = TursoQueryTimer::start("turso.mark_ots_trajectory_persisted");
+        let conn = self.connection()?;
+        conn.execute(
+            "UPDATE ots_trajectories \
+             SET persistence_status = 'persisted', last_error = NULL, updated_at = datetime('now') \
+             WHERE trajectory_id = ?1",
+            params![trajectory_id.to_string()],
+        )
+        .await
+        .map_err(storage_error)?;
+        Ok(())
+    }
+
+    /// Mark a queued OTS trajectory as failed after retries exhaust.
+    pub async fn mark_ots_trajectory_failed(
+        &self,
+        trajectory_id: &str,
+        error: &str,
+    ) -> Result<(), PersistenceError> {
+        let _timer = TursoQueryTimer::start("turso.mark_ots_trajectory_failed");
+        let conn = self.connection()?;
+        conn.execute(
+            "UPDATE ots_trajectories \
+             SET persistence_status = 'failed', persist_attempts = persist_attempts + 1, last_error = ?2, updated_at = datetime('now') \
+             WHERE trajectory_id = ?1",
+            params![trajectory_id.to_string(), error.to_string()],
+        )
+        .await
+        .map_err(storage_error)?;
+        Ok(())
+    }
+
+    /// List queued OTS trajectory artifacts for startup replay.
+    pub async fn list_queued_ots_trajectories(
+        &self,
+        limit: i64,
+    ) -> Result<Vec<OtsQueuedTrajectoryRow>, PersistenceError> {
+        let _timer = TursoQueryTimer::start("turso.list_queued_ots_trajectories");
+        let conn = self.connection()?;
+        let mut rows = conn
+            .query(
+                "SELECT trajectory_id, tenant, agent_id, session_id, outcome, turn_count, data, persist_attempts \
+                 FROM ots_trajectories \
+                 WHERE persistence_status = 'queued' \
+                 ORDER BY updated_at ASC, created_at ASC \
+                 LIMIT ?1",
+                params![limit],
+            )
+            .await
+            .map_err(storage_error)?;
+
+        let mut result = Vec::new();
+        while let Some(row) = rows.next().await.map_err(storage_error)? {
+            result.push(OtsQueuedTrajectoryRow {
+                trajectory_id: row.get(0).unwrap_or_default(),
+                tenant: row.get(1).unwrap_or_default(),
+                agent_id: row.get(2).unwrap_or_default(),
+                session_id: row.get(3).unwrap_or_default(),
+                outcome: row.get(4).unwrap_or_default(),
+                turn_count: row.get(5).unwrap_or(0),
+                data: row.get(6).unwrap_or_default(),
+                persist_attempts: row.get(7).unwrap_or(0),
+            });
+        }
+        Ok(result)
     }
 
     /// List OTS trajectories (metadata only, without full data blob).
@@ -74,7 +200,7 @@ impl TursoEventStore {
 
         // Build query with optional filters.
         let mut sql = String::from(
-            "SELECT trajectory_id, tenant, agent_id, session_id, outcome, turn_count, created_at FROM ots_trajectories WHERE tenant = ?1",
+            "SELECT trajectory_id, tenant, agent_id, session_id, outcome, turn_count, persistence_status, persist_attempts, last_error, created_at, updated_at FROM ots_trajectories WHERE tenant = ?1",
         );
         let mut idx = 2;
         if agent_id.is_some() {
@@ -108,7 +234,11 @@ impl TursoEventStore {
                 session_id: row.get(3).unwrap_or_default(),
                 outcome: row.get(4).unwrap_or_default(),
                 turn_count: row.get(5).unwrap_or(0),
-                created_at: row.get(6).unwrap_or_default(),
+                persistence_status: row.get(6).unwrap_or_else(|_| "persisted".to_string()),
+                persist_attempts: row.get(7).unwrap_or(0),
+                last_error: row.get(8).ok(),
+                created_at: row.get(9).unwrap_or_default(),
+                updated_at: row.get(10).unwrap_or_default(),
             });
         }
 
@@ -137,5 +267,85 @@ impl TursoEventStore {
         } else {
             Ok(None)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn test_store() -> (TursoEventStore, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let db_path = dir.path().join("ots-outbox.db");
+        let db_url = format!("file:{}", db_path.display());
+        let store = TursoEventStore::new(&db_url, None)
+            .await
+            .expect("create local turso store");
+        (store, dir)
+    }
+
+    fn params<'a>(trajectory_id: &'a str, data: &'a str) -> OtsTrajectoryParams<'a> {
+        OtsTrajectoryParams {
+            trajectory_id,
+            tenant: "tenant",
+            agent_id: "agent",
+            session_id: "session",
+            outcome: "success",
+            turn_count: 2,
+            data,
+        }
+    }
+
+    #[tokio::test]
+    async fn ots_outbox_status_lifecycle_is_durable() {
+        let (store, _dir) = test_store().await;
+        let data = r#"{"trajectory_id":"traj-durable","turns":[]}"#;
+
+        store
+            .enqueue_ots_trajectory(&params("traj-durable", data))
+            .await
+            .expect("enqueue trajectory");
+
+        let rows = store
+            .list_ots_trajectories("tenant", None, None, 10)
+            .await
+            .expect("list trajectories");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].persistence_status, "queued");
+
+        let queued = store
+            .list_queued_ots_trajectories(10)
+            .await
+            .expect("list queued trajectories");
+        assert_eq!(queued.len(), 1);
+        assert_eq!(queued[0].trajectory_id, "traj-durable");
+        assert_eq!(queued[0].data, data);
+
+        store
+            .mark_ots_trajectory_persisted("traj-durable")
+            .await
+            .expect("mark persisted");
+        let rows = store
+            .list_ots_trajectories("tenant", None, None, 10)
+            .await
+            .expect("list persisted trajectory");
+        assert_eq!(rows[0].persistence_status, "persisted");
+        assert!(rows[0].last_error.is_none());
+
+        store
+            .enqueue_ots_trajectory(&params("traj-durable", data))
+            .await
+            .expect("requeue trajectory");
+        store
+            .mark_ots_trajectory_failed("traj-durable", "transient")
+            .await
+            .expect("mark failed");
+        let rows = store
+            .list_ots_trajectories("tenant", None, None, 10)
+            .await
+            .expect("list failed trajectory");
+        assert_eq!(rows[0].persistence_status, "failed");
+        assert_eq!(rows[0].persist_attempts, 1);
+        assert_eq!(rows[0].last_error.as_deref(), Some("transient"));
     }
 }

--- a/crates/temper-store-turso/src/store/query_page.rs
+++ b/crates/temper-store-turso/src/store/query_page.rs
@@ -38,12 +38,12 @@ impl TursoEventStore {
         let order_sql = turso_query_field_order_sql(order_by);
         let limit_param = params.len() + 3;
         let offset_param = params.len() + 4;
-        let sql = format!(
-            "SELECT entity_id, COUNT(*) OVER() AS total_count \
-             FROM entity_catalog \
-             WHERE tenant = ?1 AND entity_type = ?2 AND ({where_clause}) \
-             ORDER BY {order_sql} \
-             LIMIT ?{limit_param} OFFSET ?{offset_param}"
+        let sql = turso_query_field_page_sql(
+            where_clause,
+            &order_sql,
+            limit_param,
+            offset_param,
+            include_count,
         );
 
         let mut all_params: Vec<libsql::Value> = vec![
@@ -111,6 +111,27 @@ impl TursoEventStore {
     }
 }
 
+fn turso_query_field_page_sql(
+    where_clause: &str,
+    order_sql: &str,
+    limit_param: usize,
+    offset_param: usize,
+    include_count: bool,
+) -> String {
+    let select = if include_count {
+        "entity_id, COUNT(*) OVER() AS total_count"
+    } else {
+        "entity_id"
+    };
+    format!(
+        "SELECT {select} \
+         FROM entity_catalog \
+         WHERE tenant = ?1 AND entity_type = ?2 AND ({where_clause}) \
+         ORDER BY {order_sql} \
+         LIMIT ?{limit_param} OFFSET ?{offset_param}"
+    )
+}
+
 fn turso_query_field_order_sql(order_by: &[(String, bool)]) -> String {
     let mut clauses = Vec::new();
     for (field_name, descending) in order_by {
@@ -154,4 +175,24 @@ fn turso_json_path_literal(field_name: &str) -> String {
         .replace('"', "\\\"")
         .replace('\'', "''");
     format!("'$.\"{escaped}\"'")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_count_page_sql_does_not_compute_window_count() {
+        let sql = turso_query_field_page_sql("entity_id = ?3", "entity_id ASC", 4, 5, false);
+
+        assert!(sql.starts_with("SELECT entity_id FROM entity_catalog"));
+        assert!(!sql.contains("COUNT(*) OVER()"));
+    }
+
+    #[test]
+    fn count_page_sql_computes_count_only_when_requested() {
+        let sql = turso_query_field_page_sql("entity_id = ?3", "entity_id ASC", 4, 5, true);
+
+        assert!(sql.contains("COUNT(*) OVER() AS total_count"));
+    }
 }

--- a/crates/temper-store-turso/src/store/tests/mod.rs
+++ b/crates/temper-store-turso/src/store/tests/mod.rs
@@ -711,6 +711,25 @@ async fn query_field_index_page_orders_and_limits_inside_turso() {
     assert_eq!(ids, vec!["entry-10".to_string()]);
     assert_eq!(count, Some(3));
 
+    let (ids, count) = store
+        .query_field_index_page(
+            &tenant,
+            entity_type,
+            "entity_id IN (SELECT entity_id FROM entity_field_index \
+             WHERE tenant = ?1 AND entity_type = ?2 \
+             AND field_name = ?3 AND field_value = ?4)",
+            vec!["SessionId".to_string(), "ss-bounded".to_string()],
+            &[("Sequence".to_string(), true)],
+            0,
+            1,
+            false,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(ids, vec!["entry-10".to_string()]);
+    assert_eq!(count, None);
+
     let missing_sequence_id = "entry-missing-sequence";
     let missing_sequence_fields = serde_json::json!({
         "SessionId": "ss-bounded",

--- a/docs/adrs/0148-bounded-derived-write-hot-path.md
+++ b/docs/adrs/0148-bounded-derived-write-hot-path.md
@@ -1,0 +1,183 @@
+# ADR-0148: Bound Derived Writes Off The Dispatch Hot Path
+
+- Status: Proposed
+- Date: 2026-06-18
+- Deciders: Temper core maintainers
+- Supersedes: ADR-0142
+- Related:
+  - ADR-0067: Trajectory outbox
+  - ADR-0091: Query projection diff index upserts
+  - ADR-0095: Projection transaction fast path
+  - ADR-0134: Query plane read contract
+  - ADR-0135: Authorized query plane pages
+  - `crates/temper-server/src/entity_actor/actor.rs`
+  - `crates/temper-server/src/state/dispatch/effects.rs`
+  - `crates/temper-server/src/state/dispatch/composite.rs`
+  - `crates/temper-store-postgres/src/platform.rs`
+  - `crates/temper-store-postgres/src/store.rs`
+
+## Context
+
+Canonical Foresight runs on the `foresight` deployment backed by the Supabase
+pooler. Datadog evidence shows DB time dominates run latency. The hottest
+Temper-core buckets are derived writes and broad reads, not the event journal
+append itself: `snapshots`, `snapshot_history`, `entity_catalog`,
+`entity_field_index`, OTS trajectory/session artifact persistence, and Session
+OData reads that can materialize far more rows than the caller needs.
+
+ADR-0142 moved dispatch projection writes inline to provide read-your-writes
+for OData point reads. That fixed a correctness bug, but it also put
+`entity_catalog` and `entity_field_index` writes on every successful dispatch.
+Foresight dispatches many Session-related transitions in tight loops, so this
+turns one synchronous journal append into several synchronous DB operations.
+
+Snapshots have the same shape. The event journal must stay synchronous because
+it is the durable commit record. Snapshot rows are replay accelerators and
+segment boundaries. Waiting for both latest-snapshot and history writes in the
+entity actor path increases tail latency and couples dispatch success to a
+derived checkpoint that can safely lag when lag is measured and bounded.
+
+## Decision
+
+Dispatch commits continue to synchronously append the event journal. Derived
+persistence is moved behind bounded, observable queues:
+
+### Sub-Decision 1: Snapshots Are Enqueued After Journal Commit
+
+Entity actors serialize a snapshot at the configured interval, enqueue it to a
+bounded snapshot writer, and advance their in-memory replay budget only after
+the enqueue succeeds. The writer coalesces by persistence ID and sequence so an
+older pending snapshot is skipped before a database connection is acquired.
+
+When the queue is full or enqueue fails, the actor keeps its unsnapshotted tail
+count. It may eventually reject new transitions at the existing
+`MAX_EVENTS_SINCE_SNAPSHOT` budget rather than pretending a durable checkpoint
+exists.
+
+**Why this approach**: snapshots are optimization state, but the replay budget
+is a safety invariant. Enqueue-success semantics keep the actor fast while
+preserving a bounded replay tail if the writer falls behind.
+
+### Sub-Decision 2: Query Projection Writes Are Bounded And Coalesced
+
+Single-dispatch and composite-dispatch query projection updates enqueue durable
+work instead of awaiting `entity_catalog`/`entity_field_index` writes inline.
+The queue coalesces by `(tenant, entity_type, entity_id)` and keeps only the
+highest sequence number. Stale work is skipped before acquiring a database
+connection.
+
+Read-your-writes is preserved by response semantics and read planning:
+
+- the dispatch response remains authoritative for the write it just committed;
+- point reads that require immediate consistency can fall back to the actor
+  when the projection sequence is behind the requested sequence;
+- collection reads use projection rows only for bounded, indexed pages and
+  surface projection lag through telemetry.
+
+**Why this approach**: ADR-0142's correctness problem was an acknowledged write
+being served stale by a projection-only read. The fix is to make reads aware of
+projection lag, not to make every dispatch wait for all derived indexes.
+
+### Sub-Decision 3: Session Collection Reads Must Push Down Bounds
+
+Supported Session/OData queries used by Foresight and DSF2 must use the query
+plane or a Temper-native read model with SQL-side tenant/type/filter/page
+limits. They must not materialize the full Session entity set to answer a
+bounded page, filtered lookup, or latest-session style query.
+
+**Why this approach**: moving writes off the hot path is not enough if a
+follow-up read immediately asks Postgres and the actor layer to hydrate every
+Session row.
+
+### Sub-Decision 4: OTS And Terminal Session Emission Use Durable Outbox Semantics
+
+Full OTS trajectory POST persistence and terminal Session trajectory emission
+effects are not dispatch-critical. They use a durable or replay-safe outbox
+with bounded in-memory admission, batched drains, and Session-visible emission
+status fields that distinguish `queued`, `persisted`, and `failed`.
+
+**Why this approach**: Foresight needs reliable trajectory artifacts, but the
+large JSON artifact write should not decide the latency of the Session state
+transition that made it eligible for emission.
+
+## Rollout Plan
+
+1. **Immediate PR** -- introduce bounded coalescing writers for snapshots and
+   query projection updates, route single and composite dispatch through them,
+   add lag/error metrics, and add tests proving dispatch no longer awaits the
+   derived writes.
+2. **Same effort** -- add Session query tests for the Foresight/DSF2 query
+   shapes and make the query plane satisfy them without full table
+   materialization.
+3. **Same effort or narrow follow-up PR** -- move the full OTS trajectory
+   persistence path behind the durable outbox when the touched code confirms
+   it is directly on the canonical run hot path.
+
+## Readiness Gates
+
+- Event journal append remains synchronous and optimistic-concurrency guarded.
+- Snapshot enqueue failure does not reset `events_since_snapshot`.
+- Projection updates skip stale sequences before opening a DB write.
+- Composite dispatch does not synchronously wait for query projection writes
+  after the atomic journal batch commits.
+- Supported Session OData queries are bounded in the backing store.
+- Datadog re-measurement uses `@version:<deployed-version>` and
+  `@peer.service:foresight-supabase`.
+
+## Consequences
+
+### Positive
+
+- Dispatch latency is no longer multiplied by snapshot, projection index, and
+  trajectory artifact writes.
+- Derived DB writes can batch and coalesce naturally under bursty Foresight
+  traffic.
+- Projection and snapshot lag becomes visible as a product signal instead of a
+  hidden tail-latency tax.
+
+### Negative
+
+- Some reads must reason about projection freshness instead of assuming the
+  projection is always current at dispatch acknowledgement time.
+- A saturated derived-write queue can delay OData collection freshness, though
+  the journal remains authoritative.
+
+### Risks
+
+- If lag metrics are ignored, stale projections could persist longer than
+  acceptable. Mitigation: emit per-queue depth, lag, skipped-stale, error, and
+  applied-sequence metrics.
+- If a read path cannot tolerate projection lag and lacks actor fallback, it
+  can observe stale data. Mitigation: add sequence-aware read tests for the
+  Foresight/DSF2 Session paths touched by this work.
+
+### DST Compliance
+
+- Simulation-visible transition semantics remain unchanged: action evaluation,
+  journal envelopes, and replay use the existing deterministic path.
+- New wall-clock timing is metrics-only and annotated where necessary.
+- Bounded queues are production side-effect infrastructure and do not affect
+  deterministic simulation state.
+
+## Non-Goals
+
+- Switching Foresight away from Codex or changing model/provider behavior.
+- Increasing broad run concurrency before the DB hot path is reduced.
+- Moving app or agent logic from TemperPaw into the Temper kernel.
+- Removing existing projection correctness repair or parity mechanisms.
+
+## Alternatives Considered
+
+1. **Keep ADR-0142 inline projection writes** -- preserves immediate projection
+   freshness, but keeps `entity_catalog` and `entity_field_index` latency on
+   every dispatch and does not address Foresight DB amplification.
+2. **Disable projection writes during Foresight runs** -- fast but incorrect;
+   OData and file/session read paths depend on the projection.
+3. **Only tune PostgreSQL indexes** -- useful, but it does not reduce the
+   number of writes or the fact that derived writes are awaited by dispatch.
+
+## Rollback Policy
+
+Set the derived-write mode back to inline for projection and synchronous for
+snapshots, drain outstanding queues, and keep the new lag metrics in place to
+confirm the rollback removes stale projection exposure.

--- a/docs/adrs/0148-bounded-derived-write-hot-path.md
+++ b/docs/adrs/0148-bounded-derived-write-hot-path.md
@@ -89,16 +89,21 @@ bounded page, filtered lookup, or latest-session style query.
 follow-up read immediately asks Postgres and the actor layer to hydrate every
 Session row.
 
-### Sub-Decision 4: OTS And Terminal Session Emission Use Durable Outbox Semantics
+### Sub-Decision 4: OTS Uploads Use Durable Admission And Retryable Status
 
 Full OTS trajectory POST persistence and terminal Session trajectory emission
-effects are not dispatch-critical. They use a durable or replay-safe outbox
-with bounded in-memory admission, batched drains, and Session-visible emission
-status fields that distinguish `queued`, `persisted`, and `failed`.
+effects are not dispatch-critical. The POST handler durably records the
+artifact by `trajectory_id` with a persistence status before acknowledging the
+upload. A bounded in-memory worker drains accepted work and advances the
+durable status from `queued` to `persisted` or `failed`; restart recovery can
+replay rows still marked `queued`. MCP clients treat `503` and transient
+transport errors as retryable with bounded backoff, including final trajectory
+uploads on session close.
 
 **Why this approach**: Foresight needs reliable trajectory artifacts, but the
-large JSON artifact write should not decide the latency of the Session state
-transition that made it eligible for emission.
+terminal Session transition should not be coupled to a best-effort in-memory
+side effect. The durable admission write is the reliability boundary; the
+status transition and any retry/failure accounting happen outside dispatch.
 
 ## Rollout Plan
 
@@ -109,9 +114,9 @@ transition that made it eligible for emission.
 2. **Same effort** -- add Session query tests for the Foresight/DSF2 query
    shapes and make the query plane satisfy them without full table
    materialization.
-3. **Same effort or narrow follow-up PR** -- move the full OTS trajectory
-   persistence path behind the durable outbox when the touched code confirms
-   it is directly on the canonical run hot path.
+3. **Same effort** -- give OTS trajectory uploads durable admission,
+   retryable MCP finalization, and status telemetry so terminal artifacts are
+   not silently lost under transient saturation.
 
 ## Readiness Gates
 
@@ -121,8 +126,13 @@ transition that made it eligible for emission.
 - Composite dispatch does not synchronously wait for query projection writes
   after the atomic journal batch commits.
 - Supported Session OData queries are bounded in the backing store.
+- OTS upload admission either returns success after a durable queued row exists
+  or returns a retryable error to the caller.
+- MCP final trajectory upload retries `503` and transient transport failures
+  with a bounded backoff.
 - Datadog re-measurement uses `@version:<deployed-version>` and
-  `@peer.service:foresight-supabase`.
+  the active database peer/service tag for the deployed target (`Postgres-v79y`
+  currently reports as `foresight-railway-postgres`).
 
 ## Consequences
 
@@ -139,8 +149,13 @@ transition that made it eligible for emission.
 
 - Some reads must reason about projection freshness instead of assuming the
   projection is always current at dispatch acknowledgement time.
+- Keyed and bounded-candidate OData reads can fall back to actor materialization
+  and repair missing catalog rows; pure collection membership remains eventual
+  until the projection queue catches up.
 - A saturated derived-write queue can delay OData collection freshness, though
   the journal remains authoritative.
+- OTS POST acknowledgements now mean durable admission, not necessarily that
+  downstream status advancement has completed.
 
 ### Risks
 
@@ -150,6 +165,10 @@ transition that made it eligible for emission.
 - If a read path cannot tolerate projection lag and lacks actor fallback, it
   can observe stale data. Mitigation: add sequence-aware read tests for the
   Foresight/DSF2 Session paths touched by this work.
+- If the durable OTS admission write itself is slow, the POST caller still
+  pays that cost. Mitigation: keep the admission row keyed and compact, retry
+  transient failures at the MCP boundary, and measure the outbox status/latency
+  metrics separately from dispatch latency.
 
 ### DST Compliance
 

--- a/docs/adrs/0148-bounded-derived-write-hot-path.md
+++ b/docs/adrs/0148-bounded-derived-write-hot-path.md
@@ -94,11 +94,14 @@ Session row.
 Full OTS trajectory POST persistence and terminal Session trajectory emission
 effects are not dispatch-critical. The POST handler durably records the
 artifact by `trajectory_id` with a persistence status before acknowledging the
-upload. A bounded in-memory worker drains accepted work and advances the
-durable status from `queued` to `persisted` or `failed`; restart recovery can
-replay rows still marked `queued`. MCP clients treat `503` and transient
-transport errors as retryable with bounded backoff, including final trajectory
-uploads on session close.
+upload. This admission write includes the full trajectory JSON artifact, so the
+tradeoff is explicit: OTS POST latency pays one durable write to avoid lossy
+terminal artifacts, while Session dispatch does not wait for the POST handler.
+A bounded in-memory worker drains accepted work and advances the durable status
+from `queued` to `persisted` or `failed`; restart recovery can replay rows
+still marked `queued`. MCP clients treat `503` and transient transport errors
+as retryable with bounded backoff, including final trajectory uploads on
+session close.
 
 **Why this approach**: Foresight needs reliable trajectory artifacts, but the
 terminal Session transition should not be coupled to a best-effort in-memory
@@ -123,9 +126,14 @@ status transition and any retry/failure accounting happen outside dispatch.
 - Event journal append remains synchronous and optimistic-concurrency guarded.
 - Snapshot enqueue failure does not reset `events_since_snapshot`.
 - Projection updates skip stale sequences before opening a DB write.
+- Projection update failures are retried with bounded backoff, and stale
+  retries are skipped if a newer update for the same entity has already been
+  queued.
 - Composite dispatch does not synchronously wait for query projection writes
   after the atomic journal batch commits.
 - Supported Session OData queries are bounded in the backing store.
+- Supported bounded Session OData page reads do not compute storage counts
+  unless `$count=true` was requested.
 - OTS upload admission either returns success after a durable queued row exists
   or returns a retryable error to the caller.
 - MCP final trajectory upload retries `503` and transient transport failures
@@ -156,6 +164,9 @@ status transition and any retry/failure accounting happen outside dispatch.
   the journal remains authoritative.
 - OTS POST acknowledgements now mean durable admission, not necessarily that
   downstream status advancement has completed.
+- OTS POST latency still includes one full-artifact durable write; this is a
+  reliability tradeoff for terminal trajectory artifacts, not a dispatch-path
+  write reduction by itself.
 
 ### Risks
 
@@ -166,9 +177,9 @@ status transition and any retry/failure accounting happen outside dispatch.
   can observe stale data. Mitigation: add sequence-aware read tests for the
   Foresight/DSF2 Session paths touched by this work.
 - If the durable OTS admission write itself is slow, the POST caller still
-  pays that cost. Mitigation: keep the admission row keyed and compact, retry
-  transient failures at the MCP boundary, and measure the outbox status/latency
-  metrics separately from dispatch latency.
+  pays that cost. Mitigation: keep this out of the Session dispatch path,
+  retry transient failures at the MCP boundary, and measure OTS POST latency
+  and outbox status/latency metrics separately from dispatch latency.
 
 ### DST Compliance
 


### PR DESCRIPTION
## Summary
- Adds ADR-0148 for moving derived DB writes off the canonical Foresight dispatch hot path while keeping the event journal append synchronous.
- Adds a bounded/coalescing snapshot write queue for `snapshots` / `snapshot_history`; entity actors only advance the replay boundary after the queued snapshot write applies.
- Adds a bounded/coalescing query projection queue for dispatch and composite atomic batch paths so `entity_catalog` / `entity_field_index` updates happen after journal commit and stale updates are skipped before DB work.
- Adds Session/OData proof coverage for context-prep shaped broad filters (`SessionId eq ... &$top=10000`) to verify native bounded page pushdown instead of full SessionEntry-style materialization.
- Adds a bounded, batched, retrying OTS trajectory artifact outbox so `POST /api/ots/trajectories` no longer awaits full trajectory metadata-store persistence on the session-close/upload path.

## Current Status
- CI-green at `34a28b89`; `mergeStateStatus=CLEAN`.
- Draft PR remains open because canonical deploy/Datadog re-measure is still pending.
- Lane 4 may move Foresight DB placement to dedicated collocated Railway Postgres; this PR reduces DB work regardless of Supabase vs Railway target, and re-measure should use the active canonical DB.

## Verification
- GitHub CI green: Verification Contract, Compile & Lint, Integrity & DST Patterns, Tests, DST/Platform suites, Spec Verification L0-L3, Instrumentation Hygiene. Bench Build was skipped by workflow configuration.
- `cargo fmt -p temper-server`
- `cargo test -p temper-server`
- `cargo test -p temper-mcp`
- `cargo test -p temper-server --features observe ots_trajectory_outbox --lib`
- `cargo clippy -p temper-server --features observe --all-targets -- -D warnings`
- `cargo clippy -p temper-server --all-targets -- -D warnings`
- `bash scripts/readability-ratchet.sh check .ci/readability-baseline.env`
- `git diff --check`
- Focused tests cover: enqueue does not wait for slow persistence, retry success, exhausted retry visibility, and full queue retryable rejection.
- DST reviewer: no blocking findings for the OTS diff; marker written.
- Code reviewer: PASS. Warnings addressed by removing high-cardinality metric labels and adding exhausted-retry coverage.

## OTS Behavior
- `POST /api/ots/trajectories` parses and indexes the artifact synchronously, then enqueues owned artifact data to the outbox.
- Accepted enqueue returns `202 Accepted`; MCP caller already treats any 2xx as success.
- Full/closed queue returns `503 Service Unavailable` with retryable text, preserving caller-visible failure semantics under backpressure.
- Background worker drains in bounded batches and retries transient store failures before terminal failure logging/metrics.
- Metrics use bounded labels only: tenant, backend, outcome, result.
- Residual risk: the current outbox is bounded/retryable and nonblocking, but not crash-durable after HTTP acceptance and before drain. If canonical proof requires crash-durable artifact handoff, the next hardening step is a small durable outbox table keyed by trajectory_id.

## Datadog / Canonical Proof Handoff
- Datadog skills loaded: traces, PostgreSQL DBM, querying patterns, metrics. A `datadog/visualizations` skill is not available in this account.
- DBM sample check previously returned zero samples for `@peer.service:foresight-supabase` over 6h and zero broad `foresight` samples over 24h.
- Required after deploy: run the same canonical Foresight workload and compare DB span/sample time, query count, rows touched, total run time, snapshot/projection queue lag/depth/drop metrics, and OTS outbox depth/retry/failure metrics.
- Filters: use `@version:<deployed version>` plus the active DB peer. Historical Supabase peer was `@peer.service:foresight-supabase`; if Lane 4 switches canonical Foresight to Railway Postgres first, use the Railway peer/service from that deployment.

## Linear
- ARN-50 and ARN-63 are updated with scope changes, commits, tests, CI-green status, Datadog availability, and Lane 4 DB-placement coordination.