### PR TITLE
fix(query-plane): harden the declared-key backfill for tenant scale (ARN-68)

### DIFF
--- a/crates/temper-runtime/src/persistence/mod.rs
+++ b/crates/temper-runtime/src/persistence/mod.rs
@@ -193,6 +193,21 @@ pub trait EventStore: Send + Sync + 'static {
         async { Ok(Vec::new()) }
     }
 
+    /// The `entity_id`s that already have at least one `entity_key_index` row for
+    /// `(tenant, entity_type)`. Lets the backfill **resume** cheaply: it skips
+    /// already-keyed entities (the expensive part is loading each entity's state),
+    /// so a re-run after a partial pass only processes the remainder instead of
+    /// re-loading all N. Default empty (no resumption — a backend without the index
+    /// re-processes everything, which is correct, just not incremental).
+    fn keyed_entity_ids_for_type(
+        &self,
+        tenant: &str,
+        entity_type: &str,
+    ) -> impl std::future::Future<Output = Result<Vec<String>, PersistenceError>> + Send {
+        let _ = (tenant, entity_type);
+        async { Ok(Vec::new()) }
+    }
+
     /// Atomically append events to multiple journals.
     ///
     /// Backends must either commit every append in `appends`, or commit none.

--- a/crates/temper-server/src/entity_actor/actor.rs
+++ b/crates/temper-server/src/entity_actor/actor.rs
@@ -459,12 +459,19 @@ impl EntityActor {
         table: &TransitionTable,
         store: &BoxedEventStore,
         backend: BackendLabel,
-        persistence_id: &str,
         state: &mut EntityState,
         tenant: &str,
         blob_store: Option<&crate::blob_store::BlobStore>,
+        // When true, a journal read failure PROPAGATES as an error instead of being
+        // swallowed ("start fresh"). The key-index backfill needs this: it must
+        // distinguish "entity genuinely has no events" from "could not read the
+        // journal", or it would watermark a type while a present entity is unkeyed
+        // (a wrong-absent bug). Actor hydration keeps the lenient default (false).
+        strict_journal_read: bool,
     ) -> Result<(), ActorError> {
         let replay_start = Instant::now(); // determinism-ok: wall-clock for production replay duration metric only
+        let persistence_id = format!("{tenant}:{}:{}", state.entity_type, state.entity_id);
+        let persistence_id = persistence_id.as_str();
         let mut from_sequence = 0;
         let mut loaded_snapshot = false;
 
@@ -661,6 +668,12 @@ impl EntityActor {
                 }
             }
             Err(e) => {
+                if strict_journal_read {
+                    return Err(ActorError::custom(format!(
+                        "failed to read events for replay of {}:{}: {e}",
+                        state.entity_type, state.entity_id
+                    )));
+                }
                 tracing::error!(
                     entity = %state.entity_id, error = %e,
                     "failed to read events for replay — starting fresh"
@@ -676,6 +689,13 @@ impl EntityActor {
     }
 }
 
+/// Rebuild an entity's current state from its snapshot + event tail.
+///
+/// `strict_journal_read`: when true, a journal read failure PROPAGATES as an error
+/// instead of being swallowed into a "start fresh"/stale state. The key-index backfill
+/// passes `true` so it can tell "no events" apart from "could not read the journal" —
+/// keying decisions and the per-type watermark depend on that distinction (ADR-0153
+/// soundness gate). Actor hydration passes `false` (keep serving on a transient read).
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn recover_entity_state_from_store(
     tenant: &str,
@@ -686,17 +706,17 @@ pub(crate) async fn recover_entity_state_from_store(
     backend: BackendLabel,
     initial_fields: &serde_json::Value,
     blob_store: Option<&crate::blob_store::BlobStore>,
+    strict_journal_read: bool,
 ) -> Result<EntityState, ActorError> {
-    let persistence_id = format!("{tenant}:{entity_type}:{entity_id}");
     let mut state = EntityActor::build_initial_state(entity_type, entity_id, table, initial_fields);
     EntityActor::replay_events(
         table,
         store,
         backend,
-        &persistence_id,
         &mut state,
         tenant,
         blob_store,
+        strict_journal_read,
     )
     .await?;
     Ok(state)
@@ -731,6 +751,7 @@ impl Actor for EntityActor {
                 backend,
                 &self.initial_fields,
                 self.blob_store.as_ref(),
+                false, // hydration: keep serving on a transient journal read failure
             )
             .await?;
         }
@@ -1005,10 +1026,12 @@ impl Actor for EntityActor {
                                         &table,
                                         store,
                                         backend,
-                                        &self.persistence_id(),
                                         state,
                                         &self.tenant,
                                         self.blob_store.as_ref(),
+                                        // Actor hydration keeps the lenient "start
+                                        // fresh on read error" behavior (unchanged).
+                                        false,
                                     )
                                     .await?;
 

--- a/crates/temper-server/src/odata/query_plane_read/tests/keyed_existence.rs
+++ b/crates/temper-server/src/odata/query_plane_read/tests/keyed_existence.rs
@@ -164,6 +164,217 @@ async fn key_index_backfill_keys_store_entities_absent_from_the_lazy_index() {
     }
 }
 
+/// Robustness (ADR-0153): the backfill is RESUMABLE — already-keyed entities are
+/// skipped (not re-loaded), so a re-run after a partial pass only processes the
+/// remainder instead of re-loading all N. Pre-key one entity directly, then run the
+/// backfill, and confirm it completes + watermarks with both entities keyed.
+#[tokio::test]
+async fn key_index_backfill_skips_already_keyed_entities_and_still_watermarks() {
+    let (state, store) = build_order_state_with_sim("key-backfill-resume");
+    let tenant = TenantId::default();
+    let agent_ctx = AgentContext::for_service("resume-test");
+    for (eid, ws, path) in [("ord-a", "ws1", "/a"), ("ord-b", "ws1", "/b")] {
+        state
+            .dispatch_tenant_action(
+                &tenant,
+                "Order",
+                eid,
+                "Create",
+                serde_json::json!({}),
+                &agent_ctx,
+            )
+            .await
+            .expect("create");
+        let snap = serde_json::json!({
+            "entity_type": "Order", "entity_id": eid, "status": "Draft", "item_count": 0,
+            "fields": { "Id": eid, "WorkspaceId": ws, "Path": path },
+        });
+        store
+            .save_snapshot(
+                &format!("{tenant}:Order:{eid}"),
+                1,
+                &serde_json::to_vec(&snap).unwrap(),
+            )
+            .await
+            .expect("snap");
+    }
+    // Pre-key ord-a directly (a prior partial pass / co-commit already keyed it).
+    store
+        .backfill_entity_keys(
+            tenant.as_str(),
+            "Order",
+            "ord-a",
+            &[temper_runtime::persistence::EntityKeyRow {
+                key_name: "ws_path".to_string(),
+                key_hash: ws_path_hash("ws1", "/a"),
+            }],
+        )
+        .await
+        .expect("pre-key");
+
+    state.populate_key_index_from_snapshots(&tenant).await;
+
+    // ord-a was skipped via the already-keyed set; ord-b keyed fresh; type watermarked.
+    assert!(state.key_index_backfill_complete(&tenant, "Order").await);
+    for (ws, path) in [("ws1", "/a"), ("ws1", "/b")] {
+        assert!(
+            store
+                .lookup_by_key(tenant.as_str(), "Order", "ws_path", &ws_path_hash(ws, path))
+                .await
+                .unwrap()
+                .is_some()
+        );
+    }
+}
+
+/// Soundness (ADR-0153): a DELETED entity is correctly skipped (not keyed) and does
+/// NOT block the watermark — only entities that exist-but-cannot-load do. A deleted
+/// entity alongside a live one: the type still watermarks, the live one is keyed, the
+/// deleted one is not.
+#[tokio::test]
+async fn key_index_backfill_skips_deleted_entities_without_blocking_watermark() {
+    let (state, store) = build_order_state_with_sim("key-backfill-deleted");
+    let tenant = TenantId::default();
+    let agent_ctx = AgentContext::for_service("deleted-test");
+    for (eid, status, path) in [
+        ("ord-live", "Draft", "/live"),
+        ("ord-del", "Deleted", "/del"),
+    ] {
+        state
+            .dispatch_tenant_action(
+                &tenant,
+                "Order",
+                eid,
+                "Create",
+                serde_json::json!({}),
+                &agent_ctx,
+            )
+            .await
+            .expect("create");
+        let snap = serde_json::json!({
+            "entity_type": "Order", "entity_id": eid, "status": status, "item_count": 0,
+            "fields": { "Id": eid, "WorkspaceId": "ws1", "Path": path },
+        });
+        store
+            .save_snapshot(
+                &format!("{tenant}:Order:{eid}"),
+                1,
+                &serde_json::to_vec(&snap).unwrap(),
+            )
+            .await
+            .expect("snap");
+    }
+
+    state.populate_key_index_from_snapshots(&tenant).await;
+
+    assert!(
+        state.key_index_backfill_complete(&tenant, "Order").await,
+        "a deleted entity must not block the watermark"
+    );
+    assert!(
+        store
+            .lookup_by_key(
+                tenant.as_str(),
+                "Order",
+                "ws_path",
+                &ws_path_hash("ws1", "/live")
+            )
+            .await
+            .unwrap()
+            .is_some(),
+        "live entity is keyed"
+    );
+    assert!(
+        store
+            .lookup_by_key(
+                tenant.as_str(),
+                "Order",
+                "ws_path",
+                &ws_path_hash("ws1", "/del")
+            )
+            .await
+            .unwrap()
+            .is_none(),
+        "deleted entity is not keyed"
+    );
+}
+
+/// Soundness gate (ADR-0153): an entity that EXISTS but whose journal cannot be read
+/// is classified `LoadFailed` — it must NOT be keyed AND must block the watermark
+/// (otherwise a keyed miss for it would wrongly read as authoritative absence). The
+/// backfill then resumes on a later run once the read succeeds. Without this, a
+/// transient journal-read error during backfill would silently produce a permanent
+/// wrong-absent.
+#[tokio::test]
+async fn key_index_backfill_loadfailed_entity_blocks_watermark_then_resumes() {
+    let (state, store) = build_order_state_with_sim("key-backfill-loadfail");
+    let tenant = TenantId::default();
+    let agent_ctx = AgentContext::for_service("loadfail-test");
+    let pid = format!("{tenant}:Order:ord-x");
+    state
+        .dispatch_tenant_action(
+            &tenant,
+            "Order",
+            "ord-x",
+            "Create",
+            serde_json::json!({}),
+            &agent_ctx,
+        )
+        .await
+        .expect("create");
+    let snap = serde_json::json!({
+        "entity_type": "Order", "entity_id": "ord-x", "status": "Draft", "item_count": 0,
+        "total_event_count": 1,
+        "fields": { "Id": "ord-x", "WorkspaceId": "ws1", "Path": "/x" },
+    });
+    store
+        .save_snapshot(&pid, 1, &serde_json::to_vec(&snap).unwrap())
+        .await
+        .expect("snap");
+
+    // Run 1: the entity's journal read fails → LoadFailed → type NOT watermarked,
+    // entity NOT keyed.
+    store.fail_next_reads(&pid, 1);
+    state.populate_key_index_from_snapshots(&tenant).await;
+    assert!(
+        !state.key_index_backfill_complete(&tenant, "Order").await,
+        "an unloadable entity must block the watermark"
+    );
+    assert!(
+        store
+            .lookup_by_key(
+                tenant.as_str(),
+                "Order",
+                "ws_path",
+                &ws_path_hash("ws1", "/x")
+            )
+            .await
+            .unwrap()
+            .is_none(),
+        "the unloadable entity must not be keyed"
+    );
+
+    // Run 2 (resume): the read now succeeds → entity keyed → type watermarked.
+    state.populate_key_index_from_snapshots(&tenant).await;
+    assert!(
+        state.key_index_backfill_complete(&tenant, "Order").await,
+        "backfill must resume and watermark once the read succeeds"
+    );
+    assert!(
+        store
+            .lookup_by_key(
+                tenant.as_str(),
+                "Order",
+                "ws_path",
+                &ws_path_hash("ws1", "/x")
+            )
+            .await
+            .unwrap()
+            .is_some(),
+        "the entity is keyed on resume"
+    );
+}
+
 /// C (ADR-0153): once the backfill watermark is set, a keyed read MISS is
 /// authoritative absence — the read returns empty WITHOUT the full-type scan that
 /// otherwise 413s at scale (ARN-68). Before the watermark, the same miss falls back

--- a/crates/temper-server/src/state/projection_backfill.rs
+++ b/crates/temper-server/src/state/projection_backfill.rs
@@ -202,6 +202,7 @@ pub(super) async fn populate_field_index_from_snapshots(state: &ServerState, ten
             backend,
             &serde_json::json!({}),
             tenant_blob_store.as_ref(),
+            false, // field-index backfill: lenient (unchanged behavior)
         )
         .await;
         let replayed = match replayed {

--- a/crates/temper-server/src/state/projection_backfill/key_index.rs
+++ b/crates/temper-server/src/state/projection_backfill/key_index.rs
@@ -2,12 +2,29 @@
 //! and record the per-(tenant, entity_type) watermark, so a keyed read MISS can mean
 //! authoritative absence (retiring #324's full-type scan — the 413, ARN-68).
 
+use std::collections::BTreeSet;
+
 use temper_runtime::tenant::TenantId;
 
 use crate::ServerState;
 use crate::entity_actor::recover_entity_state_from_store;
 
 use super::transition_table_for;
+
+/// Outcome of loading one entity's current state for keying.
+enum LoadOutcome {
+    /// Loaded — key it from these fields.
+    Fields(serde_json::Value),
+    /// Definitively skippable: deleted, or a phantom with no events. Correctly NOT
+    /// keyed, and NOT a failure (it must not block the watermark).
+    Skip,
+    /// The entity exists (it was enumerated from the durable store) but its current
+    /// state could not be loaded — no transition table to replay with, an unreadable
+    /// snapshot, or a replay error. Keying it is impossible, so the type must NOT be
+    /// watermarked: otherwise a keyed miss for this present entity would wrongly read
+    /// as authoritative absence. This is the soundness gate.
+    LoadFailed,
+}
 
 /// Backfill `entity_key_index` for existing entities, then record the watermark.
 ///
@@ -16,10 +33,19 @@ use super::transition_table_for;
 /// which is populated only when an actor spawns (lazy) and is therefore near-empty at
 /// boot — the original bug that left ~0 of N entities keyed.
 ///
-/// Each entity's current field state is taken from its snapshot, falling back to event
-/// replay when no snapshot exists, so snapshot-less entities are still keyed — a gap
-/// there would make the watermark unsound (a missed entity would read as absent). A
-/// type is only watermarked when every entity was processed without an upsert failure.
+/// Robustness at scale (tenants hold 10k–100k+ entities of a keyed type):
+/// - **Resumable**: already-keyed entities are skipped (the costly step is loading
+///   each entity's state), so a re-run after a partial pass only processes the
+///   remainder instead of re-loading all N.
+/// - **Sound**: a type is watermarked only if EVERY existing entity was either keyed
+///   or is definitively skippable (deleted/phantom). One entity that exists but
+///   cannot be loaded fails the type — it is not watermarked, and keyed misses keep
+///   scanning (correct, just not bounded) until the data issue is resolved. The
+///   failing `entity_id`s are logged so the integrity problem is visible.
+/// - **Cooperative**: yields between entities and runs as a background task, so the
+///   heavy types (e.g. SessionEntry) do not block boot or the smaller, higher-value
+///   types. Types are processed in the registry's sorted order.
+///
 /// Idempotent; entities written after the key was declared already co-commit their
 /// keys at write time.
 pub(in crate::state) async fn populate_key_index_from_snapshots(
@@ -69,14 +95,29 @@ pub(in crate::state) async fn populate_key_index_from_snapshots(
             }
         };
 
+        // Resumability: skip entities already keyed (avoids re-loading their state).
+        let already_keyed: BTreeSet<String> = match store
+            .keyed_entity_ids_for_type(tenant.as_str(), entity_type)
+            .await
+        {
+            Ok(ids) => ids.into_iter().collect(),
+            Err(_) => BTreeSet::new(), // cannot resume → process all (correct, slower)
+        };
+
         let table = transition_table_for(state, tenant, entity_type);
         let blob_store = state.blob_store_for_tenant(tenant).ok();
         let total = entity_ids.len();
-        let mut indexed = 0usize;
-        let mut failed = false;
+        let mut newly_keyed = 0usize;
+        let mut already = 0usize;
+        let mut skipped = 0usize;
+        let mut failed = 0usize;
 
         for entity_id in &entity_ids {
-            let fields = match current_entity_fields(
+            if already_keyed.contains(entity_id) {
+                already += 1;
+                continue;
+            }
+            match load_entity_fields(
                 tenant,
                 entity_type,
                 entity_id,
@@ -87,63 +128,80 @@ pub(in crate::state) async fn populate_key_index_from_snapshots(
             )
             .await
             {
-                Some(fields) => fields,
-                None => continue, // deleted / empty / unreplayable: nothing to key
-            };
-            let Some(field_map) = fields.as_object() else {
-                continue;
-            };
-            let mut key_rows = Vec::new();
-            for key in keys {
-                if let Some(hash) =
-                    crate::key_index::canonical_key_hash(&key.name, &key.properties, field_map)
-                {
-                    key_rows.push(temper_runtime::persistence::EntityKeyRow {
-                        key_name: key.name.clone(),
-                        key_hash: hash,
-                    });
+                LoadOutcome::Fields(fields) => {
+                    let Some(field_map) = fields.as_object() else {
+                        skipped += 1;
+                        continue;
+                    };
+                    let mut key_rows = Vec::new();
+                    for key in keys {
+                        if let Some(hash) = crate::key_index::canonical_key_hash(
+                            &key.name,
+                            &key.properties,
+                            field_map,
+                        ) {
+                            key_rows.push(temper_runtime::persistence::EntityKeyRow {
+                                key_name: key.name.clone(),
+                                key_hash: hash,
+                            });
+                        }
+                    }
+                    if key_rows.is_empty() {
+                        // No resolvable key (all key components absent/null) — the
+                        // entity is not addressable by this key, so skipping is sound.
+                        skipped += 1;
+                        continue;
+                    }
+                    match store
+                        .backfill_entity_keys(tenant.as_str(), entity_type, entity_id, &key_rows)
+                        .await
+                    {
+                        Ok(()) => newly_keyed += 1,
+                        Err(e) => {
+                            failed += 1;
+                            tracing::warn!(
+                                error = %e, entity_type = %entity_type, entity_id = %entity_id,
+                                "key index backfill: upsert failed"
+                            );
+                        }
+                    }
                 }
-            }
-            if key_rows.is_empty() {
-                continue;
-            }
-            match store
-                .backfill_entity_keys(tenant.as_str(), entity_type, entity_id, &key_rows)
-                .await
-            {
-                Ok(()) => indexed += 1,
-                Err(e) => {
-                    failed = true;
-                    tracing::debug!(
-                        error = %e, entity_type = %entity_type, entity_id = %entity_id,
-                        "key index backfill: upsert failed"
+                LoadOutcome::Skip => skipped += 1,
+                LoadOutcome::LoadFailed => {
+                    failed += 1;
+                    tracing::warn!(
+                        entity_type = %entity_type, entity_id = %entity_id,
+                        "key index backfill: existing entity could not be loaded; type will NOT be watermarked (data integrity issue)"
                     );
                 }
             }
             tokio::task::yield_now().await;
         }
 
-        // Only declare the type complete (authoritative-absence eligible) if every
-        // entity was keyed without failure — otherwise keyed misses keep scanning.
-        if failed {
-            tracing::warn!(
-                tenant = %tenant, entity_type = %entity_type, total, indexed,
-                "key index backfill: had upsert failures; type NOT watermarked (keyed misses keep scanning)"
-            );
-        } else {
+        // Watermark only if nothing failed — every existing entity was keyed or is
+        // definitively skippable. Otherwise keyed misses keep scanning (sound), and a
+        // later boot resumes from the remainder.
+        if failed == 0 {
             state.mark_key_index_backfilled(tenant, entity_type).await;
             tracing::info!(
-                tenant = %tenant, entity_type = %entity_type, total, indexed,
+                tenant = %tenant, entity_type = %entity_type,
+                total, newly_keyed, already, skipped,
                 "entity_key_index backfill complete; type watermarked"
+            );
+        } else {
+            tracing::warn!(
+                tenant = %tenant, entity_type = %entity_type,
+                total, newly_keyed, already, skipped, failed,
+                "key index backfill: {failed} entities unresolved; type NOT watermarked (keyed misses keep scanning; will resume next run)"
             );
         }
     }
 }
 
-/// Current field state for one entity: snapshot if present, else event replay.
-/// Returns `None` for deleted/empty/unreplayable entities (nothing to key). Replay
-/// requires the transition table; without one, snapshot-less entities are skipped.
-async fn current_entity_fields(
+/// Load one entity's current state for keying: snapshot if present and readable,
+/// else event replay. Distinguishes "key it" from "definitively skip" from "exists
+/// but unloadable" (the last fails the watermark — see [`LoadOutcome`]).
+async fn load_entity_fields(
     tenant: &TenantId,
     entity_type: &str,
     entity_id: &str,
@@ -151,20 +209,17 @@ async fn current_entity_fields(
     store: &crate::storage::BoxedEventStore,
     backend: crate::storage::BackendLabel,
     blob_store: Option<&crate::blob_store::BlobStore>,
-) -> Option<serde_json::Value> {
-    let persistence_id = format!("{tenant}:{entity_type}:{entity_id}");
-    if let Ok(Some((_seq, snapshot_bytes))) = store.load_snapshot(&persistence_id).await
-        && let Ok(snap) =
-            serde_json::from_slice::<crate::entity_actor::EntityState>(&snapshot_bytes)
-    {
-        if snap.status == "Deleted" {
-            return None;
-        }
-        return Some(snap.fields);
-    }
-    // No snapshot — replay from the journal to recover current state.
-    let table = table?;
-    let replayed = recover_entity_state_from_store(
+) -> LoadOutcome {
+    // Recover CURRENT state via snapshot + event-tail (so a field mutated after the
+    // last snapshot — e.g. a Directory rename/move changing `Name`/`ParentId` — is
+    // keyed at its current value, not a stale snapshot value). The STRICT path makes a
+    // journal read failure propagate as `Err` instead of silently "starting fresh", so
+    // we can tell "no events" apart from "could not read the journal". Without a
+    // transition table we cannot replay → the entity is unresolved.
+    let Some(table) = table else {
+        return LoadOutcome::LoadFailed;
+    };
+    match recover_entity_state_from_store(
         tenant.as_str(),
         entity_type,
         entity_id,
@@ -173,11 +228,17 @@ async fn current_entity_fields(
         backend,
         &serde_json::json!({}),
         blob_store,
+        true, // strict: a journal read failure → Err → LoadFailed (don't watermark)
     )
     .await
-    .ok()?;
-    if replayed.total_event_count == 0 || replayed.status == "Deleted" {
-        return None;
+    {
+        // Read failed (strict), replay budget exceeded, etc. — cannot key it, so the
+        // type must NOT be watermarked.
+        Err(_) => LoadOutcome::LoadFailed,
+        Ok(state) if state.status == "Deleted" => LoadOutcome::Skip,
+        // Strict guarantees the journal read succeeded, so zero events is a genuine
+        // phantom (a catalog/field-index row with no journal) — unkeyable; safe to skip.
+        Ok(state) if state.total_event_count == 0 => LoadOutcome::Skip,
+        Ok(state) => LoadOutcome::Fields(state.fields),
     }
-    Some(replayed.fields)
 }

--- a/crates/temper-server/src/state/projection_backfill/replay_parity.rs
+++ b/crates/temper-server/src/state/projection_backfill/replay_parity.rs
@@ -287,6 +287,7 @@ pub(in crate::state) async fn verify_query_projection_replay_parity(
                 backend,
                 &serde_json::json!({}),
                 tenant_blob_store.as_ref(),
+                false, // replay-parity check: lenient (unchanged behavior)
             )
             .await;
             let replayed = match replayed {

--- a/crates/temper-server/src/storage/mod.rs
+++ b/crates/temper-server/src/storage/mod.rs
@@ -106,6 +106,12 @@ pub trait DynEventStore: Send + Sync {
         tenant: &'a str,
     ) -> EventStoreFuture<'a, Result<Vec<String>, PersistenceError>>;
 
+    fn keyed_entity_ids_for_type<'a>(
+        &'a self,
+        tenant: &'a str,
+        entity_type: &'a str,
+    ) -> EventStoreFuture<'a, Result<Vec<String>, PersistenceError>>;
+
     fn save_snapshot<'a>(
         &'a self,
         persistence_id: &'a str,
@@ -235,6 +241,18 @@ where
         tenant: &'a str,
     ) -> EventStoreFuture<'a, Result<Vec<String>, PersistenceError>> {
         Box::pin(EventStore::key_index_backfilled_types(self, tenant))
+    }
+
+    fn keyed_entity_ids_for_type<'a>(
+        &'a self,
+        tenant: &'a str,
+        entity_type: &'a str,
+    ) -> EventStoreFuture<'a, Result<Vec<String>, PersistenceError>> {
+        Box::pin(EventStore::keyed_entity_ids_for_type(
+            self,
+            tenant,
+            entity_type,
+        ))
     }
 
     fn save_snapshot<'a>(
@@ -390,6 +408,14 @@ impl BoxedEventStore {
         tenant: &str,
     ) -> Result<Vec<String>, PersistenceError> {
         self.0.key_index_backfilled_types(tenant).await
+    }
+
+    pub async fn keyed_entity_ids_for_type(
+        &self,
+        tenant: &str,
+        entity_type: &str,
+    ) -> Result<Vec<String>, PersistenceError> {
+        self.0.keyed_entity_ids_for_type(tenant, entity_type).await
     }
 
     pub async fn save_snapshot(

--- a/crates/temper-store-postgres/src/store.rs
+++ b/crates/temper-store-postgres/src/store.rs
@@ -377,6 +377,28 @@ impl EventStore for PostgresEventStore {
         Ok(rows.into_iter().map(|(entity_type,)| entity_type).collect())
     }
 
+    async fn keyed_entity_ids_for_type(
+        &self,
+        tenant: &str,
+        entity_type: &str,
+    ) -> Result<Vec<String>, PersistenceError> {
+        let mut conn = self
+            .pool
+            .acquire()
+            .await
+            .map_err(|e| PersistenceError::Storage(e.to_string()))?;
+        let rows: Vec<(String,)> = crate::dbm::postgres_query_as!(
+            "SELECT DISTINCT entity_id FROM entity_key_index \
+             WHERE tenant = $1 AND entity_type = $2",
+        )
+        .bind(tenant)
+        .bind(entity_type)
+        .fetch_all(&mut *conn)
+        .await
+        .map_err(|e| PersistenceError::Storage(e.to_string()))?;
+        Ok(rows.into_iter().map(|(entity_id,)| entity_id).collect())
+    }
+
     async fn lookup_by_key(
         &self,
         tenant: &str,

--- a/crates/temper-store-postgres/src/store_projection_test.rs
+++ b/crates/temper-store-postgres/src/store_projection_test.rs
@@ -101,6 +101,91 @@ fn entity_key_index_present_absent_and_atomic_reject() {
     });
 }
 
+/// ADR-0153 backfill robustness: the real postgres store honors the backfill
+/// primitives the resumable, watermark-gated backfill relies on —
+/// `backfill_entity_keys` (no journal event), `keyed_entity_ids_for_type` (resume:
+/// which entities are already keyed), and the watermark round-trip
+/// (`mark_key_index_backfilled` / `key_index_backfilled_types`, table from migration
+/// 0010). Gated on DATABASE_URL; isolated by a unique tenant.
+#[test]
+fn key_index_backfill_and_watermark_methods_round_trip_on_postgres() {
+    let database_url = match std::env::var("DATABASE_URL") {
+        Ok(url) => url,
+        Err(_) => return,
+    };
+
+    sqlx::test_block_on(async {
+        let pool = PgPool::connect(&database_url).await.unwrap();
+        run_migrations(&pool).await.unwrap();
+        let store = PostgresEventStore::new(pool.clone());
+        let tenant = format!("tenant-backfill-{}", uuid::Uuid::new_v4());
+        let key = EntityKeyRow {
+            key_name: "name_parent".to_string(),
+            key_hash: format!("root-{}", uuid::Uuid::new_v4()),
+        };
+
+        // Backfill (no journal event) keys a pre-existing entity — the root case.
+        store
+            .backfill_entity_keys(&tenant, "Directory", "dir-root", std::slice::from_ref(&key))
+            .await
+            .unwrap();
+
+        // Resumability source: the entity now shows as already-keyed for the type.
+        assert_eq!(
+            store
+                .keyed_entity_ids_for_type(&tenant, "Directory")
+                .await
+                .unwrap(),
+            vec!["dir-root".to_string()],
+        );
+        // And it resolves by the declared key.
+        assert_eq!(
+            store
+                .lookup_by_key(&tenant, "Directory", "name_parent", &key.key_hash)
+                .await
+                .unwrap(),
+            Some("dir-root".to_string()),
+        );
+
+        // Watermark round-trip: not set until marked, then present for that type only.
+        assert!(
+            store
+                .key_index_backfilled_types(&tenant)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        store
+            .mark_key_index_backfilled(&tenant, "Directory")
+            .await
+            .unwrap();
+        assert_eq!(
+            store.key_index_backfilled_types(&tenant).await.unwrap(),
+            vec!["Directory".to_string()],
+        );
+        // Idempotent.
+        store
+            .mark_key_index_backfilled(&tenant, "Directory")
+            .await
+            .unwrap();
+        assert_eq!(
+            store.key_index_backfilled_types(&tenant).await.unwrap(),
+            vec!["Directory".to_string()],
+        );
+
+        let _ = crate::dbm::postgres_query!("DELETE FROM entity_key_index WHERE tenant = $1")
+            .bind(&tenant)
+            .execute(&pool)
+            .await;
+        let _ = crate::dbm::postgres_query!(
+            "DELETE FROM key_index_backfill_watermark WHERE tenant = $1"
+        )
+        .bind(&tenant)
+        .execute(&pool)
+        .await;
+    });
+}
+
 #[test]
 fn list_entity_ids_by_type_unions_catalog_field_index_and_events() {
     let database_url = match std::env::var("DATABASE_URL") {

--- a/crates/temper-store-sim/src/lib.rs
+++ b/crates/temper-store-sim/src/lib.rs
@@ -135,6 +135,12 @@ struct SimEventStoreInner {
     /// retry-path tests where probabilistic injection would be flaky. See
     /// `inject_concurrency_violations`.
     pending_concurrency_violations: BTreeMap<String, u64>,
+    /// Each entry makes `read_events` return a storage error on the next N calls for
+    /// that id, then behave normally. Deterministic analogue to
+    /// `pending_concurrency_violations`, for tests that need a journal-read failure
+    /// (e.g. proving the key-index backfill treats an unreadable entity as
+    /// `LoadFailed` and does not watermark its type). See `fail_next_reads`.
+    pending_read_failures: BTreeMap<String, usize>,
     /// One-shot append delays per `persistence_id`.
     ///
     /// Used by dispatch retry tests to deterministically model "the actor
@@ -174,6 +180,7 @@ impl SimEventStore {
                 rng: DeterministicRng::new(seed),
                 faults,
                 pending_concurrency_violations: BTreeMap::new(),
+                pending_read_failures: BTreeMap::new(),
                 pending_append_delays: BTreeMap::new(),
                 key_index: BTreeMap::new(),
                 key_index_watermark: BTreeSet::new(),
@@ -197,6 +204,22 @@ impl SimEventStore {
         } else {
             inner
                 .pending_concurrency_violations
+                .insert(persistence_id.to_string(), count);
+        }
+    }
+
+    /// Make the next `count` `read_events` calls for `persistence_id` fail with a
+    /// storage error, then behave normally. Deterministic (unlike
+    /// `read_truncation_prob`) so tests can prove read-failure handling — e.g. that
+    /// the key-index backfill classifies an unreadable entity as `LoadFailed` and
+    /// therefore does not watermark its type. `count == 0` clears the injection.
+    pub fn fail_next_reads(&self, persistence_id: &str, count: usize) {
+        let mut inner = self.inner.lock().expect("SimEventStore lock poisoned"); // ci-ok: infallible lock
+        if count == 0 {
+            inner.pending_read_failures.remove(persistence_id);
+        } else {
+            inner
+                .pending_read_failures
                 .insert(persistence_id.to_string(), count);
         }
     }
@@ -592,6 +615,21 @@ impl EventStore for SimEventStore {
             .collect())
     }
 
+    async fn keyed_entity_ids_for_type(
+        &self,
+        tenant: &str,
+        entity_type: &str,
+    ) -> Result<Vec<String>, PersistenceError> {
+        let inner = self.inner.lock().expect("SimEventStore lock poisoned"); // ci-ok: infallible lock
+        let mut ids: BTreeSet<String> = BTreeSet::new();
+        for ((t, et, _, _), entity_id) in inner.key_index.iter() {
+            if t.as_str() == tenant && et.as_str() == entity_type {
+                ids.insert(entity_id.clone());
+            }
+        }
+        Ok(ids.into_iter().collect())
+    }
+
     async fn append_batch(
         &self,
         appends: &[PersistenceAppend],
@@ -695,6 +733,18 @@ impl EventStore for SimEventStore {
         from_sequence: u64,
     ) -> Result<Vec<PersistenceEnvelope>, PersistenceError> {
         let mut inner = self.inner.lock().expect("SimEventStore lock poisoned"); // ci-ok: infallible lock
+
+        // Deterministic injected read failure (see `fail_next_reads`).
+        if let Some(remaining) = inner.pending_read_failures.get_mut(persistence_id) {
+            *remaining -= 1;
+            let cleared = *remaining == 0;
+            if cleared {
+                inner.pending_read_failures.remove(persistence_id);
+            }
+            return Err(PersistenceError::Storage(format!(
+                "injected read failure for {persistence_id}"
+            )));
+        }
 
         let journal = match inner.journals.get(persistence_id) {
             Some(j) => j,


### PR DESCRIPTION
## What & why

Follow-up to #330 (which made the declared composite-key index an authoritative existence oracle). #330 was verified in isolation (sim store + Order fixture); inspecting the **real openpaw data** showed the backfill must cleanly key ~125,000 entities (Directory 10,754 / File 19,288 / SessionEntry 95,355, **~51k requiring event replay**) — all-or-nothing per type. That scale exposed a soundness gap and a robustness gap. This PR hardens the backfill before it ships.

An independent code review caught the soundness bug: **`recover` silently swallows journal read errors** ("start fresh" → empty state), so my `total_event_count==0 → Skip` would have misclassified a *transient read failure during backfill* as a phantom → the type gets watermarked anyway → a present entity reads as **authoritative-absent, permanently** (sticky watermark). That only bites on the real replay path, invisible to sim-only tests. A deploy-to-test loop would have shipped it silently.

## Changes

- **Soundness (`strict_journal_read`)** — `replay_events`/`recover_entity_state_from_store` gained a strict flag. When strict, a `read_events` failure PROPAGATES as `Err` instead of "start fresh". The backfill passes `true` → a read failure becomes `LoadFailed` → the type is **not** watermarked (and resumes on a later pass). Actor hydration, field-index backfill, and replay-parity pass `false` (behavior unchanged). A type is watermarked **only if every existing entity was keyed or is definitively skippable** (deleted/phantom).
- **Stale-snapshot fix** — the backfill now always recovers via snapshot **+ event tail** (current state), so a `Name`/`ParentId` mutated after the last snapshot is keyed at its current value (was: keyed from the stale snapshot — a second wrong-absent vector for mutable keys like Directory rename/move).
- **Resumable at scale** — new `EventStore::keyed_entity_ids_for_type` (postgres + sim; default empty) lets the backfill skip already-keyed entities, so a re-run after a partial pass only processes the remainder instead of re-loading all N.
- **3-way `LoadOutcome`** (Fields / Skip / LoadFailed) replaces the `Option` that conflated "deleted" with "unloadable".

## Why the deploy is no longer a poke-in-the-dark

With this, the watermark is a **proof**: `Directory` watermarked ⟺ every existing Directory was keyed ⟺ the soul-write root lookup resolves. After deploy I confirm the watermark in prod Postgres *before* any retry; if it's absent, the WARN logs name the exact unloadable `entity_id`. No retry-and-see loop.

## Tests
- Sim: resumability (skip already-keyed), deleted-skip (doesn't block watermark), and the **LoadFailed soundness gate** (`…loadfailed_entity_blocks_watermark_then_resumes`) — via a new deterministic `SimEventStore::fail_next_reads` (mirrors the existing `inject_concurrency_violations`).
- Real Postgres (local Docker, DATABASE_URL-gated): round-trip of the new backfill/watermark/resumability store methods.
- Regression green (entity_actor 56, read-plane 29, dst 9, sim 12, real-PG 49); clippy clean; readability ratchet at baseline (no `#[allow]` added — `replay_events` derives `persistence_id` internally to stay at 7 args).
- Independent code review + DST review: **PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013bA4uNPBg2Jr4jMkYkqu4G
