### PR TITLE
[codex] fix OData lossless filter conjunct pushdown

### DIFF
--- a/crates/temper-actor-runtime/src/actor.rs
+++ b/crates/temper-actor-runtime/src/actor.rs
@@ -17,7 +17,7 @@ pub struct ActorHandle {
 }
 
 impl ActorHandle {
-    // TODO: ActorHandle::new() does no validation — the actor may not exist.
+    // Note: ActorHandle::new() does no validation — the actor may not exist.
     // Messages sent to a nonexistent handle sit in actor_messages forever (dead letters).
     // Consider making this pub(crate) and forcing all external handle creation through
     // spawn() or lookup(), which validate against PG.

--- a/crates/temper-server/src/odata/filter_sql.rs
+++ b/crates/temper-server/src/odata/filter_sql.rs
@@ -29,6 +29,7 @@ pub(super) struct TranslatedFilter {
 /// Returns `None` if the expression contains constructs that cannot be
 /// translated (cross-field comparisons, unsupported functions, etc.).
 /// The caller should fall back to in-memory filtering in that case.
+#[cfg(test)]
 pub(super) fn try_translate_filter(filter: &FilterExpr) -> Option<TranslatedFilter> {
     let mut ctx = TranslateCtx {
         params: Vec::new(),
@@ -49,10 +50,15 @@ pub(super) fn try_translate_filter(filter: &FilterExpr) -> Option<TranslatedFilt
 /// this predicate as a candidate narrowing step and still re-evaluate the
 /// original filter after materialization.
 pub(super) fn try_translate_candidate_filter(filter: &FilterExpr) -> Option<TranslatedFilter> {
-    if !candidate_filter_is_lossless(filter) {
-        return None;
-    }
-    try_translate_filter(filter)
+    let mut ctx = TranslateCtx {
+        params: Vec::new(),
+        next_param: 3, // ?1 = tenant, ?2 = entity_type (prepended by query_field_index)
+    };
+    let clause = translate_candidate_expr(filter, &mut ctx)?;
+    Some(TranslatedFilter {
+        where_clause: clause,
+        params: ctx.params,
+    })
 }
 
 struct TranslateCtx {
@@ -110,6 +116,61 @@ fn translate_expr(expr: &FilterExpr, ctx: &mut TranslateCtx) -> Option<String> {
 
         // Bare property or literal at top level — not a valid boolean filter
         FilterExpr::Property(_) | FilterExpr::Literal(_) => None,
+    }
+}
+
+/// Translate the lossless candidate portion of a filter.
+///
+/// The query-plane candidate SQL is a narrowing step, not the final OData
+/// filter. For `AND`, lossless conjuncts can be pushed independently while
+/// non-lossless conjuncts are still re-checked after materialization. For
+/// `OR`, dropping one side would change the candidate set, so the whole
+/// expression must be lossless or it is not pushed.
+fn translate_candidate_expr(expr: &FilterExpr, ctx: &mut TranslateCtx) -> Option<String> {
+    match expr {
+        FilterExpr::BinaryOp { left, op, right } => match op {
+            BinaryOperator::And => {
+                let left_clause = translate_candidate_expr(left, ctx);
+                let right_clause = translate_candidate_expr(right, ctx);
+                match (left_clause, right_clause) {
+                    (Some(left_clause), Some(right_clause)) => {
+                        Some(format!("({left_clause} AND {right_clause})"))
+                    }
+                    (Some(clause), None) | (None, Some(clause)) => Some(clause),
+                    (None, None) => None,
+                }
+            }
+            BinaryOperator::Or => {
+                if candidate_filter_is_lossless(expr) {
+                    translate_expr(expr, ctx)
+                } else {
+                    None
+                }
+            }
+            BinaryOperator::Eq
+            | BinaryOperator::Ne
+            | BinaryOperator::Gt
+            | BinaryOperator::Ge
+            | BinaryOperator::Lt
+            | BinaryOperator::Le
+            | BinaryOperator::Has => {
+                if candidate_filter_is_lossless(expr) {
+                    translate_expr(expr, ctx)
+                } else {
+                    None
+                }
+            }
+        },
+        FilterExpr::UnaryOp { .. }
+        | FilterExpr::FunctionCall { .. }
+        | FilterExpr::Property(_)
+        | FilterExpr::Literal(_) => {
+            if candidate_filter_is_lossless(expr) {
+                translate_expr(expr, ctx)
+            } else {
+                None
+            }
+        }
     }
 }
 

--- a/crates/temper-server/src/odata/filter_sql/tests.rs
+++ b/crates/temper-server/src/odata/filter_sql/tests.rs
@@ -89,6 +89,66 @@ fn candidate_and_equality_filter_is_lossless_for_string_fields() {
 }
 
 #[test]
+fn candidate_and_filter_keeps_lossless_equalities_when_status_ne_is_present() {
+    let filter = FilterExpr::BinaryOp {
+        left: Box::new(FilterExpr::BinaryOp {
+            left: Box::new(FilterExpr::BinaryOp {
+                left: Box::new(FilterExpr::Property("Path".into())),
+                op: BinaryOperator::Eq,
+                right: Box::new(FilterExpr::Literal(ODataValue::String(
+                    "/proofs/live.txt".into(),
+                ))),
+            }),
+            op: BinaryOperator::And,
+            right: Box::new(FilterExpr::BinaryOp {
+                left: Box::new(FilterExpr::Property("WorkspaceId".into())),
+                op: BinaryOperator::Eq,
+                right: Box::new(FilterExpr::Literal(ODataValue::String("ws-1".into()))),
+            }),
+        }),
+        op: BinaryOperator::And,
+        right: Box::new(FilterExpr::BinaryOp {
+            left: Box::new(FilterExpr::Property("Status".into())),
+            op: BinaryOperator::Ne,
+            right: Box::new(FilterExpr::Literal(ODataValue::String("Archived".into()))),
+        }),
+    };
+
+    let result = try_translate_candidate_filter(&filter).unwrap();
+    assert!(result.where_clause.contains("AND"));
+    assert!(result.where_clause.contains("field_name = ?3"));
+    assert!(result.where_clause.contains("field_value = ?4"));
+    assert!(result.where_clause.contains("field_name = ?5"));
+    assert!(result.where_clause.contains("field_value = ?6"));
+    assert!(!result.where_clause.contains("status !="));
+    assert_eq!(
+        result.params,
+        vec!["Path", "/proofs/live.txt", "WorkspaceId", "ws-1"]
+    );
+}
+
+#[test]
+fn candidate_or_filter_does_not_drop_non_lossless_branch() {
+    let filter = FilterExpr::BinaryOp {
+        left: Box::new(FilterExpr::BinaryOp {
+            left: Box::new(FilterExpr::Property("Path".into())),
+            op: BinaryOperator::Eq,
+            right: Box::new(FilterExpr::Literal(ODataValue::String(
+                "/proofs/live.txt".into(),
+            ))),
+        }),
+        op: BinaryOperator::Or,
+        right: Box::new(FilterExpr::BinaryOp {
+            left: Box::new(FilterExpr::Property("Status".into())),
+            op: BinaryOperator::Ne,
+            right: Box::new(FilterExpr::Literal(ODataValue::String("Archived".into()))),
+        }),
+    };
+
+    assert!(try_translate_candidate_filter(&filter).is_none());
+}
+
+#[test]
 fn startswith_function() {
     let filter = FilterExpr::FunctionCall {
         name: "startswith".into(),

--- a/crates/temper-server/src/odata/query_plane_read/tests/proof.rs
+++ b/crates/temper-server/src/odata/query_plane_read/tests/proof.rs
@@ -1,5 +1,95 @@
 use super::*;
 
+async fn upsert_order_projection_with_status(
+    store: &TursoEventStore,
+    tenant: &TenantId,
+    entity_id: &str,
+    status: &str,
+    mut fields: serde_json::Value,
+    sequence_nr: u64,
+) {
+    fields["Id"] = serde_json::json!(entity_id);
+    let state_json = serde_json::json!({
+        "entity_type": "Order",
+        "entity_id": entity_id,
+        "status": status,
+        "fields": fields,
+        "sequence_nr": sequence_nr,
+        "events": [],
+    });
+    store
+        .upsert_query_projection_with_state(
+            tenant.as_str(),
+            "Order",
+            entity_id,
+            status,
+            state_json.get("fields").unwrap(),
+            &state_json,
+            sequence_nr,
+        )
+        .await
+        .expect("upsert projection");
+}
+
+#[test]
+fn native_plan_pushes_file_lookup_equalities_with_status_ne_recheck() {
+    let state = build_order_state("query-plane-native-file-status-ne");
+    let tenant = TenantId::default();
+    let security_ctx = SecurityContext::system();
+    let query_options = QueryOptions {
+        filter: Some(FilterExpr::BinaryOp {
+            left: Box::new(FilterExpr::BinaryOp {
+                left: Box::new(FilterExpr::BinaryOp {
+                    left: Box::new(FilterExpr::Property("Path".to_string())),
+                    op: BinaryOperator::Eq,
+                    right: Box::new(FilterExpr::Literal(ODataValue::String(
+                        "/proofs/live.txt".to_string(),
+                    ))),
+                }),
+                op: BinaryOperator::And,
+                right: Box::new(FilterExpr::BinaryOp {
+                    left: Box::new(FilterExpr::Property("WorkspaceId".to_string())),
+                    op: BinaryOperator::Eq,
+                    right: Box::new(FilterExpr::Literal(ODataValue::String("ws-1".to_string()))),
+                }),
+            }),
+            op: BinaryOperator::And,
+            right: Box::new(FilterExpr::BinaryOp {
+                left: Box::new(FilterExpr::Property("Status".to_string())),
+                op: BinaryOperator::Ne,
+                right: Box::new(FilterExpr::Literal(ODataValue::String(
+                    "Archived".to_string(),
+                ))),
+            }),
+        }),
+        top: Some(1),
+        ..QueryOptions::default()
+    };
+    let request = QueryPlaneReadRequest {
+        state: &state,
+        tenant: &tenant,
+        security_ctx: &security_ctx,
+        entity_type: "Order",
+        entity_set_name: "Orders",
+        query_options: &query_options,
+        budget: QueryPlaneReadBudget {
+            default_page_size: 100,
+            max_entities: 100,
+        },
+    };
+
+    let plan = native_candidate_page_plan(&request).expect("native plan");
+
+    assert!(plan.filter_pushdown);
+    assert!(plan.where_clause.contains("AND"));
+    assert!(!plan.where_clause.contains("status !="));
+    assert_eq!(
+        plan.params,
+        vec!["Path", "/proofs/live.txt", "WorkspaceId", "ws-1"]
+    );
+    assert!(should_try_native_before_catalog_coverage(&request, &plan));
+}
+
 #[tokio::test]
 async fn ordinary_null_filter_uses_lossless_candidate_scan() {
     let db_path =
@@ -235,6 +325,168 @@ async fn context_prep_shaped_filter_with_huge_top_uses_bounded_native_page() {
     assert_eq!(result.telemetry.materialized_count, 1000);
     assert_eq!(result.telemetry.pushdown_page_count, 1000);
     assert_eq!(result.telemetry.returned_count, 1000);
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
+async fn file_point_lookup_with_status_ne_uses_lossless_equality_candidates() {
+    let db_path = std::env::temp_dir().join(format!(
+        "temper-query-plane-file-status-ne-{}.db",
+        sim_uuid()
+    ));
+    let _ = std::fs::remove_file(&db_path);
+    let db_url = format!("file:{}", db_path.display());
+    let store = TursoEventStore::new(&db_url, None)
+        .await
+        .expect("create local turso db");
+    let mut state = build_order_state("query-plane-file-status-ne");
+    state.set_storage_stack(StorageStack::from_turso(store.clone()));
+    let tenant = TenantId::default();
+    let target_path = "/proofs/katagami-temper-write-live.txt";
+    let workspace_id = "ws-proof";
+
+    for index in 0usize..120 {
+        upsert_order_projection(
+            &store,
+            &tenant,
+            &format!("noise-{index:04}"),
+            serde_json::json!({
+                "Path": format!("/noise/{index:04}.txt"),
+                "WorkspaceId": workspace_id,
+            }),
+            index as u64 + 1,
+        )
+        .await;
+    }
+    upsert_order_projection_with_status(
+        &store,
+        &tenant,
+        "zz-target-archived",
+        "Archived",
+        serde_json::json!({
+            "Path": target_path,
+            "WorkspaceId": workspace_id,
+        }),
+        2000,
+    )
+    .await;
+    upsert_order_projection_with_status(
+        &store,
+        &tenant,
+        "zz-target-ready",
+        "Created",
+        serde_json::json!({
+            "Path": target_path,
+            "WorkspaceId": workspace_id,
+        }),
+        2001,
+    )
+    .await;
+
+    let security_ctx = SecurityContext::system();
+    let query_options = QueryOptions {
+        filter: Some(FilterExpr::BinaryOp {
+            left: Box::new(FilterExpr::BinaryOp {
+                left: Box::new(FilterExpr::BinaryOp {
+                    left: Box::new(FilterExpr::Property("Path".to_string())),
+                    op: BinaryOperator::Eq,
+                    right: Box::new(FilterExpr::Literal(ODataValue::String(
+                        target_path.to_string(),
+                    ))),
+                }),
+                op: BinaryOperator::And,
+                right: Box::new(FilterExpr::BinaryOp {
+                    left: Box::new(FilterExpr::Property("WorkspaceId".to_string())),
+                    op: BinaryOperator::Eq,
+                    right: Box::new(FilterExpr::Literal(ODataValue::String(
+                        workspace_id.to_string(),
+                    ))),
+                }),
+            }),
+            op: BinaryOperator::And,
+            right: Box::new(FilterExpr::BinaryOp {
+                left: Box::new(FilterExpr::Property("Status".to_string())),
+                op: BinaryOperator::Ne,
+                right: Box::new(FilterExpr::Literal(ODataValue::String(
+                    "Archived".to_string(),
+                ))),
+            }),
+        }),
+        top: Some(1),
+        select: Some(vec![
+            "Id".to_string(),
+            "Path".to_string(),
+            "WorkspaceId".to_string(),
+        ]),
+        ..QueryOptions::default()
+    };
+
+    let request = QueryPlaneReadRequest {
+        state: &state,
+        tenant: &tenant,
+        security_ctx: &security_ctx,
+        entity_type: "Order",
+        entity_set_name: "Orders",
+        query_options: &query_options,
+        budget: QueryPlaneReadBudget {
+            default_page_size: 10,
+            max_entities: 10,
+        },
+    };
+    let native_plan = native_candidate_page_plan(&request).expect("native plan");
+    assert!(native_plan.filter_pushdown);
+    let (candidate_ids, _) = store
+        .query_field_index_page(
+            tenant.as_str(),
+            "Order",
+            &native_plan.where_clause,
+            native_plan.params.clone(),
+            &[],
+            0,
+            10,
+            false,
+        )
+        .await
+        .expect("native candidate query should execute");
+    assert_eq!(
+        candidate_ids,
+        vec![
+            "zz-target-archived".to_string(),
+            "zz-target-ready".to_string()
+        ]
+    );
+
+    let result = match read_entity_set_from_query_plane(request).await {
+        Ok(result) => result,
+        Err(QueryPlaneReadError::QueryTooLarge { telemetry }) => panic!(
+            "file point lookup should push down equality candidates: QueryTooLarge filter_pushdown={} fallback={:?} candidates={} pushed={}",
+            telemetry.filter_pushdown,
+            telemetry.fallback_reason,
+            telemetry.candidate_count,
+            telemetry.pushdown_page_count
+        ),
+        Err(QueryPlaneReadError::AuthorizationDenied(_)) => {
+            panic!("file point lookup should not be denied by read authorization")
+        }
+    };
+
+    assert_eq!(result.entities.len(), 1);
+    assert_eq!(result.entities[0]["Id"].as_str(), Some("zz-target-ready"));
+    assert_eq!(result.entities[0]["Path"].as_str(), Some(target_path));
+    assert_eq!(
+        result.entities[0]["WorkspaceId"].as_str(),
+        Some(workspace_id)
+    );
+    assert_eq!(
+        result.telemetry.strategy,
+        QueryPlaneReadStrategy::NativePagePushdown
+    );
+    assert!(result.telemetry.filter_pushdown);
+    assert_eq!(result.telemetry.candidate_count, 2);
+    assert_eq!(result.telemetry.materialized_count, 2);
+    assert_eq!(result.telemetry.pushdown_page_count, 2);
+    assert_eq!(result.telemetry.returned_count, 1);
 
     let _ = std::fs::remove_file(db_path);
 }

--- a/crates/temper-server/src/query_eval.rs
+++ b/crates/temper-server/src/query_eval.rs
@@ -120,6 +120,35 @@ fn evaluate_value(entity: &serde_json::Value, expr: &FilterExpr) -> Option<serde
 /// Resolve a property name against an entity, checking top-level first,
 /// then falling back to the `fields` sub-object.
 fn resolve_property(entity: &serde_json::Value, prop: &str) -> Option<serde_json::Value> {
+    if prop == "Status" {
+        return entity
+            .get("Status")
+            .or_else(|| entity.get("status"))
+            .cloned()
+            .or_else(|| {
+                entity.get("fields").and_then(|fields| {
+                    fields
+                        .get("Status")
+                        .or_else(|| fields.get("status"))
+                        .cloned()
+                })
+            });
+    }
+    if prop == "status" {
+        return entity
+            .get("status")
+            .or_else(|| entity.get("Status"))
+            .cloned()
+            .or_else(|| {
+                entity.get("fields").and_then(|fields| {
+                    fields
+                        .get("status")
+                        .or_else(|| fields.get("Status"))
+                        .cloned()
+                })
+            });
+    }
+
     entity
         .get(prop)
         .cloned()
@@ -633,6 +662,25 @@ mod tests {
         assert_eq!(filtered.len(), 2);
         assert_eq!(filtered[0]["Name"], "Alice");
         assert_eq!(filtered[1]["Name"], "Charlie");
+    }
+
+    #[test]
+    fn status_filter_matches_catalog_status_aliases() {
+        let entities = vec![
+            serde_json::json!({"Id": "1", "status": "Created", "fields": {"Name": "Ready"}}),
+            serde_json::json!({"Id": "2", "status": "Archived", "fields": {"Name": "Old"}}),
+            serde_json::json!({"Id": "3", "fields": {"status": "Created", "Name": "Nested"}}),
+        ];
+        let filter = FilterExpr::BinaryOp {
+            left: Box::new(FilterExpr::Property("Status".into())),
+            op: BinaryOperator::Ne,
+            right: Box::new(FilterExpr::Literal(ODataValue::String("Archived".into()))),
+        };
+        let filtered = filter_entities(entities, &filter);
+
+        assert_eq!(filtered.len(), 2);
+        assert_eq!(filtered[0]["Id"], "1");
+        assert_eq!(filtered[1]["Id"], "3");
     }
 
     #[test]


### PR DESCRIPTION
## What
- Pushes lossless `$filter` conjuncts from `AND` expressions into query-plane candidate SQL while preserving full post-materialization OData filter verification.
- Keeps `OR` all-or-nothing so candidate narrowing never drops a branch.
- Aliases OData `Status`/`status` during in-memory verification to match the catalog `status` column used by SQL pushdown.
- Adds planner and query-plane proofs for `Path eq X and WorkspaceId eq Y and Status ne 'Archived'`, including an archived matching twin.

This extends #316 for the ARN-54/ARN-68 bounded-read class and is intended to replace per-call-site 413 workarounds once deployed behind TemperPaw/OpenPaw.

## Verification
- `cargo fmt --check`
- `cargo test -p temper-server odata::filter_sql::tests -- --nocapture`
- `cargo test -p temper-server query_eval::tests -- --nocapture`
- `cargo test -p temper-server odata::query_plane_read::tests -- --nocapture`
- `cargo test -p temper-server --test odata_read -- --nocapture`
- `cargo clippy -p temper-server --all-targets -- -D warnings`