### PR TITLE
fix(key-index): index null key components so the FS root lookup is keyed (ARN-68)

### DIFF
--- a/crates/temper-server/src/key_index.rs
+++ b/crates/temper-server/src/key_index.rs
@@ -23,16 +23,20 @@ const RECORD_SEP: u8 = 0x1E;
 const TAG_STRING: u8 = b'S';
 const TAG_NUMBER: u8 = b'N';
 const TAG_BOOL: u8 = b'B';
+/// Null is a distinct, indexable key value (e.g. a filesystem root's null
+/// `ParentId`), tagged so it can never collide with the empty string.
+const TAG_NULL: u8 = b'0';
 
 /// Canonical `key_hash` for a declared key's values, or `None` when the key is
 /// not fully present.
 ///
 /// `properties` is the declared key's property set **in declared order** (the
 /// order is part of the canonical form). For each property the entity's current
-/// scalar value is encoded as `(type_tag, canonical_text)`. Returns `None` if the
-/// key has no properties, or if any property is missing, null, or non-scalar — a
-/// partial key is not indexable, so the entity simply has no `entity_key_index`
-/// row for that key (it is still reachable by `Id`).
+/// scalar value is encoded as `(type_tag, canonical_text)`. A `null` value is a
+/// valid, indexable key component (e.g. a filesystem root's null `ParentId`).
+/// Returns `None` only if the key has no properties, or if any property is
+/// **absent** from `fields` or non-scalar — a partial key is not indexable, so the
+/// entity simply has no `entity_key_index` row for that key (still reachable by `Id`).
 pub fn canonical_key_hash(
     key_name: &str,
     properties: &[String],
@@ -82,10 +86,13 @@ fn lookup_field<'a>(
 fn canonical_value(value: &serde_json::Value) -> Option<(u8, String)> {
     use serde_json::Value;
     match value {
-        Value::Null => None,
+        // Null is a real, distinct key value (a root's null `ParentId`), indexed
+        // under its own tag so it never collides with the empty string.
+        Value::Null => Some((TAG_NULL, String::new())),
         Value::Bool(b) => Some((TAG_BOOL, if *b { "1" } else { "0" }.to_string())),
         Value::Number(n) => Some((TAG_NUMBER, n.to_string())),
         Value::String(s) => Some((TAG_STRING, s.clone())),
+        // Arrays/objects are not scalar key components.
         Value::Array(_) | Value::Object(_) => None,
     }
 }
@@ -96,19 +103,19 @@ fn canonical_value(value: &serde_json::Value) -> Option<(u8, String)> {
 /// probe `entity_key_index` instead of scanning. `None` if no declared key
 /// matches.
 ///
-/// Values are taken as strings (how the OData URL / `$filter` deliver them),
-/// which matches the write-side hash for string-typed key properties — the case
-/// for every declared business key today (File `WorkspaceId+Path`, etc.). A
-/// non-string key property would need the value coerced to its declared type
-/// before this matches; that is tracked as a follow-up and a mismatch only
-/// declines the fast path (the caller falls back to the scan), never a wrong hit.
+/// Values are the **typed** literals from the `$filter` (string, number, bool,
+/// or `null`), so the read-side hash matches the write-side hash component-for-
+/// component — including a `null` key value (a filesystem root's null `ParentId`),
+/// which is what makes the root directory lookup keyed instead of a scan. A
+/// type/value mismatch only declines the fast path (caller falls back to the
+/// scan), never a wrong hit.
 pub fn resolve_query_to_key(
     keys: &[DeclaredKey],
-    equality_pairs: &[(String, String)],
+    equality_pairs: &[(String, serde_json::Value)],
 ) -> Option<(String, String)> {
     let mut fields = serde_json::Map::new();
     for (prop, value) in equality_pairs {
-        fields.insert(prop.clone(), serde_json::Value::String(value.clone()));
+        fields.insert(prop.clone(), value.clone());
     }
     for key in keys {
         if key.properties.len() == equality_pairs.len()
@@ -182,15 +189,15 @@ mod tests {
     }
 
     #[test]
-    fn missing_or_null_or_empty_yields_none() {
+    fn absent_or_empty_key_yields_none_but_null_is_indexable() {
         let props = vec!["WorkspaceId".to_string(), "Path".to_string()];
-        // missing Path
+        // ABSENT property (not in fields at all) -> not indexable.
         let missing = fields(&[("WorkspaceId", json!("ws1"))]);
         assert!(canonical_key_hash("path", &props, &missing).is_none());
-        // null Path
+        // NULL value present -> now a valid, indexable key component.
         let null_path = fields(&[("WorkspaceId", json!("ws1")), ("Path", json!(null))]);
-        assert!(canonical_key_hash("path", &props, &null_path).is_none());
-        // no declared properties
+        assert!(canonical_key_hash("path", &props, &null_path).is_some());
+        // no declared properties -> nothing to index.
         let f = fields(&[("WorkspaceId", json!("ws1"))]);
         assert!(canonical_key_hash("path", &[], &f).is_none());
     }
@@ -205,8 +212,8 @@ mod tests {
     #[test]
     fn resolve_query_matches_declared_key_and_agrees_with_write_hash() {
         let pairs = vec![
-            ("WorkspaceId".to_string(), "ws1".to_string()),
-            ("Path".to_string(), "/a.md".to_string()),
+            ("WorkspaceId".to_string(), json!("ws1")),
+            ("Path".to_string(), json!("/a.md")),
         ];
         let (name, hash) = resolve_query_to_key(&path_key(), &pairs).expect("matches declared key");
         assert_eq!(name, "path");
@@ -239,8 +246,8 @@ mod tests {
 
         // Read side: resolve a PascalCase $filter against the same declared key.
         let read_pairs = vec![
-            ("WorkspaceId".to_string(), "ws-1".to_string()),
-            ("Path".to_string(), "/a.md".to_string()),
+            ("WorkspaceId".to_string(), json!("ws-1")),
+            ("Path".to_string(), json!("/a.md")),
         ];
         let decl = vec![DeclaredKey {
             name: "ws_path".to_string(),
@@ -264,18 +271,65 @@ mod tests {
     fn resolve_query_declines_when_no_key_matches() {
         // wrong arity, wrong property, and no declared keys -> decline (fall back to scan)
         assert!(
-            resolve_query_to_key(&path_key(), &[("WorkspaceId".into(), "ws1".into())]).is_none()
+            resolve_query_to_key(&path_key(), &[("WorkspaceId".into(), json!("ws1"))]).is_none()
         );
         assert!(
             resolve_query_to_key(
                 &path_key(),
                 &[
-                    ("Other".into(), "x".into()),
-                    ("Path".into(), "/a.md".into())
+                    ("Other".into(), json!("x")),
+                    ("Path".into(), json!("/a.md"))
                 ]
             )
             .is_none()
         );
-        assert!(resolve_query_to_key(&[], &[("WorkspaceId".into(), "ws1".into())]).is_none());
+        assert!(resolve_query_to_key(&[], &[("WorkspaceId".into(), json!("ws1"))]).is_none());
+    }
+
+    #[test]
+    fn null_key_component_is_indexable_and_read_matches_write() {
+        // The filesystem root directory case (ARN-68): the root has a null ParentId.
+        // Write side: hash the entity's (Name='/', WorkspaceId, ParentId=null).
+        let key = vec![
+            "Name".to_string(),
+            "WorkspaceId".to_string(),
+            "ParentId".to_string(),
+        ];
+        let write_fields = fields(&[
+            ("Name", json!("/")),
+            ("WorkspaceId", json!("katagami")),
+            ("ParentId", json!(null)),
+        ]);
+        let write_hash =
+            canonical_key_hash("name_parent", &key, &write_fields).expect("null is indexable");
+
+        // Read side: `Name eq '/' and WorkspaceId eq 'katagami' and ParentId eq null`
+        // resolves to the SAME hash — so the root lookup is keyed, not a scan.
+        let decl = vec![DeclaredKey {
+            name: "name_parent".to_string(),
+            properties: key.clone(),
+        }];
+        let read_pairs = vec![
+            ("Name".to_string(), json!("/")),
+            ("WorkspaceId".to_string(), json!("katagami")),
+            ("ParentId".to_string(), json!(null)),
+        ];
+        let (_, read_hash) = resolve_query_to_key(&decl, &read_pairs).expect("null read resolves");
+        assert_eq!(
+            write_hash, read_hash,
+            "null ParentId must hash equal on write and read — else the root lookup misses and scans (413)"
+        );
+
+        // A null component must NOT collide with the empty string.
+        let empty_fields = fields(&[
+            ("Name", json!("/")),
+            ("WorkspaceId", json!("katagami")),
+            ("ParentId", json!("")),
+        ]);
+        assert_ne!(
+            canonical_key_hash("name_parent", &key, &empty_fields).unwrap(),
+            write_hash,
+            "null and empty-string must be distinct key values"
+        );
     }
 }

--- a/crates/temper-server/src/odata/filter_sql.rs
+++ b/crates/temper-server/src/odata/filter_sql.rs
@@ -76,12 +76,33 @@ pub(super) fn try_translate_candidate_filter(filter: &FilterExpr) -> Option<Tran
 /// asynchronously-projected row (ARN-89). `null`-equality leaves count as
 /// equality here; the authoritative read re-evaluates the original filter, so
 /// null semantics stay correct.
-pub(super) fn equality_field_predicates(filter: &FilterExpr) -> Option<Vec<(String, String)>> {
+pub(super) fn equality_field_predicates(
+    filter: &FilterExpr,
+) -> Option<Vec<(String, serde_json::Value)>> {
     let mut pairs = Vec::new();
     collect_equality_field_predicates(filter, &mut pairs).then_some(pairs)
 }
 
-fn collect_equality_field_predicates(expr: &FilterExpr, out: &mut Vec<(String, String)>) -> bool {
+/// Convert an OData literal to the JSON value the entity stores it as, so the
+/// read-side key hash matches the write-side hash component-for-component.
+/// `null` maps to `Value::Null` (a distinct, indexable key value).
+fn odata_value_to_json(value: &ODataValue) -> Option<serde_json::Value> {
+    use serde_json::Value;
+    Some(match value {
+        ODataValue::Null => Value::Null,
+        ODataValue::Boolean(b) => Value::Bool(*b),
+        ODataValue::Int(i) => Value::Number((*i).into()),
+        ODataValue::Float(f) => Value::Number(serde_json::Number::from_f64(*f)?),
+        ODataValue::String(s) => Value::String(s.clone()),
+        ODataValue::Guid(g) => Value::String(g.to_string()),
+        ODataValue::DateTimeOffset(dt) => Value::String(dt.to_rfc3339()),
+    })
+}
+
+fn collect_equality_field_predicates(
+    expr: &FilterExpr,
+    out: &mut Vec<(String, serde_json::Value)>,
+) -> bool {
     match expr {
         FilterExpr::BinaryOp {
             left,
@@ -99,14 +120,10 @@ fn collect_equality_field_predicates(expr: &FilterExpr, out: &mut Vec<(String, S
             let Some((field_name, value)) = property_literal_pair(left, right) else {
                 return false;
             };
-            let rendered = match value {
-                ODataValue::Null => String::new(),
-                other => match odata_value_to_text(other) {
-                    Some(text) => text,
-                    None => return false,
-                },
+            let Some(json) = odata_value_to_json(value) else {
+                return false;
             };
-            out.push((field_name.to_string(), rendered));
+            out.push((field_name.to_string(), json));
             true
         }
         _ => false,

--- a/crates/temper-server/src/odata/filter_sql/tests.rs
+++ b/crates/temper-server/src/odata/filter_sql/tests.rs
@@ -309,8 +309,8 @@ fn equality_predicates_accepts_two_scalar_conjuncts() {
     assert_eq!(
         pairs,
         vec![
-            ("Path".to_string(), "/proofs/live.txt".to_string()),
-            ("WorkspaceId".to_string(), "ws-1".to_string()),
+            ("Path".to_string(), serde_json::json!("/proofs/live.txt")),
+            ("WorkspaceId".to_string(), serde_json::json!("ws-1")),
         ]
     );
 }
@@ -332,10 +332,11 @@ fn equality_predicates_accepts_null_leaf_in_directory_conjunction() {
     assert_eq!(
         pairs,
         vec![
-            ("Name".to_string(), "inbox".to_string()),
-            ("WorkspaceId".to_string(), "ws-1".to_string()),
-            // null renders as the empty string sentinel.
-            ("ParentId".to_string(), String::new()),
+            ("Name".to_string(), serde_json::json!("inbox")),
+            ("WorkspaceId".to_string(), serde_json::json!("ws-1")),
+            // null is carried as a typed null (a distinct, indexable key value),
+            // NOT conflated with the empty string.
+            ("ParentId".to_string(), serde_json::Value::Null),
         ]
     );
 }

--- a/crates/temper-server/src/odata/read.rs
+++ b/crates/temper-server/src/odata/read.rs
@@ -309,9 +309,15 @@ async fn try_resolve_composite_entity_key(
     // scan. On a miss we fall through to the scan, which still covers
     // pre-backfill entities — a safe additive fast path until #324's scan is
     // retired behind the backfill gate.
+    // Composite-key URL addressing delivers string values; carry them typed so
+    // `resolve_query_to_key` hashes them the same way the write side does.
+    let typed_pairs: Vec<(String, serde_json::Value)> = key_pairs
+        .iter()
+        .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
+        .collect();
     if let Some(table) = state.transition_tables.get(entity_type)
         && let Some((key_name, key_hash)) =
-            crate::key_index::resolve_query_to_key(&table.keys, key_pairs)
+            crate::key_index::resolve_query_to_key(&table.keys, &typed_pairs)
         && let Some((store, _)) = state.event_journal()
         && let Ok(Some(entity_id)) = store
             .lookup_by_key(tenant.as_str(), entity_type, &key_name, &key_hash)


### PR DESCRIPTION
**Root cause of the still-persisting 413.** TemperFS path resolution (`ensure_dirs`) always starts by looking up the workspace **root** directory: `Directories?$filter=Name eq '/' and WorkspaceId eq X and ParentId eq null`. The root's `ParentId` is **null**, and Path A made null key components unindexable (`canonical_value(Null) -> None`) — so the root got no `entity_key_index` row, the keyed read couldn't resolve `ParentId eq null`, and it fell back to the full directory scan → **413 QueryTooLarge**. Every `temper.write` walks from root, so every write still 413'd (non-root dir + file-by-path lookups were already keyed).

**Fix:** make `null` a first-class, distinct key value.
- `canonical_value(Null)` → `(TAG_NULL, "")` (was `None`).
- Carry the read-side `$filter` values **typed** (`serde_json::Value`) through `equality_field_predicates` → `resolve_query_to_key`, so `eq null` hashes as `TAG_NULL` matching the write side — and null never collides with the empty string. String keys are unchanged; this also fixes int/bool key values that were silently string-coerced before.

Tests: `null read == write hash` + `null != empty-string`; read-plane 23/23, DST 3/3.

Follow-up to temper#326/#327 (Path A). Closes the root-directory gap behind ARN-68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfDeyvWdKTTrsJ8QXaB1sU