### PR TITLE
fix(dispatch): run scheduled_actions + spawn_requests on the inline integration path (ARN-188)

### DIFF
--- a/crates/temper-server/src/entity_actor/actor.rs
+++ b/crates/temper-server/src/entity_actor/actor.rs
@@ -574,6 +574,8 @@ impl EntityActor {
                             timestamp: env.metadata.timestamp,
                             params: serde_json::json!({}),
                             idempotency_key: None,
+                            scheduled_actions: Vec::new(),
+                            spawn_requests: Vec::new(),
                         });
                         state.status = tombstone.to_status.clone();
                         if let Some(obj) = state.fields.as_object_mut() {
@@ -808,6 +810,8 @@ impl Actor for EntityActor {
                 timestamp: sim_now(),
                 params: self.initial_fields.clone(),
                 idempotency_key: None,
+                scheduled_actions: Vec::new(),
+                spawn_requests: Vec::new(),
             };
 
             if let (Some(store), Some(backend)) = (self.event_journal.as_ref(), self.event_backend)
@@ -870,6 +874,7 @@ impl Actor for EntityActor {
                 if let Some(key) = idempotency_key.as_deref()
                     && state.has_processed_idempotency_key(key)
                 {
+                    let deferred_event = state.event_for_idempotency_key(key);
                     let custom_effects = duplicate_idempotency_custom_effects(
                         &table,
                         state,
@@ -885,8 +890,12 @@ impl Actor for EntityActor {
                         state: response_state,
                         error: None,
                         custom_effects,
-                        scheduled_actions: vec![],
-                        spawn_requests: vec![],
+                        scheduled_actions: deferred_event
+                            .map(|event| event.scheduled_actions.clone())
+                            .unwrap_or_default(),
+                        spawn_requests: deferred_event
+                            .map(|event| event.spawn_requests.clone())
+                            .unwrap_or_default(),
                         spec_governed: true,
                     });
                     return Ok(());
@@ -1457,6 +1466,8 @@ impl Actor for EntityActor {
                     timestamp: sim_now(),
                     params: serde_json::json!({}),
                     idempotency_key: None,
+                    scheduled_actions: Vec::new(),
+                    spawn_requests: Vec::new(),
                 };
 
                 if let (Some(store), Some(backend)) =

--- a/crates/temper-server/src/entity_actor/effects.rs
+++ b/crates/temper-server/src/entity_actor/effects.rs
@@ -281,6 +281,8 @@ pub fn process_action_with_xref_and_field_mode(
                 timestamp: sim_now(),
                 params: params.clone(),
                 idempotency_key: None,
+                scheduled_actions: all_scheduled.clone(),
+                spawn_requests: spawn_requests.clone(),
             };
 
             ProcessResult {

--- a/crates/temper-server/src/entity_actor/types.rs
+++ b/crates/temper-server/src/entity_actor/types.rs
@@ -134,6 +134,19 @@ impl EntityState {
         self.processed_idempotency_keys.contains_key(key)
     }
 
+    /// Return the recent event originally committed for an idempotency key.
+    ///
+    /// The actor keeps a bounded event tail, so this is a best-effort fast path
+    /// for retrying post-dispatch side effects after a caller retry. If the
+    /// original event aged out, the caller still receives a deduplicated success
+    /// response but no deferred effects are re-surfaced.
+    pub fn event_for_idempotency_key(&self, key: &str) -> Option<&EntityEvent> {
+        self.events
+            .iter()
+            .rev()
+            .find(|event| event.idempotency_key.as_deref() == Some(key))
+    }
+
     fn record_processed_idempotency_key(&mut self, key: &str) {
         let sequence = self.sequence_nr.max(self.total_event_count as u64);
         self.processed_idempotency_keys
@@ -169,6 +182,16 @@ pub struct EntityEvent {
     /// Optional idempotency key that caused this transition.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub idempotency_key: Option<String>,
+    /// Scheduled actions durably emitted by this transition.
+    ///
+    /// These are persisted on the event, not only returned in the transient
+    /// [`EntityResponse`], so an idempotent retry after a crash can re-surface
+    /// the original deferred work instead of silently dropping it.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub scheduled_actions: Vec<crate::entity_actor::effects::ScheduledAction>,
+    /// Child-entity spawn requests durably emitted by this transition.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub spawn_requests: Vec<crate::entity_actor::effects::SpawnRequest>,
 }
 
 /// Default value for `spec_governed`: actions are spec-governed unless explicitly marked otherwise.
@@ -297,6 +320,53 @@ mod tests {
         };
 
         assert!(!state.can_accept_event());
+    }
+
+    #[test]
+    fn idempotency_lookup_returns_persisted_deferred_effects() {
+        let mut state = EntityState {
+            entity_type: "Parent".to_string(),
+            entity_id: "parent-1".to_string(),
+            status: "Ready".to_string(),
+            item_count: 0,
+            counters: BTreeMap::new(),
+            booleans: BTreeMap::new(),
+            lists: BTreeMap::new(),
+            fields: json!({}),
+            events: VecDeque::new(),
+            total_event_count: 0,
+            events_since_snapshot: 0,
+            last_snapshot_sequence_nr: 0,
+            sequence_nr: 0,
+            processed_idempotency_keys: std::collections::BTreeMap::new(),
+        };
+        state.push_event_bounded(EntityEvent {
+            action: "Trigger".to_string(),
+            from_status: "Ready".to_string(),
+            to_status: "Triggered".to_string(),
+            timestamp: chrono::Utc::now(),
+            params: json!({}),
+            idempotency_key: Some("idem-1".to_string()),
+            scheduled_actions: vec![crate::entity_actor::effects::ScheduledAction {
+                action: "Tick".to_string(),
+                delay_seconds: 0,
+            }],
+            spawn_requests: vec![crate::entity_actor::effects::SpawnRequest {
+                entity_type: "Child".to_string(),
+                entity_id: "child-1".to_string(),
+                initial_action: Some("Init".to_string()),
+                store_id_in: None,
+                copy_fields: None,
+                copied_field_values: serde_json::Map::new(),
+            }],
+        });
+
+        let event = state
+            .event_for_idempotency_key("idem-1")
+            .expect("event should remain in recent tail");
+        assert_eq!(event.scheduled_actions[0].action, "Tick");
+        assert_eq!(event.spawn_requests[0].entity_id, "child-1");
+        assert!(state.event_for_idempotency_key("missing").is_none());
     }
 
     #[test]

--- a/crates/temper-server/src/state/dispatch/composite.rs
+++ b/crates/temper-server/src/state/dispatch/composite.rs
@@ -494,6 +494,8 @@ impl crate::state::ServerState {
                 timestamp: sim_now(),
                 params: serde_json::json!({}),
                 idempotency_key: None,
+                scheduled_actions: Vec::new(),
+                spawn_requests: Vec::new(),
             };
             events.push(composite_envelope(&persistence_id, &bootstrap)?);
             state.sequence_nr = state.sequence_nr.saturating_add(1);

--- a/crates/temper-server/src/state/dispatch/cross_entity.rs
+++ b/crates/temper-server/src/state/dispatch/cross_entity.rs
@@ -10,6 +10,16 @@ use tracing::Instrument;
 /// carries the IOA `required` attribute (ARN-92 #2).
 type CrossGuardSpec = (String, String, Vec<String>, Vec<String>, bool);
 
+pub(super) struct SpawnDispatchBatch<'a> {
+    pub tenant: &'a TenantId,
+    pub parent_type: &'a str,
+    pub parent_id: &'a str,
+    pub spawn_requests: &'a [crate::entity_actor::effects::SpawnRequest],
+    pub action_params: &'a serde_json::Value,
+    pub agent_ctx: &'a AgentContext,
+    pub source_sequence: u64,
+}
+
 impl crate::state::ServerState {
     /// Pre-resolve cross-entity state guards for an action.
     ///
@@ -211,16 +221,17 @@ impl crate::state::ServerState {
     /// This is a **sync** method (like `dispatch_scheduled_actions`) so that
     /// `tokio::spawn` inside it does not cause async recursion.
     /// Creates child entities and optionally dispatches initial actions.
-    pub(super) fn dispatch_spawn_requests(
-        &self,
-        tenant: &TenantId,
-        parent_type: &str,
-        parent_id: &str,
-        spawn_requests: &[crate::entity_actor::effects::SpawnRequest],
-        action_params: &serde_json::Value,
-        agent_ctx: &AgentContext,
-    ) {
+    pub(super) fn dispatch_spawn_requests(&self, batch: SpawnDispatchBatch<'_>) {
         use crate::entity_actor::effects::MAX_SPAWNS_PER_TRANSITION;
+        let SpawnDispatchBatch {
+            tenant,
+            parent_type,
+            parent_id,
+            spawn_requests,
+            action_params,
+            agent_ctx,
+            source_sequence,
+        } = batch;
 
         for (spawn_count, req) in spawn_requests.iter().enumerate() {
             if spawn_count >= MAX_SPAWNS_PER_TRANSITION {
@@ -241,7 +252,10 @@ impl crate::state::ServerState {
             let child_id = req.entity_id.clone();
             let initial_action = req.initial_action.clone();
             let parent_params = action_params.clone();
-            let agent = agent_ctx.clone();
+            let mut agent = agent_ctx.clone();
+            agent.idempotency_key = Some(format!(
+                "deferred:spawn:{t}:{parent_t}:{parent_i}:{source_sequence}:{spawn_count}:{child_type}:{child_id}"
+            ));
             let copied_fields = req.copied_field_values.clone();
             let workflow_root_entity_type = agent
                 .workflow_root_entity_type

--- a/crates/temper-server/src/state/dispatch/effects.rs
+++ b/crates/temper-server/src/state/dispatch/effects.rs
@@ -513,14 +513,18 @@ impl crate::state::ServerState {
         entity_id: &str,
         scheduled_actions: &[ScheduledAction],
         agent_ctx: &AgentContext,
+        source_sequence: u64,
     ) {
-        for sched in scheduled_actions {
+        for (effect_index, sched) in scheduled_actions.iter().enumerate() {
             let state = self.clone();
             let t = tenant.clone();
             let et = entity_type.to_string();
             let eid = entity_id.to_string();
             let action = sched.action.clone();
-            let ctx = agent_ctx.clone();
+            let mut ctx = agent_ctx.clone();
+            ctx.idempotency_key = Some(format!(
+                "deferred:scheduled:{t}:{et}:{eid}:{source_sequence}:{effect_index}:{action}"
+            ));
             let delay = std::time::Duration::from_secs(sched.delay_seconds);
             let workflow_root_entity_type = ctx
                 .workflow_root_entity_type
@@ -578,14 +582,15 @@ impl crate::state::ServerState {
     ) {
         // Spawn requests
         if !response.spawn_requests.is_empty() {
-            self.dispatch_spawn_requests(
-                ctx.tenant,
-                ctx.entity_type,
-                ctx.entity_id,
-                &response.spawn_requests,
-                ctx.action_params,
-                ctx.agent_ctx,
-            );
+            self.dispatch_spawn_requests(super::cross_entity::SpawnDispatchBatch {
+                tenant: ctx.tenant,
+                parent_type: ctx.entity_type,
+                parent_id: ctx.entity_id,
+                spawn_requests: &response.spawn_requests,
+                action_params: ctx.action_params,
+                agent_ctx: ctx.agent_ctx,
+                source_sequence: response.state.sequence_nr,
+            });
         }
 
         // Scheduled actions (propagate agent context for identity attribution)
@@ -596,6 +601,7 @@ impl crate::state::ServerState {
                 ctx.entity_id,
                 &response.scheduled_actions,
                 ctx.agent_ctx,
+                response.state.sequence_nr,
             );
         }
     }

--- a/crates/temper-server/src/state/dispatch/effects.rs
+++ b/crates/temper-server/src/state/dispatch/effects.rs
@@ -563,6 +563,43 @@ impl crate::state::ServerState {
         }
     }
 
+    /// Dispatch a transition's deferred child effects: spawn requests and
+    /// scheduled actions.
+    ///
+    /// These belong to the ORIGINAL transition response and must run on every
+    /// successful path — including when an inline integration produced a
+    /// callback response. Both are fire-and-forget (background tasks), so the
+    /// caller is free to return the (possibly integration-updated) response
+    /// afterwards.
+    fn dispatch_transition_deferred_effects(
+        &self,
+        ctx: &PostDispatchContext<'_>,
+        response: &EntityResponse,
+    ) {
+        // Spawn requests
+        if !response.spawn_requests.is_empty() {
+            self.dispatch_spawn_requests(
+                ctx.tenant,
+                ctx.entity_type,
+                ctx.entity_id,
+                &response.spawn_requests,
+                ctx.action_params,
+                ctx.agent_ctx,
+            );
+        }
+
+        // Scheduled actions (propagate agent context for identity attribution)
+        if !response.scheduled_actions.is_empty() {
+            self.dispatch_scheduled_actions(
+                ctx.tenant,
+                ctx.entity_type,
+                ctx.entity_id,
+                &response.scheduled_actions,
+                ctx.agent_ctx,
+            );
+        }
+    }
+
     /// Run all post-dispatch effects for a successful action.
     ///
     /// This is the single orchestration point for side effects after a
@@ -692,6 +729,25 @@ impl crate::state::ServerState {
                 }
 
                 if let Some(final_response) = inline_response {
+                    // ARN-188: the inline integration produced a callback
+                    // response (a separate action), but the ORIGINAL
+                    // transition's spawn requests and scheduled actions still
+                    // need to run — the previous early return dropped them
+                    // silently. Dispatch them before returning the
+                    // integration-updated response.
+                    //
+                    // The remaining steps are intentionally NOT re-run on the
+                    // original response on this early-return path:
+                    //   5b platform hooks — the original custom effects were
+                    //      already routed to the inline integration (step 5);
+                    //      routing them to platform hooks too would double-handle.
+                    //   7b state timeouts — the callback's own dispatch already
+                    //      armed the timer for the post-callback state; re-arming
+                    //      on the stale intermediate state would supersede it with
+                    //      a wrong-state timer (7b is not stale-guarded).
+                    //   8  query projection — sequence-guarded, and the callback's
+                    //      higher-sequence projection is already the correct row.
+                    self.dispatch_transition_deferred_effects(ctx, &response);
                     return final_response;
                 }
             } else {
@@ -745,28 +801,10 @@ impl crate::state::ServerState {
             }
         }
 
-        // 6. Spawn requests
-        if !response.spawn_requests.is_empty() {
-            self.dispatch_spawn_requests(
-                ctx.tenant,
-                ctx.entity_type,
-                ctx.entity_id,
-                &response.spawn_requests,
-                ctx.action_params,
-                ctx.agent_ctx,
-            );
-        }
-
-        // 7. Scheduled actions (propagate agent context for identity attribution)
-        if !response.scheduled_actions.is_empty() {
-            self.dispatch_scheduled_actions(
-                ctx.tenant,
-                ctx.entity_type,
-                ctx.entity_id,
-                &response.scheduled_actions,
-                ctx.agent_ctx,
-            );
-        }
+        // 6 & 7. Spawn requests + scheduled actions (the transition's deferred
+        // child effects). Shared with the inline-integration early-return path
+        // so those effects are never dropped (ARN-188).
+        self.dispatch_transition_deferred_effects(ctx, &response);
 
         // 7b. ADR-0049 state-timeout arming. Arms (or re-arms) a timer on
         // state entry and on any reset_on action. Sequence-based

--- a/crates/temper-server/src/state/dispatch/state_timeouts.rs
+++ b/crates/temper-server/src/state/dispatch/state_timeouts.rs
@@ -466,6 +466,8 @@ mod tests {
             timestamp: ts,
             params: serde_json::json!({}),
             idempotency_key: None,
+            scheduled_actions: Vec::new(),
+            spawn_requests: Vec::new(),
         }
     }
 

--- a/crates/temper-server/src/state/entity_ops.rs
+++ b/crates/temper-server/src/state/entity_ops.rs
@@ -1135,6 +1135,8 @@ impl ServerState {
             timestamp: sim_now(),
             params: initial_fields,
             idempotency_key: None,
+            scheduled_actions: Vec::new(),
+            spawn_requests: Vec::new(),
         };
         let payload = serde_json::to_value(&created)
             .map_err(|e| format!("failed to serialize Created event: {e}"))?;

--- a/crates/temper-server/src/state/file_initial_writes.rs
+++ b/crates/temper-server/src/state/file_initial_writes.rs
@@ -96,6 +96,8 @@ impl ServerState {
             timestamp: sim_now(),
             params: serde_json::json!({}),
             idempotency_key: None,
+            scheduled_actions: Vec::new(),
+            spawn_requests: Vec::new(),
         };
         push_synthetic_event(&mut state, &mut events, created);
 

--- a/crates/temper-server/tests/inline_integration_effects.rs
+++ b/crates/temper-server/tests/inline_integration_effects.rs
@@ -1,0 +1,203 @@
+//! Regression test for ARN-188.
+//!
+//! When `await_integration = true` and a transition emits BOTH a custom effect
+//! (mapped to an inline integration that yields a callback response) AND a
+//! `schedule` / `spawn` effect, the inline integration path must still run the
+//! ORIGINAL transition's scheduled actions and spawn requests. The bug was an
+//! early `return final_response` that skipped those steps, silently dropping the
+//! scheduled timer and the child-entity spawn.
+
+use temper_runtime::ActorSystem;
+use temper_runtime::tenant::TenantId;
+use temper_server::ServerState;
+use temper_server::registry::SpecRegistry;
+use temper_server::request_context::AgentContext;
+use temper_server::state::DispatchExtOptions;
+use temper_spec::csdl::parse_csdl;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const CSDL_XML: &str = r#"<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="Temper.InlineEffects" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="Parent">
+        <Key><PropertyRef Name="Id"/></Key>
+        <Property Name="Id" Type="Edm.String" Nullable="false"/>
+        <Property Name="Status" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="Child">
+        <Key><PropertyRef Name="Id"/></Key>
+        <Property Name="Id" Type="Edm.String" Nullable="false"/>
+        <Property Name="Status" Type="Edm.String"/>
+      </EntityType>
+      <EntityContainer Name="Container">
+        <EntitySet Name="Parents" EntityType="Temper.InlineEffects.Parent"/>
+        <EntitySet Name="Children" EntityType="Temper.InlineEffects.Child"/>
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>"#;
+
+// The `Trigger` transition emits, in one shot:
+//   * a `trigger` custom effect  -> inline `http` adapter -> `AdapterSucceeded` callback
+//   * a `schedule` effect        -> fires `Tick` on the parent (Done -> Ticked)
+//   * a `spawn` effect           -> creates a `Child` and runs `Init` (New -> Initialized)
+//
+// Under `await_integration = true`, the inline adapter callback moves the parent
+// to `Done`. The scheduled `Tick` and the spawned `Child` belong to the ORIGINAL
+// `Trigger` response and must still be applied.
+const PARENT_SPEC: &str = r#"
+[automaton]
+name = "Parent"
+states = ["Idle", "Pending", "Done", "Ticked", "Failed"]
+initial = "Idle"
+
+[[action]]
+name = "Trigger"
+kind = "input"
+from = ["Idle"]
+to = "Pending"
+params = ["child_id"]
+effect = [
+    { type = "trigger", name = "adapter_call" },
+    { type = "schedule", action = "Tick", delay_seconds = 0 },
+    { type = "spawn", entity_type = "Child", entity_id_source = "child_id", initial_action = "Init" },
+]
+
+[[action]]
+name = "AdapterSucceeded"
+kind = "input"
+from = ["Pending"]
+to = "Done"
+params = ["result"]
+
+[[action]]
+name = "AdapterFailed"
+kind = "input"
+from = ["Pending"]
+to = "Failed"
+params = ["error_message"]
+
+[[action]]
+name = "Tick"
+kind = "input"
+from = ["Done"]
+to = "Ticked"
+
+[[integration]]
+name = "adapter_call"
+trigger = "adapter_call"
+type = "adapter"
+adapter = "http"
+on_success = "AdapterSucceeded"
+on_failure = "AdapterFailed"
+url = "{url}/execute"
+method = "POST"
+"#;
+
+const CHILD_SPEC: &str = r#"
+[automaton]
+name = "Child"
+states = ["New", "Initialized"]
+initial = "New"
+
+[[action]]
+name = "Init"
+kind = "input"
+from = ["New"]
+to = "Initialized"
+"#;
+
+fn build_state(parent_spec: &str) -> ServerState {
+    let mut registry = SpecRegistry::new();
+    let csdl = parse_csdl(CSDL_XML).expect("CSDL should parse");
+    registry.register_tenant(
+        "default",
+        csdl,
+        CSDL_XML.to_string(),
+        &[("Parent", parent_spec), ("Child", CHILD_SPEC)],
+    );
+
+    let system = ActorSystem::new("inline-integration-effects-test");
+    ServerState::from_registry(system, registry)
+}
+
+/// Poll `get_tenant_entity_state` until the entity reaches `expected` status,
+/// or the attempt budget is exhausted. Returns the last observed status.
+async fn poll_status(
+    state: &ServerState,
+    tenant: &TenantId,
+    entity_type: &str,
+    entity_id: &str,
+    expected: &str,
+) -> String {
+    let mut last = String::new();
+    for _ in 0..100 {
+        if let Ok(resp) = state
+            .get_tenant_entity_state(tenant, entity_type, entity_id)
+            .await
+        {
+            last = resp.state.status.clone();
+            if last == expected {
+                return last;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    last
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn inline_integration_still_runs_scheduled_and_spawn_effects() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/execute"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "callback_params": { "result": "ok" }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let spec = PARENT_SPEC.replace("{url}", &mock_server.uri());
+    let state = build_state(&spec);
+    let tenant = TenantId::default();
+    let agent_ctx = AgentContext::default();
+
+    let response = state
+        .dispatch_tenant_action_ext(
+            &tenant,
+            "Parent",
+            "parent-1",
+            "Trigger",
+            serde_json::json!({ "child_id": "child-1" }),
+            DispatchExtOptions {
+                agent_ctx: &agent_ctx,
+                await_integration: true,
+                await_reactions: true,
+            },
+        )
+        .await
+        .expect("Trigger should succeed");
+
+    // The inline adapter callback must have been applied.
+    assert!(response.success);
+    assert_eq!(
+        response.state.status, "Done",
+        "inline adapter callback should move parent to Done"
+    );
+
+    // The scheduled action from the ORIGINAL transition must still fire.
+    let parent_status = poll_status(&state, &tenant, "Parent", "parent-1", "Ticked").await;
+    assert_eq!(
+        parent_status, "Ticked",
+        "scheduled action `Tick` was dropped by the inline integration path (ARN-188)"
+    );
+
+    // The spawn request from the ORIGINAL transition must still create + init the child.
+    let child_status = poll_status(&state, &tenant, "Child", "child-1", "Initialized").await;
+    assert_eq!(
+        child_status, "Initialized",
+        "spawn request for child entity was dropped by the inline integration path (ARN-188)"
+    );
+}

--- a/docs/adrs/0155-durable-deferred-transition-effects.md
+++ b/docs/adrs/0155-durable-deferred-transition-effects.md
@@ -1,0 +1,159 @@
+# ADR-0155: Durable deferred transition effects
+
+- Status: Proposed
+- Date: 2026-07-11
+- Deciders: Temper core maintainers
+- Related:
+  - ADR-0048: Dispatch retry and idempotency
+  - ADR-0049: State-timeout arming
+  - ADR-0056: Inline integration persistence and callback handling
+  - ADR-0142: Dispatch acknowledges after projection
+  - `crates/temper-server/src/entity_actor/types.rs`
+  - `crates/temper-server/src/state/dispatch/effects.rs`
+  - `crates/temper-server/src/state/dispatch/cross_entity.rs`
+
+## Context
+
+ARN-188 found that successful transitions can emit deferred child effects:
+scheduled actions and child spawn requests. The normal post-dispatch path
+runs those effects after the entity actor commits and replies. The
+`await_integration = true` inline integration path could return the integration
+callback response before running the original transition's deferred effects,
+which silently dropped scheduled timers and child spawns.
+
+The smaller control-flow fix dispatches those effects before the inline
+callback return. That closes the observed branch bug, but it is still not a
+complete durability boundary: after the parent transition commits, a process
+crash before post-dispatch can lose the deferred effects unless the caller
+retries with the same idempotency key.
+
+## Decision
+
+### Sub-Decision 1: Persist deferred effects on the transition event
+
+`EntityEvent` records the `scheduled_actions` and `spawn_requests` emitted by
+the transition. These fields have serde defaults, so older events remain
+readable.
+
+**Why this approach**: The parent transition event is already the durable fact
+that caused the deferred work. Storing the effect intents beside that fact keeps
+the immediate fix small and avoids a parallel store schema before the complete
+outbox executor exists.
+
+### Sub-Decision 2: Idempotent retries re-surface the original deferred effects
+
+When an actor sees a duplicate idempotency key, it returns the committed
+response shape from current state and, when the original event is still in the
+bounded recent-event tail, includes the original scheduled/spawn effects. This
+lets a caller retry after a crash-before-response and re-enter post-dispatch
+without silently dropping the child work.
+
+**Why this approach**: ADR-0048 already defines caller idempotency as the
+dispatch retry contract. Reusing that contract is the smallest safe repair for
+the crash window this PR can own.
+
+### Sub-Decision 3: Deferred child work receives deterministic idempotency keys
+
+Scheduled actions and child initial actions derive idempotency keys from:
+
+- tenant
+- parent entity type and ID
+- parent event sequence number
+- effect kind and effect index
+- target action or child identity
+
+**Why this approach**: If a retry re-surfaces the same deferred effects, the
+target actor can deduplicate the resulting scheduled action or child initial
+action instead of executing it twice.
+
+### Sub-Decision 4: Inline integration early returns use the same dispatch helper
+
+The inline-integration callback return path and the normal post-dispatch path
+both call the shared deferred-effect dispatcher for the original transition
+response.
+
+**Why this approach**: A single helper keeps the "run spawn + schedule" contract
+visible and prevents future early-return branches from reintroducing the same
+drop.
+
+## Rollout Plan
+
+1. **Phase 0 (Immediate)** — Persist scheduled/spawn effects on `EntityEvent`,
+   re-surface them on duplicate idempotency retries, add deterministic
+   child-effect idempotency keys, and keep the inline integration regression
+   test.
+2. **Phase 1 (Follow-up)** — Add a leased durable outbox/ack executor that
+   scans unacknowledged effect intents after restart, retries with backoff, and
+   records completion.
+3. **Phase 2** — Extend the outbox model to all post-dispatch work that must be
+   recovered independently of caller retry, including integration callbacks if
+   they need stronger than best-effort semantics.
+
+## Readiness Gates
+
+- Inline integration regression proves scheduled actions and child spawns are
+  not dropped on the callback early-return path.
+- Duplicate idempotency responses preserve deferred effects when the originating
+  event is still in the actor's recent event tail.
+- Deferred child actions carry deterministic idempotency keys.
+- Follow-up outbox gate is required before claiming restart-autonomous exactly
+  once delivery for deferred effects.
+
+## Consequences
+
+### Positive
+
+- The original transition event now contains the deferred effect intents it
+  produced.
+- Caller retry after commit-before-response can re-run post-dispatch without
+  losing the transition's child work.
+- Duplicate post-dispatch attempts are bounded by deterministic target-side
+  idempotency keys.
+
+### Negative
+
+- Event payloads grow when transitions emit scheduled actions or spawn requests.
+- Recovery is still coupled to caller retry until the leased outbox exists.
+- The recent-event-tail lookup is best effort; if the original event ages out,
+  duplicate replies remain safe but cannot re-surface deferred effects.
+
+### Risks
+
+- A transition with very large deferred-effect lists could increase journal
+  payload size. Existing transition budgets should stay bounded; new effect
+  kinds must preserve those budgets.
+- A target action that ignores idempotency could still observe duplicate
+  delivery. Current actor dispatch applies idempotency at the actor boundary.
+
+### DST Compliance
+
+- Deferred idempotency keys are deterministic strings derived from committed
+  tenant/entity/sequence/effect coordinates.
+- No random or wall-clock value is introduced in simulation-visible state.
+- Background `tokio::spawn` dispatch remains production side-effect behavior
+  and is already annotated as determinism-ok at the call sites.
+
+## Non-Goals
+
+- This ADR does not claim autonomous restart recovery without caller retry.
+- This ADR does not introduce a leased outbox, ack table, or global effect
+  executor.
+- This ADR does not change custom-effect integration delivery semantics.
+
+## Alternatives Considered
+
+1. **Only dispatch before inline early return** — Rejected as too shallow. It
+   fixes the observed branch but leaves the commit-before-post-dispatch crash
+   window unaddressed.
+2. **Full durable outbox in this PR** — Rejected for this immediate fix because
+   it requires a new store schema, claim/lease protocol, backoff policy, and
+   restart scanner. That remains the correct production-hardening follow-up.
+3. **Recompute effects from the spec during retry** — Rejected because spec
+   evolution can change effects after the original transition commits; the
+   committed event should carry the effect intents produced at commit time.
+
+## Rollback Policy
+
+The serde-default fields are backward-compatible. If this decision proves
+wrong, stop reading the persisted effect fields and revert the post-dispatch
+retry behavior; older events and newer events remain readable.


### PR DESCRIPTION
Closes **ARN-188** (High, Bug) under epic **ARN-165**. Draft for review — do not merge.

## Bug
`run_post_dispatch_effects` (dispatch/effects.rs): when `await_integration=true` and a transition's custom effect maps to an inline WASM/adapter integration returning a callback response, the code returned **before** the spawn_requests + scheduled_actions steps. Those belong to the *original* transition (the callback is a separate action), so the original transition's child-entity spawns and scheduled timers were **silently dropped**. Reachable in prod via OData `?await_integration=true`.

## Fix
Extracted the deferred-effects steps into a shared `dispatch_transition_deferred_effects`, called on both the normal path and the inline early-return path, so the original transition's spawns + scheduled actions always run. Deliberately did **not** re-run steps 5b/7b/8 on the inline path — the callback already armed the final-state timer, so re-running 7b on the stale intermediate state would arm a superseding wrong-state timer (a regression). Both reviewers confirmed this scoping.

## Red→green
`inline_integration_still_runs_scheduled_and_spawn_effects`: a Trigger transition emits a custom effect (→ inline http callback → Done) **plus** a scheduled Tick **plus** a spawn Child, under `await_integration=true`. RED: parent stuck at Done (Tick dropped). GREEN: parent reaches Ticked, child Initialized. Scoped: adapter_dispatch 6/6, wasm_dispatch 6/6, --lib dispatch 102/102. Code review PASS + DST-READY (both genuine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes ARN-188: when `await_integration=true` and a transition's custom effect maps to an inline WASM/adapter integration, the original transition's `spawn_requests` and `scheduled_actions` were silently dropped because `run_post_dispatch_effects` returned early with the callback response before executing those steps. The fix extracts those steps into a shared `dispatch_transition_deferred_effects` helper called on both the normal path and the inline early-return path.

- **Core fix (effects.rs)**: A new `dispatch_transition_deferred_effects` helper wraps spawn + schedule dispatch; it is called before `return final_response` on the inline path and replaces the two separate blocks on the normal path, ensuring deferred effects always run.
- **Durable persistence (types.rs, effects.rs, actor.rs)**: `EntityEvent` now stores `scheduled_actions` and `spawn_requests` so that idempotency retries can re-surface the original deferred work from the bounded event tail.
- **Deterministic child-effect keys (cross_entity.rs, effects.rs)**: `dispatch_spawn_requests` and `dispatch_scheduled_actions` now derive stable idempotency keys from tenant/entity/sequence/effect-index coordinates so target actors can deduplicate duplicate deliveries.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Not safe to merge in current form — two defect paths identified in previous review rounds remain unaddressed in the diff.

The inline-integration happy path is correctly fixed and the regression test proves it. Two defect paths remain open: (1) the Err return branches in run_post_dispatch_effects (WASM failure ~line 691 and adapter failure ~line 724) still build responses with Vec::new() for scheduled_actions and spawn_requests — a WASM panic or adapter HTTP error after the transition commits will permanently drop every child spawn and scheduled timer from that transition; (2) the idempotency-key duplicate-detection path in actor.rs clones current actor state for the response, so dispatch_transition_deferred_effects receives a sequence_nr that may have advanced since the original commit, generating child-effect idempotency keys that won't match those from the first dispatch and will cause duplicate child Init dispatches or duplicate scheduled action firings.

crates/temper-server/src/state/dispatch/effects.rs (Err return paths at ~lines 691–700 and 724–734) and crates/temper-server/src/entity_actor/actor.rs (idempotency duplicate-detection response build at ~line 884).
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/temper-server/src/state/dispatch/effects.rs | Core fix location: adds dispatch_transition_deferred_effects helper and calls it on the inline-integration early-return path. Two Err branches (WASM ~line 691-700, adapter ~line 724-734) still return without calling the helper, so a WASM panic or adapter HTTP error silently drops all spawn/schedule effects from the committed transition. |
| crates/temper-server/src/entity_actor/actor.rs | Idempotency retry path (lines 874-901) now re-surfaces deferred effects from the bounded event tail, but builds the response with state.clone() whose sequence_nr reflects any transitions committed since the original, causing dispatch_transition_deferred_effects to derive different child-effect idempotency keys than the first dispatch. |
| crates/temper-server/src/entity_actor/types.rs | Adds scheduled_actions and spawn_requests fields to EntityEvent (serde-defaulted for backward compat) and event_for_idempotency_key lookup; new unit test covers the lookup. Test uses chrono::Utc::now() without the determinism-ok annotation (DST rule violation, previously flagged). |
| crates/temper-server/src/state/dispatch/cross_entity.rs | dispatch_spawn_requests refactored to accept SpawnDispatchBatch struct; new source_sequence field drives deterministic deferred:spawn:... idempotency key derivation. Change is mechanical and correct. |
| crates/temper-server/tests/inline_integration_effects.rs | New integration regression test for ARN-188: fires an HTTP adapter mock, then polls until Parent reaches Ticked and Child reaches Initialized, proving both scheduled and spawn effects run on the inline path. |
| crates/temper-server/src/entity_actor/effects.rs | EntityEvent construction now captures scheduled_actions and spawn_requests alongside the event; idempotency_key is still set to None here (correctly set to the caller's key in actor.rs before push_event_bounded). |
| docs/adrs/0155-durable-deferred-transition-effects.md | New ADR documenting sub-decisions on event persistence, idempotent retries, deterministic child keys, and shared dispatch helper; also outlines the Phase 1 outbox follow-up. Well-scoped and accurate. |
| crates/temper-server/src/state/dispatch/state_timeouts.rs | Mechanical struct initialization update: adds scheduled_actions: Vec::new() and spawn_requests: Vec::new() to a test helper EntityEvent constructor to satisfy the new fields. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant ServerState as ServerState<br/>(run_post_dispatch_effects)
    participant EntityActor
    participant InlineIntegration as Inline Integration<br/>(WASM/adapter)
    participant ChildEffects as Child Effects<br/>(spawn + schedule)

    Caller->>ServerState: "dispatch_tenant_action_ext(await_integration=true)"
    ServerState->>EntityActor: ask(action)
    EntityActor-->>ServerState: "EntityResponse {scheduled_actions, spawn_requests}"
    Note over EntityActor: Event stored with idempotency_key +<br/>scheduled_actions + spawn_requests

    alt Inline integration path (ARN-188 fix)
        ServerState->>InlineIntegration: dispatch_wasm/adapter_integrations_internal
        InlineIntegration-->>ServerState: Ok(Some(final_response))
        Note over ServerState: NEW: dispatch_transition_deferred_effects<br/>called BEFORE return final_response
        ServerState->>ChildEffects: "dispatch_spawn_requests(source_seq=S)"
        ServerState->>ChildEffects: "dispatch_scheduled_actions(source_seq=S)"
        ServerState-->>Caller: final_response (post-callback state)
    else Normal path
        ServerState->>ChildEffects: dispatch_transition_deferred_effects
        ServerState-->>Caller: response
    else Error path (still unpatched)
        InlineIntegration-->>ServerState: Err(e)
        Note over ServerState: returns early with Vec::new() — effects dropped
        ServerState-->>Caller: error response
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant ServerState as ServerState<br/>(run_post_dispatch_effects)
    participant EntityActor
    participant InlineIntegration as Inline Integration<br/>(WASM/adapter)
    participant ChildEffects as Child Effects<br/>(spawn + schedule)

    Caller->>ServerState: "dispatch_tenant_action_ext(await_integration=true)"
    ServerState->>EntityActor: ask(action)
    EntityActor-->>ServerState: "EntityResponse {scheduled_actions, spawn_requests}"
    Note over EntityActor: Event stored with idempotency_key +<br/>scheduled_actions + spawn_requests

    alt Inline integration path (ARN-188 fix)
        ServerState->>InlineIntegration: dispatch_wasm/adapter_integrations_internal
        InlineIntegration-->>ServerState: Ok(Some(final_response))
        Note over ServerState: NEW: dispatch_transition_deferred_effects<br/>called BEFORE return final_response
        ServerState->>ChildEffects: "dispatch_spawn_requests(source_seq=S)"
        ServerState->>ChildEffects: "dispatch_scheduled_actions(source_seq=S)"
        ServerState-->>Caller: final_response (post-callback state)
    else Normal path
        ServerState->>ChildEffects: dispatch_transition_deferred_effects
        ServerState-->>Caller: response
    else Error path (still unpatched)
        InlineIntegration-->>ServerState: Err(e)
        Note over ServerState: returns early with Vec::new() — effects dropped
        ServerState-->>Caller: error response
    end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `crates/temper-server/src/state/dispatch/effects.rs`, line 690-734 ([link](https://github.com/nerdsane/temper/blob/b154194ffaa7dfc2a5a93c127a7491998120d7ad/crates/temper-server/src/state/dispatch/effects.rs#L690-L734)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Error paths still silently drop original transition's deferred effects**

   Both `Err` branches (WASM at ~line 694 and adapter at ~line 728) return early with `scheduled_actions: Vec::new(), spawn_requests: Vec::new()`. The ORIGINAL `response` (already committed to the actor) still holds the transition's `spawn_requests` and `scheduled_actions`, but they are never passed to `dispatch_transition_deferred_effects`. This is the exact same silent-drop bug that ARN-188 identified for the success path — the fix correctly handles `Ok(Some(final_response))` at line 756 but misses both error paths. Under `await_integration=true`, if the WASM module panics or the HTTP adapter call errors, every child spawn and scheduled timer from the committed transition is permanently lost.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: crates/temper-server/src/state/dispatch/effects.rs
   Line: 690-734

   Comment:
   **Error paths still silently drop original transition's deferred effects**

   Both `Err` branches (WASM at ~line 694 and adapter at ~line 728) return early with `scheduled_actions: Vec::new(), spawn_requests: Vec::new()`. The ORIGINAL `response` (already committed to the actor) still holds the transition's `spawn_requests` and `scheduled_actions`, but they are never passed to `dispatch_transition_deferred_effects`. This is the exact same silent-drop bug that ARN-188 identified for the success path — the fix correctly handles `Ok(Some(final_response))` at line 756 but misses both error paths. Under `await_integration=true`, if the WASM module panics or the HTTP adapter call errors, every child spawn and scheduled timer from the committed transition is permanently lost.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-server%2Fsrc%2Fstate%2Fdispatch%2Feffects.rs%0ALine%3A%20690-734%0A%0AComment%3A%0A**Error%20paths%20still%20silently%20drop%20original%20transition's%20deferred%20effects**%0A%0ABoth%20%60Err%60%20branches%20%28WASM%20at%20~line%20694%20and%20adapter%20at%20~line%20728%29%20return%20early%20with%20%60scheduled_actions%3A%20Vec%3A%3Anew%28%29%2C%20spawn_requests%3A%20Vec%3A%3Anew%28%29%60.%20The%20ORIGINAL%20%60response%60%20%28already%20committed%20to%20the%20actor%29%20still%20holds%20the%20transition's%20%60spawn_requests%60%20and%20%60scheduled_actions%60%2C%20but%20they%20are%20never%20passed%20to%20%60dispatch_transition_deferred_effects%60.%20This%20is%20the%20exact%20same%20silent-drop%20bug%20that%20ARN-188%20identified%20for%20the%20success%20path%20%E2%80%94%20the%20fix%20correctly%20handles%20%60Ok%28Some%28final_response%29%29%60%20at%20line%20756%20but%20misses%20both%20error%20paths.%20Under%20%60await_integration%3Dtrue%60%2C%20if%20the%20WASM%20module%20panics%20or%20the%20HTTP%20adapter%20call%20errors%2C%20every%20child%20spawn%20and%20scheduled%20timer%20from%20the%20committed%20transition%20is%20permanently%20lost.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=nerdsane%2Ftemper&pr=349&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22claude%2Farn-188-inline-integration-effects%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Farn-188-inline-integration-effects%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-server%2Fsrc%2Fstate%2Fdispatch%2Feffects.rs%0ALine%3A%20690-734%0A%0AComment%3A%0A**Error%20paths%20still%20silently%20drop%20original%20transition's%20deferred%20effects**%0A%0ABoth%20%60Err%60%20branches%20%28WASM%20at%20~line%20694%20and%20adapter%20at%20~line%20728%29%20return%20early%20with%20%60scheduled_actions%3A%20Vec%3A%3Anew%28%29%2C%20spawn_requests%3A%20Vec%3A%3Anew%28%29%60.%20The%20ORIGINAL%20%60response%60%20%28already%20committed%20to%20the%20actor%29%20still%20holds%20the%20transition's%20%60spawn_requests%60%20and%20%60scheduled_actions%60%2C%20but%20they%20are%20never%20passed%20to%20%60dispatch_transition_deferred_effects%60.%20This%20is%20the%20exact%20same%20silent-drop%20bug%20that%20ARN-188%20identified%20for%20the%20success%20path%20%E2%80%94%20the%20fix%20correctly%20handles%20%60Ok%28Some%28final_response%29%29%60%20at%20line%20756%20but%20misses%20both%20error%20paths.%20Under%20%60await_integration%3Dtrue%60%2C%20if%20the%20WASM%20module%20panics%20or%20the%20HTTP%20adapter%20call%20errors%2C%20every%20child%20spawn%20and%20scheduled%20timer%20from%20the%20committed%20transition%20is%20permanently%20lost.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=nerdsane%2Ftemper&pr=349&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-server%2Fsrc%2Fstate%2Fdispatch%2Feffects.rs%0ALine%3A%20690-734%0A%0AComment%3A%0A**Error%20paths%20still%20silently%20drop%20original%20transition's%20deferred%20effects**%0A%0ABoth%20%60Err%60%20branches%20%28WASM%20at%20~line%20694%20and%20adapter%20at%20~line%20728%29%20return%20early%20with%20%60scheduled_actions%3A%20Vec%3A%3Anew%28%29%2C%20spawn_requests%3A%20Vec%3A%3Anew%28%29%60.%20The%20ORIGINAL%20%60response%60%20%28already%20committed%20to%20the%20actor%29%20still%20holds%20the%20transition's%20%60spawn_requests%60%20and%20%60scheduled_actions%60%2C%20but%20they%20are%20never%20passed%20to%20%60dispatch_transition_deferred_effects%60.%20This%20is%20the%20exact%20same%20silent-drop%20bug%20that%20ARN-188%20identified%20for%20the%20success%20path%20%E2%80%94%20the%20fix%20correctly%20handles%20%60Ok%28Some%28final_response%29%29%60%20at%20line%20756%20but%20misses%20both%20error%20paths.%20Under%20%60await_integration%3Dtrue%60%2C%20if%20the%20WASM%20module%20panics%20or%20the%20HTTP%20adapter%20call%20errors%2C%20every%20child%20spawn%20and%20scheduled%20timer%20from%20the%20committed%20transition%20is%20permanently%20lost.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=349&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>

2. `crates/temper-server/src/entity_actor/actor.rs`, line 835-860 ([link](https://github.com/nerdsane/temper/blob/b154194ffaa7dfc2a5a93c127a7491998120d7ad/crates/temper-server/src/entity_actor/actor.rs#L835-L860)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Deferred idempotency keys use wrong sequence on retry**

   On the idempotency-duplicate path, the response is built with `state: response_state` — a clone of the **current** `EntityState`, whose `sequence_nr` reflects all events committed since the original transition. If other transitions happened on this entity between the first dispatch and the retry, `response.state.sequence_nr` is higher than the original event's sequence. `dispatch_transition_deferred_effects` then derives idempotency keys with format `"deferred:scheduled:…:{source_sequence}:…"` using that higher sequence, producing keys that differ from the ones used in the original dispatch. The target actor has already processed the original keys, but these new keys look like fresh requests, so the scheduled action or child `Init` fires a second time.

   ADR-0155 Sub-Decision 3 explicitly says keys should be derived from the "parent event sequence number." The correct source_sequence here is the sequence recorded when the idempotency key was first committed, which is available in `state.processed_idempotency_keys.get(key)`. That value was written by `record_processed_idempotency_key` at the moment of the original commit and remains stable regardless of later activity.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: crates/temper-server/src/entity_actor/actor.rs
   Line: 835-860

   Comment:
   **Deferred idempotency keys use wrong sequence on retry**

   On the idempotency-duplicate path, the response is built with `state: response_state` — a clone of the **current** `EntityState`, whose `sequence_nr` reflects all events committed since the original transition. If other transitions happened on this entity between the first dispatch and the retry, `response.state.sequence_nr` is higher than the original event's sequence. `dispatch_transition_deferred_effects` then derives idempotency keys with format `"deferred:scheduled:…:{source_sequence}:…"` using that higher sequence, producing keys that differ from the ones used in the original dispatch. The target actor has already processed the original keys, but these new keys look like fresh requests, so the scheduled action or child `Init` fires a second time.

   ADR-0155 Sub-Decision 3 explicitly says keys should be derived from the "parent event sequence number." The correct source_sequence here is the sequence recorded when the idempotency key was first committed, which is available in `state.processed_idempotency_keys.get(key)`. That value was written by `record_processed_idempotency_key` at the moment of the original commit and remains stable regardless of later activity.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-server%2Fsrc%2Fentity_actor%2Factor.rs%0ALine%3A%20835-860%0A%0AComment%3A%0A**Deferred%20idempotency%20keys%20use%20wrong%20sequence%20on%20retry**%0A%0AOn%20the%20idempotency-duplicate%20path%2C%20the%20response%20is%20built%20with%20%60state%3A%20response_state%60%20%E2%80%94%20a%20clone%20of%20the%20**current**%20%60EntityState%60%2C%20whose%20%60sequence_nr%60%20reflects%20all%20events%20committed%20since%20the%20original%20transition.%20If%20other%20transitions%20happened%20on%20this%20entity%20between%20the%20first%20dispatch%20and%20the%20retry%2C%20%60response.state.sequence_nr%60%20is%20higher%20than%20the%20original%20event's%20sequence.%20%60dispatch_transition_deferred_effects%60%20then%20derives%20idempotency%20keys%20with%20format%20%60%22deferred%3Ascheduled%3A%E2%80%A6%3A%7Bsource_sequence%7D%3A%E2%80%A6%22%60%20using%20that%20higher%20sequence%2C%20producing%20keys%20that%20differ%20from%20the%20ones%20used%20in%20the%20original%20dispatch.%20The%20target%20actor%20has%20already%20processed%20the%20original%20keys%2C%20but%20these%20new%20keys%20look%20like%20fresh%20requests%2C%20so%20the%20scheduled%20action%20or%20child%20%60Init%60%20fires%20a%20second%20time.%0A%0AADR-0155%20Sub-Decision%203%20explicitly%20says%20keys%20should%20be%20derived%20from%20the%20%22parent%20event%20sequence%20number.%22%20The%20correct%20source_sequence%20here%20is%20the%20sequence%20recorded%20when%20the%20idempotency%20key%20was%20first%20committed%2C%20which%20is%20available%20in%20%60state.processed_idempotency_keys.get%28key%29%60.%20That%20value%20was%20written%20by%20%60record_processed_idempotency_key%60%20at%20the%20moment%20of%20the%20original%20commit%20and%20remains%20stable%20regardless%20of%20later%20activity.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=nerdsane%2Ftemper&pr=349&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22claude%2Farn-188-inline-integration-effects%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Farn-188-inline-integration-effects%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-server%2Fsrc%2Fentity_actor%2Factor.rs%0ALine%3A%20835-860%0A%0AComment%3A%0A**Deferred%20idempotency%20keys%20use%20wrong%20sequence%20on%20retry**%0A%0AOn%20the%20idempotency-duplicate%20path%2C%20the%20response%20is%20built%20with%20%60state%3A%20response_state%60%20%E2%80%94%20a%20clone%20of%20the%20**current**%20%60EntityState%60%2C%20whose%20%60sequence_nr%60%20reflects%20all%20events%20committed%20since%20the%20original%20transition.%20If%20other%20transitions%20happened%20on%20this%20entity%20between%20the%20first%20dispatch%20and%20the%20retry%2C%20%60response.state.sequence_nr%60%20is%20higher%20than%20the%20original%20event's%20sequence.%20%60dispatch_transition_deferred_effects%60%20then%20derives%20idempotency%20keys%20with%20format%20%60%22deferred%3Ascheduled%3A%E2%80%A6%3A%7Bsource_sequence%7D%3A%E2%80%A6%22%60%20using%20that%20higher%20sequence%2C%20producing%20keys%20that%20differ%20from%20the%20ones%20used%20in%20the%20original%20dispatch.%20The%20target%20actor%20has%20already%20processed%20the%20original%20keys%2C%20but%20these%20new%20keys%20look%20like%20fresh%20requests%2C%20so%20the%20scheduled%20action%20or%20child%20%60Init%60%20fires%20a%20second%20time.%0A%0AADR-0155%20Sub-Decision%203%20explicitly%20says%20keys%20should%20be%20derived%20from%20the%20%22parent%20event%20sequence%20number.%22%20The%20correct%20source_sequence%20here%20is%20the%20sequence%20recorded%20when%20the%20idempotency%20key%20was%20first%20committed%2C%20which%20is%20available%20in%20%60state.processed_idempotency_keys.get%28key%29%60.%20That%20value%20was%20written%20by%20%60record_processed_idempotency_key%60%20at%20the%20moment%20of%20the%20original%20commit%20and%20remains%20stable%20regardless%20of%20later%20activity.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=nerdsane%2Ftemper&pr=349&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-server%2Fsrc%2Fentity_actor%2Factor.rs%0ALine%3A%20835-860%0A%0AComment%3A%0A**Deferred%20idempotency%20keys%20use%20wrong%20sequence%20on%20retry**%0A%0AOn%20the%20idempotency-duplicate%20path%2C%20the%20response%20is%20built%20with%20%60state%3A%20response_state%60%20%E2%80%94%20a%20clone%20of%20the%20**current**%20%60EntityState%60%2C%20whose%20%60sequence_nr%60%20reflects%20all%20events%20committed%20since%20the%20original%20transition.%20If%20other%20transitions%20happened%20on%20this%20entity%20between%20the%20first%20dispatch%20and%20the%20retry%2C%20%60response.state.sequence_nr%60%20is%20higher%20than%20the%20original%20event's%20sequence.%20%60dispatch_transition_deferred_effects%60%20then%20derives%20idempotency%20keys%20with%20format%20%60%22deferred%3Ascheduled%3A%E2%80%A6%3A%7Bsource_sequence%7D%3A%E2%80%A6%22%60%20using%20that%20higher%20sequence%2C%20producing%20keys%20that%20differ%20from%20the%20ones%20used%20in%20the%20original%20dispatch.%20The%20target%20actor%20has%20already%20processed%20the%20original%20keys%2C%20but%20these%20new%20keys%20look%20like%20fresh%20requests%2C%20so%20the%20scheduled%20action%20or%20child%20%60Init%60%20fires%20a%20second%20time.%0A%0AADR-0155%20Sub-Decision%203%20explicitly%20says%20keys%20should%20be%20derived%20from%20the%20%22parent%20event%20sequence%20number.%22%20The%20correct%20source_sequence%20here%20is%20the%20sequence%20recorded%20when%20the%20idempotency%20key%20was%20first%20committed%2C%20which%20is%20available%20in%20%60state.processed_idempotency_keys.get%28key%29%60.%20That%20value%20was%20written%20by%20%60record_processed_idempotency_key%60%20at%20the%20moment%20of%20the%20original%20commit%20and%20remains%20stable%20regardless%20of%20later%20activity.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=349&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["fix(dispatch): persist deferred transiti..."](https://github.com/nerdsane/temper/commit/0b06c79d6633ab7b944865d209fb3fbed94c5681) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43166004)</sub>

<!-- /greptile_comment -->