### PR TITLE
fix(key-index): treat absent declared-key property as null — FS root keys (ARN-68)

### DIFF
--- a/crates/temper-server/src/key_index.rs
+++ b/crates/temper-server/src/key_index.rs
@@ -35,8 +35,10 @@ const TAG_NULL: u8 = b'0';
 /// scalar value is encoded as `(type_tag, canonical_text)`. A `null` value — or a
 /// property **absent** from `fields` (e.g. a filesystem root has no `ParentId`
 /// field at all) — is a valid, indexable key component encoded under `TAG_NULL`,
-/// matching OData's `prop eq null` semantics. Returns `None` only if the key has
-/// no properties, or if a **present** property is non-scalar (array/object).
+/// matching OData's `prop eq null` semantics. Returns `None` if the key has no
+/// properties, if a **present** property is non-scalar (array/object), or if
+/// **every** component is null/absent (an all-null key has no distinguishing value
+/// and would collide for every such entity).
 pub fn canonical_key_hash(
     key_name: &str,
     properties: &[String],
@@ -52,15 +54,30 @@ pub fn canonical_key_hash(
     // as null — consistent with OData, where `prop eq null` matches a missing
     // field. This is what keys a filesystem root directory: it is created with no
     // `ParentId` field at all (Directory has no ParentId state var), and the read
-    // looks it up by `ParentId eq null`. Absent and explicit-null therefore both
-    // index under TAG_NULL so the keyed read resolves the root instead of scanning.
+    // looks it up by `ParentId eq null`. Absent and explicit-null both index under
+    // TAG_NULL so the keyed read resolves the root instead of scanning.
+    //
+    // But an entity with EVERY key component null/absent has no distinguishing key
+    // value, so it is NOT indexed — otherwise all such entities would collide on a
+    // single all-null hash and trip the uniqueness constraint. The root is safe: it
+    // has `Name`/`WorkspaceId` present, only `ParentId` is null.
     let null = serde_json::Value::Null;
+    let mut any_present = false;
     for prop in properties {
-        let value = lookup_field(fields, prop).unwrap_or(&null);
+        let value = match lookup_field(fields, prop) {
+            Some(v) if !v.is_null() => {
+                any_present = true;
+                v
+            }
+            other => other.unwrap_or(&null),
+        };
         let (tag, canon) = canonical_value(value)?;
         hasher.update([tag]);
         hasher.update(canon.as_bytes());
         hasher.update([RECORD_SEP]);
+    }
+    if !any_present {
+        return None;
     }
     Some(format!("{:x}", hasher.finalize()))
 }
@@ -218,6 +235,20 @@ mod tests {
         // no declared properties -> nothing to index.
         let f = fields(&[("WorkspaceId", json!("ws1"))]);
         assert!(canonical_key_hash("path", &[], &f).is_none());
+    }
+
+    #[test]
+    fn all_null_or_absent_key_is_not_indexed() {
+        // An entity with NO key values set (e.g. an Order created with `{}`) must
+        // not be keyed — else every such entity collides on a single all-null hash
+        // and the second co-commit trips the uniqueness constraint.
+        let props = vec!["WorkspaceId".to_string(), "Path".to_string()];
+        assert!(canonical_key_hash("path", &props, &fields(&[])).is_none());
+        let all_null = fields(&[("WorkspaceId", json!(null)), ("Path", json!(null))]);
+        assert!(canonical_key_hash("path", &props, &all_null).is_none());
+        // But one present component is enough to key it (the root's case).
+        let one_present = fields(&[("WorkspaceId", json!("ws1"))]);
+        assert!(canonical_key_hash("path", &props, &one_present).is_some());
     }
 
     #[test]

--- a/crates/temper-server/src/key_index.rs
+++ b/crates/temper-server/src/key_index.rs
@@ -32,11 +32,11 @@ const TAG_NULL: u8 = b'0';
 ///
 /// `properties` is the declared key's property set **in declared order** (the
 /// order is part of the canonical form). For each property the entity's current
-/// scalar value is encoded as `(type_tag, canonical_text)`. A `null` value is a
-/// valid, indexable key component (e.g. a filesystem root's null `ParentId`).
-/// Returns `None` only if the key has no properties, or if any property is
-/// **absent** from `fields` or non-scalar — a partial key is not indexable, so the
-/// entity simply has no `entity_key_index` row for that key (still reachable by `Id`).
+/// scalar value is encoded as `(type_tag, canonical_text)`. A `null` value — or a
+/// property **absent** from `fields` (e.g. a filesystem root has no `ParentId`
+/// field at all) — is a valid, indexable key component encoded under `TAG_NULL`,
+/// matching OData's `prop eq null` semantics. Returns `None` only if the key has
+/// no properties, or if a **present** property is non-scalar (array/object).
 pub fn canonical_key_hash(
     key_name: &str,
     properties: &[String],
@@ -48,8 +48,16 @@ pub fn canonical_key_hash(
     let mut hasher = Sha256::new();
     hasher.update(key_name.as_bytes());
     hasher.update([UNIT_SEP]);
+    // A declared-key property that is ABSENT from the entity's fields is treated
+    // as null — consistent with OData, where `prop eq null` matches a missing
+    // field. This is what keys a filesystem root directory: it is created with no
+    // `ParentId` field at all (Directory has no ParentId state var), and the read
+    // looks it up by `ParentId eq null`. Absent and explicit-null therefore both
+    // index under TAG_NULL so the keyed read resolves the root instead of scanning.
+    let null = serde_json::Value::Null;
     for prop in properties {
-        let (tag, canon) = canonical_value(lookup_field(fields, prop)?)?;
+        let value = lookup_field(fields, prop).unwrap_or(&null);
+        let (tag, canon) = canonical_value(value)?;
         hasher.update([tag]);
         hasher.update(canon.as_bytes());
         hasher.update([RECORD_SEP]);
@@ -189,17 +197,60 @@ mod tests {
     }
 
     #[test]
-    fn absent_or_empty_key_yields_none_but_null_is_indexable() {
+    fn absent_and_null_key_components_are_indexable_as_null() {
         let props = vec!["WorkspaceId".to_string(), "Path".to_string()];
-        // ABSENT property (not in fields at all) -> not indexable.
+        // ABSENT property (not in fields at all) -> indexed as null...
         let missing = fields(&[("WorkspaceId", json!("ws1"))]);
-        assert!(canonical_key_hash("path", &props, &missing).is_none());
-        // NULL value present -> now a valid, indexable key component.
+        // ...and equal to an explicit-null value for the same property.
         let null_path = fields(&[("WorkspaceId", json!("ws1")), ("Path", json!(null))]);
-        assert!(canonical_key_hash("path", &props, &null_path).is_some());
+        assert_eq!(
+            canonical_key_hash("path", &props, &missing),
+            canonical_key_hash("path", &props, &null_path),
+            "absent and explicit-null must hash identically (OData eq-null semantics)"
+        );
+        assert!(canonical_key_hash("path", &props, &missing).is_some());
+        // A present non-empty value must differ from null/absent.
+        let present = fields(&[("WorkspaceId", json!("ws1")), ("Path", json!("/a.md"))]);
+        assert_ne!(
+            canonical_key_hash("path", &props, &present),
+            canonical_key_hash("path", &props, &missing)
+        );
         // no declared properties -> nothing to index.
         let f = fields(&[("WorkspaceId", json!("ws1"))]);
         assert!(canonical_key_hash("path", &[], &f).is_none());
+    }
+
+    #[test]
+    fn root_directory_absent_parentid_keys_and_matches_eq_null_read() {
+        // The real bug (ARN-68): the FS root Directory is created with no ParentId
+        // field at all (Directory has no ParentId state var). The WRITE/backfill
+        // hashes its actual fields {Name, WorkspaceId} (ParentId absent); the READ
+        // looks it up by `... and ParentId eq null`. Both must agree.
+        let key = vec![
+            "Name".to_string(),
+            "WorkspaceId".to_string(),
+            "ParentId".to_string(),
+        ];
+        // Write side: root entity fields — ParentId genuinely absent.
+        let root_fields = fields(&[("Name", json!("/")), ("WorkspaceId", json!("katagami"))]);
+        let write_hash =
+            canonical_key_hash("name_parent", &key, &root_fields).expect("absent ParentId indexes");
+
+        // Read side: `Name eq '/' and WorkspaceId eq 'katagami' and ParentId eq null`.
+        let decl = vec![DeclaredKey {
+            name: "name_parent".to_string(),
+            properties: key.clone(),
+        }];
+        let read_pairs = vec![
+            ("Name".to_string(), json!("/")),
+            ("WorkspaceId".to_string(), json!("katagami")),
+            ("ParentId".to_string(), serde_json::Value::Null),
+        ];
+        let (_, read_hash) = resolve_query_to_key(&decl, &read_pairs).expect("root read resolves");
+        assert_eq!(
+            write_hash, read_hash,
+            "absent-ParentId write must equal eq-null read — else the root lookup scans (413)"
+        );
     }
 
     fn path_key() -> Vec<DeclaredKey> {


### PR DESCRIPTION
**The actual root cause of the persisting root-dir 413.** The TemperFS root Directory is created with **no `ParentId` field at all** (Directory declares no ParentId state var; the WASM creates root as `{Name, Path, WorkspaceId}`). The earlier null-key fix (temper#328) handled *present*-null, but `canonical_key_hash` hit an **absent** property and returned `None` → the root was never keyed → its `ParentId eq null` lookup scanned → **413** for large workspaces. (Small workspaces scanned under budget, masking it — which misled the earlier 'verified' check.)

**Fix:** treat an **absent** declared-key property as null (`TAG_NULL`), matching OData's `prop eq null` semantics. The root now keys as `(Name='/', WorkspaceId, ParentId=null)` on the write/backfill side, and the eq-null read resolves to the same hash.

Tests: absent-write == eq-null-read (the exact root case); absent == explicit-null; present != null. key_index 10/10, filter 10/10.

Follow-up to temper#326/#327/#328. This is the piece that actually keys the FS root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfDeyvWdKTTrsJ8QXaB1sU