### PR TITLE
Fix app skill docs canonical field projection

### DIFF
--- a/crates/temper-platform/src/os_apps/entity_aliases.rs
+++ b/crates/temper-platform/src/os_apps/entity_aliases.rs
@@ -1,0 +1,125 @@
+use sha2::{Digest, Sha256};
+use temper_runtime::tenant::TenantId;
+
+use crate::state::PlatformState;
+
+pub(super) async fn ensure_created_file_initialized(
+    state: &PlatformState,
+    tenant_id: &TenantId,
+    agent_ctx: &temper_server::request_context::AgentContext,
+    file_id: &str,
+    create_fields: serde_json::Value,
+) -> Result<(), String> {
+    let response = state
+        .server
+        .get_tenant_entity_state(tenant_id, "File", file_id)
+        .await
+        .map_err(|e| format!("failed to inspect File('{file_id}') status: {e}"))?;
+    if response.state.status != "Created" {
+        return Ok(());
+    }
+
+    state
+        .server
+        .dispatch(temper_server::state::DispatchCommand {
+            tenant: tenant_id,
+            entity_type: "File",
+            entity_id: file_id,
+            action: "Create",
+            params: create_fields,
+            agent_ctx,
+            await_integration: false,
+            await_reactions: true,
+        })
+        .await
+        .map(|_| ())
+        .map_err(|e| format!("failed to initialize File('{file_id}'): {e}"))
+}
+
+pub(super) async fn ensure_entity_field_aliases(
+    state: &PlatformState,
+    tenant_id: &TenantId,
+    entity_type: &str,
+    entity_id: &str,
+    aliases: serde_json::Value,
+) -> Result<(), String> {
+    let current = state
+        .server
+        .get_tenant_entity_state(tenant_id, entity_type, entity_id)
+        .await
+        .map_err(|e| format!("failed to inspect {entity_type}('{entity_id}') aliases: {e}"))?;
+
+    let Some(alias_map) = aliases.as_object() else {
+        return Ok(());
+    };
+    let mut updates = serde_json::Map::new();
+    for (key, expected) in alias_map {
+        if current.state.fields.get(key) != Some(expected) {
+            updates.insert(key.clone(), expected.clone());
+        }
+    }
+    if updates.is_empty() {
+        return Ok(());
+    }
+
+    state
+        .server
+        .update_tenant_entity_fields(
+            tenant_id,
+            entity_type,
+            entity_id,
+            serde_json::Value::Object(updates),
+            false,
+        )
+        .await
+        .map(|_| ())
+        .map_err(|e| format!("failed to repair {entity_type}('{entity_id}') aliases: {e}"))
+}
+
+pub(super) async fn file_already_contains(
+    state: &PlatformState,
+    tenant_id: &TenantId,
+    file_id: &str,
+    desired_hash: &str,
+) -> Result<bool, String> {
+    let response = state
+        .server
+        .get_tenant_entity_state(tenant_id, "File", file_id)
+        .await
+        .map_err(|e| format!("failed to inspect File('{file_id}'): {e}"))?;
+
+    let has_content = response
+        .state
+        .booleans
+        .get("has_content")
+        .copied()
+        .unwrap_or(false);
+    let current_hash = response
+        .state
+        .fields
+        .get("content_hash")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
+    Ok(has_content && current_hash == desired_hash)
+}
+
+pub(super) fn content_sha256(content: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(content);
+    format!("sha256:{:x}", hasher.finalize())
+}
+
+pub(super) fn slug_fragment(value: &str) -> String {
+    let mut slug = String::new();
+    let mut last_was_sep = true;
+    for ch in value.chars() {
+        if ch.is_ascii_alphanumeric() {
+            slug.push(ch.to_ascii_lowercase());
+            last_was_sep = false;
+        } else if !last_was_sep {
+            slug.push('-');
+            last_was_sep = true;
+        }
+    }
+    slug.trim_matches('-').to_string()
+}

