### PR TITLE
fix(query-plane): backfill the field index authoritatively so non-keyed lookups bind (ARN-68)

### DIFF
--- a/crates/temper-server/src/odata/query_plane_read/tests/keyed_existence.rs
+++ b/crates/temper-server/src/odata/query_plane_read/tests/keyed_existence.rs
@@ -501,6 +501,156 @@ fn directory_root_souls_scenario_on_postgres() {
     });
 }
 
+/// ARN-68 (generic bound): the FIELD-index backfill must enumerate authoritatively
+/// (registry + `store.list_entity_ids_by_type`), not the lazy `entity_index`. The flow
+/// looks up directories by `Path` (e.g. `Path eq '/souls' and WorkspaceId eq …`), which
+/// is NOT a declared key — so it relies on the field index. If the backfill reads the
+/// lazy index (near-empty at boot), pre-existing dirs stay unindexed and that lookup
+/// falls back to the full scan → 413 at scale. Proven on real Postgres: with the field
+/// index empty the Path lookup 413s, and after the (authoritative) backfill it binds via
+/// the native page. Gated on DATABASE_URL; unique tenant.
+#[test]
+fn field_index_backfill_bounds_non_keyed_path_lookup_on_postgres() {
+    use temper_runtime::scheduler::sim_uuid as runtime_sim_uuid;
+    let database_url = match std::env::var("DATABASE_URL") {
+        Ok(url) => url,
+        Err(_) => return,
+    };
+    sqlx::test_block_on(async {
+        let pool = sqlx::PgPool::connect(&database_url).await.unwrap();
+        temper_store_postgres::migration::run_migrations(&pool)
+            .await
+            .unwrap();
+        let store = temper_store_postgres::PostgresEventStore::new(pool.clone());
+        let tenant = TenantId::from(format!("fieldidx-pg-{}", runtime_sim_uuid()));
+        let csdl = parse_csdl(CSDL_XML).expect("CSDL parses");
+        let mut registry = SpecRegistry::new();
+        registry.register_tenant(
+            tenant.as_str(),
+            csdl,
+            CSDL_XML.to_string(),
+            &[("Order", ORDER_IOA), ("Directory", DIRECTORY_IOA)],
+        );
+        let mut state = ServerState::from_registry(ActorSystem::new("fieldidx-pg"), registry);
+        state.set_storage_stack(StorageStack::from_postgres(store.clone()));
+        let agent_ctx = AgentContext::for_service("fieldidx-pg-test");
+        let security_ctx = SecurityContext::system();
+
+        // root + /souls + padding (> budget). `/souls` is looked up by Path (non-keyed).
+        pg_seed_dir(
+            &state,
+            &tenant,
+            &agent_ctx,
+            "fx-root",
+            ("/", "/", "wsA", None),
+        )
+        .await;
+        pg_seed_dir(
+            &state,
+            &tenant,
+            &agent_ctx,
+            "fx-souls",
+            ("souls", "/souls", "wsA", Some("fx-root")),
+        )
+        .await;
+        for i in 0..13 {
+            pg_seed_dir(
+                &state,
+                &tenant,
+                &agent_ctx,
+                &format!("fx-sub-{i}"),
+                (
+                    &format!("sub{i}"),
+                    &format!("/sub{i}"),
+                    "wsA",
+                    Some("fx-root"),
+                ),
+            )
+            .await;
+        }
+
+        // Fresh-boot, pre-existing-data state: the lazy index is empty (what the pre-fix
+        // backfill read), and the field index has no rows for these dirs (as it would for
+        // entities written before the projection existed). Clearing both is the exact
+        // "old dirs the backfill must reach" condition.
+        state.entity_index.write().unwrap().clear();
+        state.entity_index_hydrated.write().unwrap().clear();
+        sqlx::query("DELETE FROM entity_field_index WHERE tenant = $1")
+            .bind(tenant.as_str())
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let budget = QueryPlaneReadBudget {
+            default_page_size: 1,
+            max_entities: 1,
+        };
+        // `Path eq '/souls' and WorkspaceId eq 'wsA'` — non-keyed; needs the field index.
+        let eq = |p: &str, v: &str| FilterExpr::BinaryOp {
+            left: Box::new(FilterExpr::Property(p.to_string())),
+            op: BinaryOperator::Eq,
+            right: Box::new(FilterExpr::Literal(ODataValue::String(v.to_string()))),
+        };
+        let qo = QueryOptions {
+            filter: Some(FilterExpr::BinaryOp {
+                left: Box::new(eq("Path", "/souls")),
+                op: BinaryOperator::And,
+                right: Box::new(eq("WorkspaceId", "wsA")),
+            }),
+            ..QueryOptions::default()
+        };
+
+        // (1) Field index empty (pre-existing dirs unindexed): the non-keyed Path lookup
+        // enumerates the full type from the store (> budget) with nothing to narrow it →
+        // 413 QueryTooLarge — exactly the prod failure.
+        match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+            state: &state,
+            tenant: &tenant,
+            security_ctx: &security_ctx,
+            entity_type: "Directory",
+            entity_set_name: "Directories",
+            query_options: &qo,
+            budget,
+        })
+        .await
+        {
+            Err(QueryPlaneReadError::QueryTooLarge { .. }) => {}
+            Ok(_) => panic!("expected 413 for the Path lookup before the field-index backfill"),
+            Err(_) => panic!("expected QueryTooLarge before the field-index backfill"),
+        }
+
+        // (2) The FIXED field-index backfill enumerates authoritatively (registry +
+        // store), NOT the cleared lazy index, and indexes the pre-existing dirs. The OLD
+        // lazy-index enumeration would index nothing here and /souls would stay invisible.
+        // The enumeration has NO declared-key branch (unlike the key-index backfill), so
+        // it covers every registered type identically — keyed or not; this case exercises
+        // a non-key FIELD (`Path`) on a keyed type, which is the field index's job.
+        state.populate_field_index_from_snapshots(&tenant).await;
+
+        // (3) The same Path lookup now binds via the native page and finds /souls — proof
+        // the backfill populated the field index for entities absent from the lazy index.
+        let r = match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+            state: &state,
+            tenant: &tenant,
+            security_ctx: &security_ctx,
+            entity_type: "Directory",
+            entity_set_name: "Directories",
+            query_options: &qo,
+            budget,
+        })
+        .await
+        {
+            Ok(r) => r,
+            Err(_) => panic!("Path lookup must bind via the field index after the backfill"),
+        };
+        assert_eq!(
+            r.entities.len(),
+            1,
+            "the authoritative field-index backfill makes the non-keyed Path lookup resolve /souls"
+        );
+    });
+}
+
 /// `WorkspaceId eq <ws> and Path eq <path>` — the shape that resolves to Order's
 /// declared `ws_path` key.
 fn ws_path_filter(ws: &str, path: &str) -> FilterExpr {

--- a/crates/temper-server/src/state/projection_backfill.rs
+++ b/crates/temper-server/src/state/projection_backfill.rs
@@ -33,6 +33,15 @@ pub(super) fn transition_table_for(
     })
 }
 
