### PR TITLE
fix(odata): bound $filter recursion + stop tokenizer $-loop (ARN-176)

### DIFF
--- a/crates/temper-odata/src/query/filter.rs
+++ b/crates/temper-odata/src/query/filter.rs
@@ -172,7 +172,10 @@ fn push_token(
 /// request thread's stack overflows and the process aborts — a denial-of-service
 /// reachable from the public OData query surface. A well-formed query never
 /// nests anywhere near this deep.
-const FILTER_DEPTH_BUDGET: usize = 128;
+// Keep ample headroom below the request worker's stack: filter canaries
+// exercise the accepted boundary on 512 KiB, rather than merely fitting a
+// default 2 MiB worker before the surrounding request frames are considered.
+const FILTER_DEPTH_BUDGET: usize = 32;
 
 struct FilterParser<'a> {
     tokens: &'a [Token],
@@ -251,38 +254,28 @@ impl<'a> FilterParser<'a> {
 
     // or_expr = and_expr ( 'or' and_expr )*
     fn parse_or(&mut self) -> Result<FilterExpr, ODataError> {
-        let mut left = self.parse_and()?;
+        let mut operands = vec![self.parse_and()?];
         while self.peek_text_is("or") {
             let operator_offset = self.current_offset();
             self.budget.consume_operator(operator_offset)?;
             self.budget.consume_node(operator_offset)?;
             self.advance();
-            let right = self.parse_and()?;
-            left = FilterExpr::BinaryOp {
-                left: Box::new(left),
-                op: BinaryOperator::Or,
-                right: Box::new(right),
-            };
+            operands.push(self.parse_and()?);
         }
-        Ok(left)
+        Ok(balance_associative(operands, BinaryOperator::Or))
     }
 
     // and_expr = not_expr ( 'and' not_expr )*
     fn parse_and(&mut self) -> Result<FilterExpr, ODataError> {
-        let mut left = self.parse_not()?;
+        let mut operands = vec![self.parse_not()?];
         while self.peek_text_is("and") {
             let operator_offset = self.current_offset();
             self.budget.consume_operator(operator_offset)?;
             self.budget.consume_node(operator_offset)?;
             self.advance();
-            let right = self.parse_not()?;
-            left = FilterExpr::BinaryOp {
-                left: Box::new(left),
-                op: BinaryOperator::And,
-                right: Box::new(right),
-            };
+            operands.push(self.parse_not()?);
         }
-        Ok(left)
+        Ok(balance_associative(operands, BinaryOperator::And))
     }
 
     // not_expr = 'not' not_expr | comparison
@@ -461,6 +454,40 @@ impl<'a> FilterParser<'a> {
             _ => None,
         })
     }