--- a/crates/temper-platform/src/os_apps/mod.rs
+++ b/crates/temper-platform/src/os_apps/mod.rs
@@ -2336,6 +2336,19 @@ pub(super) async fn ensure_directory(
         .ensure_entity_loaded(tenant_id, "Directory", target.directory_id)
         .await
     {
+        ensure_entity_field_aliases(
+            state,
+            tenant_id,
+            "Directory",
+            target.directory_id,
+            serde_json::json!({
+                "Name": target.name,
+                "Path": target.path,
+                "ParentId": target.parent_id,
+                "WorkspaceId": target.workspace_id,
+            }),
+        )
+        .await?;
         return Ok(());
     }
 
@@ -2363,9 +2376,13 @@ pub(super) async fn ensure_directory(
             action: "Create",
             params: serde_json::json!({
                 "name": target.name,
+                "Name": target.name,
                 "path": target.path,
+                "Path": target.path,
                 "parent_id": target.parent_id,
+                "ParentId": target.parent_id,
                 "workspace_id": target.workspace_id,
+                "WorkspaceId": target.workspace_id,
             }),
             agent_ctx,
             await_integration: false,
@@ -2419,6 +2436,25 @@ pub(super) async fn ensure_markdown_file(
     target: MarkdownFileBootstrapTarget<'_>,
     content: &[u8],
 ) -> Result<(), String> {
+    let create_fields = serde_json::json!({
+        "name": target.name,
+        "Name": target.name,
+        "path": target.path,
+        "Path": target.path,
+        "directory_id": target.directory_id,
+        "DirectoryId": target.directory_id,
+        "workspace_id": target.workspace_id,
+        "WorkspaceId": target.workspace_id,
+        "mime_type": "text/markdown",
+        "MimeType": "text/markdown",
+    });
+    let canonical_fields = serde_json::json!({
+        "Name": target.name,
+        "Path": target.path,
+        "DirectoryId": target.directory_id,
+        "WorkspaceId": target.workspace_id,
+        "MimeType": "text/markdown",
+    });
     let existed = state
         .server
         .ensure_entity_loaded(tenant_id, "File", target.file_id)
@@ -2429,13 +2465,7 @@ pub(super) async fn ensure_markdown_file(
             .create_file_with_initial_stream_content(
                 tenant_id,
                 target.file_id,
-                serde_json::json!({
-                    "name": target.name,
-                    "path": target.path,
-                    "directory_id": target.directory_id,
-                    "workspace_id": target.workspace_id,
-                    "mime_type": "text/markdown",
-                }),
+                create_fields.clone(),
                 content,
                 "text/markdown",
                 agent_ctx,
@@ -2469,6 +2499,16 @@ pub(super) async fn ensure_markdown_file(
         return Ok(());
     }
 
+    ensure_created_file_initialized(
+        state,
+        tenant_id,
+        agent_ctx,
+        target.file_id,
+        create_fields.clone(),
+    )
+    .await?;
+    ensure_entity_field_aliases(state, tenant_id, "File", target.file_id, canonical_fields).await?;
+
     let desired_hash = content_sha256(content);
     if file_already_contains(state, tenant_id, target.file_id, &desired_hash).await? {
         return Ok(());
@@ -2487,6 +2527,79 @@ pub(super) async fn ensure_markdown_file(
         .map_err(|e| format!("failed to upload File('{}') content: {e}", target.file_id))?;
 
     Ok(())
+}
+
+async fn ensure_created_file_initialized(
+    state: &PlatformState,
+    tenant_id: &TenantId,
+    agent_ctx: &temper_server::request_context::AgentContext,
+    file_id: &str,
+    create_fields: serde_json::Value,
+) -> Result<(), String> {
+    let response = state
+        .server
+        .get_tenant_entity_state(tenant_id, "File", file_id)
+        .await
+        .map_err(|e| format!("failed to inspect File('{file_id}') status: {e}"))?;
+    if response.state.status != "Created" {
+        return Ok(());
+    }
+
+    state
+        .server
+        .dispatch(temper_server::state::DispatchCommand {
+            tenant: tenant_id,
+            entity_type: "File",
+            entity_id: file_id,
+            action: "Create",
+            params: create_fields,
+            agent_ctx,
+            await_integration: false,
+            await_reactions: true,
+        })
+        .await
+        .map(|_| ())
+        .map_err(|e| format!("failed to initialize File('{file_id}'): {e}"))
+}
+
+async fn ensure_entity_field_aliases(
+    state: &PlatformState,
+    tenant_id: &TenantId,
+    entity_type: &str,
+    entity_id: &str,
+    aliases: serde_json::Value,
+) -> Result<(), String> {
+    let current = state
+        .server
+        .get_tenant_entity_state(tenant_id, entity_type, entity_id)
+        .await
+        .map_err(|e| format!("failed to inspect {entity_type}('{entity_id}') aliases: {e}"))?;
+
+    let Some(alias_map) = aliases.as_object() else {
+        return Ok(());
+    };
+    let mut updates = serde_json::Map::new();
+    for (key, expected) in alias_map {
+        if current.state.fields.get(key) != Some(expected) {
+            updates.insert(key.clone(), expected.clone());
+        }
+    }
+    if updates.is_empty() {
+        return Ok(());
+    }
+
+    state
+        .server
+        .update_tenant_entity_fields(
+            tenant_id,
+            entity_type,
+            entity_id,
+            serde_json::Value::Object(updates),
+            false,
+        )
+        .await
+        .map(|_| ())
+        .map_err(|e| format!("failed to repair {entity_type}('{entity_id}') aliases: {e}"))
 }
 
 async fn file_already_contains(

--- a/crates/temper-platform/src/os_apps/mod.rs
+++ b/crates/temper-platform/src/os_apps/mod.rs
@@ -12,7 +12,6 @@ use std::time::Instant;
 
 use chrono::{DateTime, NaiveDateTime, Utc};
 use serde::Serialize;
-use sha2::{Digest, Sha256};
 use temper_runtime::tenant::TenantId;
 use temper_server::state::WasmModuleSource;
 use temper_spec::automaton;
@@ -24,6 +23,7 @@ use crate::state::PlatformState;
 mod agent_bootstrap;
 mod app_catalog;
 mod closure_bootstrap;
+mod entity_aliases;
 mod policy_rows;
 mod reconcile;
 mod runtime_heal;
@@ -38,6 +38,10 @@ pub use closure_bootstrap::{
     ClosureBootstrapResult, OS_APP_CLOSURE_RESOLVER_VERSION, OsAppClosure,
     bootstrap_closure_manifest, os_app_closure_for_roots, parse_bootstrap_manifest_str,
     startup_os_app_closure,
+};
+use entity_aliases::{
+    content_sha256, ensure_created_file_initialized, ensure_entity_field_aliases,
+    file_already_contains, slug_fragment,
 };
 #[cfg(test)]
 pub(super) use policy_rows::os_app_policy_row_id;
@@ -2527,127 +2531,6 @@ pub(super) async fn ensure_markdown_file(
         .map_err(|e| format!("failed to upload File('{}') content: {e}", target.file_id))?;
 
     Ok(())
-}
-
-async fn ensure_created_file_initialized(
-    state: &PlatformState,
-    tenant_id: &TenantId,
-    agent_ctx: &temper_server::request_context::AgentContext,
-    file_id: &str,
-    create_fields: serde_json::Value,
-) -> Result<(), String> {
-    let response = state
-        .server
-        .get_tenant_entity_state(tenant_id, "File", file_id)
-        .await
-        .map_err(|e| format!("failed to inspect File('{file_id}') status: {e}"))?;
-    if response.state.status != "Created" {
-        return Ok(());
-    }
-
-    state
-        .server
-        .dispatch(temper_server::state::DispatchCommand {
-            tenant: tenant_id,
-            entity_type: "File",
-            entity_id: file_id,
-            action: "Create",
-            params: create_fields,
-            agent_ctx,
-            await_integration: false,
-            await_reactions: true,
-        })
-        .await
-        .map(|_| ())
-        .map_err(|e| format!("failed to initialize File('{file_id}'): {e}"))
-}
-
-async fn ensure_entity_field_aliases(
-    state: &PlatformState,
-    tenant_id: &TenantId,
-    entity_type: &str,
-    entity_id: &str,
-    aliases: serde_json::Value,
-) -> Result<(), String> {
-    let current = state
-        .server
-        .get_tenant_entity_state(tenant_id, entity_type, entity_id)
-        .await
-        .map_err(|e| format!("failed to inspect {entity_type}('{entity_id}') aliases: {e}"))?;
-
-    let Some(alias_map) = aliases.as_object() else {
-        return Ok(());
-    };
-    let mut updates = serde_json::Map::new();
-    for (key, expected) in alias_map {
-        if current.state.fields.get(key) != Some(expected) {
-            updates.insert(key.clone(), expected.clone());
-        }
-    }
-    if updates.is_empty() {
-        return Ok(());
-    }
-
-    state
-        .server
-        .update_tenant_entity_fields(
-            tenant_id,
-            entity_type,
-            entity_id,
-            serde_json::Value::Object(updates),
-            false,
-        )
-        .await
-        .map(|_| ())
-        .map_err(|e| format!("failed to repair {entity_type}('{entity_id}') aliases: {e}"))
-}
-
-async fn file_already_contains(
-    state: &PlatformState,
-    tenant_id: &TenantId,
-    file_id: &str,
-    desired_hash: &str,
-) -> Result<bool, String> {
-    let response = state
-        .server
-        .get_tenant_entity_state(tenant_id, "File", file_id)
-        .await
-        .map_err(|e| format!("failed to inspect File('{file_id}'): {e}"))?;
-
-    let has_content = response
-        .state
-        .booleans
-        .get("has_content")
-        .copied()
-        .unwrap_or(false);
-    let current_hash = response
-        .state
-        .fields
-        .get("content_hash")
-        .and_then(|value| value.as_str())
-        .unwrap_or_default();
-    Ok(has_content && current_hash == desired_hash)
-}
-
-fn content_sha256(content: &[u8]) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(content);
-    format!("sha256:{:x}", hasher.finalize())
-}
-
-pub(super) fn slug_fragment(value: &str) -> String {
-    let mut slug = String::new();
-    let mut last_was_sep = true;
-    for ch in value.chars() {
-        if ch.is_ascii_alphanumeric() {
-            slug.push(ch.to_ascii_lowercase());
-            last_was_sep = false;
-        } else if !last_was_sep {
-            slug.push('-');
-            last_was_sep = true;
-        }
-    }
-    slug.trim_matches('-').to_string()
 }
 
 /// Bootstrap seed data instances into the tenant.

--- a/crates/temper-platform/src/os_apps/mod_test.rs
+++ b/crates/temper-platform/src/os_apps/mod_test.rs
@@ -2840,6 +2840,226 @@ async fn test_install_app_bootstraps_adrs_into_temper_fs() {
 }
 
 #[tokio::test]
+async fn test_install_app_skill_docs_are_query_readable_by_canonical_path_fields() {
+    use temper_store_turso::TursoEventStore;
+
+    let app_root =
+        std::env::temp_dir().join(format!("temper-skill-doc-app-{}", uuid::Uuid::new_v4()));
+    let app_dir = app_root.join("skill-doc-app");
+    fs::create_dir_all(app_dir.join("agents/curator/skills/research-direction")).unwrap();
+    fs::create_dir_all(app_dir.join("specs")).unwrap();
+    fs::write(
+        app_dir.join("app.toml"),
+        "name = \"skill-doc-app\"\ndescription = \"Temporary skill doc app\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(
+        app_dir.join("APP.md"),
+        "# Skill Doc App\n\nTemporary skill doc app.\n",
+    )
+    .unwrap();
+    fs::write(app_dir.join("agents/curator/AGENT.md"), "# Curator\n").unwrap();
+    fs::write(
+        app_dir.join("agents/curator/skills/research-direction/SKILL.md"),
+        "# Research Direction\n\nFind useful source material.\n",
+    )
+    .unwrap();
+    fs::write(
+        app_dir.join("specs/soul.ioa.toml"),
+        r#"
+[automaton]
+name = "Soul"
+states = ["Created", "Published"]
+initial = "Created"
+
+[[action]]
+name = "Create"
+kind = "input"
+from = ["Created"]
+to = "Created"
+params = ["name", "description", "content_file_id"]
+
+[[action]]
+name = "Publish"
+kind = "input"
+from = ["Created", "Published"]
+to = "Published"
+"#,
+    )
+    .unwrap();
+
+    let db_path = format!("/tmp/temper-skill-doc-test-{}.db", uuid::Uuid::new_v4());
+    let db_url = format!("file:{db_path}");
+    let turso = TursoEventStore::new(&db_url, None).await.unwrap();
+    let mut state = PlatformState::new(None);
+    state
+        .server
+        .set_storage_stack(temper_server::StorageStack::from_turso(turso));
+    state.server.data_dir = std::path::PathBuf::from(format!(
+        "/tmp/temper-skill-doc-test-{}-data",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&state.server.data_dir).unwrap();
+
+    add_os_apps_dir(app_root.clone());
+    install_os_app(&state, "test-skill-doc-app", "temper-fs")
+        .await
+        .expect("install temper-fs");
+    add_os_apps_dir(app_root.clone());
+    install_os_app(&state, "test-skill-doc-app", "skill-doc-app")
+        .await
+        .expect("install skill-doc-app");
+
+    let tenant = TenantId::new("test-skill-doc-app");
+    let agent_id = bootstrapped_agent_soul_entity_id("curator");
+    let file_id = format!(
+        "os-agent-skill-file-{}-research-direction",
+        slug_fragment(&agent_id)
+    );
+    let expected_path = format!("/agents/{agent_id}/skills/research-direction/SKILL.md");
+    let file = state
+        .server
+        .get_tenant_entity_state(&tenant, "File", &file_id)
+        .await
+        .expect("skill file should exist");
+
+    assert_eq!(file.state.status, "Ready");
+    assert_eq!(
+        file.state
+            .fields
+            .get("path")
+            .and_then(|value| value.as_str()),
+        Some(expected_path.as_str())
+    );
+    assert_eq!(
+        file.state
+            .fields
+            .get("Path")
+            .and_then(|value| value.as_str()),
+        Some(expected_path.as_str())
+    );
+    assert_eq!(
+        file.state
+            .fields
+            .get("workspace_id")
+            .and_then(|value| value.as_str()),
+        Some(APP_DOCS_WORKSPACE_ID)
+    );
+    assert_eq!(
+        file.state
+            .fields
+            .get("WorkspaceId")
+            .and_then(|value| value.as_str()),
+        Some(APP_DOCS_WORKSPACE_ID)
+    );
+
+    let _ = fs::remove_dir_all(&app_root);
+    let _ = fs::remove_file(&db_path);
+    let _ = fs::remove_file(format!("{db_path}-wal"));
+    let _ = fs::remove_file(format!("{db_path}-shm"));
+}
+
+#[tokio::test]
+async fn test_ensure_markdown_file_repairs_existing_canonical_query_aliases() {
+    use temper_store_turso::TursoEventStore;
+
+    let db_path = format!(
+        "/tmp/temper-skill-doc-repair-test-{}.db",
+        uuid::Uuid::new_v4()
+    );
+    let db_url = format!("file:{db_path}");
+    let turso = TursoEventStore::new(&db_url, None).await.unwrap();
+    let mut state = PlatformState::new(None);
+    state
+        .server
+        .set_storage_stack(temper_server::StorageStack::from_turso(turso));
+    state.server.data_dir = std::path::PathBuf::from(format!(
+        "/tmp/temper-skill-doc-repair-test-{}-data",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&state.server.data_dir).unwrap();
+
+    install_os_app(&state, "test-skill-doc-repair", "temper-fs")
+        .await
+        .expect("install temper-fs");
+
+    let tenant = TenantId::new("test-skill-doc-repair");
+    let agent_ctx = AgentContext::for_service("test-bootstrap");
+    let path = "/agents/sl-bootstrap-agent-soul-curator/skills/research-direction/SKILL.md";
+    let file_id = "os-agent-skill-file-sl-bootstrap-agent-soul-curator-research-direction";
+    state
+        .server
+        .create_file_with_initial_stream_content(
+            &tenant,
+            file_id,
+            serde_json::json!({
+                "name": "SKILL.md",
+                "path": path,
+                "directory_id": "os-agent-skill-dir-sl-bootstrap-agent-soul-curator-research-direction",
+                "workspace_id": APP_DOCS_WORKSPACE_ID,
+                "mime_type": "text/markdown",
+            }),
+            b"# Research Direction\n",
+            "text/markdown",
+            &agent_ctx,
+        )
+        .await
+        .expect("create legacy lower-case-only skill file");
+
+    let before = state
+        .server
+        .get_tenant_entity_state(&tenant, "File", file_id)
+        .await
+        .expect("legacy file should exist");
+    assert!(
+        before.state.fields.get("Path").is_none(),
+        "test setup should match lower-case-only legacy projection"
+    );
+
+    ensure_markdown_file(
+        &state,
+        &tenant,
+        &agent_ctx,
+        MarkdownFileBootstrapTarget {
+            file_id,
+            name: "SKILL.md",
+            path,
+            directory_id: "os-agent-skill-dir-sl-bootstrap-agent-soul-curator-research-direction",
+            workspace_id: APP_DOCS_WORKSPACE_ID,
+        },
+        b"# Research Direction\n",
+    )
+    .await
+    .expect("repair skill file aliases");
+
+    let after = state
+        .server
+        .get_tenant_entity_state(&tenant, "File", file_id)
+        .await
+        .expect("repaired file should exist");
+    assert_eq!(
+        after
+            .state
+            .fields
+            .get("Path")
+            .and_then(|value| value.as_str()),
+        Some(path)
+    );
+    assert_eq!(
+        after
+            .state
+            .fields
+            .get("WorkspaceId")
+            .and_then(|value| value.as_str()),
+        Some(APP_DOCS_WORKSPACE_ID)
+    );
+
+    let _ = fs::remove_file(&db_path);
+    let _ = fs::remove_file(format!("{db_path}-wal"));
+    let _ = fs::remove_file(format!("{db_path}-shm"));
+}
+
+#[tokio::test]
 async fn test_install_os_app_rebuilds_reaction_dispatcher_for_inline_entity_triggers() {
     use serde_json::json;
     use temper_runtime::tenant::TenantId;

--- a/crates/temper-server/src/entity_actor/effects.rs
+++ b/crates/temper-server/src/entity_actor/effects.rs
@@ -60,8 +60,8 @@ pub struct ScheduleAtRequest {
 
 /// Maximum cross-entity lookups per transition (TigerStyle budget).
 ///
-/// Rich artifact contracts, such as Katagami's design-language review gate,
-/// legitimately verify several sibling File records in one guarded transition.
+/// Rich contracts may legitimately verify several sibling entities in one
+/// guarded transition.
 pub const MAX_CROSS_ENTITY_LOOKUPS: usize = 16;
 /// Maximum entity spawns per transition (TigerStyle budget).
 pub const MAX_SPAWNS_PER_TRANSITION: usize = 8;
@@ -1107,49 +1107,49 @@ guard = [
     }
 
     #[test]
-    fn cross_entity_budget_covers_artifact_review_contract() {
+    fn cross_entity_budget_covers_multi_entity_guard_contract() {
         let _guard = temper_runtime::scheduler::install_deterministic_context(42);
 
         let spec = r#"
 [automaton]
-name = "DesignLanguage"
-states = ["Draft", "UnderReview"]
+name = "ReviewPacket"
+states = ["Draft", "Submitted"]
 initial = "Draft"
 
 [[action]]
-name = "SubmitForReview"
+name = "Submit"
 from = ["Draft"]
-to = "UnderReview"
+to = "Submitted"
 guard = [
-    { type = "cross_entity_state", entity_type = "File", entity_id_source = "embodiment_file_id", required_status = ["Ready", "Locked"] },
-    { type = "cross_entity_state", entity_type = "File", entity_id_source = "landing_file_id", required_status = ["Ready", "Locked"] },
-    { type = "cross_entity_state", entity_type = "File", entity_id_source = "dashboard_file_id", required_status = ["Ready", "Locked"] },
-    { type = "cross_entity_state", entity_type = "File", entity_id_source = "thumbnail_file_id", required_status = ["Ready", "Locked"] },
-    { type = "cross_entity_state", entity_type = "File", entity_id_source = "design_md_file_id", required_status = ["Ready", "Locked"] },
-    { type = "cross_entity_state", entity_type = "File", entity_id_source = "shadcn_export_file_id", required_status = ["Ready", "Locked"] },
-    { type = "cross_entity_state", entity_type = "File", entity_id_source = "shadcn_component_spec_file_id", required_status = ["Ready", "Locked"] },
-    { type = "cross_entity_state", entity_type = "File", entity_id_source = "shadcn_preview_shots_file_id", required_status = ["Ready", "Locked"] }
+    { type = "cross_entity_state", entity_type = "Attachment", entity_id_source = "attachment_a_id", required_status = ["Ready", "Locked"] },
+    { type = "cross_entity_state", entity_type = "Attachment", entity_id_source = "attachment_b_id", required_status = ["Ready", "Locked"] },
+    { type = "cross_entity_state", entity_type = "Attachment", entity_id_source = "attachment_c_id", required_status = ["Ready", "Locked"] },
+    { type = "cross_entity_state", entity_type = "Attachment", entity_id_source = "attachment_d_id", required_status = ["Ready", "Locked"] },
+    { type = "cross_entity_state", entity_type = "Attachment", entity_id_source = "attachment_e_id", required_status = ["Ready", "Locked"] },
+    { type = "cross_entity_state", entity_type = "Attachment", entity_id_source = "attachment_f_id", required_status = ["Ready", "Locked"] },
+    { type = "cross_entity_state", entity_type = "Attachment", entity_id_source = "attachment_g_id", required_status = ["Ready", "Locked"] },
+    { type = "cross_entity_state", entity_type = "Attachment", entity_id_source = "attachment_h_id", required_status = ["Ready", "Locked"] }
 ]
 "#;
 
         let table = temper_jit::table::TransitionTable::from_ioa_source(spec);
         let mut state = EntityState {
-            entity_type: "DesignLanguage".into(),
-            entity_id: "dl-1".into(),
+            entity_type: "ReviewPacket".into(),
+            entity_id: "rp-1".into(),
             status: "Draft".into(),
             item_count: 0,
             counters: std::collections::BTreeMap::new(),
             booleans: std::collections::BTreeMap::new(),
             lists: std::collections::BTreeMap::new(),
             fields: serde_json::json!({
-                "embodiment_file_id": "fl-1",
-                "landing_file_id": "fl-2",
-                "dashboard_file_id": "fl-3",
-                "thumbnail_file_id": "fl-4",
-                "design_md_file_id": "fl-5",
-                "shadcn_export_file_id": "fl-6",
-                "shadcn_component_spec_file_id": "fl-7",
-                "shadcn_preview_shots_file_id": "fl-8"
+                "attachment_a_id": "att-1",
+                "attachment_b_id": "att-2",
+                "attachment_c_id": "att-3",
+                "attachment_d_id": "att-4",
+                "attachment_e_id": "att-5",
+                "attachment_f_id": "att-6",
+                "attachment_g_id": "att-7",
+                "attachment_h_id": "att-8"
             }),
             events: std::collections::VecDeque::new(),
             total_event_count: 0,
@@ -1159,37 +1159,29 @@ guard = [
             processed_idempotency_keys: std::collections::BTreeMap::new(),
         };
         let xref = std::collections::BTreeMap::from([
-            ("__xref:File:embodiment_file_id".to_string(), true),
-            ("__xref:File:landing_file_id".to_string(), true),
-            ("__xref:File:dashboard_file_id".to_string(), true),
-            ("__xref:File:thumbnail_file_id".to_string(), true),
-            ("__xref:File:design_md_file_id".to_string(), true),
-            ("__xref:File:shadcn_export_file_id".to_string(), true),
-            (
-                "__xref:File:shadcn_component_spec_file_id".to_string(),
-                true,
-            ),
-            ("__xref:File:shadcn_preview_shots_file_id".to_string(), true),
+            ("__xref:Attachment:attachment_a_id".to_string(), true),
+            ("__xref:Attachment:attachment_b_id".to_string(), true),
+            ("__xref:Attachment:attachment_c_id".to_string(), true),
+            ("__xref:Attachment:attachment_d_id".to_string(), true),
+            ("__xref:Attachment:attachment_e_id".to_string(), true),
+            ("__xref:Attachment:attachment_f_id".to_string(), true),
+            ("__xref:Attachment:attachment_g_id".to_string(), true),
+            ("__xref:Attachment:attachment_h_id".to_string(), true),
         ]);
-        let required_artifact_lookup_count = xref.len();
+        let required_guard_lookup_count = xref.len();
         assert!(
-            MAX_CROSS_ENTITY_LOOKUPS >= required_artifact_lookup_count,
-            "artifact review gates need at least {required_artifact_lookup_count} cross-entity File lookups"
+            MAX_CROSS_ENTITY_LOOKUPS >= required_guard_lookup_count,
+            "multi-entity guards need at least {required_guard_lookup_count} cross-entity lookups"
         );
 
-        let result = process_action_with_xref(
-            &mut state,
-            &table,
-            "SubmitForReview",
-            &serde_json::json!({}),
-            &xref,
-        );
+        let result =
+            process_action_with_xref(&mut state, &table, "Submit", &serde_json::json!({}), &xref);
 
         assert!(
             result.success,
-            "eight resolved artifact File guards should allow SubmitForReview"
+            "eight resolved cross-entity guards should allow Submit"
         );
-        assert_eq!(state.status, "UnderReview");
+        assert_eq!(state.status, "Submitted");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- write canonical Path/WorkspaceId/DirectoryId aliases when OS app directories and markdown files are bootstrapped
- repair existing lower-case-only app-doc entities during install/reconcile
- initialize bare Created File shells before streaming markdown content
- de-pollute the cross-entity lookup budget regression from #322 so Temper core uses neutral entity names and comments

## Why
A clean Katagami curation proof run failed because source-search was told to read `/agents/sl-bootstrap-agent-soul-curator/skills/research-direction/SKILL.md`, but the bootstrapped File only had lower-case `path`/`workspace_id` fields. The prompt builder could find it through a lower-case fallback, while the agent `temper.read` canonical path lookup could not. This is the ARN-68/ARN-71 skill-delivery class, not an agent judgment failure.

The cross-entity budget belongs in Temper, but the kernel test/comment should not name Katagami-specific artifacts. This PR keeps the generic budget coverage and moves product-specific coverage back out of Temper core.

## Tests
- `cargo test -p temper-server entity_actor::effects::tests::cross_entity_budget_covers_multi_entity_guard_contract`
- `cargo test -p temper-platform test_install_app_skill_docs_are_query_readable_by_canonical_path_fields`
- `cargo test -p temper-platform test_ensure_markdown_file_repairs_existing_canonical_query_aliases`
- `cargo test -p temper-platform test_install_app_bootstraps_adrs_into_temper_fs`

Refs ARN-71, ARN-68.