### PR TITLE
fix(query-plane): bound empty equality lists on large types via field-coverage gap reconcile (ARN-68)

### DIFF
--- a/crates/temper-server/src/odata/query_plane_read/mod.rs
+++ b/crates/temper-server/src/odata/query_plane_read/mod.rs
@@ -110,7 +110,9 @@ fn should_reconcile_empty_exact_match_against_authoritative(
     // correctness; it never serializes the write hot path. The gate is tight —
     // only pushdown-able equality conjunctions pay it; ranges/Or/Ne/contains/
     // functions return `None` from `equality_field_predicates` and are
-    // unaffected.
+    // unaffected. When the type is too large for that scan, the budget gate
+    // bounds the reconcile to the field-index coverage gap (ARN-68) —
+    // see `read_entity_set_from_query_plane`.
     request
         .query_options
         .filter
@@ -166,7 +168,9 @@ pub(in crate::odata) async fn read_entity_set_from_query_plane(
     // Set when an empty native page for an exact-match resolution is treated as
     // a possibly-lagging projection and we fall through to the authoritative
     // path below (ARN-89). It suppresses the native retry on that path and
-    // selects the `ProjectionLagReconcile` telemetry reason.
+    // selects the `ProjectionLagReconcile` telemetry reason. If the type then
+    // turns out to be too large for the reconcile scan, the budget gate bounds
+    // the reconcile to the field-index coverage gap instead of rejecting (ARN-68).
     let mut reconciling_exact_match_lag = false;
     if let Some(plan) = native_plan.clone()
         && should_try_native_before_catalog_coverage(&request, &plan)
@@ -260,6 +264,124 @@ pub(in crate::odata) async fn read_entity_set_from_query_plane(
     if needs_full_proof
         && !should_check_source_cursor_catalog_coverage(all_entity_ids.len(), request.budget)
     {
+        // ARN-68 (the SessionEntries-list flavor): the reconcile scan is over budget,
+        // which used to be an unconditional 413 — so EVERY empty equality-conjunction
+        // list on a high-cardinality type failed (e.g. a session bootstrap listing
+        // `SessionId eq '<new>'` against 95k entries). The full scan is only needed for
+        // entities the native page cannot see: the ones with NO `entity_field_index`
+        // row for a filtered field (a just-committed entity whose async projection has
+        // not landed, a crash-lost projection, or a pre-projection-era entity). That
+        // gap is enumerable per field and normally tiny, so reconcile the GAP instead
+        // of the type: union a RE-RUN native page (probe-then-page ordering makes the
+        // union complete — anything covered at probe time is visible to the later
+        // page, anything uncovered is in the gap, so a projection landing between the
+        // first page and the probe is not dropped) with the materialized gap, in one
+        // source-cursor pass. A committed-but-unprojected match is FOUND
+        // (read-after-write repaired, not rejected); a genuine miss returns bounded
+        // empty. If the union exceeds the scan budget, or the backend has no
+        // field-index coverage probe, keep the honest rejection. Entities whose field
+        // row exists with a STALE value stay invisible — the same trust every
+        // non-empty native page already gets at any type size (the small-type ARN-89
+        // reconcile is stronger; this gate trades that for boundedness).
+        // Reconcile-affordable types never reach this gate, so their ARN-89 repair
+        // semantics are unchanged.
+        if reconciling_exact_match_lag
+            && let Some(pairs) = request
+                .query_options
+                .filter
+                .as_ref()
+                .and_then(super::filter_sql::equality_field_predicates)
+            && let Some(query_plane) = request.state.query_plane_store()
+        {
+            let field_names: std::collections::BTreeSet<String> =
+                pairs.into_iter().map(|(name, _)| name).collect();
+            let mut gap_ids: Option<std::collections::BTreeSet<String>> =
+                Some(std::collections::BTreeSet::new());
+            for field_name in field_names {
+                let covered = query_plane
+                    .query_field_index(
+                        request.tenant.as_str(),
+                        request.entity_type,
+                        "entity_id IN (SELECT entity_id FROM entity_field_index \
+                         WHERE tenant = ?1 AND entity_type = ?2 AND field_name = ?3)",
+                        vec![field_name],
+                    )
+                    .await;
+                match covered {
+                    Ok(Some(covered_ids)) => {
+                        let covered: std::collections::BTreeSet<&String> =
+                            covered_ids.iter().collect();
+                        if let Some(gap) = gap_ids.as_mut() {
+                            gap.extend(
+                                all_entity_ids
+                                    .iter()
+                                    .filter(|id| !covered.contains(id))
+                                    .cloned(),
+                            );
+                        }
+                    }
+                    // Unsupported backend or probe failure: never trust the empty
+                    // page without coverage proof — fall through to the rejection.
+                    Ok(None) | Err(_) => {
+                        gap_ids = None;
+                        break;
+                    }
+                }
+            }
+            // Re-run the page with `$select` stripped (the union needs `entity_id`,
+            // which selection would drop) and `$skip` folded into `$top` (the union
+            // must carry the FULL covered prefix; the final cursor pass applies the
+            // real `$skip`/`$top`/`$select` exactly once).
+            let rescue_options = temper_odata::query::types::QueryOptions {
+                select: None,
+                skip: None,
+                top: Some(
+                    request.query_options.skip.unwrap_or(0)
+                        + request.budget.requested_top(request.query_options),
+                ),
+                ..request.query_options.clone()
+            };
+            let rescue_request = QueryPlaneReadRequest {
+                query_options: &rescue_options,
+                ..request
+            };
+            if let Some(gap_ids) = gap_ids
+                && let Some(plan) = native_plan.clone()
+                && let Some(page) =
+                    try_native_page_read(&rescue_request, plan, QueryPlaneCoverageReport::default())
+                        .await
+            {
+                let page = page?;
+                let gap_len = gap_ids.len();
+                let missing_ids: Vec<String> = gap_ids.iter().cloned().collect();
+                let mut candidate_ids = gap_ids;
+                for entity in &page.entities {
+                    if let Some(id) = entity.get("entity_id").and_then(|v| v.as_str()) {
+                        candidate_ids.insert(id.to_string());
+                    }
+                }
+                if candidate_ids.len() <= request.budget.scan_candidate_budget() {
+                    let ids: Vec<String> = candidate_ids.into_iter().collect();
+                    let coverage = QueryPlaneCoverageReport {
+                        missing: gap_len,
+                        matched: 0,
+                    };
+                    let result = read_from_source_cursor(
+                        &request,
+                        &ids,
+                        coverage,
+                        &missing_ids,
+                        QueryPlaneFallbackReason::ProjectionLagReconcile,
+                    )
+                    .await?;
+                    return Ok(QueryPlaneReadResult {
+                        entities: result.entities,
+                        count: result.count,
+                        telemetry: result.telemetry,
+                    });
+                }
+            }
+        }
         return Err(budget_rejection(
             &request,
             QueryPlaneReadStrategy::ReadSourceCursor,

--- a/crates/temper-server/src/odata/query_plane_read/tests/keyed_existence.rs
+++ b/crates/temper-server/src/odata/query_plane_read/tests/keyed_existence.rs
@@ -413,7 +413,13 @@ fn directory_root_souls_scenario_on_postgres() {
             filter: Some(dir_root_filter("wsA")),
             ..QueryOptions::default()
         };
-        // (1) Pre-watermark: a NEW workspace's root lookup misses → scans 15 > budget → 413.
+        // (1) Pre-watermark: a NEW workspace's root lookup misses. Historically this
+        // scanned 15 > budget → 413 (the original prod failure). The ARN-68 empty-list
+        // gap reconcile now bounds it: roots have NO ParentId field-index row, so they
+        // form the (small) coverage gap, get materialized, and `ParentId eq null`
+        // matches none for wsB → a bounded EMPTY answer instead of the 413. Were the
+        // gap larger than the budget (prod's 1688 duplicate roots), the 413 would
+        // remain — the keyed path below stays the authoritative fix for roots.
         match read_entity_set_from_query_plane(QueryPlaneReadRequest {
             state: &state,
             tenant: &tenant,
@@ -425,9 +431,11 @@ fn directory_root_souls_scenario_on_postgres() {
         })
         .await
         {
-            Err(QueryPlaneReadError::QueryTooLarge { .. }) => {}
-            Ok(_) => panic!("expected 413 for a missing root before watermark, got Ok"),
-            Err(_) => panic!("expected QueryTooLarge before watermark, got another error"),
+            Ok(result) => assert!(
+                result.entities.is_empty(),
+                "wsB has no root; the bounded gap reconcile must return empty"
+            ),
+            Err(_) => panic!("the gap reconcile must bound the pre-watermark root miss"),
         }
 
         // (2) Backfill on real Postgres → Directory watermarked (duplicate roots are

--- a/crates/temper-server/src/odata/query_plane_read/tests/proof.rs
+++ b/crates/temper-server/src/odata/query_plane_read/tests/proof.rs
@@ -1061,3 +1061,265 @@ async fn unsafe_order_uses_read_source_full_proof() {
 
     let _ = std::fs::remove_file(db_path);
 }
+
+/// ARN-68 (the SessionEntries-list flavor) shared harness: `count` journal-durable
+/// Orders (dispatched, so they enumerate from the journal) that are ALSO projected with
+/// `SessionId: "session-hot"` — the prod shape of a type whose cardinality exceeds the
+/// scan budget. Returns the state wired to the shared store.
+async fn build_large_projected_type(
+    store: &TursoEventStore,
+    tenant: &TenantId,
+    system_name: &str,
+    count: usize,
+) -> ServerState {
+    let mut state = build_order_state(system_name);
+    state.set_storage_stack(StorageStack::from_turso(store.clone()));
+    let agent_ctx = AgentContext::for_service(system_name);
+    for index in 0..count {
+        let entity_id = format!("entry-{index:04}");
+        state
+            .dispatch_tenant_action(
+                tenant,
+                "Order",
+                &entity_id,
+                "Create",
+                serde_json::json!({}),
+                &agent_ctx,
+            )
+            .await
+            .expect("create order");
+        // Deterministic projected fields (high sequence wins over the async queue).
+        upsert_order_projection(
+            store,
+            tenant,
+            &entity_id,
+            serde_json::json!({ "SessionId": "session-hot" }),
+            1_000 + index as u64,
+        )
+        .await;
+    }
+    state
+}
+
+fn session_filter_options(session: &str) -> QueryOptions {
+    QueryOptions {
+        filter: Some(FilterExpr::BinaryOp {
+            left: Box::new(FilterExpr::Property("SessionId".to_string())),
+            op: BinaryOperator::Eq,
+            right: Box::new(FilterExpr::Literal(ODataValue::String(session.to_string()))),
+        }),
+        top: Some(200),
+        ..QueryOptions::default()
+    }
+}
+
+/// ARN-68: an EMPTY bounded native page for an equality-conjunction list on a type
+/// LARGER than the scan budget is served bounded when the projection has no gaps —
+/// no full-type scan, no 413. This is the prod session-bootstrap shape:
+/// `SessionEntries?$filter=SessionId eq '<new>'` against 95k fully-projected entries.
+/// Before the fix this was an unconditional budget rejection.
+#[tokio::test]
+async fn empty_equality_list_on_large_type_is_authoritative_absent_without_scan() {
+    let db_path = std::env::temp_dir().join(format!("temper-arn68-empty-list-{}.db", sim_uuid()));
+    let _ = std::fs::remove_file(&db_path);
+    let db_url = format!("file:{}", db_path.display());
+    let store = TursoEventStore::new(&db_url, None)
+        .await
+        .expect("create local turso db");
+    let tenant = TenantId::default();
+    // 15 journal-durable + projected entities; scan budget is 10.
+    let state = build_large_projected_type(&store, &tenant, "arn68-empty-list", 15).await;
+
+    let security_ctx = SecurityContext::system();
+    let query_options = session_filter_options("session-brand-new");
+    let result = match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+        state: &state,
+        tenant: &tenant,
+        security_ctx: &security_ctx,
+        entity_type: "Order",
+        entity_set_name: "Orders",
+        query_options: &query_options,
+        budget: QueryPlaneReadBudget {
+            default_page_size: 1,
+            max_entities: 1,
+        },
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => panic!("empty equality list on a fully-projected large type must not 413"),
+    };
+    assert!(result.entities.is_empty());
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+/// ARN-68 + ARN-89 at scale: a journal-durable entity whose projected row is MISSING
+/// (never projected here; a crash-lost projection in prod) must be FOUND by an equality list
+/// even when the type exceeds the scan budget — the gap reconcile materializes only the
+/// unprojected entities. A filter matching neither the projected majority nor the gap
+/// stays a bounded empty answer. Before the fix both were budget rejections.
+#[tokio::test]
+async fn equality_list_on_large_type_repairs_unprojected_match_boundedly() {
+    let db_path = std::env::temp_dir().join(format!("temper-arn68-gap-list-{}.db", sim_uuid()));
+    let _ = std::fs::remove_file(&db_path);
+    let db_url = format!("file:{}", db_path.display());
+    let store = TursoEventStore::new(&db_url, None)
+        .await
+        .expect("create local turso db");
+    let tenant = TenantId::default();
+    let state = build_large_projected_type(&store, &tenant, "arn68-gap-list", 15).await;
+
+    // The lagging entity: journal-durable via DIRECT append — its projection was never
+    // enqueued (the crash-lost shape, deterministic: no async worker to race). The
+    // snapshot carries the queried SessionId for materialization.
+    use temper_runtime::persistence::{EventMetadata, EventStore as _, PersistenceEnvelope};
+    use temper_runtime::scheduler::{sim_now, sim_uuid as runtime_sim_uuid};
+    store
+        .append(
+            &format!("{tenant}:Order:entry-lagging"),
+            0,
+            &[PersistenceEnvelope {
+                sequence_nr: 1,
+                event_type: "Create".to_string(),
+                payload: serde_json::json!({
+                    "action": "Create",
+                    "params": { "SessionId": "session-brand-new" },
+                }),
+                metadata: EventMetadata {
+                    event_id: runtime_sim_uuid(),
+                    causation_id: runtime_sim_uuid(),
+                    correlation_id: runtime_sim_uuid(),
+                    timestamp: sim_now(),
+                    actor_id: "arn68-gap-list".to_string(),
+                },
+            }],
+        )
+        .await
+        .expect("append lagging order");
+    let snapshot = serde_json::json!({
+        "entity_type": "Order",
+        "entity_id": "entry-lagging",
+        "status": "Draft",
+        "item_count": 0,
+        "fields": { "Id": "entry-lagging", "Status": "Draft", "SessionId": "session-brand-new" },
+    });
+    store
+        .save_snapshot(
+            &format!("{tenant}:Order:entry-lagging"),
+            1,
+            &serde_json::to_vec(&snapshot).unwrap(),
+        )
+        .await
+        .expect("seed snapshot");
+
+    let security_ctx = SecurityContext::system();
+    let budget = QueryPlaneReadBudget {
+        default_page_size: 1,
+        max_entities: 1,
+    };
+
+    // The unprojected match is repaired and returned — not a 413, not a wrong empty.
+    let query_options = session_filter_options("session-brand-new");
+    let result = match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+        state: &state,
+        tenant: &tenant,
+        security_ctx: &security_ctx,
+        entity_type: "Order",
+        entity_set_name: "Orders",
+        query_options: &query_options,
+        budget,
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => panic!("gap reconcile must repair the unprojected match, not reject"),
+    };
+    assert_eq!(result.entities.len(), 1, "the unprojected entity is found");
+    assert_eq!(
+        result.telemetry.fallback_reason,
+        QueryPlaneFallbackReason::ProjectionLagReconcile
+    );
+
+    // A session matching nothing (projected or gap) stays a bounded empty answer.
+    let query_options = session_filter_options("session-nowhere");
+    let result = match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+        state: &state,
+        tenant: &tenant,
+        security_ctx: &security_ctx,
+        entity_type: "Order",
+        entity_set_name: "Orders",
+        query_options: &query_options,
+        budget,
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => panic!("a genuine miss with a bounded gap must not 413"),
+    };
+    assert!(result.entities.is_empty());
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+/// ARN-68 rescue with `$skip`/`$select`: the covered prefix must not be double-skipped
+/// (page re-runs with skip folded into top; the cursor applies `$skip` once) and
+/// `$select` must not strip the union's `entity_id` key.
+#[tokio::test]
+async fn equality_list_rescue_honors_skip_and_select() {
+    let db_path = std::env::temp_dir().join(format!("temper-arn68-skip-list-{}.db", sim_uuid()));
+    let _ = std::fs::remove_file(&db_path);
+    let db_url = format!("file:{}", db_path.display());
+    let store = TursoEventStore::new(&db_url, None)
+        .await
+        .expect("create local turso db");
+    let tenant = TenantId::default();
+    let state = build_large_projected_type(&store, &tenant, "arn68-skip-list", 15).await;
+
+    // Two PROJECTED matches for the queried session (visible only to the page)...
+    for (id, seq) in [("paged-c1", 5001u64), ("paged-c2", 5002)] {
+        upsert_order_projection(
+            &store,
+            &tenant,
+            id,
+            serde_json::json!({ "SessionId": "session-paged" }),
+            seq,
+        )
+        .await;
+    }
+    // ...and they must also be journal-durable so enumeration sees the type as-is.
+    // (The 15 harness entities already push the type over budget.)
+
+    let security_ctx = SecurityContext::system();
+    let budget = QueryPlaneReadBudget {
+        default_page_size: 1,
+        max_entities: 1,
+    };
+    let mut query_options = session_filter_options("session-paged");
+    query_options.top = Some(2);
+    query_options.skip = Some(1);
+    query_options.select = Some(vec!["Id".to_string()]);
+
+    let result = match read_entity_set_from_query_plane(QueryPlaneReadRequest {
+        state: &state,
+        tenant: &tenant,
+        security_ctx: &security_ctx,
+        entity_type: "Order",
+        entity_set_name: "Orders",
+        query_options: &query_options,
+        budget,
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => panic!("rescue must serve the skip/select page, not reject"),
+    };
+    // 2 matches, skip 1 → exactly 1 row survives; double-skip would return 0.
+    assert_eq!(
+        result.entities.len(),
+        1,
+        "skip must apply exactly once across the union"
+    );
+
+    let _ = std::fs::remove_file(db_path);
+}


### PR DESCRIPTION
## What & why

The last ARN-68 flavor: `SessionEntries?$filter=SessionId eq '<id>'&$top&$skip` 413s on the 95k-row default tenant — an EMPTY native page triggers the ARN-89 reconcile, which needs a full-type scan → over budget → unconditional rejection. Every source_search session bootstrap fails (repro: CurationQuery `en-019f2e67`, Session `ss-019f2e67-6b58…`).

## Fix

The full scan is only needed for entities the native page cannot see: those with **no `entity_field_index` row for a filtered field**. At the over-budget gate:
1. probe per-field coverage (`query_field_index`, static subquery — no backend changes),
2. gap = authoritative ids − covered (normally ~0),
3. union a **re-run** native page (`$select` stripped so `entity_id` survives; `$skip` folded into `$top` so the covered prefix is complete) with the materialized gap in ONE source-cursor pass — the real `$skip/$top/$select` applied exactly once,
4. gap over budget or probe unsupported → the honest 413 stays.

Committed-but-unprojected matches are FOUND (read-after-write repaired); genuine misses return bounded empty; small types never reach the gate (ARN-89 semantics + its 2 tests unchanged); stale-valued rows keep the same trust as any non-empty native page (documented inline).

## Review trail (honest)

DST review PASS (deterministic: BTreeSet throughout, static SQL, both backends' `?N` contracts verified). Code review round 1 FAIL → fixed: union race (re-run page + union), probe soundness (field-coverage not catalog). Round 2 FAIL → fixed with the reviewer's prescribed directions verbatim: `$skip` double-apply and `$select` key-loss (the `rescue_options` clone), plus their suggested regression test. No third formal pass — gate + this CI arbitrate; flagging for transparency.

## Tests

`empty_equality_list_on_large_type_is_authoritative_absent_without_scan` (was 413), `equality_list_on_large_type_repairs_unprojected_match_boundedly` (journal-durable unprojected match found; was 413), `equality_list_rescue_honors_skip_and_select` (skip applies exactly once), souls-scenario pre-watermark step updated (bounded empty; prod-scale gaps still 413). 551 lib + 3 postgres-gated green; full workspace suite via the pre-push gate.

Follow-ups → ARN-149: bounded anti-join for the probe (perf), rescue telemetry counters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)