+/// Backfill the broad `entity_field_index` (every field of every entity) so the native
+/// AND-equality candidate pushdown can bound any non-keyed point lookup (e.g. `Path eq
+/// '/souls' and WorkspaceId eq …`) instead of full-scanning and 413ing at tenant scale
+/// (ARN-68). Enumerates authoritatively (registry types + `store.list_entity_ids_by_type`),
+/// loads each entity's current state from its snapshot (or event replay), and upserts the
+/// query projection. Idempotent (re-runs converge; it re-processes every entity — there
+/// is no watermark/skip like the key-index backfill has); runs as a background task off
+/// the boot path. This is the generic counterpart to the declared-key backfill — covers ALL
+/// types, where the key backfill covers only declared-key shapes (incl. null components).
 pub(super) async fn populate_field_index_from_snapshots(state: &ServerState, tenant: &TenantId) {
     let overall_started_at = Instant::now(); // determinism-ok: production-only backfill duration metric
     let Some((store, backend)) = state.event_journal() else {
@@ -42,14 +51,39 @@ pub(super) async fn populate_field_index_from_snapshots(state: &ServerState, ten
         return;
     };
 
+    // Enumerate authoritatively: every entity type from the registry, and its entity
+    // ids from `store.list_entity_ids_by_type`. It must NOT read `state.entity_index`,
+    // which is populated only when an actor spawns (lazy) and is therefore near-empty at
+    // boot — the original bug that left pre-existing entities out of the field index, so
+    // their non-keyed equality lookups (e.g. `Path eq '/souls' and WorkspaceId eq …`)
+    // fell back to the full-type scan and 413'd at tenant scale (ARN-68). This mirrors
+    // the authoritative enumeration the declared-key backfill already uses; the field
+    // index covers ALL types (not just keyed ones), so no key filter is applied.
     let entities = {
-        let index = state.entity_index.read().unwrap();
+        let entity_types: Vec<String> = {
+            let registry = state.registry.read().unwrap();
+            registry
+                .entity_types(tenant)
+                .into_iter()
+                .map(ToString::to_string)
+                .collect()
+        };
         let mut result = Vec::new();
-        for (index_key, ids) in index.iter() {
-            let prefix = format!("{tenant}:");
-            if let Some(entity_type) = index_key.strip_prefix(&prefix) {
-                for id in ids {
-                    result.push((entity_type.to_string(), id.clone()));
+        for entity_type in &entity_types {
+            match store
+                .list_entity_ids_by_type(tenant.as_str(), entity_type)
+                .await
+            {
+                Ok(ids) => {
+                    for id in ids {
+                        result.push((entity_type.clone(), id));
+                    }
+                }
+                Err(e) => {
+                    tracing::error!(
+                        tenant = %tenant, entity_type = %entity_type, error = %e,
+                        "field index backfill: failed to enumerate entities; type skipped"
+                    );
                 }
             }
         }
@@ -158,6 +192,10 @@ pub(super) async fn populate_field_index_from_snapshots(state: &ServerState, ten
                 );
             }
         }
+        // Phase 1 now iterates EVERY entity (not the near-empty lazy index), so yield
+        // between entities for cooperative back-pressure on large tenants — mirroring
+        // phase 2 and the key-index backfill.
+        tokio::task::yield_now().await;
     }
 
     tracing::info!(


### PR DESCRIPTION
## What & why

Follow-up to #333 / TemperPaw #445. Those fixed the Directory **root** lookup (`… ParentId eq null`) via the co-committed key index — but the soul/finalization flow does other directory lookups by **`Path`** (`Path eq '/souls' and WorkspaceId eq …`), `ParentId`, and File-by-`Path`. Those are **not** declared-key shapes; they rely on the broad `entity_field_index` and its AND-equality native-page pushdown. In prod they still returned **413 QueryTooLarge**.

Root cause: `populate_field_index_from_snapshots` enumerated the **lazy in-memory `state.entity_index`** (near-empty at boot) instead of the authoritative store — so pre-existing entities never reached the field index, and any non-keyed equality lookup over old data couldn't be bounded → full scan → 413. This is the **exact same Layer-B lazy-enumeration bug already fixed for the key-index backfill** (`key_index.rs`); that fix was applied to one backfill and not the other.

## Fix

`populate_field_index_from_snapshots` now enumerates authoritatively — every registered entity type from the registry, ids from `store.list_entity_ids_by_type` — mirroring the key-index backfill, but with **no key filter** (the field index covers all types). This is the **generic** bound: once the field index is populated, *any* AND-of-equalities point lookup binds. **No per-action declared keys, no per-flow patches.**

## Proven (kernel + e2e)

- **Kernel regression test** `field_index_backfill_bounds_non_keyed_path_lookup_on_postgres` (DATABASE_URL-gated): with the field index empty the `Path eq '/souls'` lookup 413s; after the authoritative backfill it binds to the one matching dir. It fails on the old lazy-enumeration code.
- **e2e on the local temperpaw stack** (real Postgres): field index empty → `Path eq '/souls'`, `ParentId eq …`, File-`Path` all 413; after the fixed backfill the field index repopulates (95 rows, was 0) and all return 200.
- Full `temper-server` lib suite green (549). DST + code reviews PASS.

## Deploy note

After merge: temperpaw bumps temper, redeploys, and sets `TEMPERPAW_QUERY_PROJECTION_BACKFILL_ON_STARTUP=true` (the field-index backfill flag — currently off) alongside the key-index one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)