### PR TITLE
fix(odata): @odata.nextLink keyset continuation + projection parity (ARN-160, ARN-97)

### DIFF
--- a/crates/temper-odata/src/query/types.rs
+++ b/crates/temper-odata/src/query/types.rs
@@ -27,6 +27,12 @@ pub struct QueryOptions {
     pub skip: Option<usize>,
     /// The `$count` flag, if present.
     pub count: Option<bool>,
+    /// The `$skiptoken` server-driven-paging continuation token, if present.
+    ///
+    /// Opaque to clients: the server issues it inside an `@odata.nextLink` and
+    /// interprets it as a keyset cursor over the response's ordering. Clients
+    /// echo it back verbatim; they never construct one.
+    pub skiptoken: Option<String>,
 }
 
 /// An item in a `$expand` clause, optionally with nested query options.
@@ -182,6 +188,12 @@ pub fn parse_query_options(query_string: &str) -> Result<QueryOptions, ODataErro
             }
             "$count" => {
                 opts.count = Some(parse_bool("$count", &value)?);
+            }
+            "$skiptoken" => {
+                let token = value.trim();
+                if !token.is_empty() {
+                    opts.skiptoken = Some(token.to_string());
+                }
             }
             other => {
                 // Ignore non-system query options (custom options, $format, etc.)
@@ -589,6 +601,16 @@ mod tests {
     fn empty_query_string() {
         let opts = parse_query_options("").unwrap();
         assert_eq!(opts, QueryOptions::default());
+    }
+
+    #[test]
+    fn skiptoken_is_parsed_and_blank_is_ignored() {
+        let opts =
+            parse_query_options("$filter=Status eq 'Published'&$skiptoken=Zm9vLTAx").unwrap();
+        assert_eq!(opts.skiptoken.as_deref(), Some("Zm9vLTAx"));
+
+        let blank = parse_query_options("$skiptoken=").unwrap();
+        assert_eq!(blank.skiptoken, None);
     }
 
     #[test]

--- a/crates/temper-server/src/odata/query_plane_read/mod.rs
+++ b/crates/temper-server/src/odata/query_plane_read/mod.rs
@@ -6,11 +6,10 @@ mod scan;
 mod tests;
 mod types;
 
+pub(in crate::odata) use pagination::read_entity_set_from_query_plane;
 pub(in crate::odata) use types::{
     QueryPlaneReadBudget, QueryPlaneReadError, QueryPlaneReadRequest, QueryPlaneReadResult,
 };
-
-use temper_odata::query::types::QueryOptions;
 
 use super::authz::{LIST_ACTION, authorize_read};
 use super::read_support::missing_catalog_entity_ids;
@@ -448,103 +447,6 @@ pub(in crate::odata) async fn read_entity_set_page(
     })
 }
 
-/// Execute one OData entity-set read with server-driven paging.
-///
-/// Wraps [`read_entity_set_page`] with a keyset continuation (ARN-160): a read
-/// truncated by the page size returns a `next_skiptoken` the caller renders into
-/// an `@odata.nextLink`, and an incoming `$skiptoken` is honored by folding a
-/// keyset `$filter` predicate + canonical `$orderby` into the read so the
-/// existing plan (native narrowing + in-memory re-check) resumes exactly after
-/// the previous page. `$select` is applied here, after the continuation cursor is
-/// taken, so a projected read returns the same entity set as the canonical read —
-/// only the field shape differs (ARN-97).
-pub(in crate::odata) async fn read_entity_set_from_query_plane(
-    request: QueryPlaneReadRequest<'_>,
-) -> Result<QueryPlaneReadResult, QueryPlaneReadError> {
-    let query_options = request.query_options;
-    let page_size = request.budget.requested_top(query_options);
-    let order = pagination::canonical_pagination_order(query_options.orderby.as_deref());
-
-    // Decode an incoming continuation, if any, into the keyset predicate that
-    // resumes after the previous page's last row.
-    let resume_predicate = match query_options.skiptoken.as_deref() {
-        Some(token) => {
-            let cursor =
-                pagination::decode_cursor(token).ok_or(QueryPlaneReadError::InvalidContinuation)?;
-            Some(
-                pagination::keyset_after_predicate(&cursor, &order)
-                    .ok_or(QueryPlaneReadError::InvalidContinuation)?,
-            )
-        }
-        None => None,
-    };
-
-    // The `$select` set is applied by this layer (after the cursor is taken), so
-    // the underlying page read always materializes full bodies — the cursor can
-    // read the ordering properties, and projection can never change membership.
-    let select = query_options.select.clone();
-    let base_filter = match resume_predicate {
-        Some(keyset) => Some(pagination::and_filter(query_options.filter.clone(), keyset)),
-        None => query_options.filter.clone(),
-    };
-    // A page order is only forced when the caller sorts (append the id tiebreaker
-    // for a total order). Without `$orderby`, every backend already returns
-    // entity_id-ascending, so leaving it unset keeps the cheap unsorted paths.
-    let effective_orderby = query_options.orderby.as_ref().map(|_| order.clone());
-    // Fetch one row past the page to detect truncation. The read budget is given
-    // one row of headroom so this probe row can never itself trip a `413` at the
-    // page boundary; the client's page size (`page_size`) is unchanged.
-    let fetch_top = page_size.saturating_add(1);
-    let page_budget = QueryPlaneReadBudget {
-        default_page_size: request.budget.default_page_size,
-        max_entities: request.budget.max_entities.saturating_add(1),
-    };
-
-    let page_options = QueryOptions {
-        filter: base_filter,
-        select: None,
-        expand: None,
-        orderby: effective_orderby,
-        top: Some(fetch_top),
-        // `$skip` composes with page one only; a continuation replaces it.
-        skip: if query_options.skiptoken.is_some() {
-            None
-        } else {
-            query_options.skip
-        },
-        count: query_options.count,
-        skiptoken: None,
-    };
-    let page_request = QueryPlaneReadRequest {
-        query_options: &page_options,
-        budget: page_budget,
-        ..request
-    };
-    let mut result = read_entity_set_page(page_request).await?;
-
-    // Telemetry is recorded against the original request shape, not the rewritten
-    // page read (which strips `$select` and adds the keyset filter).
-    result.telemetry.select_requested = scan::select_requested(query_options);
-    result.telemetry.select_count = select.as_ref().map_or(0, Vec::len);
-
-    let truncated = result.entities.len() > page_size;
-    result.entities.truncate(page_size);
-
-    let next_skiptoken = if truncated {
-        result
-            .entities
-            .last()
-            .map(|last| pagination::encode_cursor(&pagination::cursor_for_row(last, &order)))
-    } else {
-        None
-    };
-
-    if let Some(select) = select.as_deref() {
-        result.entities = crate::query_eval::select_fields(result.entities, select);
-    }
-
-    Ok(QueryPlaneReadResult {
-        next_skiptoken,
-        ..result
-    })
-}
+// The server-driven paging wrapper (`read_entity_set_from_query_plane`) lives in
+// `pagination` and is re-exported above; it layers a keyset `$skiptoken`
+// continuation over this core planner.

--- a/crates/temper-server/src/odata/query_plane_read/mod.rs
+++ b/crates/temper-server/src/odata/query_plane_read/mod.rs
@@ -1,5 +1,6 @@
 //! OData entity-set reads through the query-plane contract.
 
+mod pagination;
 mod scan;
 #[cfg(test)]
 mod tests;
@@ -8,6 +9,8 @@ mod types;
 pub(in crate::odata) use types::{
     QueryPlaneReadBudget, QueryPlaneReadError, QueryPlaneReadRequest, QueryPlaneReadResult,
 };
+
+use temper_odata::query::types::QueryOptions;
 
 use super::authz::{LIST_ACTION, authorize_read};
 use super::read_support::missing_catalog_entity_ids;
@@ -146,8 +149,10 @@ async fn catalog_coverage_report(
     )
 }
 
-/// Execute one OData entity-set read through the query-plane contract.
-pub(in crate::odata) async fn read_entity_set_from_query_plane(
+/// Execute one page of an OData entity-set read through the query-plane
+/// contract. Pagination (server-driven `@odata.nextLink` continuation) is
+/// layered on top by [`read_entity_set_from_query_plane`].
+pub(in crate::odata) async fn read_entity_set_page(
     request: QueryPlaneReadRequest<'_>,
 ) -> Result<QueryPlaneReadResult, QueryPlaneReadError> {
     if let Err(response) = authorize_read(
@@ -193,6 +198,7 @@ pub(in crate::odata) async fn read_entity_set_from_query_plane(
                             entities: result.entities,
                             count: result.count,
                             telemetry: result.telemetry,
+                            next_skiptoken: None,
                         });
                     }
                 }
@@ -209,6 +215,7 @@ pub(in crate::odata) async fn read_entity_set_from_query_plane(
                     entities: result.entities,
                     count: result.count,
                     telemetry: result.telemetry,
+                    next_skiptoken: None,
                 });
             }
         } else if let Some(result) =
@@ -226,6 +233,7 @@ pub(in crate::odata) async fn read_entity_set_from_query_plane(
                     entities: result.entities,
                     count: result.count,
                     telemetry: result.telemetry,
+                    next_skiptoken: None,
                 });
             }
         }
@@ -284,6 +292,7 @@ pub(in crate::odata) async fn read_entity_set_from_query_plane(
             entities: result.entities,
             count: result.count,
             telemetry: result.telemetry,
+            next_skiptoken: None,
         });
     }
 
@@ -312,5 +321,107 @@ pub(in crate::odata) async fn read_entity_set_from_query_plane(
         entities: result.entities,
         count: result.count,
         telemetry: result.telemetry,
+        next_skiptoken: None,
+    })
+}
+
+/// Execute one OData entity-set read with server-driven paging.
+///
+/// Wraps [`read_entity_set_page`] with a keyset continuation (ARN-160): a read
+/// truncated by the page size returns a `next_skiptoken` the caller renders into
+/// an `@odata.nextLink`, and an incoming `$skiptoken` is honored by folding a
+/// keyset `$filter` predicate + canonical `$orderby` into the read so the
+/// existing plan (native narrowing + in-memory re-check) resumes exactly after
+/// the previous page. `$select` is applied here, after the continuation cursor is
+/// taken, so a projected read returns the same entity set as the canonical read —
+/// only the field shape differs (ARN-97).
+pub(in crate::odata) async fn read_entity_set_from_query_plane(
+    request: QueryPlaneReadRequest<'_>,
+) -> Result<QueryPlaneReadResult, QueryPlaneReadError> {
+    let query_options = request.query_options;
+    let page_size = request.budget.requested_top(query_options);
+    let order = pagination::canonical_pagination_order(query_options.orderby.as_deref());
+
+    // Decode an incoming continuation, if any, into the keyset predicate that
+    // resumes after the previous page's last row.
+    let resume_predicate = match query_options.skiptoken.as_deref() {
+        Some(token) => {
+            let cursor =
+                pagination::decode_cursor(token).ok_or(QueryPlaneReadError::InvalidContinuation)?;
+            Some(
+                pagination::keyset_after_predicate(&cursor, &order)
+                    .ok_or(QueryPlaneReadError::InvalidContinuation)?,
+            )
+        }
+        None => None,
+    };
+
+    // The `$select` set is applied by this layer (after the cursor is taken), so
+    // the underlying page read always materializes full bodies — the cursor can
+    // read the ordering properties, and projection can never change membership.
+    let select = query_options.select.clone();
+    let base_filter = match resume_predicate {
+        Some(keyset) => Some(pagination::and_filter(query_options.filter.clone(), keyset)),
+        None => query_options.filter.clone(),
+    };
+    // A page order is only forced when the caller sorts (append the id tiebreaker
+    // for a total order). Without `$orderby`, every backend already returns
+    // entity_id-ascending, so leaving it unset keeps the cheap unsorted paths.
+    let effective_orderby = query_options.orderby.as_ref().map(|_| order.clone());
+    // Fetch one row past the page to detect truncation. The read budget is given
+    // one row of headroom so this probe row can never itself trip a `413` at the
+    // page boundary; the client's page size (`page_size`) is unchanged.
+    let fetch_top = page_size.saturating_add(1);
+    let page_budget = QueryPlaneReadBudget {
+        default_page_size: request.budget.default_page_size,
+        max_entities: request.budget.max_entities.saturating_add(1),
+    };
+
+    let page_options = QueryOptions {
+        filter: base_filter,
+        select: None,
+        expand: None,
+        orderby: effective_orderby,
+        top: Some(fetch_top),
+        // `$skip` composes with page one only; a continuation replaces it.
+        skip: if query_options.skiptoken.is_some() {
+            None
+        } else {
+            query_options.skip
+        },
+        count: query_options.count,
+        skiptoken: None,
+    };
+    let page_request = QueryPlaneReadRequest {
+        query_options: &page_options,
+        budget: page_budget,
+        ..request
+    };
+    let mut result = read_entity_set_page(page_request).await?;
+
+    // Telemetry is recorded against the original request shape, not the rewritten
+    // page read (which strips `$select` and adds the keyset filter).
+    result.telemetry.select_requested = scan::select_requested(query_options);
+    result.telemetry.select_count = select.as_ref().map_or(0, Vec::len);
+
+    let truncated = result.entities.len() > page_size;
+    result.entities.truncate(page_size);
+
+    let next_skiptoken = if truncated {
+        result
+            .entities
+            .last()
+            .map(|last| pagination::encode_cursor(&pagination::cursor_for_row(last, &order)))
+    } else {
+        None
+    };
+
+    if let Some(select) = select.as_deref() {
+        result.entities = crate::query_eval::select_fields(result.entities, select);
+    }
+
+    Ok(QueryPlaneReadResult {
+        next_skiptoken,
+        ..result
     })
 }