+}
+
+/// Build an order-preserving balanced tree for an associative boolean operator.
+///
+/// A left fold makes an accepted wide filter's AST as deep as its width. Every
+/// downstream consumer then inherits that attacker-controlled recursion depth,
+/// including in-memory evaluation, SQL translation, and `Drop`. Pairing adjacent
+/// operands keeps the same left-to-right order and boolean meaning while bounding
+/// tree depth logarithmically.
+fn balance_associative(mut operands: Vec<FilterExpr>, op: BinaryOperator) -> FilterExpr {
+    assert!(
+        !operands.is_empty(),
+        "boolean chain must contain an operand"
+    );
+
+    while operands.len() > 1 {
+        let mut next_level = Vec::with_capacity(operands.len().div_ceil(2));
+        let mut iter = operands.into_iter();
+        while let Some(left) = iter.next() {
+            if let Some(right) = iter.next() {
+                next_level.push(FilterExpr::BinaryOp {
+                    left: Box::new(left),
+                    op,
+                    right: Box::new(right),
+                });
+            } else {
+                next_level.push(left);
+            }
+        }
+        operands = next_level;
+    }
+
+    debug_assert_eq!(operands.len(), 1, "balancing must produce one root");
+    operands.remove(0)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/temper-odata/src/query/filter.rs
+++ b/crates/temper-odata/src/query/filter.rs
@@ -51,6 +51,7 @@ fn tokenize_filter(input: &str) -> Result<Vec<Token>, ODataError> {
         if chars[i] == '\'' {
             i += 1;
             let mut s = String::new();
+            let mut closed = false;
             while i < chars.len() {
                 if chars[i] == '\'' {
                     // Check for escaped quote ''
@@ -59,12 +60,21 @@ fn tokenize_filter(input: &str) -> Result<Vec<Token>, ODataError> {
                         i += 2;
                     } else {
                         i += 1;
+                        closed = true;
                         break;
                     }
                 } else {
                     s.push(chars[i]);
                     i += 1;
                 }
+            }
+            // An unterminated literal (no closing quote) must be rejected rather
+            // than silently accepted as if it were closed.
+            if !closed {
+                return Err(ODataError::InvalidFilter {
+                    message: "unterminated string literal".into(),
+                    position: offset,
+                });
             }
             tokens.push(Token {
                 text: format!("'{s}'"),
@@ -100,8 +110,14 @@ fn tokenize_filter(input: &str) -> Result<Vec<Token>, ODataError> {
             continue;
         }
 
-        // Identifiers and keywords (including dotted names like 'guid', property paths)
-        if chars[i].is_ascii_alphabetic() || chars[i] == '_' || chars[i] == '$' {
+        // Identifiers and keywords (dotted names like 'guid', property paths).
+        //
+        // '$' is deliberately NOT an identifier-start character. It is not valid
+        // in a property path, and accepting it here while the loop below does not
+        // consume it previously spun forever without advancing `i` — a
+        // denial-of-service on any `$filter` value containing a bare '$'. A stray
+        // '$' now falls through to the "unexpected character" error below (400).
+        if chars[i].is_ascii_alphabetic() || chars[i] == '_' {
             let mut word = String::new();
             while i < chars.len()
                 && (chars[i].is_ascii_alphanumeric()
@@ -110,13 +126,13 @@ fn tokenize_filter(input: &str) -> Result<Vec<Token>, ODataError> {
                     || chars[i] == '/'
                     || chars[i] == '-')
             {
-                // Stop at '.' if it looks like it's followed by whitespace or end
-                // (to not consume e.g. "Name eq" as "Name.eq"). Actually, dots
-                // are used in property paths like Address/City and in GUIDs.
-                // Let's keep consuming alphanumeric, underscore, dot, slash, and hyphen.
                 word.push(chars[i]);
                 i += 1;
             }
+            // Invariant: the identifier-start set (alphabetic | '_') is a subset
+            // of the continue set above, so the loop always consumes at least one
+            // character. This guarantees the tokenizer makes forward progress.
+            debug_assert!(i > offset, "tokenizer failed to advance on identifier");
             tokens.push(Token { text: word, offset });
             continue;
         }
@@ -132,14 +148,54 @@ fn tokenize_filter(input: &str) -> Result<Vec<Token>, ODataError> {
 
 // -- Recursive descent parser ------------------------------------------------
 
+/// Maximum nesting depth for a `$filter` expression.
+///
+/// The recursive-descent parser descends one level per parenthesized
+/// sub-expression, `not` operand, and function-call argument. Without a bound, a
+/// crafted filter such as `((((…))))` or `not not not …` would recurse until the
+/// request thread's stack overflows and the process aborts — a denial-of-service
+/// reachable from the public OData query surface. A well-formed query never
+/// nests anywhere near this deep.
+const MAX_FILTER_DEPTH: usize = 128;
+
 struct FilterParser<'a> {
     tokens: &'a [Token],
     pos: usize,
+    /// Current recursion depth, bounded by [`MAX_FILTER_DEPTH`].
+    depth: usize,
 }
 
 impl<'a> FilterParser<'a> {
     fn new(tokens: &'a [Token]) -> Self {
-        Self { tokens, pos: 0 }
+        Self {
+            tokens,
+            pos: 0,
+            depth: 0,
+        }
+    }
+
+    /// Enter one nesting level, rejecting filters that nest past
+    /// [`MAX_FILTER_DEPTH`] before the recursion can overflow the stack.
+    ///
+    /// Every recursive descent (parentheses, `not`, function arguments) must be
+    /// wrapped in a matching [`descend`](Self::descend)/[`ascend`](Self::ascend)
+    /// pair so that width (many siblings) does not count as depth.
+    fn descend(&mut self) -> Result<(), ODataError> {
+        self.depth += 1;
+        if self.depth > MAX_FILTER_DEPTH {
+            return Err(ODataError::InvalidFilter {
+                message: format!(
+                    "filter expression nesting exceeds maximum depth of {MAX_FILTER_DEPTH}"
+                ),
+                position: self.current_offset(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Leave a nesting level previously entered via [`descend`](Self::descend).
+    fn ascend(&mut self) {
+        self.depth = self.depth.saturating_sub(1);
     }
 
     fn peek(&self) -> Option<&Token> {
@@ -208,7 +264,10 @@ impl<'a> FilterParser<'a> {
     fn parse_not(&mut self) -> Result<FilterExpr, ODataError> {
         if self.peek_text_is("not") {
             self.advance();
-            let operand = self.parse_not()?;
+            self.descend()?;
+            let operand = self.parse_not();
+            self.ascend();
+            let operand = operand?;
             return Ok(FilterExpr::UnaryOp {
                 op: UnaryOperator::Not,
                 operand: Box::new(operand),
@@ -250,7 +309,10 @@ impl<'a> FilterParser<'a> {
         // Parenthesized sub-expression
         if text == "(" {
             self.advance();
-            let expr = self.parse_or()?;
+            self.descend()?;
+            let expr = self.parse_or();
+            self.ascend();
+            let expr = expr?;
             self.expect_text(")")?;
             return Ok(expr);
         }
@@ -326,7 +388,10 @@ impl<'a> FilterParser<'a> {
         }
 
         loop {
-            args.push(self.parse_or()?);
+            self.descend()?;
+            let arg = self.parse_or();
+            self.ascend();
+            args.push(arg?);
             if self.peek_text_is(",") {
                 self.advance();
             } else {
@@ -533,6 +598,165 @@ mod tests {
                 op: BinaryOperator::Gt,
                 right: Box::new(FilterExpr::Literal(ODataValue::Int(-10))),
             }
+        );
+    }
+
+    // -- Security regression tests (ARN-176) ---------------------------------
+    //
+    // Two denial-of-service bugs on the public OData `$filter` surface. Each
+    // test documents the pre-fix behavior; all now return an `InvalidFilter`
+    // error (surfaced as HTTP 400) quickly instead of hanging or crashing the
+    // request thread.
+
+    #[test]
+    fn filter_dollar_sign_returns_error_not_hang() {
+        // Pre-fix: the tokenizer accepted '$' as an identifier-start character,
+        // but the identifier loop never consumed it, so `i` never advanced — an
+        // infinite loop that also grew the token vec without bound, hanging (and
+        // eventually OOM-ing) the request thread. The watchdog below turns that
+        // hang into a test failure instead of blocking the suite forever. On a
+        // regression the spawned thread is intentionally left detached (it never
+        // returns); the harness process exits and reaps it after the failure.
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        let (tx, rx) = mpsc::channel();
+        // A stray '$' outside a string literal is the trigger. Inside quotes it
+        // is fine (handled by the string-literal branch).
+        std::thread::spawn(move || {
+            let _ = tx.send(parse_filter("Name eq $foo").is_err());
+        });
+
+        match rx.recv_timeout(Duration::from_secs(5)) {
+            Ok(is_err) => assert!(
+                is_err,
+                "'$' in a filter value must return InvalidFilter, not succeed"
+            ),
+            Err(_) => {
+                panic!("parse_filter hung on '$' — tokenizer infinite loop is not fixed")
+            }
+        }
+    }
+
+    #[test]
+    fn filter_bare_dollar_sign_is_rejected() {
+        // A lone '$' is an unexpected character, not an identifier.
+        assert!(parse_filter("$").is_err());
+    }
+
+    #[test]
+    fn filter_deeply_nested_parens_returns_error_not_overflow() {
+        // Pre-fix: unbounded recursion (parse_primary -> parse_or per '(')
+        // overflowed the request thread's stack and aborted the process. Now
+        // bounded: returns InvalidFilter once nesting passes MAX_FILTER_DEPTH.
+        let depth = 100_000;
+        let mut input = String::with_capacity(depth * 2 + 16);
+        for _ in 0..depth {
+            input.push('(');
+        }
+        input.push_str("Name eq 'x'");
+        for _ in 0..depth {
+            input.push(')');
+        }
+        assert!(
+            parse_filter(&input).is_err(),
+            "deeply nested parens must return InvalidFilter, not overflow the stack"
+        );
+    }
+
+    #[test]
+    fn filter_deeply_nested_not_returns_error_not_overflow() {
+        // Pre-fix: `not not not …` recursed parse_not without bound and
+        // overflowed the stack. Now bounded past MAX_FILTER_DEPTH.
+        let mut input = String::new();
+        for _ in 0..100_000 {
+            input.push_str("not ");
+        }
+        input.push_str("Active eq true");
+        assert!(
+            parse_filter(&input).is_err(),
+            "deeply nested 'not' must return InvalidFilter, not overflow the stack"
+        );
+    }
+
+    #[test]
+    fn filter_deeply_nested_functions_returns_error_not_overflow() {
+        // Pre-fix: `f(f(f(…)))` recursed parse_argument_list -> parse_or without
+        // bound and overflowed the stack. Now bounded past MAX_FILTER_DEPTH.
+        let depth = 100_000;
+        let mut input = String::with_capacity(depth * 2 + 8);
+        for _ in 0..depth {
+            input.push_str("f(");
+        }
+        input.push('1');
+        for _ in 0..depth {
+            input.push(')');
+        }
+        assert!(
+            parse_filter(&input).is_err(),
+            "deeply nested function calls must return InvalidFilter, not overflow"
+        );
+    }
+
+    #[test]
+    fn filter_moderately_nested_parens_still_parse() {
+        // Nesting well within MAX_FILTER_DEPTH must still parse — the depth
+        // bound must not reject legitimate queries.
+        let depth = MAX_FILTER_DEPTH / 2;
+        let mut input = String::new();
+        for _ in 0..depth {
+            input.push('(');
+        }
+        input.push_str("Name eq 'x'");
+        for _ in 0..depth {
+            input.push(')');
+        }
+        assert!(
+            parse_filter(&input).is_ok(),
+            "nesting within the depth bound must still parse"
+        );
+
+        // A wide, shallow filter (many OR-ed comparisons) must not trip the
+        // depth bound — width is not depth.
+        let wide = (0..500)
+            .map(|n| format!("Id eq {n}"))
+            .collect::<Vec<_>>()
+            .join(" or ");
+        assert!(
+            parse_filter(&wide).is_ok(),
+            "wide filters must not be rejected"
+        );
+    }
+
+    #[test]
+    fn filter_unterminated_string_returns_error() {
+        // Pre-fix: an unterminated literal was silently accepted as if closed.
+        assert!(parse_filter("Name eq 'foo").is_err());
+    }
+
+    #[test]
+    fn filter_depth_bound_is_inclusive_at_the_limit() {
+        // Exercise the exact boundary so an off-by-one (e.g. flipping `>` to
+        // `>=`) is caught: MAX_FILTER_DEPTH levels of nesting must parse, and one
+        // level deeper must be rejected.
+        let nest = |levels: usize| {
+            let mut s = String::with_capacity(levels * 2 + 16);
+            for _ in 0..levels {
+                s.push('(');
+            }
+            s.push_str("Name eq 'x'");
+            for _ in 0..levels {
+                s.push(')');
+            }
+            s
+        };
+        assert!(
+            parse_filter(&nest(MAX_FILTER_DEPTH)).is_ok(),
+            "exactly MAX_FILTER_DEPTH levels must be accepted"
+        );
+        assert!(
+            parse_filter(&nest(MAX_FILTER_DEPTH + 1)).is_err(),
+            "one level past MAX_FILTER_DEPTH must be rejected"
         );
     }
 }

--- a/crates/temper-odata/src/query/filter.rs
+++ b/crates/temper-odata/src/query/filter.rs
@@ -5,10 +5,20 @@
 use super::types::{BinaryOperator, FilterExpr, ODataValue, UnaryOperator};
 use crate::error::ODataError;
 
+mod budget;
+
+use budget::FilterBudget;
+#[cfg(test)]
+use budget::{
+    FILTER_ARGUMENT_BUDGET, FILTER_INPUT_BYTE_BUDGET, FILTER_LITERAL_BYTE_BUDGET,
+    FILTER_NODE_BUDGET, FILTER_OPERATOR_BUDGET, FILTER_TOKEN_BUDGET,
+};
+
 /// Parse a `$filter` expression string into a [`FilterExpr`] AST.
 pub fn parse_filter(input: &str) -> Result<FilterExpr, ODataError> {
-    let tokens = tokenize_filter(input)?;
-    let mut parser = FilterParser::new(&tokens);
+    let mut budget = FilterBudget::new(input)?;
+    let tokens = tokenize_filter(input, &mut budget)?;
+    let mut parser = FilterParser::new(&tokens, budget);
     let expr = parser.parse_or()?;
 
     // Make sure we consumed everything
@@ -33,7 +43,7 @@ struct Token {
     offset: usize,
 }
 
-fn tokenize_filter(input: &str) -> Result<Vec<Token>, ODataError> {
+fn tokenize_filter(input: &str, budget: &mut FilterBudget) -> Result<Vec<Token>, ODataError> {
     let mut tokens = Vec::new();
     let chars: Vec<char> = input.chars().collect();
     let mut i = 0;
@@ -76,19 +86,14 @@ fn tokenize_filter(input: &str) -> Result<Vec<Token>, ODataError> {
                     position: offset,
                 });
             }
-            tokens.push(Token {
-                text: format!("'{s}'"),
-                offset,
-            });
+            budget.consume_literal_bytes(s.len(), offset)?;
+            push_token(&mut tokens, budget, format!("'{s}'"), offset)?;
             continue;
         }
 
         // Parentheses and comma
         if chars[i] == '(' || chars[i] == ')' || chars[i] == ',' {
-            tokens.push(Token {
-                text: chars[i].to_string(),
-                offset,
-            });
+            push_token(&mut tokens, budget, chars[i].to_string(), offset)?;
             i += 1;
             continue;
         }
@@ -106,7 +111,7 @@ fn tokenize_filter(input: &str) -> Result<Vec<Token>, ODataError> {
                 num.push(chars[i]);
                 i += 1;
             }
-            tokens.push(Token { text: num, offset });
+            push_token(&mut tokens, budget, num, offset)?;
             continue;
         }
 
@@ -133,7 +138,7 @@ fn tokenize_filter(input: &str) -> Result<Vec<Token>, ODataError> {
             // of the continue set above, so the loop always consumes at least one
             // character. This guarantees the tokenizer makes forward progress.
             debug_assert!(i > offset, "tokenizer failed to advance on identifier");
-            tokens.push(Token { text: word, offset });
+            push_token(&mut tokens, budget, word, offset)?;
             continue;
         }
 
@@ -146,9 +151,20 @@ fn tokenize_filter(input: &str) -> Result<Vec<Token>, ODataError> {
     Ok(tokens)
 }
 
+fn push_token(
+    tokens: &mut Vec<Token>,
+    budget: &mut FilterBudget,
+    text: String,
+    offset: usize,
+) -> Result<(), ODataError> {
+    budget.consume_token(offset)?;
+    tokens.push(Token { text, offset });
+    Ok(())
+}
+
 // -- Recursive descent parser ------------------------------------------------
 
-/// Maximum nesting depth for a `$filter` expression.
+/// Nesting-depth budget for a `$filter` expression.
 ///
 /// The recursive-descent parser descends one level per parenthesized
 /// sub-expression, `not` operand, and function-call argument. Without a bound, a
@@ -156,46 +172,49 @@ fn tokenize_filter(input: &str) -> Result<Vec<Token>, ODataError> {
 /// request thread's stack overflows and the process aborts — a denial-of-service
 /// reachable from the public OData query surface. A well-formed query never
 /// nests anywhere near this deep.
-const MAX_FILTER_DEPTH: usize = 128;
+const FILTER_DEPTH_BUDGET: usize = 128;
 
 struct FilterParser<'a> {
     tokens: &'a [Token],
     pos: usize,
-    /// Current recursion depth, bounded by [`MAX_FILTER_DEPTH`].
+    /// Current recursion depth, bounded by [`FILTER_DEPTH_BUDGET`].
     depth: usize,
+    budget: FilterBudget,
 }
 
 impl<'a> FilterParser<'a> {
-    fn new(tokens: &'a [Token]) -> Self {
+    fn new(tokens: &'a [Token], budget: FilterBudget) -> Self {
         Self {
             tokens,
             pos: 0,
             depth: 0,
+            budget,
         }
     }
 
     /// Enter one nesting level, rejecting filters that nest past
-    /// [`MAX_FILTER_DEPTH`] before the recursion can overflow the stack.
+    /// [`FILTER_DEPTH_BUDGET`] before the recursion can overflow the stack.
     ///
     /// Every recursive descent (parentheses, `not`, function arguments) must be
     /// wrapped in a matching [`descend`](Self::descend)/[`ascend`](Self::ascend)
     /// pair so that width (many siblings) does not count as depth.
     fn descend(&mut self) -> Result<(), ODataError> {
-        self.depth += 1;
-        if self.depth > MAX_FILTER_DEPTH {
+        if self.depth == FILTER_DEPTH_BUDGET {
             return Err(ODataError::InvalidFilter {
                 message: format!(
-                    "filter expression nesting exceeds maximum depth of {MAX_FILTER_DEPTH}"
+                    "filter expression nesting exceeds depth budget of {FILTER_DEPTH_BUDGET}"
                 ),
                 position: self.current_offset(),
             });
         }
+        self.depth += 1;
         Ok(())
     }
 
     /// Leave a nesting level previously entered via [`descend`](Self::descend).
     fn ascend(&mut self) {
-        self.depth = self.depth.saturating_sub(1);
+        assert!(self.depth > 0, "filter parser depth underflow");
+        self.depth -= 1;
     }
 
     fn peek(&self) -> Option<&Token> {
@@ -234,6 +253,9 @@ impl<'a> FilterParser<'a> {
     fn parse_or(&mut self) -> Result<FilterExpr, ODataError> {
         let mut left = self.parse_and()?;
         while self.peek_text_is("or") {
+            let operator_offset = self.current_offset();
+            self.budget.consume_operator(operator_offset)?;
+            self.budget.consume_node(operator_offset)?;
             self.advance();
             let right = self.parse_and()?;
             left = FilterExpr::BinaryOp {
@@ -249,6 +271,9 @@ impl<'a> FilterParser<'a> {
     fn parse_and(&mut self) -> Result<FilterExpr, ODataError> {
         let mut left = self.parse_not()?;
         while self.peek_text_is("and") {
+            let operator_offset = self.current_offset();
+            self.budget.consume_operator(operator_offset)?;
+            self.budget.consume_node(operator_offset)?;
             self.advance();
             let right = self.parse_not()?;
             left = FilterExpr::BinaryOp {
@@ -263,6 +288,9 @@ impl<'a> FilterParser<'a> {
     // not_expr = 'not' not_expr | comparison
     fn parse_not(&mut self) -> Result<FilterExpr, ODataError> {
         if self.peek_text_is("not") {
+            let operator_offset = self.current_offset();
+            self.budget.consume_operator(operator_offset)?;
+            self.budget.consume_node(operator_offset)?;
             self.advance();
             self.descend()?;
             let operand = self.parse_not();
@@ -280,6 +308,9 @@ impl<'a> FilterParser<'a> {
     fn parse_comparison(&mut self) -> Result<FilterExpr, ODataError> {
         let left = self.parse_primary()?;
         if let Some(op) = self.peek_comparison_op() {
+            let operator_offset = self.current_offset();
+            self.budget.consume_operator(operator_offset)?;
+            self.budget.consume_node(operator_offset)?;
             self.advance();
             let right = self.parse_primary()?;
             Ok(FilterExpr::BinaryOp {
@@ -319,13 +350,15 @@ impl<'a> FilterParser<'a> {
 
         // String literal
         if text.starts_with('\'') && text.ends_with('\'') && text.len() >= 2 {
-            let s = text[1..text.len() - 1].to_string();
+            self.budget.consume_node(offset)?;
             self.advance();
+            let s = text[1..text.len() - 1].to_string();
             return Ok(FilterExpr::Literal(ODataValue::String(s)));
         }
 
         // Numeric literal
         if text.starts_with(|c: char| c.is_ascii_digit() || c == '-') {
+            self.budget.consume_node(offset)?;
             self.advance();
             if text.contains('.') {
                 let val: f64 = text.parse().map_err(|_| ODataError::InvalidFilter {
@@ -344,14 +377,17 @@ impl<'a> FilterParser<'a> {
 
         // Keywords: null, true, false
         if text == "null" {
+            self.budget.consume_node(offset)?;
             self.advance();
             return Ok(FilterExpr::Literal(ODataValue::Null));
         }
         if text == "true" {
+            self.budget.consume_node(offset)?;
             self.advance();
             return Ok(FilterExpr::Literal(ODataValue::Boolean(true)));
         }
         if text == "false" {
+            self.budget.consume_node(offset)?;
             self.advance();
             return Ok(FilterExpr::Literal(ODataValue::Boolean(false)));
         }
@@ -363,6 +399,7 @@ impl<'a> FilterParser<'a> {
 
             // Check for function call: name followed by '('
             if self.peek_text_is("(") {
+                self.budget.consume_node(offset)?;
                 self.advance(); // consume '('
                 let args = self.parse_argument_list()?;
                 self.expect_text(")")?;
@@ -370,6 +407,7 @@ impl<'a> FilterParser<'a> {
             }
 
             // Otherwise it's a property reference
+            self.budget.consume_node(offset)?;
             return Ok(FilterExpr::Property(name));
         }
 
@@ -388,6 +426,7 @@ impl<'a> FilterParser<'a> {
         }
 
         loop {
+            self.budget.consume_argument(self.current_offset())?;
             self.descend()?;
             let arg = self.parse_or();
             self.ascend();
@@ -429,334 +468,9 @@ impl<'a> FilterParser<'a> {
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
-mod tests {
-    use super::*;
+#[path = "filter/basic_tests.rs"]
+mod basic_tests;
 
-    #[test]
-    fn filter_simple_eq_string() {
-        let expr = parse_filter("Name eq 'foo'").unwrap();
-        assert_eq!(
-            expr,
-            FilterExpr::BinaryOp {
-                left: Box::new(FilterExpr::Property("Name".into())),
-                op: BinaryOperator::Eq,
-                right: Box::new(FilterExpr::Literal(ODataValue::String("foo".into()))),
-            }
-        );
-    }
-
-    #[test]
-    fn filter_simple_gt_float() {
-        let expr = parse_filter("Price gt 5.0").unwrap();
-        assert_eq!(
-            expr,
-            FilterExpr::BinaryOp {
-                left: Box::new(FilterExpr::Property("Price".into())),
-                op: BinaryOperator::Gt,
-                right: Box::new(FilterExpr::Literal(ODataValue::Float(5.0))),
-            }
-        );
-    }
-
-    #[test]
-    fn filter_and_or_precedence() {
-        // `A eq 1 and B eq 2 or C eq 3` should parse as `(A eq 1 and B eq 2) or (C eq 3)`
-        let expr = parse_filter("A eq 1 and B eq 2 or C eq 3").unwrap();
-        match &expr {
-            FilterExpr::BinaryOp {
-                op: BinaryOperator::Or,
-                left,
-                right,
-            } => {
-                // Left should be the 'and' node
-                match left.as_ref() {
-                    FilterExpr::BinaryOp {
-                        op: BinaryOperator::And,
-                        ..
-                    } => {}
-                    other => panic!("expected And on left, got {other:?}"),
-                }
-                // Right should be a comparison
-                match right.as_ref() {
-                    FilterExpr::BinaryOp {
-                        op: BinaryOperator::Eq,
-                        ..
-                    } => {}
-                    other => panic!("expected Eq on right, got {other:?}"),
-                }
-            }
-            other => panic!("expected Or at top, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn filter_compound_and() {
-        let expr = parse_filter("Name eq 'foo' and Price gt 5.0").unwrap();
-        assert_eq!(
-            expr,
-            FilterExpr::BinaryOp {
-                left: Box::new(FilterExpr::BinaryOp {
-                    left: Box::new(FilterExpr::Property("Name".into())),
-                    op: BinaryOperator::Eq,
-                    right: Box::new(FilterExpr::Literal(ODataValue::String("foo".into()))),
-                }),
-                op: BinaryOperator::And,
-                right: Box::new(FilterExpr::BinaryOp {
-                    left: Box::new(FilterExpr::Property("Price".into())),
-                    op: BinaryOperator::Gt,
-                    right: Box::new(FilterExpr::Literal(ODataValue::Float(5.0))),
-                }),
-            }
-        );
-    }
-
-    #[test]
-    fn filter_not_operator() {
-        let expr = parse_filter("not Active eq true").unwrap();
-        match &expr {
-            FilterExpr::UnaryOp {
-                op: UnaryOperator::Not,
-                operand,
-            } => match operand.as_ref() {
-                FilterExpr::BinaryOp {
-                    op: BinaryOperator::Eq,
-                    ..
-                } => {}
-                other => panic!("expected Eq inside not, got {other:?}"),
-            },
-            other => panic!("expected Not at top, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn filter_parenthesized_expression() {
-        let expr = parse_filter("(A eq 1 or B eq 2) and C eq 3").unwrap();
-        match &expr {
-            FilterExpr::BinaryOp {
-                op: BinaryOperator::And,
-                left,
-                ..
-            } => match left.as_ref() {
-                FilterExpr::BinaryOp {
-                    op: BinaryOperator::Or,
-                    ..
-                } => {}
-                other => panic!("expected Or in parens, got {other:?}"),
-            },
-            other => panic!("expected And at top, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn filter_function_call() {
-        let expr = parse_filter("contains(Name, 'foo')").unwrap();
-        assert_eq!(
-            expr,
-            FilterExpr::FunctionCall {
-                name: "contains".into(),
-                args: vec![
-                    FilterExpr::Property("Name".into()),
-                    FilterExpr::Literal(ODataValue::String("foo".into())),
-                ],
-            }
-        );
-    }
-
-    #[test]
-    fn filter_null_literal() {
-        let expr = parse_filter("Name eq null").unwrap();
-        assert_eq!(
-            expr,
-            FilterExpr::BinaryOp {
-                left: Box::new(FilterExpr::Property("Name".into())),
-                op: BinaryOperator::Eq,
-                right: Box::new(FilterExpr::Literal(ODataValue::Null)),
-            }
-        );
-    }
-
-    #[test]
-    fn filter_boolean_literal() {
-        let expr = parse_filter("Active eq true").unwrap();
-        assert_eq!(
-            expr,
-            FilterExpr::BinaryOp {
-                left: Box::new(FilterExpr::Property("Active".into())),
-                op: BinaryOperator::Eq,
-                right: Box::new(FilterExpr::Literal(ODataValue::Boolean(true))),
-            }
-        );
-    }
-
-    #[test]
-    fn filter_negative_number() {
-        let expr = parse_filter("Amount gt -10").unwrap();
-        assert_eq!(
-            expr,
-            FilterExpr::BinaryOp {
-                left: Box::new(FilterExpr::Property("Amount".into())),
-                op: BinaryOperator::Gt,
-                right: Box::new(FilterExpr::Literal(ODataValue::Int(-10))),
-            }
-        );
-    }
-
-    // -- Security regression tests (ARN-176) ---------------------------------
-    //
-    // Two denial-of-service bugs on the public OData `$filter` surface. Each
-    // test documents the pre-fix behavior; all now return an `InvalidFilter`
-    // error (surfaced as HTTP 400) quickly instead of hanging or crashing the
-    // request thread.
-
-    #[test]
-    fn filter_dollar_sign_returns_error_not_hang() {
-        // Pre-fix: the tokenizer accepted '$' as an identifier-start character,
-        // but the identifier loop never consumed it, so `i` never advanced — an
-        // infinite loop that also grew the token vec without bound, hanging (and
-        // eventually OOM-ing) the request thread. The watchdog below turns that
-        // hang into a test failure instead of blocking the suite forever. On a
-        // regression the spawned thread is intentionally left detached (it never
-        // returns); the harness process exits and reaps it after the failure.
-        use std::sync::mpsc;
-        use std::time::Duration;
-
-        let (tx, rx) = mpsc::channel();
-        // A stray '$' outside a string literal is the trigger. Inside quotes it
-        // is fine (handled by the string-literal branch).
-        std::thread::spawn(move || {
-            let _ = tx.send(parse_filter("Name eq $foo").is_err());
-        });
-
-        match rx.recv_timeout(Duration::from_secs(5)) {
-            Ok(is_err) => assert!(
-                is_err,
-                "'$' in a filter value must return InvalidFilter, not succeed"
-            ),
-            Err(_) => {
-                panic!("parse_filter hung on '$' — tokenizer infinite loop is not fixed")
-            }
-        }
-    }
-
-    #[test]
-    fn filter_bare_dollar_sign_is_rejected() {
-        // A lone '$' is an unexpected character, not an identifier.
-        assert!(parse_filter("$").is_err());
-    }
-
-    #[test]
-    fn filter_deeply_nested_parens_returns_error_not_overflow() {
-        // Pre-fix: unbounded recursion (parse_primary -> parse_or per '(')
-        // overflowed the request thread's stack and aborted the process. Now
-        // bounded: returns InvalidFilter once nesting passes MAX_FILTER_DEPTH.
-        let depth = 100_000;
-        let mut input = String::with_capacity(depth * 2 + 16);
-        for _ in 0..depth {
-            input.push('(');
-        }
-        input.push_str("Name eq 'x'");
-        for _ in 0..depth {
-            input.push(')');
-        }
-        assert!(
-            parse_filter(&input).is_err(),
-            "deeply nested parens must return InvalidFilter, not overflow the stack"
-        );
-    }
-
-    #[test]
-    fn filter_deeply_nested_not_returns_error_not_overflow() {
-        // Pre-fix: `not not not …` recursed parse_not without bound and
-        // overflowed the stack. Now bounded past MAX_FILTER_DEPTH.
-        let mut input = String::new();
-        for _ in 0..100_000 {
-            input.push_str("not ");
-        }
-        input.push_str("Active eq true");
-        assert!(
-            parse_filter(&input).is_err(),
-            "deeply nested 'not' must return InvalidFilter, not overflow the stack"
-        );
-    }
-
-    #[test]
-    fn filter_deeply_nested_functions_returns_error_not_overflow() {
-        // Pre-fix: `f(f(f(…)))` recursed parse_argument_list -> parse_or without
-        // bound and overflowed the stack. Now bounded past MAX_FILTER_DEPTH.
-        let depth = 100_000;
-        let mut input = String::with_capacity(depth * 2 + 8);
-        for _ in 0..depth {
-            input.push_str("f(");
-        }
-        input.push('1');
-        for _ in 0..depth {
-            input.push(')');
-        }
-        assert!(
-            parse_filter(&input).is_err(),
-            "deeply nested function calls must return InvalidFilter, not overflow"
-        );
-    }
-
-    #[test]
-    fn filter_moderately_nested_parens_still_parse() {
-        // Nesting well within MAX_FILTER_DEPTH must still parse — the depth
-        // bound must not reject legitimate queries.
-        let depth = MAX_FILTER_DEPTH / 2;
-        let mut input = String::new();
-        for _ in 0..depth {
-            input.push('(');
-        }
-        input.push_str("Name eq 'x'");
-        for _ in 0..depth {
-            input.push(')');
-        }
-        assert!(
-            parse_filter(&input).is_ok(),
-            "nesting within the depth bound must still parse"
-        );
-
-        // A wide, shallow filter (many OR-ed comparisons) must not trip the
-        // depth bound — width is not depth.
-        let wide = (0..500)
-            .map(|n| format!("Id eq {n}"))
-            .collect::<Vec<_>>()
-            .join(" or ");
-        assert!(
-            parse_filter(&wide).is_ok(),
-            "wide filters must not be rejected"
-        );
-    }
-
-    #[test]
-    fn filter_unterminated_string_returns_error() {
-        // Pre-fix: an unterminated literal was silently accepted as if closed.
-        assert!(parse_filter("Name eq 'foo").is_err());
-    }
-
-    #[test]
-    fn filter_depth_bound_is_inclusive_at_the_limit() {
-        // Exercise the exact boundary so an off-by-one (e.g. flipping `>` to
-        // `>=`) is caught: MAX_FILTER_DEPTH levels of nesting must parse, and one
-        // level deeper must be rejected.
-        let nest = |levels: usize| {
-            let mut s = String::with_capacity(levels * 2 + 16);
-            for _ in 0..levels {
-                s.push('(');
-            }
-            s.push_str("Name eq 'x'");
-            for _ in 0..levels {
-                s.push(')');
-            }
-            s
-        };
-        assert!(
-            parse_filter(&nest(MAX_FILTER_DEPTH)).is_ok(),
-            "exactly MAX_FILTER_DEPTH levels must be accepted"
-        );
-        assert!(
-            parse_filter(&nest(MAX_FILTER_DEPTH + 1)).is_err(),
-            "one level past MAX_FILTER_DEPTH must be rejected"
-        );
-    }
-}
+#[cfg(test)]
+#[path = "filter/security_tests.rs"]
+mod security_tests;

--- a/crates/temper-odata/src/query/filter/basic_tests.rs
+++ b/crates/temper-odata/src/query/filter/basic_tests.rs
@@ -1,0 +1,170 @@
+use super::*;
+
+#[test]
+fn filter_simple_eq_string() {
+    let expr = parse_filter("Name eq 'foo'").unwrap();
+    assert_eq!(
+        expr,
+        FilterExpr::BinaryOp {
+            left: Box::new(FilterExpr::Property("Name".into())),
+            op: BinaryOperator::Eq,
+            right: Box::new(FilterExpr::Literal(ODataValue::String("foo".into()))),
+        }
+    );
+}
+
+#[test]
+fn filter_simple_gt_float() {
+    let expr = parse_filter("Price gt 5.0").unwrap();
+    assert_eq!(
+        expr,
+        FilterExpr::BinaryOp {
+            left: Box::new(FilterExpr::Property("Price".into())),
+            op: BinaryOperator::Gt,
+            right: Box::new(FilterExpr::Literal(ODataValue::Float(5.0))),
+        }
+    );
+}
+
+#[test]
+fn filter_and_or_precedence() {
+    // `A eq 1 and B eq 2 or C eq 3` should parse as `(A eq 1 and B eq 2) or (C eq 3)`
+    let expr = parse_filter("A eq 1 and B eq 2 or C eq 3").unwrap();
+    match &expr {
+        FilterExpr::BinaryOp {
+            op: BinaryOperator::Or,
+            left,
+            right,
+        } => {
+            // Left should be the 'and' node
+            match left.as_ref() {
+                FilterExpr::BinaryOp {
+                    op: BinaryOperator::And,
+                    ..
+                } => {}
+                other => panic!("expected And on left, got {other:?}"),
+            }
+            // Right should be a comparison
+            match right.as_ref() {
+                FilterExpr::BinaryOp {
+                    op: BinaryOperator::Eq,
+                    ..
+                } => {}
+                other => panic!("expected Eq on right, got {other:?}"),
+            }
+        }
+        other => panic!("expected Or at top, got {other:?}"),
+    }
+}
+
+#[test]
+fn filter_compound_and() {
+    let expr = parse_filter("Name eq 'foo' and Price gt 5.0").unwrap();
+    assert_eq!(
+        expr,
+        FilterExpr::BinaryOp {
+            left: Box::new(FilterExpr::BinaryOp {
+                left: Box::new(FilterExpr::Property("Name".into())),
+                op: BinaryOperator::Eq,
+                right: Box::new(FilterExpr::Literal(ODataValue::String("foo".into()))),
+            }),
+            op: BinaryOperator::And,
+            right: Box::new(FilterExpr::BinaryOp {
+                left: Box::new(FilterExpr::Property("Price".into())),
+                op: BinaryOperator::Gt,
+                right: Box::new(FilterExpr::Literal(ODataValue::Float(5.0))),
+            }),
+        }
+    );
+}
+
+#[test]
+fn filter_not_operator() {
+    let expr = parse_filter("not Active eq true").unwrap();
+    match &expr {
+        FilterExpr::UnaryOp {
+            op: UnaryOperator::Not,
+            operand,
+        } => match operand.as_ref() {
+            FilterExpr::BinaryOp {
+                op: BinaryOperator::Eq,
+                ..
+            } => {}
+            other => panic!("expected Eq inside not, got {other:?}"),
+        },
+        other => panic!("expected Not at top, got {other:?}"),
+    }
+}
+
+#[test]
+fn filter_parenthesized_expression() {
+    let expr = parse_filter("(A eq 1 or B eq 2) and C eq 3").unwrap();
+    match &expr {
+        FilterExpr::BinaryOp {
+            op: BinaryOperator::And,
+            left,
+            ..
+        } => match left.as_ref() {
+            FilterExpr::BinaryOp {
+                op: BinaryOperator::Or,
+                ..
+            } => {}
+            other => panic!("expected Or in parens, got {other:?}"),
+        },
+        other => panic!("expected And at top, got {other:?}"),
+    }
+}
+
+#[test]
+fn filter_function_call() {
+    let expr = parse_filter("contains(Name, 'foo')").unwrap();
+    assert_eq!(
+        expr,
+        FilterExpr::FunctionCall {
+            name: "contains".into(),
+            args: vec![
+                FilterExpr::Property("Name".into()),
+                FilterExpr::Literal(ODataValue::String("foo".into())),
+            ],
+        }
+    );
+}
+
+#[test]
+fn filter_null_literal() {
+    let expr = parse_filter("Name eq null").unwrap();
+    assert_eq!(
+        expr,
+        FilterExpr::BinaryOp {
+            left: Box::new(FilterExpr::Property("Name".into())),
+            op: BinaryOperator::Eq,
+            right: Box::new(FilterExpr::Literal(ODataValue::Null)),
+        }
+    );
+}
+
+#[test]
+fn filter_boolean_literal() {
+    let expr = parse_filter("Active eq true").unwrap();
+    assert_eq!(
+        expr,
+        FilterExpr::BinaryOp {
+            left: Box::new(FilterExpr::Property("Active".into())),
+            op: BinaryOperator::Eq,
+            right: Box::new(FilterExpr::Literal(ODataValue::Boolean(true))),
+        }
+    );
+}
+
+#[test]
+fn filter_negative_number() {
+    let expr = parse_filter("Amount gt -10").unwrap();
+    assert_eq!(
+        expr,
+        FilterExpr::BinaryOp {
+            left: Box::new(FilterExpr::Property("Amount".into())),
+            op: BinaryOperator::Gt,
+            right: Box::new(FilterExpr::Literal(ODataValue::Int(-10))),
+        }
+    );
+}

--- a/crates/temper-odata/src/query/filter/budget.rs
+++ b/crates/temper-odata/src/query/filter/budget.rs
@@ -1,0 +1,116 @@
+use crate::error::ODataError;
+
+/// Resource budgets for one `$filter` expression.
+///
+/// These budgets bound every input-controlled dimension before the parser can
+/// build an AST large enough to exhaust memory or the request thread's stack.
+pub(super) const FILTER_INPUT_BYTE_BUDGET: usize = 64 * 1024;
+pub(super) const FILTER_TOKEN_BUDGET: usize = 4_096;
+pub(super) const FILTER_NODE_BUDGET: usize = 4_096;
+pub(super) const FILTER_OPERATOR_BUDGET: usize = 1_024;
+pub(super) const FILTER_ARGUMENT_BUDGET: usize = 256;
+pub(super) const FILTER_LITERAL_BYTE_BUDGET: usize = 16 * 1024;
+
+#[derive(Debug)]
+pub(super) struct FilterBudget {
+    tokens_remaining: usize,
+    nodes_remaining: usize,
+    operators_remaining: usize,
+    arguments_remaining: usize,
+    literal_bytes_remaining: usize,
+}
+
+impl FilterBudget {
+    pub(super) fn new(input: &str) -> Result<Self, ODataError> {
+        if input.len() > FILTER_INPUT_BYTE_BUDGET {
+            return Err(budget_exceeded(
+                "input byte",
+                FILTER_INPUT_BYTE_BUDGET,
+                FILTER_INPUT_BYTE_BUDGET,
+            ));
+        }
+
+        Ok(Self {
+            tokens_remaining: FILTER_TOKEN_BUDGET,
+            nodes_remaining: FILTER_NODE_BUDGET,
+            operators_remaining: FILTER_OPERATOR_BUDGET,
+            arguments_remaining: FILTER_ARGUMENT_BUDGET,
+            literal_bytes_remaining: FILTER_LITERAL_BYTE_BUDGET,
+        })
+    }
+
+    pub(super) fn consume_token(&mut self, position: usize) -> Result<(), ODataError> {
+        consume_budget(
+            &mut self.tokens_remaining,
+            1,
+            "token",
+            FILTER_TOKEN_BUDGET,
+            position,
+        )
+    }
+
+    pub(super) fn consume_node(&mut self, position: usize) -> Result<(), ODataError> {
+        consume_budget(
+            &mut self.nodes_remaining,
+            1,
+            "AST node",
+            FILTER_NODE_BUDGET,
+            position,
+        )
+    }
+
+    pub(super) fn consume_operator(&mut self, position: usize) -> Result<(), ODataError> {
+        consume_budget(
+            &mut self.operators_remaining,
+            1,
+            "operator",
+            FILTER_OPERATOR_BUDGET,
+            position,
+        )
+    }
+
+    pub(super) fn consume_argument(&mut self, position: usize) -> Result<(), ODataError> {
+        consume_budget(
+            &mut self.arguments_remaining,
+            1,
+            "function argument",
+            FILTER_ARGUMENT_BUDGET,
+            position,
+        )
+    }
+
+    pub(super) fn consume_literal_bytes(
+        &mut self,
+        amount: usize,
+        position: usize,
+    ) -> Result<(), ODataError> {
+        consume_budget(
+            &mut self.literal_bytes_remaining,
+            amount,
+            "string literal byte",
+            FILTER_LITERAL_BYTE_BUDGET,
+            position,
+        )
+    }
+}
+
+fn consume_budget(
+    remaining: &mut usize,
+    amount: usize,
+    resource: &str,
+    allowance: usize,
+    position: usize,
+) -> Result<(), ODataError> {
+    let Some(next) = remaining.checked_sub(amount) else {
+        return Err(budget_exceeded(resource, allowance, position));
+    };
+    *remaining = next;
+    Ok(())
+}
+
+fn budget_exceeded(resource: &str, allowance: usize, position: usize) -> ODataError {
+    ODataError::InvalidFilter {
+        message: format!("filter {resource} budget of {allowance} exceeded"),
+        position,
+    }
+}

--- a/crates/temper-odata/src/query/filter/security_tests.rs
+++ b/crates/temper-odata/src/query/filter/security_tests.rs
@@ -1,0 +1,260 @@
+use super::*;
+
+// -- Security regression tests (ARN-176) ---------------------------------
+//
+// Denial-of-service regressions on the public OData `$filter` surface. Each
+// hostile input now returns `InvalidFilter` (surfaced as HTTP 400) quickly
+// instead of hanging, exhausting memory, or crashing the request thread.
+
+#[test]
+fn filter_dollar_sign_returns_error_not_hang() {
+    // Pre-fix: the tokenizer accepted '$' as an identifier-start character,
+    // but the identifier loop never consumed it, so `i` never advanced — an
+    // infinite loop that also grew the token vec without bound, hanging (and
+    // eventually OOM-ing) the request thread. The watchdog below turns that
+    // hang into a test failure instead of blocking the suite forever. On a
+    // regression the spawned thread is intentionally left detached (it never
+    // returns); the harness process exits and reaps it after the failure.
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    let (tx, rx) = mpsc::channel();
+    // A stray '$' outside a string literal is the trigger. Inside quotes it
+    // is fine (handled by the string-literal branch).
+    std::thread::spawn(move || {
+        let _ = tx.send(parse_filter("Name eq $foo").is_err());
+    });
+
+    match rx.recv_timeout(Duration::from_secs(5)) {
+        Ok(is_err) => assert!(
+            is_err,
+            "'$' in a filter value must return InvalidFilter, not succeed"
+        ),
+        Err(_) => {
+            panic!("parse_filter hung on '$' — tokenizer infinite loop is not fixed")
+        }
+    }
+}
+
+#[test]
+fn filter_bare_dollar_sign_is_rejected() {
+    // A lone '$' is an unexpected character, not an identifier.
+    assert!(parse_filter("$").is_err());
+}
+
+#[test]
+fn filter_deeply_nested_parens_returns_error_not_overflow() {
+    // Pre-fix: unbounded recursion (parse_primary -> parse_or per '(')
+    // overflowed the request thread's stack and aborted the process. Now
+    // bounded: returns InvalidFilter once nesting passes FILTER_DEPTH_BUDGET.
+    let depth = 100_000;
+    let mut input = String::with_capacity(depth * 2 + 16);
+    for _ in 0..depth {
+        input.push('(');
+    }
+    input.push_str("Name eq 'x'");
+    for _ in 0..depth {
+        input.push(')');
+    }
+    assert!(
+        parse_filter(&input).is_err(),
+        "deeply nested parens must return InvalidFilter, not overflow the stack"
+    );
+}
+
+#[test]
+fn filter_deeply_nested_not_returns_error_not_overflow() {
+    // Pre-fix: `not not not …` recursed parse_not without bound and
+    // overflowed the stack. Now bounded past FILTER_DEPTH_BUDGET.
+    let mut input = String::new();
+    for _ in 0..100_000 {
+        input.push_str("not ");
+    }
+    input.push_str("Active eq true");
+    assert!(
+        parse_filter(&input).is_err(),
+        "deeply nested 'not' must return InvalidFilter, not overflow the stack"
+    );
+}
+
+#[test]
+fn filter_deeply_nested_functions_returns_error_not_overflow() {
+    // Pre-fix: `f(f(f(…)))` recursed parse_argument_list -> parse_or without
+    // bound and overflowed the stack. Now bounded past FILTER_DEPTH_BUDGET.
+    let depth = 100_000;
+    let mut input = String::with_capacity(depth * 2 + 8);
+    for _ in 0..depth {
+        input.push_str("f(");
+    }
+    input.push('1');
+    for _ in 0..depth {
+        input.push(')');
+    }
+    assert!(
+        parse_filter(&input).is_err(),
+        "deeply nested function calls must return InvalidFilter, not overflow"
+    );
+}
+
+#[test]
+fn filter_moderately_nested_parens_still_parse() {
+    // Nesting well within FILTER_DEPTH_BUDGET must still parse — the depth
+    // bound must not reject legitimate queries.
+    let depth = FILTER_DEPTH_BUDGET / 2;
+    let mut input = String::new();
+    for _ in 0..depth {
+        input.push('(');
+    }
+    input.push_str("Name eq 'x'");
+    for _ in 0..depth {
+        input.push(')');
+    }
+    assert!(
+        parse_filter(&input).is_ok(),
+        "nesting within the depth bound must still parse"
+    );
+
+    // A useful wide, shallow filter must fit the total parse budget; width
+    // is bounded independently from recursive depth.
+    let wide = (0..500)
+        .map(|n| format!("Id eq {n}"))
+        .collect::<Vec<_>>()
+        .join(" or ");
+    assert!(
+        parse_filter(&wide).is_ok(),
+        "moderately wide filters must remain supported"
+    );
+}
+
+#[test]
+fn filter_input_byte_budget_is_inclusive() {
+    let at_budget = "a".repeat(FILTER_INPUT_BYTE_BUDGET);
+    assert!(parse_filter(&at_budget).is_ok());
+
+    let over_budget = "a".repeat(FILTER_INPUT_BYTE_BUDGET + 1);
+    assert!(parse_filter(&over_budget).is_err());
+}
+
+#[test]
+fn filter_token_budget_is_inclusive() {
+    let at_budget = std::iter::repeat_n("a", FILTER_TOKEN_BUDGET)
+        .collect::<Vec<_>>()
+        .join(" ");
+    let mut budget = FilterBudget::new(&at_budget).unwrap();
+    assert_eq!(
+        tokenize_filter(&at_budget, &mut budget).unwrap().len(),
+        FILTER_TOKEN_BUDGET
+    );
+
+    let over_budget = format!("{at_budget} a");
+    let mut budget = FilterBudget::new(&over_budget).unwrap();
+    assert!(tokenize_filter(&over_budget, &mut budget).is_err());
+}
+
+#[test]
+fn filter_node_budget_is_inclusive() {
+    let mut budget = FilterBudget::new("").unwrap();
+    for _ in 0..FILTER_NODE_BUDGET {
+        assert!(budget.consume_node(0).is_ok());
+    }
+    assert!(budget.consume_node(0).is_err());
+}
+
+#[test]
+fn filter_literal_byte_budget_is_inclusive() {
+    let at_budget = format!("Name eq '{}'", "x".repeat(FILTER_LITERAL_BYTE_BUDGET));
+    assert!(parse_filter(&at_budget).is_ok());
+
+    let over_budget = format!("Name eq '{}'", "x".repeat(FILTER_LITERAL_BYTE_BUDGET + 1));
+    assert!(parse_filter(&over_budget).is_err());
+}
+
+#[test]
+fn filter_function_argument_budget_is_inclusive() {
+    let at_budget = format!(
+        "f({})",
+        std::iter::repeat_n("a", FILTER_ARGUMENT_BUDGET)
+            .collect::<Vec<_>>()
+            .join(",")
+    );
+    assert!(parse_filter(&at_budget).is_ok());
+
+    let over_budget = format!(
+        "f({})",
+        std::iter::repeat_n("a", FILTER_ARGUMENT_BUDGET + 1)
+            .collect::<Vec<_>>()
+            .join(",")
+    );
+    assert!(parse_filter(&over_budget).is_err());
+}
+
+#[test]
+fn filter_operator_budget_is_inclusive() {
+    assert_eq!(FILTER_OPERATOR_BUDGET % 2, 0);
+    let comparisons = (0..FILTER_OPERATOR_BUDGET / 2)
+        .map(|n| format!("Id eq {n}"))
+        .collect::<Vec<_>>()
+        .join(" or ");
+    assert!(parse_filter(&format!("not {comparisons}")).is_ok());
+    assert!(parse_filter(&format!("not not {comparisons}")).is_err());
+}
+
+#[test]
+fn filter_budgeted_wide_ast_drops_on_small_stack() {
+    let input = (0..FILTER_OPERATOR_BUDGET / 2)
+        .map(|n| format!("Id eq {n}"))
+        .collect::<Vec<_>>()
+        .join(" or ");
+
+    std::thread::Builder::new()
+        .name("filter-small-stack".into())
+        .stack_size(2 * 1024 * 1024)
+        .spawn(move || {
+            let expr = parse_filter(&input).expect("expression must fit the budget");
+            drop(expr);
+        })
+        .expect("spawn parser thread")
+        .join()
+        .expect("budgeted AST must parse and drop without stack overflow");
+}
+
+#[test]
+fn filter_wide_ast_over_budget_returns_error() {
+    let input = (0..40_000)
+        .map(|n| format!("Id eq {n}"))
+        .collect::<Vec<_>>()
+        .join(" or ");
+    assert!(parse_filter(&input).is_err());
+}
+
+#[test]
+fn filter_unterminated_string_returns_error() {
+    // Pre-fix: an unterminated literal was silently accepted as if closed.
+    assert!(parse_filter("Name eq 'foo").is_err());
+}
+
+#[test]
+fn filter_depth_bound_is_inclusive_at_the_limit() {
+    // Exercise the exact boundary so an off-by-one (e.g. flipping `>` to
+    // `>=`) is caught: FILTER_DEPTH_BUDGET levels of nesting must parse, and one
+    // level deeper must be rejected.
+    let nest = |levels: usize| {
+        let mut s = String::with_capacity(levels * 2 + 16);
+        for _ in 0..levels {
+            s.push('(');
+        }
+        s.push_str("Name eq 'x'");
+        for _ in 0..levels {
+            s.push(')');
+        }
+        s
+    };
+    assert!(
+        parse_filter(&nest(FILTER_DEPTH_BUDGET)).is_ok(),
+        "exactly FILTER_DEPTH_BUDGET levels must be accepted"
+    );
+    assert!(
+        parse_filter(&nest(FILTER_DEPTH_BUDGET + 1)).is_err(),
+        "one level past FILTER_DEPTH_BUDGET must be rejected"
+    );
+}

--- a/crates/temper-odata/src/query/filter/security_tests.rs
+++ b/crates/temper-odata/src/query/filter/security_tests.rs
@@ -1,5 +1,17 @@
 use super::*;
 
+const FILTER_TEST_STACK_BYTES: usize = 512 * 1024;
+
+fn assert_on_small_stack(name: &str, test: impl FnOnce() + Send + 'static) {
+    std::thread::Builder::new()
+        .name(name.into())
+        .stack_size(FILTER_TEST_STACK_BYTES)
+        .spawn(test)
+        .expect("spawn constrained-stack filter test")
+        .join()
+        .expect("filter boundary must fit the constrained request stack");
+}
+
 // -- Security regression tests (ARN-176) ---------------------------------
 //
 // Denial-of-service regressions on the public OData `$filter` surface. Each
@@ -200,22 +212,35 @@ fn filter_operator_budget_is_inclusive() {
 }
 
 #[test]
-fn filter_budgeted_wide_ast_drops_on_small_stack() {
+fn filter_budgeted_wide_ast_parses_and_drops_on_small_stack() {
     let input = (0..FILTER_OPERATOR_BUDGET / 2)
         .map(|n| format!("Id eq {n}"))
         .collect::<Vec<_>>()
         .join(" or ");
 
-    std::thread::Builder::new()
-        .name("filter-small-stack".into())
-        .stack_size(2 * 1024 * 1024)
-        .spawn(move || {
-            let expr = parse_filter(&input).expect("expression must fit the budget");
-            drop(expr);
-        })
-        .expect("spawn parser thread")
-        .join()
-        .expect("budgeted AST must parse and drop without stack overflow");
+    assert_on_small_stack("filter-wide-boundary", move || {
+        let expr = parse_filter(&input).expect("expression must fit the budget");
+        drop(expr);
+    });
+}
+
+#[test]
+fn filter_mixed_depth_and_width_fits_small_stack() {
+    let wide = (0..FILTER_OPERATOR_BUDGET / 2)
+        .map(|n| format!("Id eq {n}"))
+        .collect::<Vec<_>>()
+        .join(" or ");
+    let input = format!(
+        "{}{}{}",
+        "(".repeat(FILTER_DEPTH_BUDGET),
+        wide,
+        ")".repeat(FILTER_DEPTH_BUDGET)
+    );
+
+    assert_on_small_stack("filter-mixed-budget-boundary", move || {
+        let expr = parse_filter(&input).expect("mixed boundary expression must parse");
+        drop(expr);
+    });
 }
 
 #[test]
@@ -249,12 +274,14 @@ fn filter_depth_bound_is_inclusive_at_the_limit() {
         }
         s
     };
-    assert!(
-        parse_filter(&nest(FILTER_DEPTH_BUDGET)).is_ok(),
-        "exactly FILTER_DEPTH_BUDGET levels must be accepted"
-    );
-    assert!(
-        parse_filter(&nest(FILTER_DEPTH_BUDGET + 1)).is_err(),
-        "one level past FILTER_DEPTH_BUDGET must be rejected"
-    );
+    assert_on_small_stack("filter-depth-boundary", move || {
+        assert!(
+            parse_filter(&nest(FILTER_DEPTH_BUDGET)).is_ok(),
+            "exactly FILTER_DEPTH_BUDGET levels must be accepted"
+        );
+        assert!(
+            parse_filter(&nest(FILTER_DEPTH_BUDGET + 1)).is_err(),
+            "one level past FILTER_DEPTH_BUDGET must be rejected"
+        );
+    });
 }

--- a/crates/temper-server/tests/odata_read.rs
+++ b/crates/temper-server/tests/odata_read.rs
@@ -38,6 +38,21 @@ async fn get_json(
     (status, body)
 }
 
+#[tokio::test]
+async fn over_budget_filter_is_rejected_through_tdata_router() {
+    let (state, _) = build_default_state(176, "odata-filter-budget");
+    let filter = (0..513)
+        .map(|n| format!("Id eq {n}"))
+        .collect::<Vec<_>>()
+        .join(" or ")
+        .replace(' ', "%20");
+
+    let (status, body) = get_json(&state, &format!("/tdata/Orders?$filter={filter}")).await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body["error"]["code"].as_str(), Some("InvalidQuery"));
+}
+
 async fn post_json(
     state: &ServerState,
     path: &str,

--- a/crates/temper-server/tests/odata_read.rs
+++ b/crates/temper-server/tests/odata_read.rs
@@ -38,19 +38,34 @@ async fn get_json(
     (status, body)
 }
 
-#[tokio::test]
-async fn over_budget_filter_is_rejected_through_tdata_router() {
-    let (state, _) = build_default_state(176, "odata-filter-budget");
-    let filter = (0..513)
+fn encoded_wide_filter(comparisons: usize) -> String {
+    (0..comparisons)
         .map(|n| format!("Id eq {n}"))
         .collect::<Vec<_>>()
         .join(" or ")
-        .replace(' ', "%20");
+        .replace(' ', "%20")
+}
+
+#[tokio::test]
+async fn over_budget_filter_is_rejected_through_tdata_router() {
+    let (state, _) = build_default_state(176, "odata-filter-budget");
+    let filter = encoded_wide_filter(513);
 
     let (status, body) = get_json(&state, &format!("/tdata/Orders?$filter={filter}")).await;
 
     assert_eq!(status, StatusCode::BAD_REQUEST);
     assert_eq!(body["error"]["code"].as_str(), Some("InvalidQuery"));
+}
+
+#[tokio::test]
+async fn budget_boundary_filter_is_accepted_through_tdata_router() {
+    let (state, _) = build_default_state(176, "odata-filter-budget-boundary");
+    let filter = encoded_wide_filter(512);
+
+    let (status, body) = get_json(&state, &format!("/tdata/Orders?$filter={filter}")).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["value"].as_array().map(Vec::len), Some(0));
 }
 
 async fn post_json(


### PR DESCRIPTION
## Summary

Fixes **ARN-176** — two denial-of-service bugs reachable from the public OData `$filter` query surface, both confirmed with running repros. All changes are in a single file, `crates/temper-odata/src/query/filter.rs`.

### Bug 1 — tokenizer infinite loop on `$`
`$` was accepted as an identifier-*start* character, but the identifier continue-loop never included `$`, so the tokenizer never advanced past it — an infinite loop that also grew the token vector without bound. Any `$filter` value containing a bare `$` (e.g. `Name eq $foo`) hung the request thread.

**Fix:** `$` is no longer an identifier-start character. The start set (`alphabetic | '_'`) is now a strict subset of the continue set, so the identifier branch always consumes at least one character (documented with a `debug_assert!`). A stray `$` now falls through to `InvalidFilter` (HTTP 400).

### Bug 2 — unbounded parser recursion
Deeply nested parentheses (`((((…))))`), `not` chains (`not not not …`), or nested function-call arguments (`f(f(f(…)))`) recursed without limit and overflowed the request thread's stack, aborting the process (SIGABRT).

**Fix:** `FilterParser` now tracks recursion depth, bounded by `MAX_FILTER_DEPTH = 128`, via `descend()`/`ascend()` wrapped around each of the three recursion sites (parenthesized primary, `not` operand, function argument list). The pairing counts nesting depth but not width, so legitimate wide-but-shallow filters are unaffected. Over-deep filters return `InvalidFilter`, not a crash. The bound is inclusive (128 levels accepted, 129 rejected) and generously under any stack limit.

### Also fixed (LOW, same issue)
Unterminated string literal (e.g. `Name eq 'foo`) was silently accepted as if closed; it now returns `InvalidFilter`.

## Red-green evidence (exploit-first)

Tests were written first and confirmed to hang/crash on the pre-fix code, then pass after the fix:

| Exploit | Pre-fix behavior (observed) | Post-fix |
| --- | --- | --- |
| `Name eq $foo` | 5.01s watchdog fired — `parse_filter` never returned (infinite loop) | `InvalidFilter`, returns instantly |
| `((((…))))` ×100k | `stack overflow, aborting` → SIGABRT (signal 6) | `InvalidFilter` |
| `not not … ×100k` | `stack overflow, aborting` → SIGABRT (signal 6) | `InvalidFilter` |
| `f(f(…)) ×100k` | unbounded recursion → stack overflow | `InvalidFilter` |
| `Name eq 'foo` (unterminated) | silently accepted (assert failed) | `InvalidFilter` |

The `$` regression test uses a watchdog thread + timeout so a future regression fails fast instead of hanging the suite. A guard test (`filter_moderately_nested_parens_still_parse`) and an exact-boundary test (`filter_depth_bound_is_inclusive_at_the_limit`) confirm legitimate deep-but-bounded and wide filters still parse.

## Test results
`cargo test -p temper-odata` — **60 passed, 0 failed** (7 new regression tests), suite finishes in ~0.08s (no hang/overflow). `cargo fmt --check` and `cargo clippy` clean.

## Reviews
- Independent code review (code-reviewer agent): **PASS**, no Critical/Important findings. Verified all three unbounded-recursion paths are guarded, the tokenizer advances on every branch, `$` removal loses no capability, and there is no off-by-one.
- DST self-review: `temper-odata` is not a simulation-visible crate; production changes are deterministic (`Vec`/`String`/`usize` only); the watchdog thread is test-only.

## Notes
- Bug fix in a single file — no ADR required per the repo rule.
- `not` precedence (a separate LOW noted in the issue) is intentionally **out of scope**: changing it is a behavioral/semantics change, not a security fix, and would alter existing parse results.

Closes ARN-176 once merged. **Draft — do not merge yet.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two denial-of-service vulnerabilities in the OData `$filter` parser (`crates/temper-odata/src/query/filter.rs`): an infinite tokenizer loop triggered by a bare `$` character, and unbounded recursive descent that allowed deeply nested parentheses, `not` chains, or function calls to overflow the request thread's stack. A third issue — silently accepting unterminated string literals — is also corrected.

- **Tokenizer fix**: `$` is removed from the identifier-start set; a stray `$` now falls through to `InvalidFilter` (HTTP 400) with a `debug_assert!` documenting the forward-progress invariant.
- **Depth budget**: `FilterParser` tracks nesting depth via `descend()`/`ascend()` pairs at all three recursion sites, capped at `FILTER_DEPTH_BUDGET = 32`; the boundary is verified on a constrained 512 KiB stack.
- **Resource budgets**: A new `FilterBudget` module enforces limits on input bytes (64 KB), tokens (4 096), AST nodes (4 096), operators (1 024), function arguments (256), and literal bytes (16 KB); `balance_associative` avoids a linear-depth AST for wide `and`/`or` chains, bounding `Drop` recursion logarithmically.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge once the draft flag is cleared; all three DoS vectors are correctly guarded and the regression test suite covers boundary conditions on a constrained stack.

The security fixes are mechanically correct: the tokenizer now makes guaranteed forward progress, the depth guard fires before recursion occurs, and ascend/descend are symmetric in every error path. The budget arithmetic uses checked_sub throughout, eliminating overflow. balance_associative bounds Drop recursion logarithmically. The one substantive finding is that the three large-input regression tests (100k-depth) exercise the 64 KB input limit rather than the depth limit their comments describe — the depth boundary is correctly validated by the explicit boundary test, so the fix is sound but three test comments are misleading.

crates/temper-odata/src/query/filter/security_tests.rs — three regression tests should be resized to inputs within the byte budget so they actually exercise the depth guard they document.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/temper-odata/src/query/filter.rs | Tokenizer $ infinite-loop fixed; depth budget (FILTER_DEPTH_BUDGET=32) wired into descend/ascend at all three recursion sites; balance_associative avoids left-fold stack depth on wide ASTs; unterminated string literal now rejected. Logic is correct and ascend/descend pairing is symmetric in all error paths. |
| crates/temper-odata/src/query/filter/budget.rs | New resource-budget module with checked_sub arithmetic for all dimensions (input bytes, tokens, nodes, operators, arguments, literal bytes). Error reporting position for the input-size case uses the budget constant as position, which is a cosmetic oddity but not incorrect. |
| crates/temper-odata/src/query/filter/security_tests.rs | Comprehensive boundary and regression tests; the three large-input 'deeply nested' tests inadvertently exercise the input-byte budget rather than the depth budget they claim to target, making them mislabeled but not incorrect in outcome. |
| crates/temper-odata/src/query/filter/basic_tests.rs | Existing unit tests migrated verbatim to a separate file via #[path]; no logic changes. |
| crates/temper-server/tests/odata_read.rs | Two integration tests confirm over-budget (513 comparisons → 1025 operators) returns HTTP 400 and at-budget (512 comparisons → 1023 operators) returns HTTP 200 through the real router. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["parse_filter(input)"] --> B["FilterBudget::new\ninput limit: 64 KB"]
    B -->|exceeded| Z["InvalidFilter HTTP 400"]
    B -->|ok| C["tokenize_filter\ntoken limit: 4096"]
    C -->|bare dollar sign| Z
    C -->|unterminated string| Z
    C -->|token budget exceeded| Z
    C -->|ok| D["FilterParser::new"]
    D --> E["parse_or — iterative\nbalance_associative"]
    E --> F["parse_and — iterative\nbalance_associative"]
    F --> G["parse_not\ndescend before recursion"]
    G -->|depth gt 32| Z
    G --> H["parse_comparison"]
    H --> I["parse_primary"]
    I -->|paren sub-expr| G
    I -->|function call| J["parse_argument_list\ndescend per arg\nlimit: 256 args"]
    J -->|depth gt 32| Z
    J -->|arg budget exceeded| Z
    I -->|literal or property| K["consume_node\nnode limit: 4096"]
    K -->|exceeded| Z
    K --> L["FilterExpr AST\nbalanced binary tree"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["parse_filter(input)"] --> B["FilterBudget::new\ninput limit: 64 KB"]
    B -->|exceeded| Z["InvalidFilter HTTP 400"]
    B -->|ok| C["tokenize_filter\ntoken limit: 4096"]
    C -->|bare dollar sign| Z
    C -->|unterminated string| Z
    C -->|token budget exceeded| Z
    C -->|ok| D["FilterParser::new"]
    D --> E["parse_or — iterative\nbalance_associative"]
    E --> F["parse_and — iterative\nbalance_associative"]
    F --> G["parse_not\ndescend before recursion"]
    G -->|depth gt 32| Z
    G --> H["parse_comparison"]
    H --> I["parse_primary"]
    I -->|paren sub-expr| G
    I -->|function call| J["parse_argument_list\ndescend per arg\nlimit: 256 args"]
    J -->|depth gt 32| Z
    J -->|arg budget exceeded| Z
    I -->|literal or property| K["consume_node\nnode limit: 4096"]
    K -->|exceeded| Z
    K --> L["FilterExpr AST\nbalanced binary tree"]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `crates/temper-odata/src/query/filter.rs`, line 432 ([link](https://github.com/nerdsane/temper/blob/8c920fe10dc381fff22dc855ee8502b4ed362fd9/crates/temper-odata/src/query/filter.rs#L432)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **File exceeds 500-line module split rule**

   `filter.rs` is now 762 lines, crossing the 500-line threshold from CLAUDE.md/AGENTS.md ("Files > 500 lines must be split into directory modules"). The pre-existing code was already ~538 lines; this PR adds ~163 test lines, widening the gap. The test module (lines 432–762, roughly 330 lines) is the natural split point — moving it to `src/query/filter/tests.rs` (or a `#[path]` submodule) would bring the main file back well under 500 while keeping all regression tests discoverable.

   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/arni-labs/github/nerdsane/temper/-/custom-context?memory=c3ad5080-2c13-46c8-b4c1-9e266e4df914))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: crates/temper-odata/src/query/filter.rs
   Line: 432
   
   Comment:
   **File exceeds 500-line module split rule**
   
   `filter.rs` is now 762 lines, crossing the 500-line threshold from CLAUDE.md/AGENTS.md ("Files > 500 lines must be split into directory modules"). The pre-existing code was already ~538 lines; this PR adds ~163 test lines, widening the gap. The test module (lines 432–762, roughly 330 lines) is the natural split point — moving it to `src/query/filter/tests.rs` (or a `#[path]` submodule) would bring the main file back well under 500 while keeping all regression tests discoverable.
   
   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/arni-labs/github/nerdsane/temper/-/custom-context?memory=c3ad5080-2c13-46c8-b4c1-9e266e4df914))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-odata%2Fsrc%2Fquery%2Ffilter.rs%0ALine%3A%20432%0A%0AComment%3A%0A**File%20exceeds%20500-line%20module%20split%20rule**%0A%0A%60filter.rs%60%20is%20now%20762%20lines%2C%20crossing%20the%20500-line%20threshold%20from%20CLAUDE.md%2FAGENTS.md%20%28%22Files%20%3E%20500%20lines%20must%20be%20split%20into%20directory%20modules%22%29.%20The%20pre-existing%20code%20was%20already%20~538%20lines%3B%20this%20PR%20adds%20~163%20test%20lines%2C%20widening%20the%20gap.%20The%20test%20module%20%28lines%20432%E2%80%93762%2C%20roughly%20330%20lines%29%20is%20the%20natural%20split%20point%20%E2%80%94%20moving%20it%20to%20%60src%2Fquery%2Ffilter%2Ftests.rs%60%20%28or%20a%20%60%23%5Bpath%5D%60%20submodule%29%20would%20bring%20the%20main%20file%20back%20well%20under%20500%20while%20keeping%20all%20regression%20tests%20discoverable.%0A%0A**Context%20Used%3A**%20CLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Farni-labs%2Fgithub%2Fnerdsane%2Ftemper%2F-%2Fcustom-context%3Fmemory%3Dc3ad5080-2c13-46c8-b4c1-9e266e4df914%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=nerdsane%2Ftemper&pr=344&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22claude%2Farn-176-odata-filter-dos%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Farn-176-odata-filter-dos%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-odata%2Fsrc%2Fquery%2Ffilter.rs%0ALine%3A%20432%0A%0AComment%3A%0A**File%20exceeds%20500-line%20module%20split%20rule**%0A%0A%60filter.rs%60%20is%20now%20762%20lines%2C%20crossing%20the%20500-line%20threshold%20from%20CLAUDE.md%2FAGENTS.md%20%28%22Files%20%3E%20500%20lines%20must%20be%20split%20into%20directory%20modules%22%29.%20The%20pre-existing%20code%20was%20already%20~538%20lines%3B%20this%20PR%20adds%20~163%20test%20lines%2C%20widening%20the%20gap.%20The%20test%20module%20%28lines%20432%E2%80%93762%2C%20roughly%20330%20lines%29%20is%20the%20natural%20split%20point%20%E2%80%94%20moving%20it%20to%20%60src%2Fquery%2Ffilter%2Ftests.rs%60%20%28or%20a%20%60%23%5Bpath%5D%60%20submodule%29%20would%20bring%20the%20main%20file%20back%20well%20under%20500%20while%20keeping%20all%20regression%20tests%20discoverable.%0A%0A**Context%20Used%3A**%20CLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Farni-labs%2Fgithub%2Fnerdsane%2Ftemper%2F-%2Fcustom-context%3Fmemory%3Dc3ad5080-2c13-46c8-b4c1-9e266e4df914%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=nerdsane%2Ftemper&pr=344&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-odata%2Fsrc%2Fquery%2Ffilter.rs%0ALine%3A%20432%0A%0AComment%3A%0A**File%20exceeds%20500-line%20module%20split%20rule**%0A%0A%60filter.rs%60%20is%20now%20762%20lines%2C%20crossing%20the%20500-line%20threshold%20from%20CLAUDE.md%2FAGENTS.md%20%28%22Files%20%3E%20500%20lines%20must%20be%20split%20into%20directory%20modules%22%29.%20The%20pre-existing%20code%20was%20already%20~538%20lines%3B%20this%20PR%20adds%20~163%20test%20lines%2C%20widening%20the%20gap.%20The%20test%20module%20%28lines%20432%E2%80%93762%2C%20roughly%20330%20lines%29%20is%20the%20natural%20split%20point%20%E2%80%94%20moving%20it%20to%20%60src%2Fquery%2Ffilter%2Ftests.rs%60%20%28or%20a%20%60%23%5Bpath%5D%60%20submodule%29%20would%20bring%20the%20main%20file%20back%20well%20under%20500%20while%20keeping%20all%20regression%20tests%20discoverable.%0A%0A**Context%20Used%3A**%20CLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Farni-labs%2Fgithub%2Fnerdsane%2Ftemper%2F-%2Fcustom-context%3Fmemory%3Dc3ad5080-2c13-46c8-b4c1-9e266e4df914%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=344&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>

2. `crates/temper-odata/src/query/filter.rs`, line 1 ([link](https://github.com/nerdsane/temper/blob/8c920fe10dc381fff22dc855ee8502b4ed362fd9/crates/temper-odata/src/query/filter.rs#L1)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **File exceeds 500-line split threshold**

   `CLAUDE.md` / `AGENTS.md` require files over 500 lines to be split into directory modules. The file was already above the limit before this PR; the 163 lines of new tests bring it to 763 lines. The natural split would be a `filter/` directory module with `tokenizer.rs`, `parser.rs`, and `tests/` (or an inline `tests.rs`). This doesn't need to block the security fix, but a follow-up split should be tracked.

   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/arni-labs/github/nerdsane/temper/-/custom-context?memory=c3ad5080-2c13-46c8-b4c1-9e266e4df914))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: crates/temper-odata/src/query/filter.rs
   Line: 1
   
   Comment:
   **File exceeds 500-line split threshold**
   
   `CLAUDE.md` / `AGENTS.md` require files over 500 lines to be split into directory modules. The file was already above the limit before this PR; the 163 lines of new tests bring it to 763 lines. The natural split would be a `filter/` directory module with `tokenizer.rs`, `parser.rs`, and `tests/` (or an inline `tests.rs`). This doesn't need to block the security fix, but a follow-up split should be tracked.
   
   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/arni-labs/github/nerdsane/temper/-/custom-context?memory=c3ad5080-2c13-46c8-b4c1-9e266e4df914))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
   
   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-odata%2Fsrc%2Fquery%2Ffilter.rs%0ALine%3A%201%0A%0AComment%3A%0A**File%20exceeds%20500-line%20split%20threshold**%0A%0A%60CLAUDE.md%60%20%2F%20%60AGENTS.md%60%20require%20files%20over%20500%20lines%20to%20be%20split%20into%20directory%20modules.%20The%20file%20was%20already%20above%20the%20limit%20before%20this%20PR%3B%20the%20163%20lines%20of%20new%20tests%20bring%20it%20to%20763%20lines.%20The%20natural%20split%20would%20be%20a%20%60filter%2F%60%20directory%20module%20with%20%60tokenizer.rs%60%2C%20%60parser.rs%60%2C%20and%20%60tests%2F%60%20%28or%20an%20inline%20%60tests.rs%60%29.%20This%20doesn't%20need%20to%20block%20the%20security%20fix%2C%20but%20a%20follow-up%20split%20should%20be%20tracked.%0A%0A**Context%20Used%3A**%20CLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Farni-labs%2Fgithub%2Fnerdsane%2Ftemper%2F-%2Fcustom-context%3Fmemory%3Dc3ad5080-2c13-46c8-b4c1-9e266e4df914%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=nerdsane%2Ftemper&pr=344&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22claude%2Farn-176-odata-filter-dos%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Farn-176-odata-filter-dos%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-odata%2Fsrc%2Fquery%2Ffilter.rs%0ALine%3A%201%0A%0AComment%3A%0A**File%20exceeds%20500-line%20split%20threshold**%0A%0A%60CLAUDE.md%60%20%2F%20%60AGENTS.md%60%20require%20files%20over%20500%20lines%20to%20be%20split%20into%20directory%20modules.%20The%20file%20was%20already%20above%20the%20limit%20before%20this%20PR%3B%20the%20163%20lines%20of%20new%20tests%20bring%20it%20to%20763%20lines.%20The%20natural%20split%20would%20be%20a%20%60filter%2F%60%20directory%20module%20with%20%60tokenizer.rs%60%2C%20%60parser.rs%60%2C%20and%20%60tests%2F%60%20%28or%20an%20inline%20%60tests.rs%60%29.%20This%20doesn't%20need%20to%20block%20the%20security%20fix%2C%20but%20a%20follow-up%20split%20should%20be%20tracked.%0A%0A**Context%20Used%3A**%20CLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Farni-labs%2Fgithub%2Fnerdsane%2Ftemper%2F-%2Fcustom-context%3Fmemory%3Dc3ad5080-2c13-46c8-b4c1-9e266e4df914%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=nerdsane%2Ftemper&pr=344&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-odata%2Fsrc%2Fquery%2Ffilter.rs%0ALine%3A%201%0A%0AComment%3A%0A**File%20exceeds%20500-line%20split%20threshold**%0A%0A%60CLAUDE.md%60%20%2F%20%60AGENTS.md%60%20require%20files%20over%20500%20lines%20to%20be%20split%20into%20directory%20modules.%20The%20file%20was%20already%20above%20the%20limit%20before%20this%20PR%3B%20the%20163%20lines%20of%20new%20tests%20bring%20it%20to%20763%20lines.%20The%20natural%20split%20would%20be%20a%20%60filter%2F%60%20directory%20module%20with%20%60tokenizer.rs%60%2C%20%60parser.rs%60%2C%20and%20%60tests%2F%60%20%28or%20an%20inline%20%60tests.rs%60%29.%20This%20doesn't%20need%20to%20block%20the%20security%20fix%2C%20but%20a%20follow-up%20split%20should%20be%20tracked.%0A%0A**Context%20Used%3A**%20CLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Farni-labs%2Fgithub%2Fnerdsane%2Ftemper%2F-%2Fcustom-context%3Fmemory%3Dc3ad5080-2c13-46c8-b4c1-9e266e4df914%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=344&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (5): Last reviewed commit: ["fix(odata): bound downstream filter recu..."](https://github.com/nerdsane/temper/commit/e2d1c3ab19106c9bd060fbb6d3c0dd67c701cb58) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42291630)</sub>

<!-- /greptile_comment -->