### PR TITLE
docs: RFC-0002 — first-class authorization for Temper apps (ARN-255)

### DIFF
--- a/docs/rfcs/0002-first-class-authorization.md
+++ b/docs/rfcs/0002-first-class-authorization.md
@@ -1,6 +1,7 @@
 # RFC-0002: First-Class Authorization for Temper Apps
 
-- Status: Draft
+- Status: Proposed — the Option B direction was decided 2026-07-11 (ARN-255);
+  this document becomes Accepted when it merges after review
 - Date: 2026-07-11
 - Authors: Claude Code, with product direction from the human director
 - Related:
@@ -142,16 +143,20 @@ resolution to three shapes, all producing a verified `SecurityContext`:
 
 With these in place, the self-declared `x-temper-principal-*` /
 `x-temper-agent-type` headers are removed from the protocol, completing what
-ADR-0033 specified and ARN-170's ingress work began. A request with no
-verified credential resolves to an anonymous principal that can reach only
-whatever policies explicitly permit anonymously. This deliberately revises
-ADR-0033's "no token = 401" posture: once headers are gone the kernel needs a
-defined identity for credential-less requests, and apps with public read
-surfaces (a catalog page, a published design language) need a way to serve
-them without handing the front end a privileged key. An anonymous principal
-governed by explicit Cedar permits is one way to provide that; whether
-generated policies include anonymous read permits per entity, or apps instead
-mint a public-reader service credential, is an open question below.
+ADR-0033 specified and ARN-170's ingress work began (the Rollout section
+stages that removal behind an explicit gate).
+
+For requests with no credential at all, this RFC proposes a future revision
+of ADR-0033's "no token = 401" posture: an anonymous principal that can reach
+only whatever policies explicitly permit anonymously. The motivation is apps
+with public read surfaces (a catalog page, a published design language) that
+should not need a privileged key in the front end to serve them. Whether that
+lands as anonymous read permits in generated policies or as a public-reader
+service credential is Open Question 2, and **credential-less requests keep
+returning 401 until that question is resolved** — no rollout step below
+changes the credential-less behavior. During the whole rollout, existing
+public pages keep working because they authenticate with the shared key,
+which remains a valid credential until step 4 retires it.
 
 ### 3. Member roles as principal attributes
 
@@ -230,21 +235,31 @@ to stamp.
 
 ## Rollout
 
