### PR TITLE
feat(backfill): decouple entity_key_index backfill from the heavy field-index re-scan (ARN-68)

### DIFF
--- a/crates/temper-server/src/state/entity_ops.rs
+++ b/crates/temper-server/src/state/entity_ops.rs
@@ -414,8 +414,18 @@ impl ServerState {
     #[instrument(skip_all, fields(otel.name = "entity.populate_field_index", tenant = %tenant))]
     pub async fn populate_field_index_from_snapshots(&self, tenant: &TenantId) {
         projection_backfill::populate_field_index_from_snapshots(self, tenant).await;
-        // ADR-0153: backfill entity_key_index for declared-key entity types in the
-        // same pass, so keyed reads can authoritatively prove absence post-backfill.
+    }
+
+    /// Backfill `entity_key_index` for declared-key entity types (ADR-0153), so a
+    /// keyed read can authoritatively prove absence for pre-existing entities.
+    ///
+    /// Independent of [`Self::populate_field_index_from_snapshots`]: the declared
+    /// key is `K` (1–3) tiny rows per entity, far cheaper than the broad `S`-wide
+    /// field-index re-scan, so it is gated and scheduled on its own rather than
+    /// riding the expensive projection backfill. Runs once as a background task;
+    /// entities written after boot are keyed inline at write time.
+    #[instrument(skip_all, fields(otel.name = "entity.populate_key_index", tenant = %tenant))]
+    pub async fn populate_key_index_from_snapshots(&self, tenant: &TenantId) {
         projection_backfill::populate_key_index_from_snapshots(self, tenant).await;
     }
 


### PR DESCRIPTION
Follow-up to temper#326 (Path A). Splits the declared-key backfill (`populate_key_index_from_snapshots`) into its own `ServerState` method so it can be gated/scheduled **independently** of the heavy broad-EAV field-index re-scan it was chained to.

**Why:** activating Path A on openpaw revealed the field-index backfill is disabled in prod, so the chained key backfill never ran — existing Files/Directories had no key row. The key index is K (1–3) tiny rows/entity; it shouldn't require the S-wide re-scan to populate.

Pairs with a temperpaw change adding an independent `spawn_key_index_backfill` (own flag). Part of ARN-68 / Path A activation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfDeyvWdKTTrsJ8QXaB1sU