### PR TITLE
[codex] Allow artifact cross-entity review gates

### DIFF
--- a/crates/temper-server/src/entity_actor/effects.rs
+++ b/crates/temper-server/src/entity_actor/effects.rs
@@ -59,7 +59,10 @@ pub struct ScheduleAtRequest {
 }
 
 /// Maximum cross-entity lookups per transition (TigerStyle budget).
-pub const MAX_CROSS_ENTITY_LOOKUPS: usize = 4;
+///
+/// Rich artifact contracts, such as Katagami's design-language review gate,
+/// legitimately verify several sibling File records in one guarded transition.
+pub const MAX_CROSS_ENTITY_LOOKUPS: usize = 16;
 /// Maximum entity spawns per transition (TigerStyle budget).
 pub const MAX_SPAWNS_PER_TRANSITION: usize = 8;
 
@@ -1101,6 +1104,92 @@ guard = [
             "should succeed with cross-entity boolean = true"
         );
         assert_eq!(state.status, "Deployed");
+    }
+
+    #[test]
+    fn cross_entity_budget_covers_artifact_review_contract() {
+        let _guard = temper_runtime::scheduler::install_deterministic_context(42);
+
+        let spec = r#"
+[automaton]
+name = "DesignLanguage"
+states = ["Draft", "UnderReview"]
+initial = "Draft"
+
+[[action]]
+name = "SubmitForReview"
+from = ["Draft"]
+to = "UnderReview"
+guard = [
+    { type = "cross_entity_state", entity_type = "File", entity_id_source = "embodiment_file_id", required_status = ["Ready", "Locked"] },
+    { type = "cross_entity_state", entity_type = "File", entity_id_source = "landing_file_id", required_status = ["Ready", "Locked"] },
+    { type = "cross_entity_state", entity_type = "File", entity_id_source = "dashboard_file_id", required_status = ["Ready", "Locked"] },
+    { type = "cross_entity_state", entity_type = "File", entity_id_source = "thumbnail_file_id", required_status = ["Ready", "Locked"] },
+    { type = "cross_entity_state", entity_type = "File", entity_id_source = "design_md_file_id", required_status = ["Ready", "Locked"] },
+    { type = "cross_entity_state", entity_type = "File", entity_id_source = "shadcn_export_file_id", required_status = ["Ready", "Locked"] },
+    { type = "cross_entity_state", entity_type = "File", entity_id_source = "shadcn_component_spec_file_id", required_status = ["Ready", "Locked"] },
+    { type = "cross_entity_state", entity_type = "File", entity_id_source = "shadcn_preview_shots_file_id", required_status = ["Ready", "Locked"] }
+]
+"#;
+
+        let table = temper_jit::table::TransitionTable::from_ioa_source(spec);
+        let mut state = EntityState {
+            entity_type: "DesignLanguage".into(),
+            entity_id: "dl-1".into(),
+            status: "Draft".into(),
+            item_count: 0,
+            counters: std::collections::BTreeMap::new(),
+            booleans: std::collections::BTreeMap::new(),
+            lists: std::collections::BTreeMap::new(),
+            fields: serde_json::json!({
+                "embodiment_file_id": "fl-1",
+                "landing_file_id": "fl-2",
+                "dashboard_file_id": "fl-3",
+                "thumbnail_file_id": "fl-4",
+                "design_md_file_id": "fl-5",
+                "shadcn_export_file_id": "fl-6",
+                "shadcn_component_spec_file_id": "fl-7",
+                "shadcn_preview_shots_file_id": "fl-8"
+            }),
+            events: std::collections::VecDeque::new(),
+            total_event_count: 0,
+            events_since_snapshot: 0,
+            last_snapshot_sequence_nr: 0,
+            sequence_nr: 0,
+            processed_idempotency_keys: std::collections::BTreeMap::new(),
+        };
+        let xref = std::collections::BTreeMap::from([
+            ("__xref:File:embodiment_file_id".to_string(), true),
+            ("__xref:File:landing_file_id".to_string(), true),
+            ("__xref:File:dashboard_file_id".to_string(), true),
+            ("__xref:File:thumbnail_file_id".to_string(), true),
+            ("__xref:File:design_md_file_id".to_string(), true),
+            ("__xref:File:shadcn_export_file_id".to_string(), true),
+            (
+                "__xref:File:shadcn_component_spec_file_id".to_string(),
+                true,
+            ),
+            ("__xref:File:shadcn_preview_shots_file_id".to_string(), true),
+        ]);
+        let required_artifact_lookup_count = xref.len();
+        assert!(
+            MAX_CROSS_ENTITY_LOOKUPS >= required_artifact_lookup_count,
+            "artifact review gates need at least {required_artifact_lookup_count} cross-entity File lookups"
+        );
+
+        let result = process_action_with_xref(
+            &mut state,
+            &table,
+            "SubmitForReview",
+            &serde_json::json!({}),
+            &xref,
+        );
+
+        assert!(
+            result.success,
+            "eight resolved artifact File guards should allow SubmitForReview"
+        );
+        assert_eq!(state.status, "UnderReview");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- raise the dispatch cross-entity lookup budget from 4 to 16 so governed artifact review transitions can resolve all sibling File guards
- add a regression for an eight-file DesignLanguage SubmitForReview guard, matching the Katagami production failure shape

## Root cause / evidence
- Clean Katagami proof query `cq-ground-up-e2e-20260621075245` failed after synthesis with `SubmitForReview` rejected from `Draft` even though all required booleans were true and all eight artifact Files were `Ready`.
- The live DesignLanguage spec has eight `cross_entity_state` File guards on `SubmitForReview`; Temper dispatch previously stopped resolving cross-entity guards after `MAX_CROSS_ENTITY_LOOKUPS = 4`, leaving the remaining guard booleans absent and making the transition fail.

## Validation
- `cargo fmt --package temper-server`
- `cargo test -p temper-server entity_actor::effects::tests::cross_entity_budget_covers_artifact_review_contract -- --nocapture`
- `cargo test -p temper-server entity_actor::effects::tests::test_cross_entity_guard_with_xref -- --nocapture`
- `git diff --check`
- Pre-push rustfmt, clippy, and readability gates passed. Full test gate failed only in Docker-backed `temper-actor-runtime` integration tests because local Docker could not start Postgres: `Client(CreateContainer(RequestTimeoutError))`; `docker info` also hung and returned `context canceled`.