-Ordered by dependency; step numbers match ARN-255. Steps 1 and 2 ship
-together (see the coordination note); steps 3 and 4 each land value on their
-own.
+Ordered by dependency; step numbers match ARN-255. Every step is additive
+and lands value on its own. The one breaking change in the whole plan —
+removing header-derived principals — is not a step of its own; it rides
+inside step 1 behind the explicit gate described there, so correctness never
+depends on two deploys landing simultaneously.
 
 1. **Kernel verifies tokens.** Extend the resolver to validate JWTs from
    allowlisted per-tenant issuers (interim Option A: katagami.ai's existing
-   authorization server is the first allowlisted issuer). Self-declared
-   principal headers are dropped in the same change.
-   *Coordination:* ARN-170 (PR #343) closes the header-trust path the
-   Katagami MCP adapter currently depends on for its contributor stamp, so
-   step 2 must land together with the header removal — otherwise contributor
-   enforcement silently disappears.
+   authorization server is the first allowlisted issuer). This is additive:
+   header-derived principals keep working while it lands.
+   *Header-removal gate:* the header-trust path is removed only after (a)
+   step 2 is deployed and (b) request telemetry shows zero
+   header-authenticated traffic over an agreed observation window. Until
+   both hold, the removal change does not merge — record the gate as a
+   blocking checklist item on the removal PR itself, referencing the step 2
+   deploy. This interacts with ARN-170 (PR #343), which closes the same
+   header-trust path for privileged principals: the Katagami MCP adapter
+   depends on that path for its contributor stamp, so the same gate applies
+   to the ARN-170 edge before it can drop `x-temper-agent-type` handling —
+   otherwise contributor enforcement silently disappears in the window
+   between the two deploys.
 2. **Katagami MCP adapter forwards tokens.** The adapter passes the caller's
-   JWT through instead of swapping to the shared key. The contributor boundary
-   becomes kernel-enforced.
+   JWT through instead of swapping to the shared key. Deployable as soon as
+   step 1's verification is live, while headers still work — the boundary
+   moves from adapter discipline to kernel enforcement with no gap.
 3. **Human token exchange + Member roles.** Kernel exchange endpoint; Member
    spec promoted to the platform; katagami.ai server actions call with
    per-user tokens; `KATAGAMI_OWNER_SUBS` retires. Unblocks ARN-248 (personal
@@ -255,6 +270,10 @@ own.
    Katagami's hand-written permit-all files are migrated to spec declarations
    in the same pass (they are the proof that the sugar covers a real app);
    ARN-163's MCP resource server points at the platform AS.
+   *Prerequisite:* ARN-230's fail-open fallback is fixed and verified first —
+   a failed or missing tenant policy load must fail closed. Shipping
+   default-deny generation on top of a permit-all fallback would silently
+   reopen every action the spec intended to deny whenever a load fails.
 
 ## Consequences
 

--- a/docs/rfcs/0002-first-class-authorization.md
+++ b/docs/rfcs/0002-first-class-authorization.md
@@ -1,0 +1,316 @@
+# RFC-0002: First-Class Authorization for Temper Apps
+
+- Status: Draft
+- Date: 2026-07-11
+- Authors: Claude Code, with product direction from the human director
+- Related:
+  - ADR-0033: Platform-Assigned Agent Identity (cite by name; three ADRs share the 0033 number)
+  - ADR-0004: Cedar Authorization for Agents
+  - ADR-0032: Granular Cedar Policy Storage
+  - Linear: ARN-255 (this effort), ARN-163 (platform MCP surface), ARN-170 (ingress auth edge), ARN-151 (contributor identity), ARN-145 (Member roles), ARN-248 (personal spaces), ARN-230 (permit-all fallback)
+  - `crates/temper-authz/src/context.rs` (SecurityContext, Principal)
+  - `crates/temper-server/src/identity/resolver.rs` (bearer credential resolution)
+  - `crates/temper-authz/src/policy_gen.rs` (Cedar generation)
+  - katagami `ui/src/lib/oauth-as.ts` (the app-level authorization server this RFC absorbs)
+
+## Summary
+
+A Temper app has three kinds of callers: people using its web front end,
+agents connecting through MCP (the Model Context Protocol, the standard way
+agents discover and call tools) or an API, and the app's own services. Today
+the platform can tell none of them apart. Every caller arrives on one shared
+API key, and each app re-implements its own access control in front-end code.
+
+This RFC makes authorization a platform capability. The platform runs the
+authorization server; apps handle sign-in and exchange the user's identity for
+a short-lived platform token; the kernel verifies every token and resolves it
+to a principal; policies written in Cedar (the policy language the kernel
+evaluates on every request) — generated from the app's spec — decide what
+that principal may do. An app built this way ships no authorization code of
+its own.
+
+The decision to build this, and to have the platform (rather than each app)
+run the authorization server, was made by the human director on 2026-07-11
+(ARN-255, "Option B") after an audit of Katagami, the first Temper app with
+both a human front end and agent clients.
+
+## Why This RFC Exists
+
+Katagami is the proof case. It has Google sign-in for humans, an OAuth 2.1
+front door for agents, a curation pipeline, and Cedar policies — every piece
+an authorized system needs. The 2026-07-11 audit traced how those pieces
+actually connect and found that the platform makes no per-caller access
+decisions:
+
+- **Humans.** katagami.ai authorizes users entirely inside its Next.js code:
+  curator powers are gated on a `KATAGAMI_OWNER_SUBS` env allowlist
+  (`ui/src/lib/owner.ts:22`), and "only the creator may edit" rules are
+  JavaScript comparisons against a session cookie. Every backend call then
+  uses one shared `TEMPER_API_KEY` (`ui/src/lib/odata.ts:30-34`). The kernel
+  never learns which human is acting; identity reaches it only as writable
+  entity data (`SetCreator(creator_sub, …)`), which the shared key could set
+  to any value.
+- **Agents.** The MCP front door mints real per-agent tokens — ES256, 15-minute
+  TTL, rotating refresh, revocable grants. The kernel cannot verify them, so
+  the adapter swaps to the same shared `TEMPER_API_KEY` and self-declares
+  `x-temper-agent-type: contributor` in headers (`mcp/src/temper.ts:25-34`).
+  The kernel trusts those headers verbatim on the non-credential path
+  (`crates/temper-server/src/odata/bindings.rs:91-101`). The contributor
+  boundary therefore depends on the adapter choosing to stamp the header.
+- **Policies.** The app's Cedar set is wildcard permit statements plus forbid
+  overlays that fire only when `principal.agent_type == "contributor"`. Human
+  identity appears in zero policies. Any holder of the shared key can publish,
+  archive, and manage grants by omitting one header.
+
+None of this is a Katagami bug. Katagami built the strongest layer it could —
+the audit's conclusion is that the missing pieces are platform pieces, and
+every future Temper app with a front end or an agent surface will hit the same
+wall. ADR-0033 already established the principle for agents (the platform
+assigns identity; self-declared identity is rejected) and shipped the
+`AgentCredential` registry and resolver. That ADR deliberately left OAuth/JWT
+validation and delegation as non-goals. This RFC picks those up and extends
+the same principle to humans.
+
+## Goals
+
+1. The kernel can tell callers apart: humans, agents, and services each
+   resolve to a distinct, verified Cedar principal.
+2. Access decisions live in Cedar, derived from the app's spec. Front-end
+   checks remain only as UX (hiding buttons a caller can't use).
+3. A new Temper app gets all of this by default, writing no authorization
+   code.
+4. The shared global API key stops being the ambient credential for
+   everything; it shrinks to explicitly registered service credentials.
+
+## Decision
+
+**The platform runs the authorization server.** Apps do sign-in and token
+exchange only. The kernel verifies every inbound token, resolves it to a
+principal with attributes, and evaluates Cedar. This was chosen over the
+lighter alternative (each app runs its own authorization server and the kernel
+federates to it via published signing keys — "Option A") because Option A
+still leaves every app implementing and operating an OAuth server, which is
+exactly the code this RFC exists to delete. Option A remains a useful interim
+integration path (see Rollout), and nothing in this design prevents a tenant
+from federating an external issuer later.
+
+## Design
+
+### 1. Platform authorization server
+
+A per-tenant authorization server in the platform, providing what
+katagami.ai's hand-rolled one (`ui/src/lib/oauth-as.ts`) provides today:
+
+- Dynamic client registration (RFC 7591) for agent clients.
+- Authorization-code flow with PKCE for interactive consent; a human approves
+  an agent's access, producing a revocable grant entity.
+- Pre-authorized grants for headless agents (CI jobs, cron agents — callers
+  with no browser to click a consent screen): a human mints the grant in the
+  app UI and the refresh token is shown once. ARN-163 flagged this consent
+  gap as a carry-over constraint; the platform AS is where it gets solved
+  once for every app.
+- Short-lived signed access tokens (minutes) carrying the owning
+  human, the acting client, the grant id, and scopes; rotating refresh tokens
+  with replay detection.
+- Published signing keys (JWKS) and discovery metadata (RFC 8414), which the
+  ARN-163 MCP resource server points at.
+
+The `OAuthClient` and `AgentGrant` entities Katagami defined in
+katagami-commons move into platform specs (alongside `AgentCredential` from
+ADR-0033), so every tenant gets them. Katagami's copies migrate.
+
+### 2. Verified principals for every caller
+
+`identity/resolver.rs` today resolves one credential shape: a bearer API key
+hashed and looked up in the `AgentCredential` registry. This RFC extends
+resolution to three shapes, all producing a verified `SecurityContext`:
+
+- **Platform-issued JWTs** (from the authorization server above): verified by
+  signature, expiry, and grant liveness. The principal is the acting agent
+  (`Agent::"<client>"`) with `acting_for` set to the owning human and
+  attributes (`agent_type`, scopes) taken from the token the platform itself
+  minted.
+- **Human token exchange**: the app front end authenticates the human however
+  it likes (Google OIDC in Katagami's case), then exchanges the proof at a
+  kernel endpoint for a short-lived platform token whose principal is
+  `Customer::"<sub>"`. The exchange endpoint verifies the upstream identity
+  (issuer allowlisted per tenant, standard OIDC ID-token validation) and loads
+  principal attributes from the tenant's Member entity (see 3).
+- **Registered service credentials** (existing ADR-0033 path): the curation
+  pipeline, SSR readers, and other app services each get their own
+  `AgentCredential` instead of sharing the global key.
+
+With these in place, the self-declared `x-temper-principal-*` /
+`x-temper-agent-type` headers are removed from the protocol, completing what
+ADR-0033 specified and ARN-170's ingress work began. A request with no
+verified credential resolves to an anonymous principal that can reach only
+whatever policies explicitly permit anonymously. This deliberately revises
+ADR-0033's "no token = 401" posture: once headers are gone the kernel needs a
+defined identity for credential-less requests, and apps with public read
+surfaces (a catalog page, a published design language) need a way to serve
+them without handing the front end a privileged key. An anonymous principal
+governed by explicit Cedar permits is one way to provide that; whether
+generated policies include anonymous read permits per entity, or apps instead
+mint a public-reader service credential, is an open question below.
+
+### 3. Member roles as principal attributes
+
+Apps need durable, queryable roles for humans (ARN-145). Katagami already
+defines a `Member` entity (Google `sub` as key; role owner / curator /
+contributor) that nothing consults. Under this RFC the Member spec becomes a
+platform spec, and the resolver injects the member's role into the principal's
+attributes at token-exchange time — the same mechanism that injects
+`agent_type` for agents today (`engine/mod.rs` principal-entity construction).
+Policies can then say:
+
+```cedar
+permit(principal, action == Action::"Publish", resource is DesignLanguage)
+  when { principal has role && ["owner", "curator"].contains(principal.role) };
+```
+
+Env-var allowlists like `KATAGAMI_OWNER_SUBS` retire.
+
+### 4. Authorization declared in the spec, compiled to Cedar
+
+Hand-written permit-all files are how Katagami ended up open by default. An
+app's behavior is declared in its IOA spec (the TOML document that defines a
+Temper app's entities, state machines, and actions), so that spec is also
+where access requirements belong:
+
+```toml
+[[action]]
+name = "Publish"
+requires_role = ["owner", "curator"]
+
+[[action]]
+name = "Withdraw"
+requires = "creator"        # resource.creator_sub == principal.sub
+```
+
+At install time the platform compiles these into Cedar policies. This
+compiler is new work: the existing Cedar-generation machinery
+(`crates/temper-authz/src/policy_gen.rs`) builds permits from
+principal/action/resource scope matrices for the denial-remediation flow, and
+would be extended — it has no resource-attribute or set-membership
+conditions, and no spec-install wiring today. Per-policy storage already
+exists (ADR-0032), and
+resource-attribute injection already puts entity fields like `creator_sub` on
+the Cedar resource, so creator rules evaluate without new engine surface.
+Actions with no declaration get no permit — the app's posture flips from
+permit-all with forbid overlays to default-deny with generated permits. That
+flip is only trustworthy once ARN-230's permit-all fallback on failed policy
+loads is fixed (see Risks). Hand-written `.cedar` files remain supported for
+policies the sugar cannot express.
+
+### 5. Front-end auth kit
+
+A thin client package so app front ends write no auth plumbing: OIDC login →
+Member upsert → token exchange → a fetch client that attaches the caller's
+platform token and refreshes it. Katagami's Next.js app is the first consumer;
+its session cookie remains purely a front-end concern (which also contains the
+blast radius of its 30-day stateless cookie — the backend stops honoring
+anything the cookie alone asserts).
+
+### How a request flows after this RFC
+
+Human path: sign in with Google on katagami.ai → front end exchanges the ID
+token at the kernel → kernel verifies issuer, loads Member, mints a 15-minute
+token for `Customer::"114585…"` with `role: "owner"` → the page's server code
+calls the kernel's OData API (the HTTP protocol Temper serves entity data and
+actions over) with that token → Cedar evaluates `Publish` against the
+generated policy → allowed because `principal.role == "owner"`.
+
+Agent path: agent completes consent (or holds a pre-authorized grant) → calls
+the MCP surface with its platform-issued JWT → resolver verifies signature +
+grant liveness → principal `Agent::"kc_abc…"`, `acting_for` the granting
+human, `agent_type: "contributor"` from the platform's own registry → Cedar
+denies `Publish`, permits `SubmitForReview`. The boundary holds because the
+kernel resolved the identity itself; there are no headers left for an adapter
+to stamp.
+
+## Rollout
+
+Ordered by dependency; step numbers match ARN-255. Steps 1 and 2 ship
+together (see the coordination note); steps 3 and 4 each land value on their
+own.
+
+1. **Kernel verifies tokens.** Extend the resolver to validate JWTs from
+   allowlisted per-tenant issuers (interim Option A: katagami.ai's existing
+   authorization server is the first allowlisted issuer). Self-declared
+   principal headers are dropped in the same change.
+   *Coordination:* ARN-170 (PR #343) closes the header-trust path the
+   Katagami MCP adapter currently depends on for its contributor stamp, so
+   step 2 must land together with the header removal — otherwise contributor
+   enforcement silently disappears.
+2. **Katagami MCP adapter forwards tokens.** The adapter passes the caller's
+   JWT through instead of swapping to the shared key. The contributor boundary
+   becomes kernel-enforced.
+3. **Human token exchange + Member roles.** Kernel exchange endpoint; Member
+   spec promoted to the platform; katagami.ai server actions call with
+   per-user tokens; `KATAGAMI_OWNER_SUBS` retires. Unblocks ARN-248 (personal
+   spaces need the kernel to know whose space is whose).
+4. **Platform authorization server + spec-compiled policies.** The AS moves
+   into the platform and katagami.ai's retires; `requires_role` / `requires`
+   sugar ships; new apps default to generated default-deny policies;
+   Katagami's hand-written permit-all files are migrated to spec declarations
+   in the same pass (they are the proof that the sugar covers a real app);
+   ARN-163's MCP resource server points at the platform AS.
+
+## Consequences
+
+### Positive
+
+- Authorization is enforced where the data lives. A compromised or buggy
+  front end can no longer publish, delete, or reassign ownership.
+- "Agents act, humans own" becomes checkable: every write carries a verified
+  acting agent and owning human.
+- New apps get login, roles, consent, grants, and policies without writing
+  any of it.
+- One audited implementation of OAuth machinery instead of one per app.
+
+### Negative
+
+- The kernel takes on OAuth surface (an AS, JWKS, token exchange) it did not
+  have; this is real security-critical code the platform must own and test.
+- Every app service needs a provisioned credential; the days of one
+  environment variable unlocking everything end, which adds setup steps.
+- Token exchange adds a network hop to first-request latency per session
+  (mitigated by short-lived token caching in the auth kit).
+
+### Risks
+
+- **Migration breakage.** Katagami is live; each rollout step changes a live
+  credential path. Every step needs the local end-to-end run against a seeded
+  server before deploy, per the standing definition of done.
+- **Spec sugar scope creep.** `requires_role` / `requires = "creator"` covers
+  the audited needs; resisting a policy-language-in-TOML is deliberate.
+  Anything more complex is a hand-written Cedar file.
+- **Fail-open regressions.** ARN-230's finding (missing tenant policies fall
+  back to permit-all) must be fixed before default-deny generation can be
+  trusted; otherwise a failed policy load reopens everything.
+
+## Non-Goals
+
+- Replacing app-chosen human identity providers. Apps keep owning sign-in
+  (Google today; anything OIDC later). The platform's job starts at verifying
+  the resulting identity and exchanging it for a platform token.
+- Agent-to-agent delegation chains beyond one `acting_for` hop (deferred, as
+  in ADR-0033).
+- SPIFFE/SPIRE integration (compatible, out of scope).
+- Fine-grained per-tool consent scopes on the MCP surface (a `contribute`
+  scope exists today; splitting it further is future work with ARN-163).
+
+## Open Questions
+
+1. **Where does consent UI live?** Today the consent screen is a katagami.ai
+   page. When the AS moves to the platform, does consent stay app-hosted
+   (branded, redirect-based) or become a platform-hosted page per tenant?
+2. **Anonymous read.** Public catalog pages currently read through the shared
+   key. Should anonymous principals get read permits in generated policies,
+   or should apps mint a public-reader service credential?
+3. **Customer credential revocation.** Human tokens are short-lived; is that
+   sufficient, or does the platform need a per-human revocation list
+   (sign-out-everywhere) from day one?
+4. **Numbering collision hygiene.** Three ADRs share number 0033; policy work
+   here will add ADRs — fix the numbering scheme before this effort's ADRs
+   land.

--- a/docs/rfcs/0002-first-class-authorization.md
+++ b/docs/rfcs/0002-first-class-authorization.md
@@ -5,7 +5,7 @@
 - Date: 2026-07-11
 - Authors: Claude Code, with product direction from the human director
 - Related:
-  - ADR-0033: Platform-Assigned Agent Identity (cite by name; three ADRs share the 0033 number)
+  - ADR-0033: Platform-Assigned Agent Identity
   - ADR-0004: Cedar Authorization for Agents
   - ADR-0032: Granular Cedar Policy Storage
   - Linear: ARN-255 (this effort), ARN-163 (platform MCP surface), ARN-170 (ingress auth edge), ARN-151 (contributor identity), ARN-145 (Member roles), ARN-248 (personal spaces), ARN-230 (permit-all fallback)
@@ -137,6 +137,15 @@ resolution to three shapes, all producing a verified `SecurityContext`:
   `Customer::"<sub>"`. The exchange endpoint verifies the upstream identity
   (issuer allowlisted per tenant, standard OIDC ID-token validation) and loads
   principal attributes from the tenant's Member entity (see 3).
+
+  Human sessions are revocable everywhere at once (decided 2026-07-14): each
+  Member carries an `auth_generation` counter, every human token embeds the
+  value current at issuance, and verification rejects tokens carrying an
+  older generation — the same liveness pattern (and the same short-TTL cache)
+  the MCP adapter already uses for agent grant checks. "Sign out everywhere"
+  bumps the counter, invalidating every outstanding token for that human on
+  every device within the cache window. Agent tokens already behave this way
+  through grant revocation.
 - **Registered service credentials** (existing ADR-0033 path): the curation
   pipeline, SSR readers, and other app services each get their own
   `AgentCredential` instead of sharing the global key.
@@ -327,9 +336,9 @@ depends on two deploys landing simultaneously.
 2. **Anonymous read.** Public catalog pages currently read through the shared
    key. Should anonymous principals get read permits in generated policies,
    or should apps mint a public-reader service credential?
-3. **Customer credential revocation.** Human tokens are short-lived; is that
-   sufficient, or does the platform need a per-human revocation list
-   (sign-out-everywhere) from day one?
-4. **Numbering collision hygiene.** Three ADRs share number 0033; policy work
-   here will add ADRs — fix the numbering scheme before this effort's ADRs
-   land.
+
+Two earlier open questions have been resolved: humans get
+sign-out-everywhere revocation from day one (decided 2026-07-14; mechanism in
+Design section 2), and the ADR numbering collisions are being fixed in a
+separate renumbering change so this effort's ADRs can land on unique
+numbers.

--- a/docs/rfcs/0002-first-class-authorization.md
+++ b/docs/rfcs/0002-first-class-authorization.md
@@ -138,14 +138,24 @@ resolution to three shapes, all producing a verified `SecurityContext`:
   (issuer allowlisted per tenant, standard OIDC ID-token validation) and loads
   principal attributes from the tenant's Member entity (see 3).
 
-  Human sessions are revocable everywhere at once (decided 2026-07-14): each
-  Member carries an `auth_generation` counter, every human token embeds the
-  value current at issuance, and verification rejects tokens carrying an
-  older generation — the same liveness pattern (and the same short-TTL cache)
-  the MCP adapter already uses for agent grant checks. "Sign out everywhere"
-  bumps the counter, invalidating every outstanding token for that human on
-  every device within the cache window. Agent tokens already behave this way
-  through grant revocation.
+  Human sessions are revocable everywhere at once (decided 2026-07-14). The
+  counter lives in a kernel-owned `PrincipalGeneration` entity keyed by the
+  principal's subject — **not** on the app's `Member` entity as this RFC
+  originally proposed, because the kernel is generic and cannot read an app's
+  entities; keeping it in the kernel makes revocation a platform capability
+  any app inherits (implemented 2026-07-19). Every human token embeds the
+  value current at issuance, and verification rejects an older generation —
+  a token that omits the claim counts as generation 0, so revocation cannot
+  be skipped by an issuer that fails to stamp it. "Sign out everywhere" bumps
+  the counter, and the app additionally revokes the human's live agent grants,
+  since an agent would otherwise refresh straight back in. The signed-in
+  session cookie carries and re-checks the same counter, so the human is
+  signed out on every device rather than merely losing API tokens.
+
+  The same counter, keyed by `grant_id`, carries per-agent revocation: any
+  bump means that grant is revoked. This closes the window in which a revoked
+  agent kept working directly against OData until its token expired, because
+  only the MCP front door had been checking grant liveness.
 - **Registered service credentials** (existing ADR-0033 path): the curation
   pipeline, SSR readers, and other app services each get their own
   `AgentCredential` instead of sharing the global key.
@@ -184,37 +194,34 @@ permit(principal, action == Action::"Publish", resource is DesignLanguage)
 
 Env-var allowlists like `KATAGAMI_OWNER_SUBS` retire.
 
-### 4. Authorization declared in the spec, compiled to Cedar
+### 4. Authorization declared in the spec — deferred, not shipped
 
-Hand-written permit-all files are how Katagami ended up open by default. An
-app's behavior is declared in its IOA spec (the TOML document that defines a
-Temper app's entities, state machines, and actions), so that spec is also
-where access requirements belong:
+This RFC originally proposed declaring access requirements on the IOA action
+itself (`requires_role = ["owner","curator"]`, `requires = "creator"`) and
+compiling them to Cedar at install. That was built and then **deliberately
+backed out** (decided 2026-07-25). Three reasons, in order of weight:
 
-```toml
-[[action]]
-name = "Publish"
-requires_role = ["owner", "curator"]
+1. **The spec format is changing.** The sugar and its parser were bound to
+   TOML; the spec language is being replaced, so this work would be rewritten
+   at that migration. Hand-written `.cedar` is format-independent and survives
+   it untouched. Authorization-in-spec belongs in the *design of the new
+   language*, where it can be genuinely expressive rather than sugar.
+2. **The contract was wrong in both directions.** Compiled as `forbid … unless
+   principal.role in [...]`, it excluded every principal *without* a role —
+   including service credentials — so it could not express this RFC's own
+   `Publish` example without locking out the curation pipeline. And
+   `requires = "creator"` compared `principal.id`, which for an agent is its
+   client id rather than the human it acts for, so an agent could never act on
+   its owner's behalf.
+3. **Two homes for one rule.** With hand-written `.cedar` still in place, the
+   same restriction could be expressed twice and drift.
 
-[[action]]
-name = "Withdraw"
-requires = "creator"        # resource.creator_sub == principal.sub
-```
-
-At install time the platform compiles these into Cedar policies. This
-compiler is new work: the existing Cedar-generation machinery
-(`crates/temper-authz/src/policy_gen.rs`) builds permits from
-principal/action/resource scope matrices for the denial-remediation flow, and
-would be extended — it has no resource-attribute or set-membership
-conditions, and no spec-install wiring today. Per-policy storage already
-exists (ADR-0032), and
-resource-attribute injection already puts entity fields like `creator_sub` on
-the Cedar resource, so creator rules evaluate without new engine surface.
-Actions with no declaration get no permit — the app's posture flips from
-permit-all with forbid overlays to default-deny with generated permits. That
-flip is only trustworthy once ARN-230's permit-all fallback on failed policy
-loads is fixed (see Risks). Hand-written `.cedar` files remain supported for
-policies the sugar cannot express.
+Authorization therefore has exactly one home today: hand-written per-entity
+`.cedar` files. Contributor boundaries there are expressed as `forbid … when
+{ principal.agent_type == "contributor" }` overlays on top of each entity's
+base permit, which is sound because Cedar's forbid always overrides permit.
+The removed compiler remains in the branch history for whoever picks up
+authorization-in-spec for the new format.
 
 ### 5. Front-end auth kit
 
@@ -273,16 +280,13 @@ depends on two deploys landing simultaneously.
    spec promoted to the platform; katagami.ai server actions call with
    per-user tokens; `KATAGAMI_OWNER_SUBS` retires. Unblocks ARN-248 (personal
    spaces need the kernel to know whose space is whose).
-4. **Platform authorization server + spec-compiled policies.** The AS moves
-   into the platform and katagami.ai's retires; `requires_role` / `requires`
-   sugar ships; new apps default to generated default-deny policies;
-   Katagami's hand-written permit-all files are migrated to spec declarations
-   in the same pass (they are the proof that the sugar covers a real app);
-   ARN-163's MCP resource server points at the platform AS.
-   *Prerequisite:* ARN-230's fail-open fallback is fixed and verified first —
-   a failed or missing tenant policy load must fail closed. Shipping
-   default-deny generation on top of a permit-all fallback would silently
-   reopen every action the spec intended to deny whenever a load fails.
+4. **Platform authorization server.** The AS moves into the platform and
+   katagami.ai's retires; ARN-163's MCP resource server points at the platform
+   AS. Spec-declared authorization is *not* part of this step — see section 4;
+   it is deferred to the design of the replacement spec language.
+   *Prerequisite for any default-deny posture:* ARN-230's fail-open fallback
+   must be fixed and verified first — a failed or missing tenant policy load
+   has to fail closed, or a load failure silently reopens everything.
 
 ## Consequences
 
@@ -310,9 +314,11 @@ depends on two deploys landing simultaneously.
 - **Migration breakage.** Katagami is live; each rollout step changes a live
   credential path. Every step needs the local end-to-end run against a seeded
   server before deploy, per the standing definition of done.
-- **Spec sugar scope creep.** `requires_role` / `requires = "creator"` covers
-  the audited needs; resisting a policy-language-in-TOML is deliberate.
-  Anything more complex is a hand-written Cedar file.
+- **Authorization-in-spec, when it returns.** The removed sugar failed on
+  service principals and on agents acting for a human. Whatever replaces it in
+  the new spec language must state, up front, how it treats a principal with
+  no role and an agent acting on someone's behalf — and must not become a
+  second home for rules that already live in Cedar.
 - **Fail-open regressions.** ARN-230's finding (missing tenant policies fall
   back to permit-all) must be fixed before default-deny generation can be
   trusted; otherwise a failed policy load reopens everything.


### PR DESCRIPTION
## What

RFC-0002 (`docs/rfcs/0002-first-class-authorization.md`) — the design record for [ARN-255](https://linear.app/arni-build/issue/ARN-255/first-class-authorization-for-temper-apps-platform-run-authorization): making authorization a platform capability.

**Decision recorded (2026-07-11, Option B):** the platform runs the authorization server; apps handle sign-in and token exchange only; the kernel verifies every principal (humans via token exchange, agents via platform-issued JWTs, services via registered credentials); app authorization is declared in the IOA spec and compiled to Cedar. Extends ADR-0033 (Platform-Assigned Agent Identity) to humans and to the OAuth/JWT validation it deferred.

## Why

The 2026-07-11 authorization audit of Katagami (the first Temper app with a human front end and agent clients) found the platform makes no per-caller access decisions: one shared `TEMPER_API_KEY` for every caller, self-asserted `x-temper-*` principal headers trusted verbatim, permit-all Cedar with contributor-only forbids, and human identity appearing in zero policies. Full evidence is in the RFC and on ARN-255.

## Notes for review

- Docs-only change; the full pre-push pipeline (fmt, clippy, ratchet, workspace tests) passed locally.
- `docs/rfcs/` was untracked until this PR — RFC-0001 (directed evolution) exists only as a local file in the primary checkout. This PR does not adopt it; numbering starts committed history at 0002 to match the existing local file's claim on 0001.
- Coordination: rollout step 1 (header removal) intersects #343 / ARN-170 — the Katagami MCP adapter depends on the header path being removed there; the RFC's rollout section pins the ordering.
- Independent review ran 3 rounds before commit (1 P1 + 10 P2 findings, all fixed, final PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0125RD5byAmmMuvhLaK2jsZR

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

RFC-0002 records the platform decision (Option B, 2026-07-11) to make authorization a first-class Temper kernel capability: the platform runs the authorization server, the kernel verifies every principal (humans via token exchange, agents via platform-issued JWTs, services via registered credentials), and Cedar policies compiled from the IOA spec govern access. This is a docs-only change; no production code is modified.

- Adds `docs/rfcs/0002-first-class-authorization.md` — a 316-line design record covering the motivation (Katagami audit findings), the four design components (platform AS, verified principals, Member roles, spec-compiled Cedar), a four-step rollout, consequences, risks, and open questions.
- Extends ADR-0033 (Platform-Assigned Agent Identity) to humans and resolves the OAuth/JWT validation that ADR deferred.
- Two rollout-sequencing gaps need attention before implementation begins: ARN-230 (permit-all fallback) is not a formal Step 4 prerequisite, and the atomic-deploy requirement for Steps 1+2 (tied to in-flight PR #343) has no specified enforcement mechanism.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge as a design record; no production code is touched, and the issues found are gaps in the rollout plan rather than problems with the current codebase.

The RFC accurately diagnoses the authorization gaps in the current platform and proposes a coherent design. The two substantive issues — ARN-230 not being a formal Step 4 gate, and the Steps 1+2 atomicity mechanism being unspecified — are rollout-plan gaps that could cause a silent security regression or live-traffic outage if implementation proceeds without addressing them.

docs/rfcs/0002-first-class-authorization.md — specifically the Rollout section (Steps 1–2 coordination and Step 4 ARN-230 dependency) and the anonymous principal discussion before Open Question 2.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/rfcs/0002-first-class-authorization.md | New RFC establishing platform-level authorization design; two rollout gaps flagged: ARN-230 must be a formal Step 4 prerequisite, and the Steps 1+2 atomic-deploy dependency needs a specified enforcement mechanism. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant FE as App Front End
    participant KE as Temper Kernel
    participant AS as Platform Auth Server
    participant Cedar as Cedar Engine

    Note over FE,Cedar: Human path (post-RFC)
    FE->>KE: Exchange Google ID token
    KE->>KE: Verify issuer, validate OIDC token
    KE->>KE: Load Member entity, inject role attribute
    KE-->>FE: Short-lived platform token (Customer, role owner)
    FE->>KE: OData API call with Bearer token
    KE->>KE: Resolve token to Customer principal
    KE->>Cedar: Evaluate Publish action
    Cedar-->>KE: "Permit (role == owner)"
    KE-->>FE: 200 OK

    Note over FE,Cedar: Agent path (post-RFC)
    participant AG as Agent
    AG->>AS: Auth-code + PKCE or pre-authorized grant
    AS-->>AG: Platform-issued JWT (Agent, acting_for human)
    AG->>KE: MCP call with Bearer JWT
    KE->>KE: Verify signature + grant liveness
    KE->>Cedar: Evaluate Publish (Agent principal)
    Cedar-->>KE: Deny
    KE->>Cedar: Evaluate SubmitForReview
    Cedar-->>KE: Permit
    KE-->>AG: 200 OK

    Note over FE,Cedar: Anonymous path (behavior TBD, Open Q2)
    FE->>KE: Request with no credential
    KE->>KE: Resolve to anonymous principal
    KE->>Cedar: Evaluate against generated policies
    Cedar-->>KE: Permit only if explicit anonymous policy exists
    KE-->>FE: 200 or 403
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant FE as App Front End
    participant KE as Temper Kernel
    participant AS as Platform Auth Server
    participant Cedar as Cedar Engine

    Note over FE,Cedar: Human path (post-RFC)
    FE->>KE: Exchange Google ID token
    KE->>KE: Verify issuer, validate OIDC token
    KE->>KE: Load Member entity, inject role attribute
    KE-->>FE: Short-lived platform token (Customer, role owner)
    FE->>KE: OData API call with Bearer token
    KE->>KE: Resolve token to Customer principal
    KE->>Cedar: Evaluate Publish action
    Cedar-->>KE: "Permit (role == owner)"
    KE-->>FE: 200 OK

    Note over FE,Cedar: Agent path (post-RFC)
    participant AG as Agent
    AG->>AS: Auth-code + PKCE or pre-authorized grant
    AS-->>AG: Platform-issued JWT (Agent, acting_for human)
    AG->>KE: MCP call with Bearer JWT
    KE->>KE: Verify signature + grant liveness
    KE->>Cedar: Evaluate Publish (Agent principal)
    Cedar-->>KE: Deny
    KE->>Cedar: Evaluate SubmitForReview
    Cedar-->>KE: Permit
    KE-->>AG: 200 OK

    Note over FE,Cedar: Anonymous path (behavior TBD, Open Q2)
    FE->>KE: Request with no credential
    KE->>KE: Resolve to anonymous principal
    KE->>Cedar: Evaluate against generated policies
    Cedar-->>KE: Permit only if explicit anonymous policy exists
    KE-->>FE: 200 or 403
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Adocs%2Frfcs%2F0002-first-class-authorization.md%3A280-290%0A**ARN-230%20fix%20is%20unsequenced%20as%20a%20Step%204%20dependency**%0A%0AThe%20Risks%20section%20correctly%20identifies%20that%20the%20permit-all%20fallback%20%28ARN-230%29%20must%20be%20fixed%20before%20default-deny%20generation%20%22can%20be%20trusted%2C%22%20but%20the%20rollout%20plan%20doesn't%20enforce%20this%20ordering%20%E2%80%94%20Step%204%20has%20no%20listed%20prerequisite.%20If%20Step%204%20ships%20before%20ARN-230%20is%20resolved%2C%20a%20failed%20policy%20load%20at%20tenant%20startup%20silently%20reopens%20every%20action%20the%20spec%20intended%20to%20deny.%20The%20ARN-230%20fix%20should%20appear%20as%20an%20explicit%20dependency%20line%20in%20Step%204%2C%20similar%20to%20how%20Step%203%20calls%20out%20that%20it%20%22unblocks%20ARN-248.%22%20Without%20that%2C%20the%20rollout%20checklist%20provides%20no%20gate%20to%20catch%20a%20premature%20Step%204%20deploy.%0A%0A%23%23%23%20Issue%202%20of%204%0Adocs%2Frfcs%2F0002-first-class-authorization.md%3A231-247%0A**Steps%201%20and%202%20atomicity%20mechanism%20is%20unspecified**%0A%0AThe%20rollout%20preamble%20says%20%22Steps%201%20and%202%20ship%20together%2C%22%20and%20the%20coordination%20note%20makes%20clear%20why%3A%20if%20header%20removal%20%28Step%201%2C%20tied%20to%20PR%20%23343%20%2F%20ARN-170%29%20lands%20before%20the%20adapter%20forwards%20tokens%20%28Step%202%29%2C%20the%20Katagami%20MCP%20adapter's%20contributor%20enforcement%20silently%20disappears%20for%20any%20window%20between%20the%20two%20deploys.%20The%20RFC%20states%20the%20ordering%20requirement%20but%20doesn't%20specify%20the%20enforcement%20mechanism%20%E2%80%94%20is%20Step%201%20gated%20on%20Step%202%20being%20merged%3F%20Does%20PR%20%23343%20carry%20an%20explicit%20merge-block%3F%20Since%20PR%20%23343%20is%20already%20in-flight%20and%20independent%2C%20without%20a%20concrete%20gate%20the%20%22ship%20together%22%20requirement%20depends%20on%20manual%20coordination%20that%20can%20fail%20silently.%0A%0A%23%23%23%20Issue%203%20of%204%0Adocs%2Frfcs%2F0002-first-class-authorization.md%3A1-3%0A**Status%20field%20does%20not%20reflect%20the%20recorded%20decision**%0A%0AThe%20PR%20description%20states%20%22Decision%20recorded%20%282026-07-11%2C%20Option%20B%29%22%20and%20the%20RFC%20body%20itself%20documents%20the%20final%20decision.%20The%20header%20still%20reads%20%60Status%3A%20Draft%60%2C%20which%20will%20cause%20confusion%20for%20anyone%20consulting%20it%20later.%20Consider%20updating%20to%20%60Accepted%60%20before%20merging.%0A%0A%23%23%23%20Issue%204%20of%204%0Adocs%2Frfcs%2F0002-first-class-authorization.md%3A143-154%0A**Anonymous%20principal%20behavior%20should%20be%20resolved%20before%20Step%201%20ships**%0A%0AThe%20RFC%20commits%20to%20anonymous%20principals%20%28revising%20ADR-0033's%20%22no%20token%20%3D%20401%22%29%20but%20leaves%20the%20concrete%20behavior%20%E2%80%94%20anonymous%20read%20permits%20in%20generated%20policies%20vs.%20a%20public-reader%20service%20credential%20%E2%80%94%20as%20Open%20Question%202.%20Step%201%20drops%20the%20self-declared%20headers%2C%20so%20after%20Step%201%20any%20credential-less%20request%20hits%20the%20anonymous%20path.%20If%20anonymous%20Cedar%20permits%20for%20public%20resources%20haven't%20been%20decided%20and%20provisioned%2C%20public%20catalog%20pages%20will%20start%20returning%20403s%20on%20a%20live%20system%20immediately%20after%20Step%201.%0A%0A&repo=nerdsane%2Ftemper&pr=352&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22claude%2Farn-255-authz-rfc%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Farn-255-authz-rfc%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Adocs%2Frfcs%2F0002-first-class-authorization.md%3A280-290%0A**ARN-230%20fix%20is%20unsequenced%20as%20a%20Step%204%20dependency**%0A%0AThe%20Risks%20section%20correctly%20identifies%20that%20the%20permit-all%20fallback%20%28ARN-230%29%20must%20be%20fixed%20before%20default-deny%20generation%20%22can%20be%20trusted%2C%22%20but%20the%20rollout%20plan%20doesn't%20enforce%20this%20ordering%20%E2%80%94%20Step%204%20has%20no%20listed%20prerequisite.%20If%20Step%204%20ships%20before%20ARN-230%20is%20resolved%2C%20a%20failed%20policy%20load%20at%20tenant%20startup%20silently%20reopens%20every%20action%20the%20spec%20intended%20to%20deny.%20The%20ARN-230%20fix%20should%20appear%20as%20an%20explicit%20dependency%20line%20in%20Step%204%2C%20similar%20to%20how%20Step%203%20calls%20out%20that%20it%20%22unblocks%20ARN-248.%22%20Without%20that%2C%20the%20rollout%20checklist%20provides%20no%20gate%20to%20catch%20a%20premature%20Step%204%20deploy.%0A%0A%23%23%23%20Issue%202%20of%204%0Adocs%2Frfcs%2F0002-first-class-authorization.md%3A231-247%0A**Steps%201%20and%202%20atomicity%20mechanism%20is%20unspecified**%0A%0AThe%20rollout%20preamble%20says%20%22Steps%201%20and%202%20ship%20together%2C%22%20and%20the%20coordination%20note%20makes%20clear%20why%3A%20if%20header%20removal%20%28Step%201%2C%20tied%20to%20PR%20%23343%20%2F%20ARN-170%29%20lands%20before%20the%20adapter%20forwards%20tokens%20%28Step%202%29%2C%20the%20Katagami%20MCP%20adapter's%20contributor%20enforcement%20silently%20disappears%20for%20any%20window%20between%20the%20two%20deploys.%20The%20RFC%20states%20the%20ordering%20requirement%20but%20doesn't%20specify%20the%20enforcement%20mechanism%20%E2%80%94%20is%20Step%201%20gated%20on%20Step%202%20being%20merged%3F%20Does%20PR%20%23343%20carry%20an%20explicit%20merge-block%3F%20Since%20PR%20%23343%20is%20already%20in-flight%20and%20independent%2C%20without%20a%20concrete%20gate%20the%20%22ship%20together%22%20requirement%20depends%20on%20manual%20coordination%20that%20can%20fail%20silently.%0A%0A%23%23%23%20Issue%203%20of%204%0Adocs%2Frfcs%2F0002-first-class-authorization.md%3A1-3%0A**Status%20field%20does%20not%20reflect%20the%20recorded%20decision**%0A%0AThe%20PR%20description%20states%20%22Decision%20recorded%20%282026-07-11%2C%20Option%20B%29%22%20and%20the%20RFC%20body%20itself%20documents%20the%20final%20decision.%20The%20header%20still%20reads%20%60Status%3A%20Draft%60%2C%20which%20will%20cause%20confusion%20for%20anyone%20consulting%20it%20later.%20Consider%20updating%20to%20%60Accepted%60%20before%20merging.%0A%0A%23%23%23%20Issue%204%20of%204%0Adocs%2Frfcs%2F0002-first-class-authorization.md%3A143-154%0A**Anonymous%20principal%20behavior%20should%20be%20resolved%20before%20Step%201%20ships**%0A%0AThe%20RFC%20commits%20to%20anonymous%20principals%20%28revising%20ADR-0033's%20%22no%20token%20%3D%20401%22%29%20but%20leaves%20the%20concrete%20behavior%20%E2%80%94%20anonymous%20read%20permits%20in%20generated%20policies%20vs.%20a%20public-reader%20service%20credential%20%E2%80%94%20as%20Open%20Question%202.%20Step%201%20drops%20the%20self-declared%20headers%2C%20so%20after%20Step%201%20any%20credential-less%20request%20hits%20the%20anonymous%20path.%20If%20anonymous%20Cedar%20permits%20for%20public%20resources%20haven't%20been%20decided%20and%20provisioned%2C%20public%20catalog%20pages%20will%20start%20returning%20403s%20on%20a%20live%20system%20immediately%20after%20Step%201.%0A%0A&repo=nerdsane%2Ftemper&pr=352&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Adocs%2Frfcs%2F0002-first-class-authorization.md%3A280-290%0A**ARN-230%20fix%20is%20unsequenced%20as%20a%20Step%204%20dependency**%0A%0AThe%20Risks%20section%20correctly%20identifies%20that%20the%20permit-all%20fallback%20%28ARN-230%29%20must%20be%20fixed%20before%20default-deny%20generation%20%22can%20be%20trusted%2C%22%20but%20the%20rollout%20plan%20doesn't%20enforce%20this%20ordering%20%E2%80%94%20Step%204%20has%20no%20listed%20prerequisite.%20If%20Step%204%20ships%20before%20ARN-230%20is%20resolved%2C%20a%20failed%20policy%20load%20at%20tenant%20startup%20silently%20reopens%20every%20action%20the%20spec%20intended%20to%20deny.%20The%20ARN-230%20fix%20should%20appear%20as%20an%20explicit%20dependency%20line%20in%20Step%204%2C%20similar%20to%20how%20Step%203%20calls%20out%20that%20it%20%22unblocks%20ARN-248.%22%20Without%20that%2C%20the%20rollout%20checklist%20provides%20no%20gate%20to%20catch%20a%20premature%20Step%204%20deploy.%0A%0A%23%23%23%20Issue%202%20of%204%0Adocs%2Frfcs%2F0002-first-class-authorization.md%3A231-247%0A**Steps%201%20and%202%20atomicity%20mechanism%20is%20unspecified**%0A%0AThe%20rollout%20preamble%20says%20%22Steps%201%20and%202%20ship%20together%2C%22%20and%20the%20coordination%20note%20makes%20clear%20why%3A%20if%20header%20removal%20%28Step%201%2C%20tied%20to%20PR%20%23343%20%2F%20ARN-170%29%20lands%20before%20the%20adapter%20forwards%20tokens%20%28Step%202%29%2C%20the%20Katagami%20MCP%20adapter's%20contributor%20enforcement%20silently%20disappears%20for%20any%20window%20between%20the%20two%20deploys.%20The%20RFC%20states%20the%20ordering%20requirement%20but%20doesn't%20specify%20the%20enforcement%20mechanism%20%E2%80%94%20is%20Step%201%20gated%20on%20Step%202%20being%20merged%3F%20Does%20PR%20%23343%20carry%20an%20explicit%20merge-block%3F%20Since%20PR%20%23343%20is%20already%20in-flight%20and%20independent%2C%20without%20a%20concrete%20gate%20the%20%22ship%20together%22%20requirement%20depends%20on%20manual%20coordination%20that%20can%20fail%20silently.%0A%0A%23%23%23%20Issue%203%20of%204%0Adocs%2Frfcs%2F0002-first-class-authorization.md%3A1-3%0A**Status%20field%20does%20not%20reflect%20the%20recorded%20decision**%0A%0AThe%20PR%20description%20states%20%22Decision%20recorded%20%282026-07-11%2C%20Option%20B%29%22%20and%20the%20RFC%20body%20itself%20documents%20the%20final%20decision.%20The%20header%20still%20reads%20%60Status%3A%20Draft%60%2C%20which%20will%20cause%20confusion%20for%20anyone%20consulting%20it%20later.%20Consider%20updating%20to%20%60Accepted%60%20before%20merging.%0A%0A%23%23%23%20Issue%204%20of%204%0Adocs%2Frfcs%2F0002-first-class-authorization.md%3A143-154%0A**Anonymous%20principal%20behavior%20should%20be%20resolved%20before%20Step%201%20ships**%0A%0AThe%20RFC%20commits%20to%20anonymous%20principals%20%28revising%20ADR-0033's%20%22no%20token%20%3D%20401%22%29%20but%20leaves%20the%20concrete%20behavior%20%E2%80%94%20anonymous%20read%20permits%20in%20generated%20policies%20vs.%20a%20public-reader%20service%20credential%20%E2%80%94%20as%20Open%20Question%202.%20Step%201%20drops%20the%20self-declared%20headers%2C%20so%20after%20Step%201%20any%20credential-less%20request%20hits%20the%20anonymous%20path.%20If%20anonymous%20Cedar%20permits%20for%20public%20resources%20haven't%20been%20decided%20and%20provisioned%2C%20public%20catalog%20pages%20will%20start%20returning%20403s%20on%20a%20live%20system%20immediately%20after%20Step%201.%0A%0A&pr=352&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
docs/rfcs/0002-first-class-authorization.md:280-290
**ARN-230 fix is unsequenced as a Step 4 dependency**

The Risks section correctly identifies that the permit-all fallback (ARN-230) must be fixed before default-deny generation "can be trusted," but the rollout plan doesn't enforce this ordering — Step 4 has no listed prerequisite. If Step 4 ships before ARN-230 is resolved, a failed policy load at tenant startup silently reopens every action the spec intended to deny. The ARN-230 fix should appear as an explicit dependency line in Step 4, similar to how Step 3 calls out that it "unblocks ARN-248." Without that, the rollout checklist provides no gate to catch a premature Step 4 deploy.

### Issue 2 of 4
docs/rfcs/0002-first-class-authorization.md:231-247
**Steps 1 and 2 atomicity mechanism is unspecified**

The rollout preamble says "Steps 1 and 2 ship together," and the coordination note makes clear why: if header removal (Step 1, tied to PR #343 / ARN-170) lands before the adapter forwards tokens (Step 2), the Katagami MCP adapter's contributor enforcement silently disappears for any window between the two deploys. The RFC states the ordering requirement but doesn't specify the enforcement mechanism — is Step 1 gated on Step 2 being merged? Does PR #343 carry an explicit merge-block? Since PR #343 is already in-flight and independent, without a concrete gate the "ship together" requirement depends on manual coordination that can fail silently.

### Issue 3 of 4
docs/rfcs/0002-first-class-authorization.md:1-3
**Status field does not reflect the recorded decision**

The PR description states "Decision recorded (2026-07-11, Option B)" and the RFC body itself documents the final decision. The header still reads `Status: Draft`, which will cause confusion for anyone consulting it later. Consider updating to `Accepted` before merging.

### Issue 4 of 4
docs/rfcs/0002-first-class-authorization.md:143-154
**Anonymous principal behavior should be resolved before Step 1 ships**

The RFC commits to anonymous principals (revising ADR-0033's "no token = 401") but leaves the concrete behavior — anonymous read permits in generated policies vs. a public-reader service credential — as Open Question 2. Step 1 drops the self-declared headers, so after Step 1 any credential-less request hits the anonymous path. If anonymous Cedar permits for public resources haven't been decided and provisioned, public catalog pages will start returning 403s on a live system immediately after Step 1.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: RFC-0002 — first-class authorizati..."](https://github.com/nerdsane/temper/commit/6e0fb185e7d549ef817d0ceeabaa3123ceab6913) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43568014)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->