--- a/crates/temper-server/src/odata/query_plane_read/pagination.rs
+++ b/crates/temper-server/src/odata/query_plane_read/pagination.rs
@@ -1,0 +1,282 @@
+//! Server-driven paging: keyset `$skiptoken` continuation for OData list reads.
+//!
+//! A list read truncated by the page size (default or `$top`-capped) must
+//! advertise a continuation (`@odata.nextLink`) per OData v4, or a caller reads
+//! the first page and concludes that is the whole set (ARN-160). We express the
+//! continuation as a keyset cursor over the read's canonical ordering so that
+//! following the link repeatedly enumerates the full result set with no
+//! duplicates or gaps — on every backend (Postgres, Turso) and the in-memory
+//! source-cursor path (the sim store).
+//!
+//! Canonical ordering = the request's `$orderby` clauses followed by `entity_id`
+//! ascending as a total-order tiebreaker (the id both the native SQL page and the
+//! in-memory sort already order by). The cursor records the ordering values of the
+//! last returned row; the next page keeps only rows that sort strictly after it,
+//! expressed as an ordinary `$filter` predicate so the existing read plan (native
+//! pushdown narrowing + in-memory re-check) honors it unchanged.
+//!
+//! Null ordering matches the backends' `NULLS LAST` for ascending / `NULLS FIRST`
+//! for descending, which is also what the in-memory sort produces (present values
+//! sort before absent for ascending). The final `entity_id` key is never null, so
+//! the tuple comparison always resolves to a strict order between distinct rows.
+
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use temper_odata::query::types::{
+    BinaryOperator, FilterExpr, ODataValue, OrderByClause, OrderDirection,
+};
+
+use crate::query_eval::resolve_property;
+
+/// The always-present final tiebreaker property. Resolves to the entity's
+/// top-level `entity_id`, which every materialized body carries.
+pub(super) const ID_PROPERTY: &str = "entity_id";
+
+/// One key of a decoded cursor: the boundary row's value for a pagination
+/// clause. `present == false` means the row had no value there (SQL NULL).
+#[derive(Clone, Debug, PartialEq)]
+struct CursorKey {
+    present: bool,
+    value: serde_json::Value,
+}
+
+/// A decoded `$skiptoken`: the boundary row's value for each canonical
+/// pagination clause, in clause order (orderby clauses, then `entity_id`).
+#[derive(Clone, Debug, PartialEq)]
+pub(super) struct Cursor {
+    keys: Vec<CursorKey>,
+}
+
+/// The canonical pagination ordering for a request: the caller's `$orderby`
+/// clauses with `entity_id` ascending appended as a total-order tiebreaker.
+///
+/// The tiebreaker is appended unless the caller's last clause is already
+/// `entity_id`, so the ordering is always a strict total order over distinct
+/// entities (entity ids are unique).
+pub(super) fn canonical_pagination_order(orderby: Option<&[OrderByClause]>) -> Vec<OrderByClause> {
+    let mut clauses = orderby.map(<[_]>::to_vec).unwrap_or_default();
+    if clauses
+        .last()
+        .map(|clause| clause.property != ID_PROPERTY)
+        .unwrap_or(true)
+    {
+        clauses.push(OrderByClause {
+            property: ID_PROPERTY.to_string(),
+            direction: OrderDirection::Asc,
+        });
+    }
+    clauses
+}
+
+/// Build the cursor for a boundary row (the last row of a returned page) under
+/// the given canonical ordering.
+pub(super) fn cursor_for_row(row: &serde_json::Value, order: &[OrderByClause]) -> Cursor {
+    let keys = order
+        .iter()
+        .map(|clause| match resolve_property(row, &clause.property) {
+            Some(value) => CursorKey {
+                present: true,
+                value,
+            },
+            None => CursorKey {
+                present: false,
+                value: serde_json::Value::Null,
+            },
+        })
+        .collect();
+    Cursor { keys }
+}
+
+/// Encode a cursor as an opaque URL-safe `$skiptoken`.
+pub(super) fn encode_cursor(cursor: &Cursor) -> String {
+    let array = serde_json::Value::Array(
+        cursor
+            .keys
+            .iter()
+            .map(|key| {
+                serde_json::Value::Array(vec![
+                    serde_json::Value::Bool(key.present),
+                    key.value.clone(),
+                ])
+            })
+            .collect(),
+    );
+    // Serializing a Vec of JSON arrays is infallible.
+    let bytes = serde_json::to_vec(&array).unwrap_or_default();
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+/// Decode a `$skiptoken` back into a cursor.
+///
+/// Returns `None` for a malformed token (bad base64, bad JSON, or the wrong
+/// shape) — a client error the caller surfaces as a 400 rather than silently
+/// restarting pagination.
+pub(super) fn decode_cursor(token: &str) -> Option<Cursor> {
+    let bytes = URL_SAFE_NO_PAD.decode(token.as_bytes()).ok()?;
+    let array = serde_json::from_slice::<serde_json::Value>(&bytes).ok()?;
+    let entries = array.as_array()?;
+    let mut keys = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let pair = entry.as_array()?;
+        if pair.len() != 2 {
+            return None;
+        }
+        let present = pair[0].as_bool()?;
+        keys.push(CursorKey {
+            present,
+            value: pair[1].clone(),
+        });
+    }
+    if keys.is_empty() {
+        return None;
+    }
+    Some(Cursor { keys })
+}
+
+/// Build the `$filter` predicate selecting rows that sort strictly after the
+/// cursor under `order`.
+///
+/// Returns `None` when the cursor does not line up with the ordering (wrong
+/// number of keys, or a non-scalar boundary value) — the caller treats that as a
+/// malformed token.
+pub(super) fn keyset_after_predicate(
+    cursor: &Cursor,
+    order: &[OrderByClause],
+) -> Option<FilterExpr> {
+    if cursor.keys.len() != order.len() {
+        return None;
+    }
+    keyset_from(cursor, order, 0)
+}
+
+fn keyset_from(cursor: &Cursor, order: &[OrderByClause], index: usize) -> Option<FilterExpr> {
+    let Some(clause) = order.get(index) else {
+        // Past the last (unique) key: two rows equal on every key are the same
+        // row, which is not strictly after itself.
+        return Some(literal_false());
+    };
+    let key = &cursor.keys[index];
+    let strictly_after = strictly_after_at(clause, key)?;
+    let equal_here = equal_at(clause, key);
+    let deeper = keyset_from(cursor, order, index + 1)?;
+    // strictly_after OR (equal_here AND after(next))
+    Some(or(strictly_after, and(equal_here, deeper)))
+}
+
+/// The predicate "this clause's value sorts strictly after the boundary value",
+/// honoring NULLS LAST for ascending and NULLS FIRST for descending.
+fn strictly_after_at(clause: &OrderByClause, key: &CursorKey) -> Option<FilterExpr> {
+    let prop = FilterExpr::Property(clause.property.clone());
+    match (clause.direction, key.present) {
+        // Ascending, boundary has a value: a larger value, or a null (nulls last).
+        (OrderDirection::Asc, true) => {
+            let literal = odata_literal(&key.value)?;
+            Some(or(
+                compare(prop.clone(), BinaryOperator::Gt, literal),
+                is_null(prop),
+            ))
+        }
+        // Ascending, boundary is null (sorts at the very end): nothing is after it.
+        (OrderDirection::Asc, false) => Some(literal_false()),
+        // Descending, boundary has a value: a smaller value (nulls sort first, so
+        // a null is before — not after — a non-null boundary).
+        (OrderDirection::Desc, true) => {
+            let literal = odata_literal(&key.value)?;
+            Some(compare(prop, BinaryOperator::Lt, literal))
+        }
+        // Descending, boundary is null (sorts at the very start): any value is after.
+        (OrderDirection::Desc, false) => Some(is_not_null(prop)),
+    }
+}
+
+/// The predicate "this clause's value equals the boundary value" (a null
+/// boundary matches a null/absent value), used to descend to the next key.
+fn equal_at(clause: &OrderByClause, key: &CursorKey) -> FilterExpr {
+    let prop = FilterExpr::Property(clause.property.clone());
+    if key.present {
+        match odata_literal(&key.value) {
+            Some(literal) => compare(prop, BinaryOperator::Eq, literal),
+            None => literal_false(),
+        }
+    } else {
+        is_null(prop)
+    }
+}
+
+fn odata_literal(value: &serde_json::Value) -> Option<FilterExpr> {
+    let literal = match value {
+        serde_json::Value::Null => ODataValue::Null,
+        serde_json::Value::Bool(b) => ODataValue::Boolean(*b),
+        serde_json::Value::String(s) => ODataValue::String(s.clone()),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                ODataValue::Int(i)
+            } else {
+                ODataValue::Float(n.as_f64()?)
+            }
+        }
+        // Arrays/objects are not orderable scalars; a cursor should never hold one.
+        serde_json::Value::Array(_) | serde_json::Value::Object(_) => return None,
+    };
+    Some(FilterExpr::Literal(literal))
+}
+
+fn compare(prop: FilterExpr, op: BinaryOperator, literal: FilterExpr) -> FilterExpr {
+    FilterExpr::BinaryOp {
+        left: Box::new(prop),
+        op,
+        right: Box::new(literal),
+    }
+}
+
+fn is_null(prop: FilterExpr) -> FilterExpr {
+    compare(
+        prop,
+        BinaryOperator::Eq,
+        FilterExpr::Literal(ODataValue::Null),
+    )
+}
+
+fn is_not_null(prop: FilterExpr) -> FilterExpr {
+    compare(
+        prop,
+        BinaryOperator::Ne,
+        FilterExpr::Literal(ODataValue::Null),
+    )
+}
+
+fn and(left: FilterExpr, right: FilterExpr) -> FilterExpr {
+    FilterExpr::BinaryOp {
+        left: Box::new(left),
+        op: BinaryOperator::And,
+        right: Box::new(right),
+    }
+}
+
+fn or(left: FilterExpr, right: FilterExpr) -> FilterExpr {
+    FilterExpr::BinaryOp {
+        left: Box::new(left),
+        op: BinaryOperator::Or,
+        right: Box::new(right),
+    }
+}
+
+/// A predicate that is always false, without referencing any property.
+/// `not (true)` — the in-memory evaluator and the SQL translator both fold it.
+fn literal_false() -> FilterExpr {
+    FilterExpr::UnaryOp {
+        op: temper_odata::query::types::UnaryOperator::Not,
+        operand: Box::new(FilterExpr::Literal(ODataValue::Boolean(true))),
+    }
+}
+
+/// Combine a caller's optional `$filter` with the keyset predicate.
+pub(super) fn and_filter(base: Option<FilterExpr>, keyset: FilterExpr) -> FilterExpr {
+    match base {
+        Some(base) => and(base, keyset),
+        None => keyset,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/temper-server/src/odata/query_plane_read/pagination.rs
+++ b/crates/temper-server/src/odata/query_plane_read/pagination.rs
@@ -23,9 +23,14 @@
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use temper_odata::query::types::{
-    BinaryOperator, FilterExpr, ODataValue, OrderByClause, OrderDirection,
+    BinaryOperator, FilterExpr, ODataValue, OrderByClause, OrderDirection, QueryOptions,
 };
 
+use super::scan;
+use super::{
+    QueryPlaneReadBudget, QueryPlaneReadError, QueryPlaneReadRequest, QueryPlaneReadResult,
+    read_entity_set_page,
+};
 use crate::query_eval::resolve_property;
 
 /// The always-present final tiebreaker property. Resolves to the entity's
@@ -271,11 +276,111 @@ fn literal_false() -> FilterExpr {
 }
 
 /// Combine a caller's optional `$filter` with the keyset predicate.
-pub(super) fn and_filter(base: Option<FilterExpr>, keyset: FilterExpr) -> FilterExpr {
+fn and_filter(base: Option<FilterExpr>, keyset: FilterExpr) -> FilterExpr {
     match base {
         Some(base) => and(base, keyset),
         None => keyset,
     }
+}
+
+/// Execute one OData entity-set read with server-driven paging.
+///
+/// Wraps [`read_entity_set_page`] with a keyset continuation (ARN-160): a read
+/// truncated by the page size returns a `next_skiptoken` the caller renders into
+/// an `@odata.nextLink`, and an incoming `$skiptoken` is honored by folding a
+/// keyset `$filter` predicate + canonical `$orderby` into the read so the
+/// existing plan (native narrowing + in-memory re-check) resumes exactly after
+/// the previous page. `$select` is applied here, after the continuation cursor is
+/// taken, so a projected read returns the same entity set as the canonical read —
+/// only the field shape differs (ARN-97).
+pub(in crate::odata) async fn read_entity_set_from_query_plane(
+    request: QueryPlaneReadRequest<'_>,
+) -> Result<QueryPlaneReadResult, QueryPlaneReadError> {
+    let query_options = request.query_options;
+    let page_size = request.budget.requested_top(query_options);
+    let order = canonical_pagination_order(query_options.orderby.as_deref());
+
+    // Decode an incoming continuation, if any, into the keyset predicate that
+    // resumes after the previous page's last row.
+    let resume_predicate = match query_options.skiptoken.as_deref() {
+        Some(token) => {
+            let cursor = decode_cursor(token).ok_or(QueryPlaneReadError::InvalidContinuation)?;
+            Some(
+                keyset_after_predicate(&cursor, &order)
+                    .ok_or(QueryPlaneReadError::InvalidContinuation)?,
+            )
+        }
+        None => None,
+    };
+
+    // The `$select` set is applied by this layer (after the cursor is taken), so
+    // the underlying page read always materializes full bodies — the cursor can
+    // read the ordering properties, and projection can never change membership.
+    let select = query_options.select.clone();
+    let base_filter = match resume_predicate {
+        Some(keyset) => Some(and_filter(query_options.filter.clone(), keyset)),
+        None => query_options.filter.clone(),
+    };
+    // A page order is only forced when the caller sorts (append the id tiebreaker
+    // for a total order). Without `$orderby`, every backend already returns
+    // entity_id-ascending, so leaving it unset keeps the cheap unsorted paths.
+    let effective_orderby = query_options.orderby.as_ref().map(|_| order.clone());
+    // Fetch one row past the page to detect truncation. The read budget is given
+    // one row of headroom so this probe row can never itself trip a `413` at the
+    // page boundary; the client's page size (`page_size`) is unchanged.
+    let fetch_top = page_size.saturating_add(1);
+    let page_budget = QueryPlaneReadBudget {
+        default_page_size: request.budget.default_page_size,
+        max_entities: request.budget.max_entities.saturating_add(1),
+    };
+
+    let page_options = QueryOptions {
+        filter: base_filter,
+        select: None,
+        expand: None,
+        orderby: effective_orderby,
+        top: Some(fetch_top),
+        // `$skip` composes with page one only; a continuation replaces it.
+        skip: if query_options.skiptoken.is_some() {
+            None
+        } else {
+            query_options.skip
+        },
+        count: query_options.count,
+        skiptoken: None,
+    };
+    let page_request = QueryPlaneReadRequest {
+        query_options: &page_options,
+        budget: page_budget,
+        ..request
+    };
+    let mut result = read_entity_set_page(page_request).await?;
+
+    // Telemetry is recorded against the original request shape, not the rewritten
+    // page read (which strips `$select` and adds the keyset filter).
+    result.telemetry.select_requested = scan::select_requested(query_options);
+    result.telemetry.select_count = select.as_ref().map_or(0, Vec::len);
+
+    let truncated = result.entities.len() > page_size;
+    result.entities.truncate(page_size);
+
+    let next_skiptoken = if truncated {
+        result
+            .entities
+            .last()
+            .map(|last| encode_cursor(&cursor_for_row(last, &order)))
+    } else {
+        None
+    };
+
+    if let Some(select) = select.as_deref() {
+        result.entities = crate::query_eval::select_fields(result.entities, select);
+    }
+
+    Ok(QueryPlaneReadResult {
+        next_skiptoken,
+        ..result
+    })
 }
 
 #[cfg(test)]

--- a/crates/temper-server/src/odata/query_plane_read/pagination/tests.rs
+++ b/crates/temper-server/src/odata/query_plane_read/pagination/tests.rs
@@ -1,0 +1,174 @@
+//! Unit tests for the keyset paging cursor and continuation predicate.
+//!
+//! The load-bearing invariant: for any canonical ordering and any boundary row,
+//! the keyset predicate selects exactly the rows that sort strictly after that
+//! boundary — the same rows the `$orderby` sort would place after it. We check it
+//! by sorting a set with the real query evaluator, then asserting the predicate
+//! partitions the set at each boundary.
+
+use super::*;
+use crate::query_eval::apply_query_options;
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use temper_odata::query::types::{OrderByClause, OrderDirection, QueryOptions};
+
+fn row(id: &str, extra: serde_json::Value) -> serde_json::Value {
+    let mut obj = serde_json::Map::new();
+    obj.insert("entity_id".to_string(), serde_json::json!(id));
+    if let Some(fields) = extra.as_object() {
+        for (k, v) in fields {
+            obj.insert(k.clone(), v.clone());
+        }
+    }
+    serde_json::Value::Object(obj)
+}
+
+fn ids(rows: &[serde_json::Value]) -> Vec<String> {
+    rows.iter()
+        .map(|r| r["entity_id"].as_str().unwrap().to_string())
+        .collect()
+}
+
+fn sorted(rows: &[serde_json::Value], order: &[OrderByClause]) -> Vec<serde_json::Value> {
+    let (out, _) = apply_query_options(
+        rows.to_vec(),
+        &QueryOptions {
+            orderby: Some(order.to_vec()),
+            ..QueryOptions::default()
+        },
+    );
+    out
+}
+
+/// Rows the keyset predicate keeps, in canonical order.
+fn after(
+    rows: &[serde_json::Value],
+    cursor: &Cursor,
+    order: &[OrderByClause],
+) -> Vec<serde_json::Value> {
+    let predicate = keyset_after_predicate(cursor, order).expect("keyset predicate");
+    let (kept, _) = apply_query_options(
+        rows.to_vec(),
+        &QueryOptions {
+            filter: Some(predicate),
+            orderby: Some(order.to_vec()),
+            ..QueryOptions::default()
+        },
+    );
+    kept
+}
+
+#[test]
+fn cursor_roundtrips_through_the_token() {
+    let order = canonical_pagination_order(Some(&[OrderByClause {
+        property: "Name".to_string(),
+        direction: OrderDirection::Asc,
+    }]));
+    let boundary = row("en-05", serde_json::json!({ "Name": "Civic Press" }));
+    let cursor = cursor_for_row(&boundary, &order);
+    let token = encode_cursor(&cursor);
+    assert_eq!(decode_cursor(&token).as_ref(), Some(&cursor));
+}
+
+#[test]
+fn malformed_token_decodes_to_none() {
+    assert!(decode_cursor("not*base64*").is_none());
+    assert!(decode_cursor("").is_none());
+    // Valid base64url of non-array JSON.
+    assert!(decode_cursor(&URL_SAFE_NO_PAD.encode(b"{}")).is_none());
+}
+
+#[test]
+fn canonical_order_appends_entity_id_tiebreaker() {
+    let order = canonical_pagination_order(None);
+    assert_eq!(order.len(), 1);
+    assert_eq!(order[0].property, ID_PROPERTY);
+
+    let with_user = canonical_pagination_order(Some(&[OrderByClause {
+        property: "Name".to_string(),
+        direction: OrderDirection::Desc,
+    }]));
+    assert_eq!(with_user.len(), 2);
+    assert_eq!(with_user[1].property, ID_PROPERTY);
+    assert_eq!(with_user[1].direction, OrderDirection::Asc);
+
+    // Already terminated by entity_id: no duplicate tiebreaker.
+    let already = canonical_pagination_order(Some(&[OrderByClause {
+        property: ID_PROPERTY.to_string(),
+        direction: OrderDirection::Asc,
+    }]));
+    assert_eq!(already.len(), 1);
+}
+
+#[test]
+fn keyset_partitions_at_every_boundary_id_only() {
+    let order = canonical_pagination_order(None);
+    let rows = vec![
+        row("en-03", serde_json::json!({})),
+        row("en-01", serde_json::json!({})),
+        row("en-02", serde_json::json!({})),
+    ];
+    let ordered = sorted(&rows, &order);
+    assert_eq!(ids(&ordered), vec!["en-01", "en-02", "en-03"]);
+
+    for cut in 0..ordered.len() {
+        let cursor = cursor_for_row(&ordered[cut], &order);
+        let tail = after(&rows, &cursor, &order);
+        let expected: Vec<String> = ids(&ordered[cut + 1..]);
+        assert_eq!(ids(&tail), expected, "boundary at index {cut}");
+    }
+}
+
+#[test]
+fn keyset_partitions_with_user_orderby_and_ties() {
+    let order = canonical_pagination_order(Some(&[OrderByClause {
+        property: "Score".to_string(),
+        direction: OrderDirection::Desc,
+    }]));
+    // Ties on Score are broken by entity_id ascending.
+    let rows = vec![
+        row("en-a", serde_json::json!({ "Score": 10 })),
+        row("en-b", serde_json::json!({ "Score": 30 })),
+        row("en-c", serde_json::json!({ "Score": 10 })),
+        row("en-d", serde_json::json!({ "Score": 20 })),
+    ];
+    let ordered = sorted(&rows, &order);
+    assert_eq!(ids(&ordered), vec!["en-b", "en-d", "en-a", "en-c"]);
+
+    for cut in 0..ordered.len() {
+        let cursor = cursor_for_row(&ordered[cut], &order);
+        let tail = after(&rows, &cursor, &order);
+        assert_eq!(
+            ids(&tail),
+            ids(&ordered[cut + 1..]),
+            "boundary at index {cut}"
+        );
+    }
+}
+
+#[test]
+fn keyset_handles_null_orderby_values() {
+    // Ascending: nulls sort last. Mix present and absent Score values.
+    let order = canonical_pagination_order(Some(&[OrderByClause {
+        property: "Score".to_string(),
+        direction: OrderDirection::Asc,
+    }]));
+    let rows = vec![
+        row("en-a", serde_json::json!({ "Score": 5 })),
+        row("en-b", serde_json::json!({})), // absent -> null, sorts last
+        row("en-c", serde_json::json!({ "Score": 8 })),
+        row("en-d", serde_json::json!({})), // absent -> null, sorts last, id tiebreak
+    ];
+    let ordered = sorted(&rows, &order);
+    assert_eq!(ids(&ordered), vec!["en-a", "en-c", "en-b", "en-d"]);
+
+    for cut in 0..ordered.len() {
+        let cursor = cursor_for_row(&ordered[cut], &order);
+        let tail = after(&rows, &cursor, &order);
+        assert_eq!(
+            ids(&tail),
+            ids(&ordered[cut + 1..]),
+            "boundary at index {cut}"
+        );
+    }
+}

--- a/crates/temper-server/src/odata/query_plane_read/tests.rs
+++ b/crates/temper-server/src/odata/query_plane_read/tests.rs
@@ -19,6 +19,7 @@ use temper_store_turso::TursoEventStore;
 
 mod dst_projection_lag;
 mod keyed_existence;
+mod paging;
 mod proof;
 
 const CSDL_XML: &str = include_str!("../../../../../test-fixtures/specs/model.csdl.xml");
@@ -216,7 +217,7 @@ async fn row_authorized_count_over_budget_returns_413() {
         ..QueryOptions::default()
     };
 
-    let error = match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+    let error = match read_entity_set_page(QueryPlaneReadRequest {
         state: &state,
         tenant: &tenant,
         security_ctx: &security_ctx,
@@ -245,6 +246,9 @@ async fn row_authorized_count_over_budget_returns_413() {
         QueryPlaneReadError::AuthorizationDenied(_) => {
             panic!("test state should allow collection reads")
         }
+        QueryPlaneReadError::InvalidContinuation => {
+            panic!("no $skiptoken was supplied")
+        }
     }
 }
 
@@ -259,7 +263,7 @@ async fn row_authorized_first_page_can_stop_after_proof() {
         ..QueryOptions::default()
     };
 
-    let result = match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+    let result = match read_entity_set_page(QueryPlaneReadRequest {
         state: &state,
         tenant: &tenant,
         security_ctx: &security_ctx,
@@ -314,7 +318,7 @@ async fn projection_lagged_actor_write_repairs_missing_catalog_row() {
         ..QueryOptions::default()
     };
 
-    let result = match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+    let result = match read_entity_set_page(QueryPlaneReadRequest {
         state: &state,
         tenant: &tenant,
         security_ctx: &security_ctx,
@@ -399,7 +403,7 @@ async fn turso_native_pages_order_and_count_inside_query_plane() {
         ..QueryOptions::default()
     };
 
-    let result = match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+    let result = match read_entity_set_page(QueryPlaneReadRequest {
         state: &state,
         tenant: &tenant,
         security_ctx: &security_ctx,
@@ -469,7 +473,7 @@ async fn native_pages_recheck_filter_before_counting_or_returning() {
         ..QueryOptions::default()
     };
 
-    let result = match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+    let result = match read_entity_set_page(QueryPlaneReadRequest {
         state: &state,
         tenant: &tenant,
         security_ctx: &security_ctx,
@@ -599,7 +603,7 @@ async fn exact_match_read_is_consistent_when_projection_queued() {
         ..QueryOptions::default()
     };
 
-    let result = match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+    let result = match read_entity_set_page(QueryPlaneReadRequest {
         state: &state,
         tenant: &tenant,
         security_ctx: &security_ctx,
@@ -699,7 +703,7 @@ async fn exact_match_absent_file_stays_bounded() {
         ..QueryOptions::default()
     };
 
-    let result = match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+    let result = match read_entity_set_page(QueryPlaneReadRequest {
         state: &state,
         tenant: &tenant,
         security_ctx: &security_ctx,
@@ -789,7 +793,7 @@ async fn populated_current_projection_uses_native_no_reconcile() {
         ..QueryOptions::default()
     };
 
-    let result = match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+    let result = match read_entity_set_page(QueryPlaneReadRequest {
         state: &state,
         tenant: &tenant,
         security_ctx: &security_ctx,

--- a/crates/temper-server/src/odata/query_plane_read/tests/dst_projection_lag.rs
+++ b/crates/temper-server/src/odata/query_plane_read/tests/dst_projection_lag.rs
@@ -2,7 +2,7 @@
 //! (ADR-0153, ARN-68).
 //!
 //! This is a TRUE DST, not a unit/integration/e2e test: it runs the **real**
-//! read planner (`read_entity_set_from_query_plane`) under
+//! read planner (`read_entity_set_page`) under
 //! `install_deterministic_context(seed)` across many seeds, against deterministic
 //! in-memory backends (`SimEventStore` for the journal + key index, `SimQueryPlane`
 //! for the catalog), with a **fault injected** — the async query projection lags,
@@ -292,7 +292,7 @@ async fn dst_projection_lag_413_eliminated_by_keyed_index() {
             }),
             ..QueryOptions::default()
         };
-        let red = read_entity_set_from_query_plane(QueryPlaneReadRequest {
+        let red = read_entity_set_page(QueryPlaneReadRequest {
             state: &state,
             tenant: &tenant,
             security_ctx: &security_ctx,
@@ -315,7 +315,7 @@ async fn dst_projection_lag_413_eliminated_by_keyed_index() {
             filter: Some(eq_filter(ws, "/no-such-path.txt")),
             ..QueryOptions::default()
         };
-        let red_absent = read_entity_set_from_query_plane(QueryPlaneReadRequest {
+        let red_absent = read_entity_set_page(QueryPlaneReadRequest {
             state: &state,
             tenant: &tenant,
             security_ctx: &security_ctx,
@@ -337,7 +337,7 @@ async fn dst_projection_lag_413_eliminated_by_keyed_index() {
             filter: Some(eq_filter(ws, target_path)),
             ..QueryOptions::default()
         };
-        let green = read_entity_set_from_query_plane(QueryPlaneReadRequest {
+        let green = read_entity_set_page(QueryPlaneReadRequest {
             state: &state,
             tenant: &tenant,
             security_ctx: &security_ctx,

--- a/crates/temper-server/src/odata/query_plane_read/tests/keyed_existence.rs
+++ b/crates/temper-server/src/odata/query_plane_read/tests/keyed_existence.rs
@@ -206,7 +206,7 @@ async fn directory_root_lookup_souls_scenario_with_real_key_and_duplicates() {
     };
 
     // (1) Before the watermark: a NEW workspace's root lookup misses → scans 15 > budget → 413.
-    match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+    match read_entity_set_page(QueryPlaneReadRequest {
         state: &state,
         tenant: &tenant,
         security_ctx: &security_ctx,
@@ -249,7 +249,7 @@ async fn directory_root_lookup_souls_scenario_with_real_key_and_duplicates() {
 
     // (3a) The souls case: a NEW workspace (no root) → authoritative-absent → empty,
     // NO 413. This is what lets ensure_dirs create the root and the soul write proceed.
-    let r = match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+    let r = match read_entity_set_page(QueryPlaneReadRequest {
         state: &state,
         tenant: &tenant,
         security_ctx: &security_ctx,
@@ -274,7 +274,7 @@ async fn directory_root_lookup_souls_scenario_with_real_key_and_duplicates() {
 
     // (3b) An existing workspace's root lookup resolves (hits the one keyed root,
     // despite the duplicates) — no 413, returns exactly one root.
-    let r = match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+    let r = match read_entity_set_page(QueryPlaneReadRequest {
         state: &state,
         tenant: &tenant,
         security_ctx: &security_ctx,
@@ -414,7 +414,7 @@ fn directory_root_souls_scenario_on_postgres() {
             ..QueryOptions::default()
         };
         // (1) Pre-watermark: a NEW workspace's root lookup misses → scans 15 > budget → 413.
-        match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+        match read_entity_set_page(QueryPlaneReadRequest {
             state: &state,
             tenant: &tenant,
             security_ctx: &security_ctx,
@@ -455,7 +455,7 @@ fn directory_root_souls_scenario_on_postgres() {
 
         // (3a) The soul-write path: a NEW workspace (no root) → authoritative-absent →
         // empty, NO 413 → ensure_dirs creates the root and the soul write proceeds.
-        let r = match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+        let r = match read_entity_set_page(QueryPlaneReadRequest {
             state: &state,
             tenant: &tenant,
             security_ctx: &security_ctx,
@@ -479,7 +479,7 @@ fn directory_root_souls_scenario_on_postgres() {
         );
 
         // (3b) The existing absent-ParentId root resolves (no 413, exactly one).
-        let r = match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+        let r = match read_entity_set_page(QueryPlaneReadRequest {
             state: &state,
             tenant: &tenant,
             security_ctx: &security_ctx,
@@ -603,7 +603,7 @@ fn field_index_backfill_bounds_non_keyed_path_lookup_on_postgres() {
         // (1) Field index empty (pre-existing dirs unindexed): the non-keyed Path lookup
         // enumerates the full type from the store (> budget) with nothing to narrow it →
         // 413 QueryTooLarge — exactly the prod failure.
-        match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+        match read_entity_set_page(QueryPlaneReadRequest {
             state: &state,
             tenant: &tenant,
             security_ctx: &security_ctx,
@@ -629,7 +629,7 @@ fn field_index_backfill_bounds_non_keyed_path_lookup_on_postgres() {
 
         // (3) The same Path lookup now binds via the native page and finds /souls — proof
         // the backfill populated the field index for entities absent from the lazy index.
-        let r = match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+        let r = match read_entity_set_page(QueryPlaneReadRequest {
             state: &state,
             tenant: &tenant,
             security_ctx: &security_ctx,
@@ -1010,7 +1010,7 @@ async fn keyed_miss_returns_empty_without_scan_413_once_watermarked() {
     };
 
     // Before the watermark: keyed miss → scan fallback → 413.
-    match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+    match read_entity_set_page(QueryPlaneReadRequest {
         state: &state,
         tenant: &tenant,
         security_ctx: &security_ctx,
@@ -1031,7 +1031,7 @@ async fn keyed_miss_returns_empty_without_scan_413_once_watermarked() {
         .mark_key_index_backfilled(&tenant, "Order", "ws_path")
         .await;
 
-    let result = match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+    let result = match read_entity_set_page(QueryPlaneReadRequest {
         state: &state,
         tenant: &tenant,
         security_ctx: &security_ctx,

--- a/crates/temper-server/src/odata/query_plane_read/tests/paging.rs
+++ b/crates/temper-server/src/odata/query_plane_read/tests/paging.rs
@@ -1,0 +1,382 @@
+//! Integration tests for server-driven paging (`@odata.nextLink` / keyset
+//! `$skiptoken`, ARN-160) and the projected-vs-canonical read invariant
+//! (ARN-97), against a real Turso store.
+//!
+//! The load-bearing property: following the continuation from the first page to
+//! the last enumerates exactly the same entity set as one big `$top` read — no
+//! duplicates, no gaps — for an unfiltered read, a filtered + `$orderby` read,
+//! and the same read under `$select`.
+
+use super::*;
+use crate::request_context::AgentContext;
+use crate::storage::{BackendLabel, BoxedEventStore};
+use temper_runtime::scheduler::install_deterministic_context;
+use temper_store_sim::SimEventStore;
+use temper_store_turso::TursoEventStore;
+
+fn body_entity_id(entity: &serde_json::Value) -> String {
+    if let Some(id) = entity.get("entity_id").and_then(|v| v.as_str()) {
+        return id.to_string();
+    }
+    if let Some(id) = entity
+        .get("fields")
+        .and_then(|f| f.get("Id"))
+        .and_then(|v| v.as_str())
+    {
+        return id.to_string();
+    }
+    // Fall back to the @odata.id annotation, which `$select` always preserves:
+    // `Orders('ord-00')`.
+    let odata_id = entity["@odata.id"].as_str().unwrap_or_default();
+    odata_id
+        .split_once('(')
+        .and_then(|(_, rest)| rest.strip_suffix(')'))
+        .map(|inner| inner.trim_matches('\'').to_string())
+        .unwrap_or_default()
+}
+
+/// Follow the continuation from the first page to the last, returning the
+/// concatenated entity ids in the order the pages delivered them.
+async fn walk_pages(
+    state: &ServerState,
+    tenant: &TenantId,
+    security_ctx: &SecurityContext,
+    base: &QueryOptions,
+    budget: QueryPlaneReadBudget,
+) -> Vec<String> {
+    let page_size = budget.requested_top(base);
+    let mut ids = Vec::new();
+    let mut skiptoken: Option<String> = None;
+    loop {
+        let options = QueryOptions {
+            skiptoken: skiptoken.clone(),
+            ..base.clone()
+        };
+        let result = read_entity_set_from_query_plane(QueryPlaneReadRequest {
+            state,
+            tenant,
+            security_ctx,
+            entity_type: "Order",
+            entity_set_name: "Orders",
+            query_options: &options,
+            budget,
+        })
+        .await
+        .unwrap_or_else(|_| panic!("page read should succeed"));
+
+        assert!(
+            result.entities.len() <= page_size,
+            "a page must never exceed the requested page size"
+        );
+        for entity in &result.entities {
+            ids.push(body_entity_id(entity));
+        }
+        match result.next_skiptoken {
+            Some(token) => {
+                assert_eq!(
+                    result.entities.len(),
+                    page_size,
+                    "only a full page may carry a continuation"
+                );
+                skiptoken = Some(token);
+            }
+            None => break,
+        }
+        assert!(ids.len() <= 1000, "pagination failed to terminate");
+    }
+    ids
+}
+
+async fn single_read(
+    state: &ServerState,
+    tenant: &TenantId,
+    security_ctx: &SecurityContext,
+    base: &QueryOptions,
+    budget: QueryPlaneReadBudget,
+) -> Vec<String> {
+    let options = QueryOptions {
+        top: Some(1000),
+        ..base.clone()
+    };
+    let result = read_entity_set_from_query_plane(QueryPlaneReadRequest {
+        state,
+        tenant,
+        security_ctx,
+        entity_type: "Order",
+        entity_set_name: "Orders",
+        query_options: &options,
+        budget,
+    })
+    .await
+    .unwrap_or_else(|_| panic!("single big read should succeed"));
+    // The one big read must not itself advertise a continuation.
+    assert!(result.next_skiptoken.is_none(), "big read was truncated");
+    result.entities.iter().map(body_entity_id).collect()
+}
+
+async fn turso_state(system_name: &str) -> (ServerState, TursoEventStore, String) {
+    let db_path = std::env::temp_dir().join(format!("temper-paging-{}.db", sim_uuid()));
+    let _ = std::fs::remove_file(&db_path);
+    let db_url = format!("file:{}", db_path.display());
+    let store = TursoEventStore::new(&db_url, None)
+        .await
+        .expect("create local turso db");
+    let mut state = build_order_state(system_name);
+    state.set_storage_stack(StorageStack::from_turso(store.clone()));
+    (state, store, db_path.display().to_string())
+}
+
+/// Commit an Order to the journal (so `list_entity_ids` enumerates it) and
+/// project its test fields into the catalog.
+async fn seed_order(
+    state: &ServerState,
+    store: &TursoEventStore,
+    tenant: &TenantId,
+    id: &str,
+    fields: serde_json::Value,
+) {
+    let agent_ctx = AgentContext::for_service("paging-test");
+    state
+        .dispatch_tenant_action(
+            tenant,
+            "Order",
+            id,
+            "Create",
+            serde_json::json!({}),
+            &agent_ctx,
+        )
+        .await
+        .expect("create order");
+    upsert_order_projection(store, tenant, id, fields, 1).await;
+}
+
+/// Unfiltered list: the default entity_id-ascending order paginates cleanly and
+/// the union of pages equals one big read. This is the ARN-160 shape — a page of
+/// 100 with no nextLink made agents read a 214-item catalog as 100.
+#[tokio::test]
+async fn unfiltered_pagination_enumerates_the_whole_set() {
+    let (state, store, db_path) = turso_state("paging-unfiltered").await;
+    let tenant = TenantId::default();
+    for index in 0..7usize {
+        seed_order(
+            &state,
+            &store,
+            &tenant,
+            &format!("ord-{index:02}"),
+            serde_json::json!({}),
+        )
+        .await;
+    }
+
+    let security_ctx = SecurityContext::system();
+    let budget = QueryPlaneReadBudget {
+        default_page_size: 2,
+        max_entities: 100,
+    };
+    let base = QueryOptions::default();
+
+    let paged = walk_pages(&state, &tenant, &security_ctx, &base, budget).await;
+    let whole = single_read(&state, &tenant, &security_ctx, &base, budget).await;
+
+    assert_eq!(whole.len(), 7);
+    assert_eq!(paged, whole, "paged union must equal the single big read");
+    let unique: std::collections::BTreeSet<_> = paged.iter().collect();
+    assert_eq!(unique.len(), paged.len(), "no duplicates across pages");
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+/// Filtered + `$orderby` list (the production shape `Status eq 'Published'` with
+/// a sort): the keyset continuation over the sorted order enumerates the whole
+/// matching set across pages with no gaps or repeats, and non-matching rows are
+/// never returned.
+#[tokio::test]
+async fn filtered_ordered_pagination_matches_single_read() {
+    let (state, store, db_path) = turso_state("paging-filtered").await;
+    let tenant = TenantId::default();
+
+    // 9 orders in the "keep" bucket with assorted Totals (ties included), plus 3
+    // in another bucket that the filter must exclude on every page.
+    let totals = [30_u64, 10, 20, 10, 40, 25, 10, 35, 5];
+    for (index, total) in totals.iter().enumerate() {
+        seed_order(
+            &state,
+            &store,
+            &tenant,
+            &format!("keep-{index:02}"),
+            serde_json::json!({ "Bucket": "keep", "Total": total }),
+        )
+        .await;
+    }
+    for index in 0..3usize {
+        seed_order(
+            &state,
+            &store,
+            &tenant,
+            &format!("drop-{index:02}"),
+            serde_json::json!({ "Bucket": "other", "Total": 99 }),
+        )
+        .await;
+    }
+
+    let security_ctx = SecurityContext::system();
+    let budget = QueryPlaneReadBudget {
+        default_page_size: 2,
+        max_entities: 100,
+    };
+    let base = QueryOptions {
+        filter: Some(FilterExpr::BinaryOp {
+            left: Box::new(FilterExpr::Property("Bucket".to_string())),
+            op: BinaryOperator::Eq,
+            right: Box::new(FilterExpr::Literal(ODataValue::String("keep".to_string()))),
+        }),
+        orderby: Some(vec![OrderByClause {
+            property: "Total".to_string(),
+            direction: OrderDirection::Asc,
+        }]),
+        ..QueryOptions::default()
+    };
+
+    let paged = walk_pages(&state, &tenant, &security_ctx, &base, budget).await;
+    let whole = single_read(&state, &tenant, &security_ctx, &base, budget).await;
+
+    assert_eq!(whole.len(), 9, "only the nine keep-bucket orders match");
+    assert_eq!(paged, whole, "paged union equals the sorted single read");
+    assert!(
+        paged.iter().all(|id| id.starts_with("keep-")),
+        "no filtered-out rows leaked"
+    );
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+/// ARN-97: a `$select` projected list-read returns exactly the same entity set
+/// as the canonical (no-`$select`) read of the same `$filter`, page for page —
+/// only the field shape differs. The set includes an entity whose `Notes` value
+/// exceeds the 2000-byte field-index cap (so it is absent from the EAV index),
+/// which previously stressed the projection path.
+#[tokio::test]
+async fn projected_read_matches_canonical_read_entity_set() {
+    let (state, store, db_path) = turso_state("paging-select-invariant").await;
+    let tenant = TenantId::default();
+
+    let oversized = "n".repeat(4096); // exceeds the 2000-byte indexable cap
+    for index in 0..6usize {
+        // One entity carries an un-indexable Notes value; all share Bucket=keep.
+        let notes = if index == 3 {
+            serde_json::json!(oversized)
+        } else {
+            serde_json::json!("short")
+        };
+        seed_order(
+            &state,
+            &store,
+            &tenant,
+            &format!("ord-{index:02}"),
+            serde_json::json!({ "Bucket": "keep", "Notes": notes }),
+        )
+        .await;
+    }
+
+    let security_ctx = SecurityContext::system();
+    let budget = QueryPlaneReadBudget {
+        default_page_size: 2,
+        max_entities: 100,
+    };
+    let filter = FilterExpr::BinaryOp {
+        left: Box::new(FilterExpr::Property("Bucket".to_string())),
+        op: BinaryOperator::Eq,
+        right: Box::new(FilterExpr::Literal(ODataValue::String("keep".to_string()))),
+    };
+
+    let canonical = QueryOptions {
+        filter: Some(filter.clone()),
+        ..QueryOptions::default()
+    };
+    let projected = QueryOptions {
+        filter: Some(filter),
+        select: Some(vec!["Id".to_string(), "Bucket".to_string()]),
+        ..QueryOptions::default()
+    };
+
+    let canonical_ids = walk_pages(&state, &tenant, &security_ctx, &canonical, budget).await;
+    let projected_ids = walk_pages(&state, &tenant, &security_ctx, &projected, budget).await;
+
+    assert_eq!(
+        canonical_ids.len(),
+        6,
+        "all six keep orders are visible canonically"
+    );
+    assert_eq!(
+        projected_ids, canonical_ids,
+        "the projected read must return the same entity set as the canonical read"
+    );
+    assert!(
+        canonical_ids.contains(&"ord-03".to_string()),
+        "the entity with an un-indexable field value must be present"
+    );
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+/// The continuation must also enumerate the whole set on the deterministic sim
+/// store (no query-plane backend → the authoritative source-cursor path), and do
+/// so identically under every seed. This is the backend the DST harness runs.
+#[tokio::test]
+async fn sim_pagination_is_deterministic_across_seeds() {
+    let mut reference: Option<Vec<String>> = None;
+    for seed in 0..16u64 {
+        let (_guard, _clock, _id) = install_deterministic_context(seed);
+        let events = BoxedEventStore::new(SimEventStore::no_faults(seed));
+        let mut state = build_order_state("paging-sim");
+        state.set_storage_stack(StorageStack::new(
+            BackendLabel::Sim,
+            events,
+            None,
+            None,
+            None,
+            None,
+            None, // no query plane: reads go through the authoritative source cursor
+            None,
+            None,
+            None,
+        ));
+        let tenant = TenantId::default();
+        let agent_ctx = AgentContext::for_service("paging-sim");
+        for index in 0..7usize {
+            state
+                .dispatch_tenant_action(
+                    &tenant,
+                    "Order",
+                    &format!("ord-{index:02}"),
+                    "Create",
+                    serde_json::json!({}),
+                    &agent_ctx,
+                )
+                .await
+                .expect("create order");
+        }
+
+        let security_ctx = SecurityContext::system();
+        let budget = QueryPlaneReadBudget {
+            default_page_size: 2,
+            max_entities: 100,
+        };
+        let base = QueryOptions::default();
+        let paged = walk_pages(&state, &tenant, &security_ctx, &base, budget).await;
+        let whole = single_read(&state, &tenant, &security_ctx, &base, budget).await;
+
+        assert_eq!(
+            paged, whole,
+            "seed {seed}: paged union must equal one big read"
+        );
+        assert_eq!(paged.len(), 7, "seed {seed}: all seven orders enumerated");
+        match &reference {
+            Some(expected) => assert_eq!(
+                &paged, expected,
+                "seed {seed}: pagination not deterministic"
+            ),
+            None => reference = Some(paged),
+        }
+    }
+}

--- a/crates/temper-server/src/odata/query_plane_read/tests/proof.rs
+++ b/crates/temper-server/src/odata/query_plane_read/tests/proof.rs
@@ -471,7 +471,7 @@ async fn ordinary_null_filter_uses_lossless_candidate_scan() {
         ..QueryOptions::default()
     };
 
-    let result = match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+    let result = match read_entity_set_page(QueryPlaneReadRequest {
         state: &state,
         tenant: &tenant,
         security_ctx: &security_ctx,
@@ -561,7 +561,7 @@ async fn nullable_scalar_order_uses_read_source_full_proof() {
         ..QueryOptions::default()
     };
 
-    let result = match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+    let result = match read_entity_set_page(QueryPlaneReadRequest {
         state: &state,
         tenant: &tenant,
         security_ctx: &security_ctx,
@@ -645,7 +645,7 @@ async fn context_prep_shaped_filter_with_huge_top_uses_bounded_native_page() {
         ..QueryOptions::default()
     };
 
-    let result = match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+    let result = match read_entity_set_page(QueryPlaneReadRequest {
         state: &state,
         tenant: &tenant,
         security_ctx: &security_ctx,
@@ -805,7 +805,7 @@ async fn file_point_lookup_with_status_ne_uses_lossless_equality_candidates() {
         ]
     );
 
-    let result = match read_entity_set_from_query_plane(request).await {
+    let result = match read_entity_set_page(request).await {
         Ok(result) => result,
         Err(QueryPlaneReadError::QueryTooLarge { telemetry }) => panic!(
             "file point lookup should push down equality candidates: QueryTooLarge filter_pushdown={} fallback={:?} candidates={} pushed={}",
@@ -816,6 +816,9 @@ async fn file_point_lookup_with_status_ne_uses_lossless_equality_candidates() {
         ),
         Err(QueryPlaneReadError::AuthorizationDenied(_)) => {
             panic!("file point lookup should not be denied by read authorization")
+        }
+        Err(QueryPlaneReadError::InvalidContinuation) => {
+            panic!("no $skiptoken was supplied")
         }
     };
 
@@ -883,7 +886,7 @@ async fn session_entry_chain_parent_lookup_uses_bounded_native_page() {
         ..QueryOptions::default()
     };
 
-    let result = match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+    let result = match read_entity_set_page(QueryPlaneReadRequest {
         state: &state,
         tenant: &tenant,
         security_ctx: &security_ctx,
@@ -960,7 +963,7 @@ async fn session_entry_leaf_id_lookup_uses_bounded_native_page() {
         ..QueryOptions::default()
     };
 
-    let result = match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+    let result = match read_entity_set_page(QueryPlaneReadRequest {
         state: &state,
         tenant: &tenant,
         security_ctx: &security_ctx,
@@ -1030,7 +1033,7 @@ async fn unsafe_order_uses_read_source_full_proof() {
         ..QueryOptions::default()
     };
 
-    let result = match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+    let result = match read_entity_set_page(QueryPlaneReadRequest {
         state: &state,
         tenant: &tenant,
         security_ctx: &security_ctx,

--- a/crates/temper-server/src/odata/query_plane_read/types.rs
+++ b/crates/temper-server/src/odata/query_plane_read/types.rs
@@ -177,6 +177,10 @@ impl QueryPlaneReadTelemetry {
 }
 
 /// Request for one OData query-plane read.
+///
+/// `Copy` (all fields are shared references or the `Copy` budget) so the paging
+/// layer can derive a rewritten page/probe request without consuming the caller's.
+#[derive(Clone, Copy)]
 pub(in crate::odata) struct QueryPlaneReadRequest<'a> {
     pub(in crate::odata) state: &'a ServerState,
     pub(in crate::odata) tenant: &'a TenantId,
@@ -195,6 +199,10 @@ pub(in crate::odata) struct QueryPlaneReadResult {
     pub(in crate::odata) count: Option<usize>,
     /// Strategy and fallback telemetry for the read.
     pub(in crate::odata) telemetry: QueryPlaneReadTelemetry,
+    /// Continuation token for the next page when this response was truncated by
+    /// the page size, else `None`. The caller renders it into an
+    /// `@odata.nextLink` (ARN-160).
+    pub(in crate::odata) next_skiptoken: Option<String>,
 }
 
 /// Error returned by the OData query-plane read contract.
@@ -203,6 +211,9 @@ pub(in crate::odata) enum QueryPlaneReadError {
     AuthorizationDenied(Box<Response>),
     /// The read would exceed the bounded candidate proof budget.
     QueryTooLarge { telemetry: QueryPlaneReadTelemetry },
+    /// The `$skiptoken` continuation could not be decoded for this request —
+    /// malformed, or its key count does not match the request's ordering.
+    InvalidContinuation,
 }
 
 impl QueryPlaneReadError {
@@ -210,6 +221,7 @@ impl QueryPlaneReadError {
         match self {
             Self::AuthorizationDenied(_) => {}
             Self::QueryTooLarge { telemetry, .. } => telemetry.record(span),
+            Self::InvalidContinuation => {}
         }
     }
 
@@ -220,6 +232,12 @@ impl QueryPlaneReadError {
                 StatusCode::PAYLOAD_TOO_LARGE,
                 "QueryTooLarge",
                 "This query requires evaluating more candidate entities than the bounded OData read budget permits. Use a narrower filter or a smaller page/count request.",
+            )
+            .into_response(),
+            Self::InvalidContinuation => odata_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidSkipToken",
+                "The $skiptoken continuation is malformed. Follow the @odata.nextLink verbatim; do not construct or edit a skiptoken.",
             )
             .into_response(),
         }

--- a/crates/temper-server/src/odata/read.rs
+++ b/crates/temper-server/src/odata/read.rs
@@ -603,7 +603,15 @@ pub(super) async fn handle_odata_get_for_tenant(
         .into_response(),
 
         ODataPath::EntitySet(name) => {
-            handle_entity_set(&state, &tenant, &security_ctx, &name, &query_options).await
+            handle_entity_set(
+                &state,
+                &tenant,
+                &security_ctx,
+                &name,
+                &query_options,
+                &query_params,
+            )
+            .await
         }
 
         ODataPath::Entity(set_name, key) => {
@@ -705,6 +713,7 @@ async fn handle_entity_set(
     security_ctx: &SecurityContext,
     name: &str,
     query_options: &QueryOptions,
+    query_params: &std::collections::BTreeMap<String, String>,
 ) -> axum::response::Response {
     tracing::debug!(name = %name, tenant = %tenant, "handle_entity_set");
     let entity_type = match resolve_entity_type(state, tenant, name) {
@@ -758,11 +767,55 @@ async fn handle_entity_set(
     if let Some(c) = count {
         body["@odata.count"] = serde_json::json!(c);
     }
+    if let Some(token) = read_result.next_skiptoken {
+        body["@odata.nextLink"] = serde_json::json!(next_link(name, query_params, &token));
+    }
     ODataResponse {
         status: StatusCode::OK,
         body,
     }
     .into_response()
+}
+
+/// Build the `@odata.nextLink` for a truncated list read: the request's own
+/// query options with `$skip`/`$skiptoken` replaced by the continuation token.
+///
+/// Values are percent-encoded so the link round-trips through the client and the
+/// `Query` extractor back to the original options; the base64url token is already
+/// URL-safe.
+fn next_link(
+    set_name: &str,
+    query_params: &std::collections::BTreeMap<String, String>,
+    token: &str,
+) -> String {
+    let mut pairs: Vec<String> = query_params
+        .iter()
+        .filter(|(key, _)| key.as_str() != "$skip" && key.as_str() != "$skiptoken")
+        .map(|(key, value)| {
+            format!(
+                "{}={}",
+                encode_query_component(key),
+                encode_query_component(value)
+            )
+        })
+        .collect();
+    pairs.push(format!("$skiptoken={token}"));
+    format!("{set_name}?{}", pairs.join("&"))
+}
+
+/// Percent-encode a query-string key or value, leaving the RFC 3986 unreserved
+/// set (`A-Za-z0-9-._~`) intact. Over-encoding is safe; the server decodes it.
+fn encode_query_component(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~') {
+            out.push(byte as char);
+        } else {
+            out.push('%');
+            out.push_str(&format!("{byte:02X}"));
+        }
+    }
+    out
 }
 
 /// Handle `Entity` path: fetch a single entity by key.

--- a/crates/temper-server/src/odata/read.rs
+++ b/crates/temper-server/src/odata/read.rs
@@ -1362,3 +1362,30 @@ async fn handle_stream_get(
     }
     .into_response()
 }
+
+#[cfg(test)]
+mod next_link_tests {
+    use super::{encode_query_component, next_link};
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn query_component_encodes_reserved_but_not_unreserved() {
+        assert_eq!(encode_query_component("Status eq 'Published'"), "Status%20eq%20%27Published%27");
+        assert_eq!(encode_query_component("Id-9._~"), "Id-9._~");
+    }
+
+    #[test]
+    fn next_link_carries_options_and_replaces_paging() {
+        let mut params = BTreeMap::new();
+        params.insert("$filter".to_string(), "Status eq 'Published'".to_string());
+        params.insert("$skip".to_string(), "100".to_string());
+        params.insert("$skiptoken".to_string(), "STALE".to_string());
+        let link = next_link("DesignLanguages", &params, "TOKEN-9");
+        // $filter is preserved (percent-encoded); $skip and the old $skiptoken are dropped.
+        assert!(link.starts_with("DesignLanguages?"));
+        assert!(link.contains("%24filter=Status%20eq%20%27Published%27"));
+        assert!(!link.contains("%24skip="));
+        assert!(link.contains("$skiptoken=TOKEN-9"));
+        assert_eq!(link.matches("skiptoken").count(), 1);
+    }
+}

--- a/crates/temper-server/src/query_eval.rs
+++ b/crates/temper-server/src/query_eval.rs
@@ -140,7 +140,14 @@ fn evaluate_value(entity: &serde_json::Value, expr: &FilterExpr) -> Option<serde
 
 /// Resolve a property name against an entity, checking top-level first,
 /// then falling back to the `fields` sub-object.
-fn resolve_property(entity: &serde_json::Value, prop: &str) -> Option<serde_json::Value> {
+///
+/// `pub(crate)` so server-driven paging builds a keyset cursor from the same
+/// property values the `$orderby` sort compares — the cursor and the sort must
+/// resolve a property identically or a continuation could skip or repeat rows.
+pub(crate) fn resolve_property(
+    entity: &serde_json::Value,
+    prop: &str,
+) -> Option<serde_json::Value> {
     if prop == "Status" {
         return entity
             .get("Status")
@@ -590,6 +597,7 @@ async fn expand_entity_recursive(
                 top: nested_opts.top,
                 skip: nested_opts.skip,
                 count: None,
+                skiptoken: None,
             };
             let (filtered, _) = apply_query_options(related_entities, &nested_query);
             related_entities = filtered;

--- a/crates/temper-server/src/query_eval_test.rs
+++ b/crates/temper-server/src/query_eval_test.rs
@@ -190,6 +190,7 @@ fn test_apply_query_options_combined() {
         select: Some(vec!["Id".into(), "Name".into()]),
         count: Some(true),
         expand: None,
+        skiptoken: None,
     };
 
     let (result, count) = apply_query_options(entities, &options);

--- a/docs/adrs/0154-odata-read-surface-truthfulness.md
+++ b/docs/adrs/0154-odata-read-surface-truthfulness.md
@@ -1,0 +1,99 @@
+# ADR-0154: OData read-surface truthfulness — keyset continuation and projection parity
+
+- Status: Accepted
+- Date: 2026-07-04
+- Deciders: Temper core maintainers
+- Related:
+  - ADR-0153: Declared composite key index (the read plane this builds on)
+  - `crates/temper-server/src/odata/query_plane_read/` (read planner)
+  - `crates/temper-odata/src/query/types.rs` (query-option parser)
+
+## Context
+
+Two ways the OData read surface lied to callers:
+
+- **ARN-160 — silent truncation.** A list read truncated by the page size
+  (default 100, or `$top` capped at `max_entities`) returned a full page with **no
+  `@odata.nextLink`** and no count. Measured in production: `GET
+  /tdata/DesignLanguages?$filter=Status eq 'Published'` returned exactly 100 rows
+  while `$top=1000` returned 214 and `$count=true` reported 214. Per OData v4 a
+  server that applies server-driven paging MUST include `@odata.nextLink` on a
+  partial result. Agents concluded the catalog held 100 items. The kernel exposed
+  no continuation the client could follow reliably; the Katagami UI had hand-rolled
+  keyset pagination (`Id lt <cursor>` + `$orderby=Id desc`) to cope.
+
+- **ARN-97 — projection changed membership.** A Published entity present in a
+  canonical list-read was **absent under a `$select` projected list-read** of the
+  same `$filter`. Historically the `$select` path was answered by a projection-only
+  fast path that bypassed the coverage/reconcile machinery the canonical path uses,
+  so an entity missing or stale in the projection could be dropped only under
+  `$select`. That fast path is already dead (`#[cfg(test)]`), but the read still
+  carried `$select` *through* the plan, leaving membership select-conditioned by
+  construction.
+
+## Decision
+
+### 1. Keyset `$skiptoken` continuation over the read's canonical order
+
+Add `$skiptoken` to `QueryOptions` and the parser. When a list read is truncated,
+the server emits `@odata.nextLink` carrying an opaque, URL-safe `$skiptoken`; a
+client echoes it back verbatim to fetch the next page.
+
+The token is a **keyset cursor** over the read's **canonical order** = the request's
+`$orderby` clauses followed by `entity_id` ascending as a total-order tiebreaker
+(the id both the native SQL page and the in-memory sort already order by, so the
+order is a strict total order over distinct entities). The token records the
+ordering values of the last returned row; the next page keeps only rows that sort
+**strictly after** it.
+
+**Why keyset, not `$skip`/offset:** offset pagination duplicates or skips rows when
+the set changes between pages, and the kernel's read budget makes deep offsets
+expensive. A keyset cursor is stable under concurrent inserts/deletes and is what
+the UI already reached for.
+
+**Why express it as a `$filter` predicate:** the continuation is lowered to an
+ordinary keyset `$filter` (row strictly after the cursor) plus the canonical
+`$orderby`, then run through the **existing** plan — native pushdown narrows by the
+lossless conjuncts, the in-memory re-check honors the keyset. No new storage
+method, and it behaves identically on Postgres, Turso, and the sim store. Null
+ordering matches the backends' `NULLS LAST` ascending / `NULLS FIRST` descending,
+which is also what the in-memory sort produces.
+
+Truncation is detected by fetching one row past the page (the read budget is given
+one row of headroom so the probe row cannot itself trip a `413` at the boundary).
+
+### 2. `$select` is a post-read projection, so it cannot change membership
+
+Paging is layered in `read_entity_set_from_query_plane` around the core planner
+`read_entity_set_page`. The wrapper strips `$select` from the underlying read (the
+planner always materializes full bodies, so the cursor can read the ordering
+properties) and applies the projection **after** the continuation cursor is taken.
+
+A projected list-read is therefore, by construction, the canonical read's entity
+set with a field projection applied — only the field shape differs. This closes
+ARN-97 structurally: `$select` can no longer condition membership.
+
+## Consequences
+
+- Following `@odata.nextLink` from the first page to the last enumerates the full
+  result set with no duplicates or gaps, proven by tests on Turso and the sim
+  store (union of pages == one big `$top` read), for unfiltered, filtered, and
+  `$orderby` reads.
+- Deep pagination is still bounded by the existing scan-candidate budget
+  (`max_entities * 10`): resuming past the budget returns `413 QueryTooLarge`
+  rather than an unbounded scan — the same contract as a large filtered/counted
+  read. A future optimization can push the keyset predicate into SQL to make deep
+  pages cheap; today they re-materialize within the budget, matching the cost of
+  the pre-existing offset scan.
+- A malformed or mismatched `$skiptoken` returns `400 InvalidSkipToken`; clients
+  must follow the link verbatim and never construct a token.
+- `$skip` still works and composes with page one; the emitted `nextLink` drops
+  `$skip` in favor of the keyset token.
+
+## Follow-ups
+
+- Remove the now-unreachable `$select` projection-only body path
+  (`catalog_row_to_selected_entity_body` and the `selected_catalog_fields`
+  materialization argument) so it cannot be re-wired; the coverage presence check
+  keeps its narrow `entity_id`-only projected load. Left out of this change to keep
+  the diff focused on read-surface behavior.


### PR DESCRIPTION
## Problem

Two ways the OData read surface under-reported to callers, both on the query-plane list-read path:

- **ARN-160 — silent truncation.** A list read truncated by the page size (default 100, or `$top` capped at `max_entities`) returned a full page with **no `@odata.nextLink`** and no continuation a client could follow. Measured in production: `GET /tdata/DesignLanguages?$filter=Status eq 'Published'` returned exactly 100 rows while `$top=1000` returned 214 and `$count=true` reported 214. Per OData v4 a server applying server-driven paging MUST advertise `@odata.nextLink` on a partial result. Agents read the 214-item catalog as 100.

- **ARN-97 — projection changed membership.** A Published `DesignLanguage` ("Civic Press") present in a canonical list-read was absent under a `$select` projected list-read of the same `$filter`.

## Root cause — ARN-97

The generic entity-set read (`materialize_entity_set_entities`) is called with `selected_catalog_fields = None` from both scan paths (`scan/mod.rs:181,208`), so in current `main` a `$select` read and a canonical read already share **one** candidate plan and `$select` only prunes fields after the fact (`apply_select_only`). The historical drop was the older **select-only projection fast path** (`catalog_row_to_selected_entity_body` / `catalog_select_projection_fields`, now `#[cfg(test)]`-dead) that answered `$select` reads from the projection alone and bypassed the coverage + projection-lag reconcile machinery the canonical path uses — so an entity missing/stale in the projection (present canonically via the journal/actor fallback) was dropped only under `$select`.

The residual defect was structural: the read still carried `$select` *through* the plan, leaving membership select-conditioned by construction. The fix hoists `$select` out of the read entirely.

## Fix

**Keyset `$skiptoken` continuation (ARN-160).** Adds `$skiptoken` to `QueryOptions` + parser (`temper-odata`). Paging is layered in `read_entity_set_from_query_plane` around the core planner (renamed `read_entity_set_page`):

- Canonical order = the request's `$orderby` + `entity_id` ascending as a total-order tiebreaker (what native SQL and the in-memory sort already order by).
- The token is an opaque base64url cursor of the last row's ordering values; the next page keeps rows sorting strictly after it, lowered to an ordinary keyset `$filter` predicate + canonical `$orderby` and run through the **existing** plan (native pushdown narrows by the lossless conjuncts; the in-memory re-check honors the keyset). No new storage method; identical on Postgres, Turso, and the sim store. Null ordering matches the backends' `NULLS LAST` asc / `NULLS FIRST` desc.
- Truncation is detected by fetching one row past the page, with one row of read-budget headroom so the probe row can't itself trip a `413` at the boundary. The token is emitted as `@odata.nextLink` in `handle_entity_set`, with `$skip`/`$skiptoken` replaced and other options percent-encoded. `$count` and `$top` semantics are preserved.

**`$select` is a post-read projection (ARN-97).** The paging wrapper strips `$select` from the underlying read (the planner always materializes full bodies, so the cursor can read the ordering properties) and applies the projection **after** the cursor is taken. A projected list-read is therefore, by construction, the canonical read's entity set with a field projection on top — `$select` can no longer change membership.

A malformed/mismatched `$skiptoken` returns `400 InvalidSkipToken`.

See `docs/adrs/0154-odata-read-surface-truthfulness.md`.

## Tests

- **Keyset unit tests** (`pagination/tests.rs`): token roundtrip, malformed decode, canonical-order tiebreaker, and the load-bearing invariant — the keyset predicate partitions a set at every boundary exactly where the `$orderby` sort does (id-only, user-orderby-with-ties, and null-orderby-values cases).
- **Integration** (`tests/paging.rs`, real Turso): following `@odata.nextLink` from first to last page enumerates the whole set with no duplicates/gaps and equals a single big `$top` read — for an unfiltered read, a filtered + `$orderby` read (the production shape, with filtered-out rows never leaking), and a `$select` read whose set equals the canonical read (including an entity whose field value exceeds the 2000-byte EAV index cap).
- **DST** (`tests/paging.rs`): pagination is deterministic across 16 seeds on the sim store (the authoritative source-cursor path).
- Existing 40 query-plane planner tests repointed to the inner planner (unchanged behavior); full `cargo test -p temper-server` green; clippy clean on the touched crates.

## Live repro references

- Truncation: `GET /tdata/DesignLanguages?$filter=Status eq 'Published'` → 100 rows, no nextLink (before); `$top=1000` → 214; `$count=true` → 214.

## Residual risk / follow-ups

- Deep pagination remains bounded by the scan-candidate budget (`max_entities * 10`): resuming past the budget returns `413 QueryTooLarge` rather than an unbounded scan (same contract as a large filtered/counted read). A future optimization can push the keyset predicate into SQL to make deep pages cheap; today they re-materialize within the budget, matching the pre-existing offset-scan cost.
- The now-unreachable `$select` projection-only body path (`catalog_row_to_selected_entity_body`, the `selected_catalog_fields` materialization argument) is left in place; removing it is safe cleanup deferred to keep this diff focused on read-surface behavior (noted in ADR-0154).

## Verification

`cargo test --workspace` was run as the definition-of-done check. All tests pass
except intermittent **libsql parallel-execution flakes** in Turso-backed tests
(e.g. `temper-store-turso::store::tests::single_event_append_bypasses_process_write_gate`
— `SQLite failure: bad parameter or other API misuse`) that surface only under
workspace-wide test concurrency and **pass on isolated re-run**. These are in
crates this PR does not touch (`git diff` touches only `temper-odata` and
`temper-server`). Confirmed on re-run:

- `temper-store-turso --lib`: 58 passed, 0 failed.
- `temper-server --lib odata`: 101 passed, 0 failed (includes the new keyset/paging/URL tests).
- `temper-odata`: green.
- `cargo clippy -p temper-odata -p temper-server --all-targets`: clean; `cargo fmt --check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VebbwT1GQeWibjsZd9YPQy

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two correctness bugs in the OData list-read surface: **ARN-160** (silent truncation — a page-sized result had no `@odata.nextLink`) and **ARN-97** (`$select` queries could drop entities present in canonical reads because a projection-only fast path bypassed the coverage/journal fallback machinery).

- **Keyset `$skiptoken` paging (ARN-160):** A new `pagination` layer wraps `read_entity_set_page`; it builds a canonical ordering (user's `$orderby` + `entity_id` tiebreaker), encodes the last returned row as an opaque base64url cursor, and folds that cursor into an ordinary `$filter` predicate for the next page — reusing the existing native-pushdown + in-memory re-check plan unchanged on all backends.
- **`$select` as post-read projection (ARN-97):** The pagination wrapper strips `$select` from the underlying page read so the cursor always has access to ordering properties, then applies the projection after the cursor is taken. A projected list-read is now, by construction, a field-narrowing of the canonical result — `$select` can no longer change which entities appear.
- A malformed or mismatched `$skiptoken` returns `400 InvalidSkipToken`; the ADR `0154` documents the design and residual risks.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The core keyset cursor logic and $select projection fix are correct and well-tested; the main unresolved issue (flagged in a prior outside-diff comment) is that @odata.count on continuation pages reflects items remaining after the cursor rather than the total matching the original $filter.

The pagination layer forwards count: query_options.count to read_entity_set_page unchanged. On page 2+, the base_filter is user_filter AND keyset_predicate, so the inner count tallies only the entities that sort after the cursor — not the total set the client asked about. A client using $count=true across pages sees a shrinking count on every continuation, which contradicts OData v4 §11.2.7.5.2. This issue was surfaced in an earlier outside-diff comment and is still present at pagination.rs:349.

crates/temper-server/src/odata/query_plane_read/pagination.rs — the count field in page_options should be stripped on continuation pages (and a separate count-only pass against the original filter run when $count=true).
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/temper-server/src/odata/query_plane_read/pagination.rs | New paging layer: encodes/decodes keyset cursors, builds keyset predicates, and drives the page loop. Core logic is sound, but count: query_options.count is forwarded unchanged to the inner read even on continuation pages, where base_filter already includes the keyset predicate — so @odata.count on page 2+ reflects items remaining after the cursor, not the total matching the user's original $filter. |
| crates/temper-server/src/odata/query_plane_read/mod.rs | Core planner renamed to read_entity_set_page; return sites now explicitly set next_skiptoken: None (pagination is the outer layer's responsibility). No logic changes to the planner itself — safe refactor. |
| crates/temper-server/src/odata/read.rs | Adds next_link() builder and encode_query_component(); emits @odata.nextLink when next_skiptoken is present. The $ in query-option keys is percent-encoded to %24 by encode_query_component while the $skiptoken key itself is appended unencoded — an inconsistency noted in a prior review thread; functionally harmless because the axum extractor decodes %24 back to $. |
| crates/temper-odata/src/query/types.rs | Adds skiptoken: Option<String> to QueryOptions and its parser; blank token treated as absent. Straightforward addition with a covering unit test. |
| crates/temper-server/src/odata/query_plane_read/pagination/tests.rs | Good unit tests for cursor roundtrip, malformed decode, tiebreaker deduplication, and the keyset partition invariant across three ordering scenarios (id-only, ties, null values). |
| crates/temper-server/src/odata/query_plane_read/tests/paging.rs | Integration tests covering unfiltered, filtered+orderby, and $select pagination against real Turso and DST sim store; no coverage for $count=true across continuation pages. |
| crates/temper-server/src/odata/query_plane_read/types.rs | Adds next_skiptoken: Option<String> to QueryPlaneReadResult and InvalidContinuation variant to QueryPlaneReadError (renders as 400 InvalidSkipToken). Clean addition. |
| crates/temper-server/src/query_eval.rs | Adds skiptoken: None to the nested expand QueryOptions struct; no substantive logic changes to the evaluator itself. |
| docs/adrs/0154-odata-read-surface-truthfulness.md | New ADR documenting the paging and projection design decisions and residual risks. No code changes. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Client
    participant H as handle_entity_set
    participant P as read_entity_set_from_query_plane
    participant R as read_entity_set_page
    participant B as Backend

    C->>H: "GET /EntitySet?$filter=...&$orderby=..."
    H->>P: QueryPlaneReadRequest (full query_options)
    Note over P: canonical_pagination_order($orderby + entity_id tiebreaker)
    Note over P: strip $select, base_filter = user_filter
    P->>R: "page_options (select=None, top=page_size+1)"
    R->>B: native pushdown or source cursor scan
    B-->>R: up to page_size+1 entities
    R-->>P: QueryPlaneReadResult
    Note over P: truncated = len > page_size
    Note over P: cursor_for_row(last entity) -> encode_cursor -> $skiptoken
    Note over P: apply $select projection after cursor taken
    P-->>H: result + next_skiptoken
    H-->>C: "value + @odata.nextLink with $skiptoken=TOKEN"

    C->>H: "GET /EntitySet?$filter=...&$skiptoken=TOKEN"
    H->>P: QueryPlaneReadRequest (skiptoken present)
    Note over P: decode TOKEN -> cursor keys
    Note over P: keyset_after_predicate -> $filter suffix
    Note over P: base_filter = user_filter AND keyset_predicate
    P->>R: "page_options (filter=combined, skip=None)"
    R->>B: scan with combined filter
    B-->>R: next page entities
    R-->>P: QueryPlaneReadResult
    P-->>H: next page + next_skiptoken or None
    H-->>C: "value + @odata.nextLink or final page"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Client
    participant H as handle_entity_set
    participant P as read_entity_set_from_query_plane
    participant R as read_entity_set_page
    participant B as Backend

    C->>H: "GET /EntitySet?$filter=...&$orderby=..."
    H->>P: QueryPlaneReadRequest (full query_options)
    Note over P: canonical_pagination_order($orderby + entity_id tiebreaker)
    Note over P: strip $select, base_filter = user_filter
    P->>R: "page_options (select=None, top=page_size+1)"
    R->>B: native pushdown or source cursor scan
    B-->>R: up to page_size+1 entities
    R-->>P: QueryPlaneReadResult
    Note over P: truncated = len > page_size
    Note over P: cursor_for_row(last entity) -> encode_cursor -> $skiptoken
    Note over P: apply $select projection after cursor taken
    P-->>H: result + next_skiptoken
    H-->>C: "value + @odata.nextLink with $skiptoken=TOKEN"

    C->>H: "GET /EntitySet?$filter=...&$skiptoken=TOKEN"
    H->>P: QueryPlaneReadRequest (skiptoken present)
    Note over P: decode TOKEN -> cursor keys
    Note over P: keyset_after_predicate -> $filter suffix
    Note over P: base_filter = user_filter AND keyset_predicate
    P->>R: "page_options (filter=combined, skip=None)"
    R->>B: scan with combined filter
    B-->>R: next page entities
    R-->>P: QueryPlaneReadResult
    P-->>H: next page + next_skiptoken or None
    H-->>C: "value + @odata.nextLink or final page"
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/temper-server/src/odata/query_plane_read/mod.rs`, line 181-201 ([link](https://github.com/nerdsane/temper/blob/5496fffa56ea543e8fa1ae7ade938a3a3ce582d4/crates/temper-server/src/odata/query_plane_read/mod.rs#L181-L201)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`$count` value is wrong on continuation pages**

   The `base_filter` sent to `read_entity_set_page` on page 2+ combines the user's `$filter` with the keyset predicate (`AND(user_filter, keyset_predicate)`). When `count: query_options.count` is included unchanged, the inner read computes the count of entities matching the **combined** filter — that is, items remaining after the cursor — rather than the total entities matching only the user's original `$filter`.

   A client requesting `?$count=true&$filter=Status eq 'Published'` on page 1 sees `@odata.count: 214`; after following `@odata.nextLink`, the same annotation on page 2 would show ~114 (items after the cursor). OData v4 §11.2.7.5.2 states the count must reflect all items matching the request's filter before server-driven paging is applied — it must be stable across pages.

   The fix is to strip `count` from `page_options` when resuming from a cursor (the count is already correct on page 1 and is wrong on subsequent pages), and either omit the annotation on continuation pages or compute it with a separate non-keyset-filtered query.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: crates/temper-server/src/odata/query_plane_read/mod.rs
   Line: 181-201

   Comment:
   **`$count` value is wrong on continuation pages**

   The `base_filter` sent to `read_entity_set_page` on page 2+ combines the user's `$filter` with the keyset predicate (`AND(user_filter, keyset_predicate)`). When `count: query_options.count` is included unchanged, the inner read computes the count of entities matching the **combined** filter — that is, items remaining after the cursor — rather than the total entities matching only the user's original `$filter`.

   A client requesting `?$count=true&$filter=Status eq 'Published'` on page 1 sees `@odata.count: 214`; after following `@odata.nextLink`, the same annotation on page 2 would show ~114 (items after the cursor). OData v4 §11.2.7.5.2 states the count must reflect all items matching the request's filter before server-driven paging is applied — it must be stable across pages.

   The fix is to strip `count` from `page_options` when resuming from a cursor (the count is already correct on page 1 and is wrong on subsequent pages), and either omit the annotation on continuation pages or compute it with a separate non-keyset-filtered query.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-server%2Fsrc%2Fodata%2Fquery_plane_read%2Fmod.rs%0ALine%3A%20181-201%0A%0AComment%3A%0A**%60%24count%60%20value%20is%20wrong%20on%20continuation%20pages**%0A%0AThe%20%60base_filter%60%20sent%20to%20%60read_entity_set_page%60%20on%20page%202%2B%20combines%20the%20user's%20%60%24filter%60%20with%20the%20keyset%20predicate%20%28%60AND%28user_filter%2C%20keyset_predicate%29%60%29.%20When%20%60count%3A%20query_options.count%60%20is%20included%20unchanged%2C%20the%20inner%20read%20computes%20the%20count%20of%20entities%20matching%20the%20**combined**%20filter%20%E2%80%94%20that%20is%2C%20items%20remaining%20after%20the%20cursor%20%E2%80%94%20rather%20than%20the%20total%20entities%20matching%20only%20the%20user's%20original%20%60%24filter%60.%0A%0AA%20client%20requesting%20%60%3F%24count%3Dtrue%26%24filter%3DStatus%20eq%20'Published'%60%20on%20page%201%20sees%20%60%40odata.count%3A%20214%60%3B%20after%20following%20%60%40odata.nextLink%60%2C%20the%20same%20annotation%20on%20page%202%20would%20show%20~114%20%28items%20after%20the%20cursor%29.%20OData%20v4%20%C2%A711.2.7.5.2%20states%20the%20count%20must%20reflect%20all%20items%20matching%20the%20request's%20filter%20before%20server-driven%20paging%20is%20applied%20%E2%80%94%20it%20must%20be%20stable%20across%20pages.%0A%0AThe%20fix%20is%20to%20strip%20%60count%60%20from%20%60page_options%60%20when%20resuming%20from%20a%20cursor%20%28the%20count%20is%20already%20correct%20on%20page%201%20and%20is%20wrong%20on%20subsequent%20pages%29%2C%20and%20either%20omit%20the%20annotation%20on%20continuation%20pages%20or%20compute%20it%20with%20a%20separate%20non-keyset-filtered%20query.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=nerdsane%2Ftemper&pr=337&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22claude%2Fodata-read-truth%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fodata-read-truth%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-server%2Fsrc%2Fodata%2Fquery_plane_read%2Fmod.rs%0ALine%3A%20181-201%0A%0AComment%3A%0A**%60%24count%60%20value%20is%20wrong%20on%20continuation%20pages**%0A%0AThe%20%60base_filter%60%20sent%20to%20%60read_entity_set_page%60%20on%20page%202%2B%20combines%20the%20user's%20%60%24filter%60%20with%20the%20keyset%20predicate%20%28%60AND%28user_filter%2C%20keyset_predicate%29%60%29.%20When%20%60count%3A%20query_options.count%60%20is%20included%20unchanged%2C%20the%20inner%20read%20computes%20the%20count%20of%20entities%20matching%20the%20**combined**%20filter%20%E2%80%94%20that%20is%2C%20items%20remaining%20after%20the%20cursor%20%E2%80%94%20rather%20than%20the%20total%20entities%20matching%20only%20the%20user's%20original%20%60%24filter%60.%0A%0AA%20client%20requesting%20%60%3F%24count%3Dtrue%26%24filter%3DStatus%20eq%20'Published'%60%20on%20page%201%20sees%20%60%40odata.count%3A%20214%60%3B%20after%20following%20%60%40odata.nextLink%60%2C%20the%20same%20annotation%20on%20page%202%20would%20show%20~114%20%28items%20after%20the%20cursor%29.%20OData%20v4%20%C2%A711.2.7.5.2%20states%20the%20count%20must%20reflect%20all%20items%20matching%20the%20request's%20filter%20before%20server-driven%20paging%20is%20applied%20%E2%80%94%20it%20must%20be%20stable%20across%20pages.%0A%0AThe%20fix%20is%20to%20strip%20%60count%60%20from%20%60page_options%60%20when%20resuming%20from%20a%20cursor%20%28the%20count%20is%20already%20correct%20on%20page%201%20and%20is%20wrong%20on%20subsequent%20pages%29%2C%20and%20either%20omit%20the%20annotation%20on%20continuation%20pages%20or%20compute%20it%20with%20a%20separate%20non-keyset-filtered%20query.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=nerdsane%2Ftemper&pr=337&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-server%2Fsrc%2Fodata%2Fquery_plane_read%2Fmod.rs%0ALine%3A%20181-201%0A%0AComment%3A%0A**%60%24count%60%20value%20is%20wrong%20on%20continuation%20pages**%0A%0AThe%20%60base_filter%60%20sent%20to%20%60read_entity_set_page%60%20on%20page%202%2B%20combines%20the%20user's%20%60%24filter%60%20with%20the%20keyset%20predicate%20%28%60AND%28user_filter%2C%20keyset_predicate%29%60%29.%20When%20%60count%3A%20query_options.count%60%20is%20included%20unchanged%2C%20the%20inner%20read%20computes%20the%20count%20of%20entities%20matching%20the%20**combined**%20filter%20%E2%80%94%20that%20is%2C%20items%20remaining%20after%20the%20cursor%20%E2%80%94%20rather%20than%20the%20total%20entities%20matching%20only%20the%20user's%20original%20%60%24filter%60.%0A%0AA%20client%20requesting%20%60%3F%24count%3Dtrue%26%24filter%3DStatus%20eq%20'Published'%60%20on%20page%201%20sees%20%60%40odata.count%3A%20214%60%3B%20after%20following%20%60%40odata.nextLink%60%2C%20the%20same%20annotation%20on%20page%202%20would%20show%20~114%20%28items%20after%20the%20cursor%29.%20OData%20v4%20%C2%A711.2.7.5.2%20states%20the%20count%20must%20reflect%20all%20items%20matching%20the%20request's%20filter%20before%20server-driven%20paging%20is%20applied%20%E2%80%94%20it%20must%20be%20stable%20across%20pages.%0A%0AThe%20fix%20is%20to%20strip%20%60count%60%20from%20%60page_options%60%20when%20resuming%20from%20a%20cursor%20%28the%20count%20is%20already%20correct%20on%20page%201%20and%20is%20wrong%20on%20subsequent%20pages%29%2C%20and%20either%20omit%20the%20annotation%20on%20continuation%20pages%20or%20compute%20it%20with%20a%20separate%20non-keyset-filtered%20query.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=337&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["refactor(odata): move the paging wrapper..."](https://github.com/nerdsane/temper/commit/19afd8c521c433ca5b66b2e545ffd978f400fd21) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42183560)</sub>

<!-- /greptile_comment -->