### PR TITLE
fix(observe): bind ClickHouse query parameters (ARN-174)

### DIFF
--- a/crates/temper-observe/src/clickhouse.rs
+++ b/crates/temper-observe/src/clickhouse.rs
@@ -4,6 +4,7 @@
 //! Write path is handled by OTEL SDK + OTLP export; this module is query-only.
 
 use std::collections::HashMap;
+use std::fmt::Write as _;
 
 use crate::error::ObserveError;
 use crate::store::{ObservabilityStore, ResultRow, ResultSet, SqlParam};
@@ -12,6 +13,22 @@ use crate::store::{ObservabilityStore, ResultRow, ResultSet, SqlParam};
 pub struct ClickHouseStore {
     base_url: String,
     client: reqwest::Client,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct BoundClickHouseQuery {
+    sql: String,
+    form_params: Vec<(String, String)>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum QueryRegion {
+    Code,
+    SingleQuoted,
+    DoubleQuoted,
+    BacktickQuoted,
+    LineComment,
+    BlockComment,
 }
 
 impl ClickHouseStore {
@@ -29,81 +46,151 @@ impl ClickHouseStore {
     }
 
     fn query_url(&self) -> String {
-        format!("{}/?default_format=JSONEachRow", self.base_url)
+        // ClickHouse resolves `default_format` before it parses a multipart
+        // request body. Keep the SQL and parameter values in multipart fields,
+        // but select the response format in the URL where the HTTP handler can
+        // see it before query execution.
+        format!(
+            "{}/?default_format=JSONEachRow",
+            self.base_url.trim_end_matches('/')
+        )
     }
 
-    /// Substitute `$N` placeholders with rendered parameter values.
-    ///
-    /// Single pass so a substituted value can never be re-scanned, and
-    /// placeholders inside single-quoted string literals are left intact —
-    /// a naive global `replace` corrupts both (e.g. `WHERE name = '$1'`
-    /// would mangle the literal, and a value containing `$2` would be
-    /// rewritten by a later iteration).
-    fn interpolate_params(sql: &str, params: &[SqlParam]) -> String {
-        let render = |param: &SqlParam| -> String {
-            match param {
-                SqlParam::String(s) => format!("'{}'", s.replace('\'', "''")),
-                SqlParam::Int(i) => i.to_string(),
-                SqlParam::Float(f) => f.to_string(),
-                SqlParam::Bool(b) => if *b { "1" } else { "0" }.to_string(),
-                SqlParam::Null => "NULL".to_string(),
-            }
-        };
-
+    /// Translate store-wide `$N` placeholders to ClickHouse's typed query
+    /// parameters. Values are returned separately for multipart form encoding
+    /// and never become part of the SQL source text.
+    fn bind_params(sql: &str, params: &[SqlParam]) -> Result<BoundClickHouseQuery, ObserveError> {
         let mut out = String::with_capacity(sql.len());
+        let mut used = vec![false; params.len()];
         let bytes = sql.as_bytes();
         let mut i = 0;
-        let mut in_string = false;
+        let mut region = QueryRegion::Code;
+
         while i < bytes.len() {
-            // Placeholders, quotes, and escapes are all ASCII; any multibyte
-            // UTF-8 sequence starts with a byte >= 0x80 and is copied verbatim
-            // below, so indexing by byte never splits a character.
             let c = bytes[i];
-            if in_string {
-                if c == b'\'' {
-                    // `''` is an escaped quote inside a literal, not a terminator.
-                    if i + 1 < bytes.len() && bytes[i + 1] == b'\'' {
-                        out.push_str("''");
-                        i += 2;
+
+            match region {
+                QueryRegion::Code => {
+                    let next = bytes.get(i + 1).copied();
+                    region = match (c, next) {
+                        (b'\'', _) => QueryRegion::SingleQuoted,
+                        (b'"', _) => QueryRegion::DoubleQuoted,
+                        (b'`', _) => QueryRegion::BacktickQuoted,
+                        (b'-', Some(b'-')) | (b'#', _) => QueryRegion::LineComment,
+                        (b'/', Some(b'*')) => QueryRegion::BlockComment,
+                        (b'$', Some(digit)) if digit.is_ascii_digit() => {
+                            let mut end = i + 1;
+                            while end < bytes.len() && bytes[end].is_ascii_digit() {
+                                end += 1;
+                            }
+                            let one_based = sql[i + 1..end].parse::<usize>().map_err(|_| {
+                                ObserveError::InvalidQuery(format!(
+                                    "invalid parameter placeholder {}",
+                                    &sql[i..end]
+                                ))
+                            })?;
+                            let index = one_based.checked_sub(1).ok_or_else(|| {
+                                ObserveError::InvalidQuery(
+                                    "parameter placeholders start at $1".to_string(),
+                                )
+                            })?;
+                            let param = params.get(index).ok_or_else(|| {
+                                ObserveError::InvalidQuery(format!(
+                                    "parameter ${one_based} was not provided"
+                                ))
+                            })?;
+                            used[index] = true;
+                            if let Some((parameter_type, _)) = clickhouse_param(param) {
+                                write!(out, "{{p{one_based}:{parameter_type}}}")
+                                    .expect("writing to a String cannot fail");
+                            } else {
+                                out.push_str("NULL");
+                            }
+                            i = end;
+                            continue;
+                        }
+                        _ => QueryRegion::Code,
+                    };
+                }
+                QueryRegion::SingleQuoted
+                | QueryRegion::DoubleQuoted
+                | QueryRegion::BacktickQuoted => {
+                    let quote = match region {
+                        QueryRegion::SingleQuoted => b'\'',
+                        QueryRegion::DoubleQuoted => b'"',
+                        QueryRegion::BacktickQuoted => b'`',
+                        _ => unreachable!(),
+                    };
+                    if c == b'\\' {
+                        push_char(sql, &mut out, &mut i);
+                        if i < bytes.len() {
+                            push_char(sql, &mut out, &mut i);
+                        }
                         continue;
                     }
-                    in_string = false;
-                    out.push('\'');
-                    i += 1;
-                    continue;
+                    if c == quote {
+                        if bytes.get(i + 1) == Some(&quote) {
+                            out.push(quote as char);
+                            out.push(quote as char);
+                            i += 2;
+                            continue;
+                        }
+                        region = QueryRegion::Code;
+                    }
                 }
-                // Fall through to the multibyte-safe char copy below.
-            } else if c == b'\'' {
-                in_string = true;
-                out.push('\'');
-                i += 1;
-                continue;
-            } else if c == b'$' && i + 1 < bytes.len() && bytes[i + 1].is_ascii_digit() {
-                let mut j = i + 1;
-                while j < bytes.len() && bytes[j].is_ascii_digit() {
-                    j += 1;
+                QueryRegion::LineComment => {
+                    if c == b'\n' {
+                        region = QueryRegion::Code;
+                    }
                 }
-                let idx: usize = sql[i + 1..j].parse().unwrap_or(0);
-                match idx.checked_sub(1).and_then(|n| params.get(n)) {
-                    Some(param) => out.push_str(&render(param)),
-                    // Out-of-range placeholder: leave it verbatim so the
-                    // query fails loudly at ClickHouse rather than silently
-                    // binding the wrong value.
-                    None => out.push_str(&sql[i..j]),
+                QueryRegion::BlockComment => {
+                    if c == b'*' && bytes.get(i + 1) == Some(&b'/') {
+                        out.push_str("*/");
+                        i += 2;
+                        region = QueryRegion::Code;
+                        continue;
+                    }
                 }
-                i = j;
-                continue;
             }
-            // ASCII byte or the leading byte of a multibyte char: copy the
-            // whole char so we never emit an invalid UTF-8 fragment.
-            let ch = sql[i..]
-                .chars()
-                .next()
-                .expect("byte index on char boundary");
-            out.push(ch);
-            i += ch.len_utf8();
+
+            push_char(sql, &mut out, &mut i);
         }
-        out
+
+        let form_params = used
+            .into_iter()
+            .zip(params)
+            .enumerate()
+            .filter_map(|(index, (is_used, param))| {
+                if !is_used {
+                    return None;
+                }
+                let (_, value) = clickhouse_param(param)?;
+                Some((format!("param_p{}", index + 1), value))
+            })
+            .collect();
+
+        Ok(BoundClickHouseQuery {
+            sql: out,
+            form_params,
+        })
+    }
+
+    fn build_request(
+        &self,
+        sql: &str,
+        params: &[SqlParam],
+    ) -> Result<reqwest::Request, ObserveError> {
+        let bound = Self::bind_params(sql, params)?;
+        let mut form = reqwest::multipart::Form::new().text("query", bound.sql);
+        for (name, value) in bound.form_params {
+            form = form.text(name, value);
+        }
+
+        self.client
+            .post(self.query_url())
+            .multipart(form)
+            .build()
+            .map_err(|e| ObserveError::ConnectionError(e.to_string()))
     }
 
     async fn execute_query(
@@ -111,12 +198,10 @@ impl ClickHouseStore {
         sql: &str,
         params: &[SqlParam],
     ) -> Result<ResultSet, ObserveError> {
-        let final_sql = Self::interpolate_params(sql, params);
+        let request = self.build_request(sql, params)?;
         let resp = self
             .client
-            .post(self.query_url())
-            .body(final_sql)
-            .send()
+            .execute(request)
             .await
             .map_err(|e| ObserveError::ConnectionError(e.to_string()))?;
 
@@ -152,6 +237,25 @@ impl ObservabilityStore for ClickHouseStore {
     ) -> Result<ResultSet, ObserveError> {
         self.execute_query(sql, params).await
     }
+}
+
+fn clickhouse_param(param: &SqlParam) -> Option<(&'static str, String)> {
+    match param {
+        SqlParam::String(value) => Some(("String", value.clone())),
+        SqlParam::Int(value) => Some(("Int64", value.to_string())),
+        SqlParam::Float(value) => Some(("Float64", value.to_string())),
+        SqlParam::Bool(value) => Some(("UInt8", u8::from(*value).to_string())),
+        SqlParam::Null => None,
+    }
+}
+
+fn push_char(source: &str, output: &mut String, index: &mut usize) {
+    let ch = source[*index..]
+        .chars()
+        .next()
+        .expect("index must be on a character boundary");
+    output.push(ch);
+    *index += ch.len_utf8();
 }
 
 /// Parse ClickHouse JSONEachRow response into a ResultSet.
@@ -200,52 +304,97 @@ mod tests {
     }
 
     #[test]
-    fn test_interpolate_params() {
+    fn bind_params_uses_clickhouse_typed_placeholders() {
         let sql = "SELECT * FROM spans WHERE service = $1 AND duration_ns > $2";
         let params = vec![SqlParam::String("api".into()), SqlParam::Int(1000)];
-        let result = ClickHouseStore::interpolate_params(sql, &params);
+        let result = ClickHouseStore::bind_params(sql, &params).unwrap();
         assert_eq!(
             result,
-            "SELECT * FROM spans WHERE service = 'api' AND duration_ns > 1000"
+            BoundClickHouseQuery {
+                sql: "SELECT * FROM spans WHERE service = {p1:String} AND duration_ns > {p2:Int64}"
+                    .into(),
+                form_params: vec![
+                    ("param_p1".into(), "api".into()),
+                    ("param_p2".into(), "1000".into()),
+                ],
+            }
         );
     }
 
     #[test]
-    fn interpolate_preserves_placeholder_inside_string_literal() {
-        // The literal '$1' must survive untouched; only the bare $1 binds.
-        let sql = "SELECT * FROM spans WHERE label = '$1' AND service = $1";
+    fn bind_params_preserves_placeholders_in_quoted_regions_and_comments() {
+        let sql = "SELECT '$1', \"$1\", `$1`, $1 -- $1\n/* $1 */ # $1\n";
         let params = vec![SqlParam::String("api".into())];
-        let result = ClickHouseStore::interpolate_params(sql, &params);
+        let result = ClickHouseStore::bind_params(sql, &params).unwrap();
         assert_eq!(
-            result,
-            "SELECT * FROM spans WHERE label = '$1' AND service = 'api'"
+            result.sql,
+            "SELECT '$1', \"$1\", `$1`, {p1:String} -- $1\n/* $1 */ # $1\n"
         );
     }
 
     #[test]
-    fn interpolate_does_not_rescan_substituted_value() {
-        // A value containing "$2" must not be rewritten by a later pass.
-        let sql = "SELECT $1, $2";
-        let params = vec![SqlParam::String("has $2 inside".into()), SqlParam::Int(7)];
-        let result = ClickHouseStore::interpolate_params(sql, &params);
-        assert_eq!(result, "SELECT 'has $2 inside', 7");
+    fn bind_params_never_places_attacker_text_in_sql() {
+        let attack = "x\\' OR 1=1; DROP TABLE spans; -- $2";
+        let result = ClickHouseStore::bind_params(
+            "SELECT * FROM spans WHERE a = $1 AND b = $2",
+            &[
+                SqlParam::String(attack.into()),
+                SqlParam::String("second".into()),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(
+            result.sql,
+            "SELECT * FROM spans WHERE a = {p1:String} AND b = {p2:String}"
+        );
+        assert!(!result.sql.contains("DROP TABLE"));
+        assert_eq!(result.form_params[0].1, attack);
     }
 
     #[test]
-    fn interpolate_handles_two_digit_and_multibyte() {
+    fn bind_params_handles_types_two_digits_and_multibyte_text() {
         let sql = "SELECT $10, name = $1, note = 'café ☕'";
         let mut params: Vec<SqlParam> = (1..=10).map(SqlParam::Int).collect();
         params[0] = SqlParam::String("first".into());
-        let result = ClickHouseStore::interpolate_params(sql, &params);
-        assert_eq!(result, "SELECT 10, name = 'first', note = 'café ☕'");
+        let result = ClickHouseStore::bind_params(sql, &params).unwrap();
+        assert_eq!(
+            result.sql,
+            "SELECT {p10:Int64}, name = {p1:String}, note = 'café ☕'"
+        );
+        assert_eq!(
+            result.form_params,
+            vec![
+                ("param_p1".into(), "first".into()),
+                ("param_p10".into(), "10".into()),
+            ]
+        );
     }
 
     #[test]
-    fn interpolate_escapes_embedded_quotes() {
-        let sql = "WHERE name = $1";
-        let params = vec![SqlParam::String("O'Brien".into())];
-        let result = ClickHouseStore::interpolate_params(sql, &params);
-        assert_eq!(result, "WHERE name = 'O''Brien'");
+    fn bind_params_handles_null_bool_and_float() {
+        let result = ClickHouseStore::bind_params(
+            "SELECT $1, $2, $3",
+            &[SqlParam::Null, SqlParam::Bool(true), SqlParam::Float(1.5)],
+        )
+        .unwrap();
+        assert_eq!(result.sql, "SELECT NULL, {p2:UInt8}, {p3:Float64}");
+        assert_eq!(
+            result.form_params,
+            vec![
+                ("param_p2".into(), "1".into()),
+                ("param_p3".into(), "1.5".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn bind_params_rejects_missing_and_zero_parameters() {
+        let missing = ClickHouseStore::bind_params("SELECT $2", &[SqlParam::Int(1)]);
+        assert!(matches!(missing, Err(ObserveError::InvalidQuery(_))));
+
+        let zero = ClickHouseStore::bind_params("SELECT $0", &[SqlParam::Int(1)]);
+        assert!(matches!(zero, Err(ObserveError::InvalidQuery(_))));
     }
 
     #[test]
@@ -267,5 +416,29 @@ mod tests {
         let body = "{\"a\":1}\n{\"a\":2}";
         let rs = parse_json_each_row(body).unwrap();
         assert_eq!(rs.len(), 2);
+    }
+
+    #[test]
+    fn build_request_keeps_parameters_out_of_url() {
+        let attack = "x\\' OR 1=1 --";
+        let store = ClickHouseStore::new("http://127.0.0.1:8123");
+        let request = store
+            .build_request(
+                "SELECT service FROM spans WHERE service = $1",
+                &[SqlParam::String(attack.into())],
+            )
+            .unwrap();
+
+        assert_eq!(request.method(), reqwest::Method::POST);
+        assert_eq!(request.url().path(), "/");
+        assert_eq!(request.url().query(), Some("default_format=JSONEachRow"));
+        assert!(!request.url().as_str().contains(attack));
+        assert!(
+            request
+                .headers()
+                .get(reqwest::header::CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok())
+                .is_some_and(|value| value.starts_with("multipart/form-data; boundary="))
+        );
     }
 }

--- a/crates/temper-observe/src/clickhouse.rs
+++ b/crates/temper-observe/src/clickhouse.rs
@@ -91,9 +91,7 @@ impl ClickHouseStore {
                     }
                     if is_clickhouse_word_char(c) {
                         let mut end = i + 1;
-                        while end < bytes.len()
-                            && (is_clickhouse_word_char(bytes[end]) || bytes[end] == b'$')
-                        {
+                        while end < bytes.len() && is_clickhouse_bareword_char(bytes[end]) {
                             end += 1;
                         }
                         out.push_str(&sql[i..end]);
@@ -127,6 +125,17 @@ impl ClickHouseStore {
                             let mut end = i + 1;
                             while end < bytes.len() && bytes[end].is_ascii_digit() {
                                 end += 1;
+                            }
+                            if bytes
+                                .get(end)
+                                .is_some_and(|byte| is_clickhouse_bareword_char(*byte))
+                            {
+                                while end < bytes.len() && is_clickhouse_bareword_char(bytes[end]) {
+                                    end += 1;
+                                }
+                                out.push_str(&sql[i..end]);
+                                i = end;
+                                continue;
                             }
                             let one_based = sql[i + 1..end].parse::<usize>().map_err(|_| {
                                 ObserveError::InvalidQuery(format!(
@@ -341,6 +350,10 @@ fn heredoc_delimiter_len(source: &str, start: usize) -> Option<usize> {
     source[start + delimiter_len..]
         .contains(delimiter)
         .then_some(delimiter_len)
+}
+
+fn is_clickhouse_bareword_char(byte: u8) -> bool {
+    is_clickhouse_word_char(byte) || byte == b'$'
 }
 
 fn is_clickhouse_word_char(byte: u8) -> bool {

--- a/crates/temper-observe/src/clickhouse.rs
+++ b/crates/temper-observe/src/clickhouse.rs
@@ -27,8 +27,14 @@ enum QueryRegion {
     SingleQuoted,
     DoubleQuoted,
     BacktickQuoted,
+    UnicodeSingleQuoted,
+    UnicodeDoubleQuoted,
     LineComment,
-    BlockComment,
+    BlockComment(usize),
+    Heredoc {
+        delimiter_start: usize,
+        delimiter_len: usize,
+    },
 }
 
 impl ClickHouseStore {
@@ -71,13 +77,52 @@ impl ClickHouseStore {
 
             match region {
                 QueryRegion::Code => {
+                    if c == b'$'
+                        && let Some(delimiter_len) = heredoc_delimiter_len(sql, i)
+                    {
+                        out.push_str(&sql[i..i + delimiter_len]);
+                        let delimiter_start = i;
+                        i += delimiter_len;
+                        region = QueryRegion::Heredoc {
+                            delimiter_start,
+                            delimiter_len,
+                        };
+                        continue;
+                    }
+                    if is_clickhouse_word_char(c) {
+                        let mut end = i + 1;
+                        while end < bytes.len()
+                            && (is_clickhouse_word_char(bytes[end]) || bytes[end] == b'$')
+                        {
+                            end += 1;
+                        }
+                        out.push_str(&sql[i..end]);
+                        i = end;
+                        continue;
+                    }
                     let next = bytes.get(i + 1).copied();
                     region = match (c, next) {
                         (b'\'', _) => QueryRegion::SingleQuoted,
                         (b'"', _) => QueryRegion::DoubleQuoted,
                         (b'`', _) => QueryRegion::BacktickQuoted,
-                        (b'-', Some(b'-')) | (b'#', _) => QueryRegion::LineComment,
-                        (b'/', Some(b'*')) => QueryRegion::BlockComment,
+                        (b'-', Some(b'-')) | (b'/', Some(b'/')) => QueryRegion::LineComment,
+                        (b'#', Some(b' ' | b'!')) => QueryRegion::LineComment,
+                        (b'/', Some(b'*')) => {
+                            out.push_str("/*");
+                            i += 2;
+                            region = QueryRegion::BlockComment(1);
+                            continue;
+                        }
+                        (0xE2, Some(0x80)) if bytes.get(i + 2) == Some(&0x98) => {
+                            push_char(sql, &mut out, &mut i);
+                            region = QueryRegion::UnicodeSingleQuoted;
+                            continue;
+                        }
+                        (0xE2, Some(0x80)) if bytes.get(i + 2) == Some(&0x9C) => {
+                            push_char(sql, &mut out, &mut i);
+                            region = QueryRegion::UnicodeDoubleQuoted;
+                            continue;
+                        }
                         (b'$', Some(digit)) if digit.is_ascii_digit() => {
                             let mut end = i + 1;
                             while end < bytes.len() && bytes[end].is_ascii_digit() {
@@ -143,10 +188,42 @@ impl ClickHouseStore {
                         region = QueryRegion::Code;
                     }
                 }
-                QueryRegion::BlockComment => {
+                QueryRegion::BlockComment(depth) => {
+                    if c == b'/' && bytes.get(i + 1) == Some(&b'*') {
+                        out.push_str("/*");
+                        i += 2;
+                        region = QueryRegion::BlockComment(depth + 1);
+                        continue;
+                    }
                     if c == b'*' && bytes.get(i + 1) == Some(&b'/') {
                         out.push_str("*/");
                         i += 2;
+                        region = if depth == 1 {
+                            QueryRegion::Code
+                        } else {
+                            QueryRegion::BlockComment(depth - 1)
+                        };
+                        continue;
+                    }
+                }
+                QueryRegion::UnicodeSingleQuoted | QueryRegion::UnicodeDoubleQuoted => {
+                    let closing = if region == QueryRegion::UnicodeSingleQuoted {
+                        "’"
+                    } else {
+                        "”"
+                    };
+                    if sql[i..].starts_with(closing) {
+                        region = QueryRegion::Code;
+                    }
+                }
+                QueryRegion::Heredoc {
+                    delimiter_start,
+                    delimiter_len,
+                } => {
+                    let delimiter = &sql[delimiter_start..delimiter_start + delimiter_len];
+                    if sql[i..].starts_with(delimiter) {
+                        out.push_str(delimiter);
+                        i += delimiter_len;
                         region = QueryRegion::Code;
                         continue;
                     }
@@ -249,6 +326,27 @@ fn clickhouse_param(param: &SqlParam) -> Option<(&'static str, String)> {
     }
 }
 
+fn heredoc_delimiter_len(source: &str, start: usize) -> Option<usize> {
+    let bytes = source.as_bytes();
+    let tag_len = bytes[start + 1..].iter().position(|byte| *byte == b'$')?;
+    let delimiter_len = tag_len + 2;
+    let tag = &bytes[start + 1..start + 1 + tag_len];
+    if !tag
+        .iter()
+        .all(|byte| byte.is_ascii_alphanumeric() || *byte == b'_')
+    {
+        return None;
+    }
+    let delimiter = &source[start..start + delimiter_len];
+    source[start + delimiter_len..]
+        .contains(delimiter)
+        .then_some(delimiter_len)
+}
+
+fn is_clickhouse_word_char(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_'
+}
+
 fn push_char(source: &str, output: &mut String, index: &mut usize) {
     let ch = source[*index..]
         .chars()
@@ -294,151 +392,5 @@ fn parse_json_each_row(body: &str) -> Result<ResultSet, ObserveError> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_store_construction() {
-        let store = ClickHouseStore::new("http://localhost:8123");
-        assert_eq!(store.base_url(), "http://localhost:8123");
-    }
-
-    #[test]
-    fn bind_params_uses_clickhouse_typed_placeholders() {
-        let sql = "SELECT * FROM spans WHERE service = $1 AND duration_ns > $2";
-        let params = vec![SqlParam::String("api".into()), SqlParam::Int(1000)];
-        let result = ClickHouseStore::bind_params(sql, &params).unwrap();
-        assert_eq!(
-            result,
-            BoundClickHouseQuery {
-                sql: "SELECT * FROM spans WHERE service = {p1:String} AND duration_ns > {p2:Int64}"
-                    .into(),
-                form_params: vec![
-                    ("param_p1".into(), "api".into()),
-                    ("param_p2".into(), "1000".into()),
-                ],
-            }
-        );
-    }
-
-    #[test]
-    fn bind_params_preserves_placeholders_in_quoted_regions_and_comments() {
-        let sql = "SELECT '$1', \"$1\", `$1`, $1 -- $1\n/* $1 */ # $1\n";
-        let params = vec![SqlParam::String("api".into())];
-        let result = ClickHouseStore::bind_params(sql, &params).unwrap();
-        assert_eq!(
-            result.sql,
-            "SELECT '$1', \"$1\", `$1`, {p1:String} -- $1\n/* $1 */ # $1\n"
-        );
-    }
-
-    #[test]
-    fn bind_params_never_places_attacker_text_in_sql() {
-        let attack = "x\\' OR 1=1; DROP TABLE spans; -- $2";
-        let result = ClickHouseStore::bind_params(
-            "SELECT * FROM spans WHERE a = $1 AND b = $2",
-            &[
-                SqlParam::String(attack.into()),
-                SqlParam::String("second".into()),
-            ],
-        )
-        .unwrap();
-
-        assert_eq!(
-            result.sql,
-            "SELECT * FROM spans WHERE a = {p1:String} AND b = {p2:String}"
-        );
-        assert!(!result.sql.contains("DROP TABLE"));
-        assert_eq!(result.form_params[0].1, attack);
-    }
-
-    #[test]
-    fn bind_params_handles_types_two_digits_and_multibyte_text() {
-        let sql = "SELECT $10, name = $1, note = 'café ☕'";
-        let mut params: Vec<SqlParam> = (1..=10).map(SqlParam::Int).collect();
-        params[0] = SqlParam::String("first".into());
-        let result = ClickHouseStore::bind_params(sql, &params).unwrap();
-        assert_eq!(
-            result.sql,
-            "SELECT {p10:Int64}, name = {p1:String}, note = 'café ☕'"
-        );
-        assert_eq!(
-            result.form_params,
-            vec![
-                ("param_p1".into(), "first".into()),
-                ("param_p10".into(), "10".into()),
-            ]
-        );
-    }
-
-    #[test]
-    fn bind_params_handles_null_bool_and_float() {
-        let result = ClickHouseStore::bind_params(
-            "SELECT $1, $2, $3",
-            &[SqlParam::Null, SqlParam::Bool(true), SqlParam::Float(1.5)],
-        )
-        .unwrap();
-        assert_eq!(result.sql, "SELECT NULL, {p2:UInt8}, {p3:Float64}");
-        assert_eq!(
-            result.form_params,
-            vec![
-                ("param_p2".into(), "1".into()),
-                ("param_p3".into(), "1.5".into()),
-            ]
-        );
-    }
-
-    #[test]
-    fn bind_params_rejects_missing_and_zero_parameters() {
-        let missing = ClickHouseStore::bind_params("SELECT $2", &[SqlParam::Int(1)]);
-        assert!(matches!(missing, Err(ObserveError::InvalidQuery(_))));
-
-        let zero = ClickHouseStore::bind_params("SELECT $0", &[SqlParam::Int(1)]);
-        assert!(matches!(zero, Err(ObserveError::InvalidQuery(_))));
-    }
-
-    #[test]
-    fn test_parse_empty() {
-        let rs = parse_json_each_row("").unwrap();
-        assert!(rs.is_empty());
-    }
-
-    #[test]
-    fn test_parse_single_row() {
-        let body = r#"{"service":"api","status":"ok"}"#;
-        let rs = parse_json_each_row(body).unwrap();
-        assert_eq!(rs.len(), 1);
-        assert_eq!(rs.get(0, "service"), Some(&serde_json::json!("api")));
-    }
-
-    #[test]
-    fn test_parse_multiple_rows() {
-        let body = "{\"a\":1}\n{\"a\":2}";
-        let rs = parse_json_each_row(body).unwrap();
-        assert_eq!(rs.len(), 2);
-    }
-
-    #[test]
-    fn build_request_keeps_parameters_out_of_url() {
-        let attack = "x\\' OR 1=1 --";
-        let store = ClickHouseStore::new("http://127.0.0.1:8123");
-        let request = store
-            .build_request(
-                "SELECT service FROM spans WHERE service = $1",
-                &[SqlParam::String(attack.into())],
-            )
-            .unwrap();
-
-        assert_eq!(request.method(), reqwest::Method::POST);
-        assert_eq!(request.url().path(), "/");
-        assert_eq!(request.url().query(), Some("default_format=JSONEachRow"));
-        assert!(!request.url().as_str().contains(attack));
-        assert!(
-            request
-                .headers()
-                .get(reqwest::header::CONTENT_TYPE)
-                .and_then(|value| value.to_str().ok())
-                .is_some_and(|value| value.starts_with("multipart/form-data; boundary="))
-        );
-    }
-}
+#[path = "clickhouse_tests.rs"]
+mod tests;

--- a/crates/temper-observe/src/clickhouse_tests.rs
+++ b/crates/temper-observe/src/clickhouse_tests.rs
@@ -1,0 +1,168 @@
+use super::*;
+
+#[test]
+fn test_store_construction() {
+    let store = ClickHouseStore::new("http://localhost:8123");
+    assert_eq!(store.base_url(), "http://localhost:8123");
+}
+
+#[test]
+fn bind_params_uses_clickhouse_typed_placeholders() {
+    let sql = "SELECT * FROM spans WHERE service = $1 AND duration_ns > $2";
+    let params = vec![SqlParam::String("api".into()), SqlParam::Int(1000)];
+    let result = ClickHouseStore::bind_params(sql, &params).unwrap();
+    assert_eq!(
+        result,
+        BoundClickHouseQuery {
+            sql: "SELECT * FROM spans WHERE service = {p1:String} AND duration_ns > {p2:Int64}"
+                .into(),
+            form_params: vec![
+                ("param_p1".into(), "api".into()),
+                ("param_p2".into(), "1000".into()),
+            ],
+        }
+    );
+}
+
+#[test]
+fn bind_params_preserves_placeholders_in_quoted_regions_and_comments() {
+    let sql = "SELECT '$1', \"$1\", `$1`, $1 -- $1\n/* $1 */ # $1\n";
+    let result = ClickHouseStore::bind_params(sql, &[SqlParam::String("api".into())]).unwrap();
+    assert_eq!(
+        result.sql,
+        "SELECT '$1', \"$1\", `$1`, {p1:String} -- $1\n/* $1 */ # $1\n"
+    );
+}
+
+#[test]
+fn bind_params_preserves_clickhouse_extended_lexical_regions() {
+    let sql = "SELECT $1 // $2\n/* outer $2 /* nested */ still $2 */\n$$$$, $$body $2$$, $tag$body $2$tag$, ‘$2’, “$2”, $2";
+    let result =
+        ClickHouseStore::bind_params(sql, &[SqlParam::String("first".into()), SqlParam::Int(2)])
+            .unwrap();
+    assert_eq!(
+        result.sql,
+        "SELECT {p1:String} // $2\n/* outer $2 /* nested */ still $2 */\n$$$$, $$body $2$$, $tag$body $2$tag$, ‘$2’, “$2”, {p2:Int64}"
+    );
+}
+
+#[test]
+fn bind_params_handles_repetition_and_escaped_quotes() {
+    let sql = r#"SELECT '$1''$1', 'escaped \' $1', "$1""$1", `$1``$1`, metric$1, 1$1, $1, $1"#;
+    let result = ClickHouseStore::bind_params(sql, &[SqlParam::Int(7)]).unwrap();
+    assert_eq!(
+        result.sql,
+        r#"SELECT '$1''$1', 'escaped \' $1', "$1""$1", `$1``$1`, metric$1, 1$1, {p1:Int64}, {p1:Int64}"#
+    );
+    assert_eq!(result.form_params, vec![("param_p1".into(), "7".into())]);
+}
+
+#[test]
+fn bind_params_never_places_attacker_text_in_sql() {
+    let attack = "x\\' OR 1=1; DROP TABLE spans; -- $2";
+    let result = ClickHouseStore::bind_params(
+        "SELECT * FROM spans WHERE a = $1 AND b = $2",
+        &[
+            SqlParam::String(attack.into()),
+            SqlParam::String("second".into()),
+        ],
+    )
+    .unwrap();
+
+    assert_eq!(
+        result.sql,
+        "SELECT * FROM spans WHERE a = {p1:String} AND b = {p2:String}"
+    );
+    assert!(!result.sql.contains("DROP TABLE"));
+    assert_eq!(result.form_params[0].1, attack);
+}
+
+#[test]
+fn bind_params_handles_types_two_digits_and_multibyte_text() {
+    let sql = "SELECT $10, name = $1, note = 'café ☕'";
+    let mut params: Vec<SqlParam> = (1..=10).map(SqlParam::Int).collect();
+    params[0] = SqlParam::String("first".into());
+    let result = ClickHouseStore::bind_params(sql, &params).unwrap();
+    assert_eq!(
+        result.sql,
+        "SELECT {p10:Int64}, name = {p1:String}, note = 'café ☕'"
+    );
+    assert_eq!(
+        result.form_params,
+        vec![
+            ("param_p1".into(), "first".into()),
+            ("param_p10".into(), "10".into()),
+        ]
+    );
+}
+
+#[test]
+fn bind_params_handles_null_bool_and_float() {
+    let result = ClickHouseStore::bind_params(
+        "SELECT $1, $2, $3",
+        &[SqlParam::Null, SqlParam::Bool(true), SqlParam::Float(1.5)],
+    )
+    .unwrap();
+    assert_eq!(result.sql, "SELECT NULL, {p2:UInt8}, {p3:Float64}");
+    assert_eq!(
+        result.form_params,
+        vec![
+            ("param_p2".into(), "1".into()),
+            ("param_p3".into(), "1.5".into()),
+        ]
+    );
+}
+
+#[test]
+fn bind_params_rejects_missing_and_zero_parameters() {
+    let missing = ClickHouseStore::bind_params("SELECT $2", &[SqlParam::Int(1)]);
+    assert!(matches!(missing, Err(ObserveError::InvalidQuery(_))));
+
+    let zero = ClickHouseStore::bind_params("SELECT $0", &[SqlParam::Int(1)]);
+    assert!(matches!(zero, Err(ObserveError::InvalidQuery(_))));
+}
+
+#[test]
+fn test_parse_empty() {
+    let rs = parse_json_each_row("").unwrap();
+    assert!(rs.is_empty());
+}
+
+#[test]
+fn test_parse_single_row() {
+    let body = r#"{"service":"api","status":"ok"}"#;
+    let rs = parse_json_each_row(body).unwrap();
+    assert_eq!(rs.len(), 1);
+    assert_eq!(rs.get(0, "service"), Some(&serde_json::json!("api")));
+}
+
+#[test]
+fn test_parse_multiple_rows() {
+    let body = "{\"a\":1}\n{\"a\":2}";
+    let rs = parse_json_each_row(body).unwrap();
+    assert_eq!(rs.len(), 2);
+}
+
+#[test]
+fn build_request_keeps_parameters_out_of_url() {
+    let attack = "x\\' OR 1=1 --";
+    let store = ClickHouseStore::new("http://127.0.0.1:8123");
+    let request = store
+        .build_request(
+            "SELECT service FROM spans WHERE service = $1",
+            &[SqlParam::String(attack.into())],
+        )
+        .unwrap();
+
+    assert_eq!(request.method(), reqwest::Method::POST);
+    assert_eq!(request.url().path(), "/");
+    assert_eq!(request.url().query(), Some("default_format=JSONEachRow"));
+    assert!(!request.url().as_str().contains(attack));
+    assert!(
+        request
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .is_some_and(|value| value.starts_with("multipart/form-data; boundary="))
+    );
+}

--- a/crates/temper-observe/src/clickhouse_tests.rs
+++ b/crates/temper-observe/src/clickhouse_tests.rs
@@ -48,11 +48,11 @@ fn bind_params_preserves_clickhouse_extended_lexical_regions() {
 
 #[test]
 fn bind_params_handles_repetition_and_escaped_quotes() {
-    let sql = r#"SELECT '$1''$1', 'escaped \' $1', "$1""$1", `$1``$1`, metric$1, 1$1, $1, $1"#;
+    let sql = r#"SELECT '$1''$1', 'escaped \' $1', "$1""$1", `$1``$1`, metric$1, 1$1, $1suffix, $1_foo, $1$, $1, $1"#;
     let result = ClickHouseStore::bind_params(sql, &[SqlParam::Int(7)]).unwrap();
     assert_eq!(
         result.sql,
-        r#"SELECT '$1''$1', 'escaped \' $1', "$1""$1", `$1``$1`, metric$1, 1$1, {p1:Int64}, {p1:Int64}"#
+        r#"SELECT '$1''$1', 'escaped \' $1', "$1""$1", `$1``$1`, metric$1, 1$1, $1suffix, $1_foo, $1$, {p1:Int64}, {p1:Int64}"#
     );
     assert_eq!(result.form_params, vec![("param_p1".into(), "7".into())]);
 }

--- a/crates/temper-observe/tests/clickhouse_multipart.rs
+++ b/crates/temper-observe/tests/clickhouse_multipart.rs
@@ -1,0 +1,95 @@
+//! ARN-174: exercise the real reqwest multipart request over a TCP socket.
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+use temper_observe::{ClickHouseStore, ObservabilityStore, SqlParam};
+
+async fn capture_request(mut stream: TcpStream) -> Vec<u8> {
+    let mut request = Vec::new();
+    let mut chunk = [0_u8; 4096];
+    let mut expected_len = None;
+
+    loop {
+        let read = stream.read(&mut chunk).await.expect("read request");
+        assert!(read > 0, "client closed before sending a complete request");
+        request.extend_from_slice(&chunk[..read]);
+
+        if expected_len.is_none()
+            && let Some(header_end) = request.windows(4).position(|bytes| bytes == b"\r\n\r\n")
+        {
+            let headers = std::str::from_utf8(&request[..header_end]).expect("ASCII headers");
+            let content_len = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length").then(|| {
+                        value
+                            .trim()
+                            .parse::<usize>()
+                            .expect("numeric content length")
+                    })
+                })
+                .expect("multipart request has a content length");
+            expected_len = Some(header_end + 4 + content_len);
+        }
+
+        if expected_len.is_some_and(|length| request.len() >= length) {
+            break;
+        }
+    }
+
+    let body = "{\"service\":\"safe\"}\n";
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    stream
+        .write_all(response.as_bytes())
+        .await
+        .expect("write response");
+    request
+}
+
+#[tokio::test]
+async fn attacker_value_is_only_in_multipart_parameter_field() {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind request capture socket");
+    let address = listener.local_addr().expect("capture socket address");
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.expect("accept request");
+        capture_request(stream).await
+    });
+
+    let attack = "x\\' OR 1=1; DROP TABLE otel_traces; -- $2";
+    let store = ClickHouseStore::new(format!("http://{address}"));
+    let result = store
+        .query_spans(
+            "SELECT service FROM otel_traces WHERE service = $1",
+            &[SqlParam::String(attack.to_string())],
+        )
+        .await
+        .expect("mock ClickHouse request succeeds");
+    assert_eq!(result.len(), 1);
+
+    let request = String::from_utf8(server.await.expect("capture task")).expect("UTF-8 request");
+    let (headers, body) = request.split_once("\r\n\r\n").expect("HTTP envelope");
+    let first_line = headers.lines().next().expect("request line");
+    assert_eq!(first_line, "POST /?default_format=JSONEachRow HTTP/1.1");
+    assert!(!first_line.contains(attack));
+    assert!(headers.to_ascii_lowercase().contains("multipart/form-data"));
+
+    let query_part = body
+        .split("\r\n--")
+        .find(|part| part.contains("name=\"query\""))
+        .expect("query multipart field");
+    assert!(query_part.contains("SELECT service FROM otel_traces WHERE service = {p1:String}"));
+    assert!(!query_part.contains(attack));
+
+    let parameter_part = body
+        .split("\r\n--")
+        .find(|part| part.contains("name=\"param_p1\""))
+        .expect("typed parameter multipart field");
+    assert!(parameter_part.contains(attack));
+}

--- a/crates/temper-store-postgres/src/query_page.rs
+++ b/crates/temper-store-postgres/src/query_page.rs
@@ -26,9 +26,9 @@ impl PostgresEventStore {
         }
 
         let clause = postgres_placeholders(where_clause, params.len() + 2);
-        let order_sql = postgres_query_field_order_sql(order_by);
-        let limit_param = params.len() + 3;
-        let offset_param = params.len() + 4;
+        let (order_sql, order_params) = postgres_query_field_order_sql(order_by, params.len() + 3);
+        let limit_param = params.len() + order_params.len() + 3;
+        let offset_param = limit_param + 1;
         let sql = postgres_query_field_page_sql(
             &clause,
             &order_sql,
@@ -44,6 +44,9 @@ impl PostgresEventStore {
             for param in params.iter().cloned() {
                 query = query.bind(param);
             }
+            for field_name in order_params.iter().cloned() {
+                query = query.bind(field_name);
+            }
             query = query
                 .bind(top.min(i64::MAX as usize) as i64)
                 .bind(skip.min(i64::MAX as usize) as i64);
@@ -57,6 +60,9 @@ impl PostgresEventStore {
             .bind(entity_type);
         for param in params.iter().cloned() {
             query = query.bind(param);
+        }
+        for field_name in order_params {
+            query = query.bind(field_name);
         }
         query = query
             .bind(top.min(i64::MAX as usize) as i64)
@@ -127,8 +133,12 @@ fn postgres_query_field_page_sql(
     )
 }
 
-fn postgres_query_field_order_sql(order_by: &[(String, bool)]) -> String {
+fn postgres_query_field_order_sql(
+    order_by: &[(String, bool)],
+    first_param: usize,
+) -> (String, Vec<String>) {
     let mut clauses = Vec::new();
+    let mut params = Vec::new();
     for (field_name, descending) in order_by {
         let direction = if *descending { "DESC" } else { "ASC" };
         let nulls = if *descending {
@@ -141,7 +151,8 @@ fn postgres_query_field_order_sql(order_by: &[(String, bool)]) -> String {
         } else if field_name == "status" || field_name == "Status" {
             clauses.push(format!("status {direction} {nulls}"));
         } else {
-            let field = postgres_string_literal(field_name);
+            let field = format!("${}", first_param + params.len());
+            params.push(field_name.clone());
             clauses.push(format!(
                 "CASE WHEN jsonb_typeof(fields -> {field}) = 'number' \
                  THEN (fields ->> {field})::numeric END {direction} {nulls}"
@@ -153,11 +164,7 @@ fn postgres_query_field_order_sql(order_by: &[(String, bool)]) -> String {
         }
     }
     clauses.push("entity_id ASC".to_string());
-    clauses.join(", ")
-}
-
-fn postgres_string_literal(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "''"))
+    (clauses.join(", "), params)
 }
 
 #[cfg(test)]
@@ -177,5 +184,15 @@ mod tests {
         let sql = postgres_query_field_page_sql("entity_id = $3", "entity_id ASC", 4, 5, true);
 
         assert!(sql.contains("COUNT(*) OVER() AS total_count"));
+    }
+
+    #[test]
+    fn custom_order_fields_are_bound_not_interpolated() {
+        let attack = "field'\\; DROP TABLE entity_catalog; --";
+        let (sql, params) = postgres_query_field_order_sql(&[(attack.to_string(), false)], 7);
+
+        assert!(sql.contains("fields -> $7"));
+        assert!(!sql.contains("DROP TABLE"));
+        assert_eq!(params, vec![attack]);
     }
 }

--- a/crates/temper-store-turso/src/store/query_page.rs
+++ b/crates/temper-store-turso/src/store/query_page.rs
@@ -35,9 +35,9 @@ impl TursoEventStore {
         }
 
         let conn = self.configured_connection().await?;
-        let order_sql = turso_query_field_order_sql(order_by);
-        let limit_param = params.len() + 3;
-        let offset_param = params.len() + 4;
+        let (order_sql, order_params) = turso_query_field_order_sql(order_by, params.len() + 3);
+        let limit_param = params.len() + order_params.len() + 3;
+        let offset_param = limit_param + 1;
         let sql = turso_query_field_page_sql(
             where_clause,
             &order_sql,
@@ -51,6 +51,7 @@ impl TursoEventStore {
             libsql::Value::from(entity_type.to_string()),
         ];
         all_params.extend(params.iter().cloned().map(libsql::Value::from));
+        all_params.extend(order_params.into_iter().map(libsql::Value::from));
         all_params.push(libsql::Value::from(top.min(i64::MAX as usize) as i64));
         all_params.push(libsql::Value::from(skip.min(i64::MAX as usize) as i64));
 
@@ -132,8 +133,12 @@ fn turso_query_field_page_sql(
     )
 }
 
-fn turso_query_field_order_sql(order_by: &[(String, bool)]) -> String {
+fn turso_query_field_order_sql(
+    order_by: &[(String, bool)],
+    first_param: usize,
+) -> (String, Vec<String>) {
     let mut clauses = Vec::new();
+    let mut params = Vec::new();
     for (field_name, descending) in order_by {
         let direction = if *descending { "DESC" } else { "ASC" };
         let null_direction = if *descending { "DESC" } else { "ASC" };
@@ -143,38 +148,37 @@ fn turso_query_field_order_sql(order_by: &[(String, bool)]) -> String {
             clauses.push(format!("status IS NULL {null_direction}"));
             clauses.push(format!("status {direction}"));
         } else {
-            let path = turso_json_path_literal(field_name);
+            let field_param = format!("?{}", first_param + params.len());
+            params.push(field_name.clone());
+            let value = format!(
+                "(SELECT value FROM json_each(fields) \
+                 WHERE key = {field_param} LIMIT 1)"
+            );
+            let value_type = format!(
+                "(SELECT type FROM json_each(fields) \
+                 WHERE key = {field_param} LIMIT 1)"
+            );
+            clauses.push(format!("{value} IS NULL {null_direction}"));
             clauses.push(format!(
-                "json_extract(fields, {path}) IS NULL {null_direction}"
+                "CASE WHEN {value_type} IN ('integer', 'real') \
+                 THEN CAST({value} AS REAL) END IS NULL ASC"
             ));
             clauses.push(format!(
-                "CASE WHEN json_type(fields, {path}) IN ('integer', 'real') \
-                 THEN CAST(json_extract(fields, {path}) AS REAL) END IS NULL ASC"
+                "CASE WHEN {value_type} IN ('integer', 'real') \
+                 THEN CAST({value} AS REAL) END {direction}"
             ));
             clauses.push(format!(
-                "CASE WHEN json_type(fields, {path}) IN ('integer', 'real') \
-                 THEN CAST(json_extract(fields, {path}) AS REAL) END {direction}"
+                "CASE WHEN {value_type} NOT IN ('integer', 'real') \
+                 THEN {value} END IS NULL ASC"
             ));
             clauses.push(format!(
-                "CASE WHEN json_type(fields, {path}) NOT IN ('integer', 'real') \
-                 THEN json_extract(fields, {path}) END IS NULL ASC"
-            ));
-            clauses.push(format!(
-                "CASE WHEN json_type(fields, {path}) NOT IN ('integer', 'real') \
-                 THEN json_extract(fields, {path}) END {direction}"
+                "CASE WHEN {value_type} NOT IN ('integer', 'real') \
+                 THEN {value} END {direction}"
             ));
         }
     }
     clauses.push("entity_id ASC".to_string());
-    clauses.join(", ")
-}
-
-fn turso_json_path_literal(field_name: &str) -> String {
-    let escaped = field_name
-        .replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('\'', "''");
-    format!("'$.\"{escaped}\"'")
+    (clauses.join(", "), params)
 }
 
 #[cfg(test)]
@@ -194,5 +198,94 @@ mod tests {
         let sql = turso_query_field_page_sql("entity_id = ?3", "entity_id ASC", 4, 5, true);
 
         assert!(sql.contains("COUNT(*) OVER() AS total_count"));
+    }
+
+    #[test]
+    fn custom_order_paths_are_bound_not_interpolated() {
+        let attack = "field'\\\"; DROP TABLE entity_catalog; --";
+        let (sql, params) = turso_query_field_order_sql(&[(attack.to_string(), false)], 7);
+
+        assert!(sql.contains("WHERE key = ?7"));
+        assert!(!sql.contains("DROP TABLE"));
+        assert_eq!(params, vec![attack]);
+    }
+
+    #[tokio::test]
+    async fn bound_json_path_round_trips_metacharacter_field_name() {
+        let field_name = "field'\\\".name";
+        let document =
+            serde_json::to_string(&std::collections::BTreeMap::from([(field_name, "found")]))
+                .unwrap();
+        let database = libsql::Builder::new_local(":memory:")
+            .build()
+            .await
+            .unwrap();
+        let connection = database.connect().unwrap();
+        let mut rows = connection
+            .query(
+                "SELECT value FROM json_each(?1) WHERE key = ?2",
+                libsql::params![document, field_name],
+            )
+            .await
+            .unwrap();
+        let row = rows.next().await.unwrap().unwrap();
+        let value: String = row.get(0).unwrap();
+
+        assert_eq!(value, "found");
+    }
+
+    #[tokio::test]
+    async fn generated_page_query_orders_by_bound_metacharacter_field() {
+        let field_name = "field'\\\".name";
+        let (order_sql, order_params) =
+            turso_query_field_order_sql(&[(field_name.to_string(), false)], 3);
+        let sql = turso_query_field_page_sql("1 = 1", &order_sql, 4, 5, false);
+
+        let database = libsql::Builder::new_local(":memory:")
+            .build()
+            .await
+            .unwrap();
+        let connection = database.connect().unwrap();
+        connection
+            .execute(
+                "CREATE TABLE entity_catalog (\
+                 tenant TEXT NOT NULL, entity_type TEXT NOT NULL, \
+                 entity_id TEXT NOT NULL, status TEXT, fields TEXT NOT NULL)",
+                (),
+            )
+            .await
+            .unwrap();
+        for (entity_id, value) in [("late", "z"), ("early", "a")] {
+            let fields =
+                serde_json::to_string(&std::collections::BTreeMap::from([(field_name, value)]))
+                    .unwrap();
+            connection
+                .execute(
+                    "INSERT INTO entity_catalog \
+                     (tenant, entity_type, entity_id, status, fields) \
+                     VALUES (?1, ?2, ?3, 'Active', ?4)",
+                    libsql::params!["tenant-a", "Document", entity_id, fields],
+                )
+                .await
+                .unwrap();
+        }
+
+        let mut params = vec![
+            libsql::Value::from("tenant-a"),
+            libsql::Value::from("Document"),
+        ];
+        params.extend(order_params.into_iter().map(libsql::Value::from));
+        params.push(libsql::Value::from(10_i64));
+        params.push(libsql::Value::from(0_i64));
+        let mut rows = connection
+            .query(&sql, libsql::params_from_iter(params))
+            .await
+            .unwrap();
+        let mut ids = Vec::new();
+        while let Some(row) = rows.next().await.unwrap() {
+            ids.push(row.get::<String>(0).unwrap());
+        }
+
+        assert_eq!(ids, vec!["early", "late"]);
     }
 }

--- a/crates/temper-store-turso/src/store/query_page.rs
+++ b/crates/temper-store-turso/src/store/query_page.rs
@@ -141,11 +141,10 @@ fn turso_query_field_order_sql(
     let mut params = Vec::new();
     for (field_name, descending) in order_by {
         let direction = if *descending { "DESC" } else { "ASC" };
-        let null_direction = if *descending { "DESC" } else { "ASC" };
         if field_name == "entity_id" || field_name == "Id" || field_name == "id" {
             clauses.push(format!("entity_id {direction}"));
         } else if field_name == "status" || field_name == "Status" {
-            clauses.push(format!("status IS NULL {null_direction}"));
+            clauses.push(format!("status IS NULL {direction}"));
             clauses.push(format!("status {direction}"));
         } else {
             let field_param = format!("?{}", first_param + params.len());
@@ -158,7 +157,7 @@ fn turso_query_field_order_sql(
                 "(SELECT type FROM json_each(fields) \
                  WHERE key = {field_param} LIMIT 1)"
             );
-            clauses.push(format!("{value} IS NULL {null_direction}"));
+            clauses.push(format!("{value} IS NULL {direction}"));
             clauses.push(format!(
                 "CASE WHEN {value_type} IN ('integer', 'real') \
                  THEN CAST({value} AS REAL) END IS NULL ASC"

--- a/docs/adrs/0163-clickhouse-typed-query-parameters.md
+++ b/docs/adrs/0163-clickhouse-typed-query-parameters.md
@@ -32,6 +32,12 @@ rewrites placeholders in SQL code. Missing and zero-indexed parameters fail loca
 `SqlParam::Null` remains the trusted SQL token `NULL`, because the cross-store enum
 does not carry the target type required for `Nullable(T)`.
 
+ClickHouse's server project documents this exact multipart protocol (`query` plus
+`param_pN` fields) in [ClickHouse/ClickHouse#8842](https://github.com/ClickHouse/ClickHouse/issues/8842),
+including a working server example. The official Java client tracks and ships the
+same body-based parameter transport in
+[ClickHouse/clickhouse-java#2324](https://github.com/ClickHouse/clickhouse-java/issues/2324).
+
 PostgreSQL will bind dynamic JSONB member names. Turso will use `json_each(fields)`
 and bind the exact member key rather than constructing a JSON path literal.
 

--- a/docs/adrs/0163-clickhouse-typed-query-parameters.md
+++ b/docs/adrs/0163-clickhouse-typed-query-parameters.md
@@ -1,0 +1,96 @@
+# ADR-0163: Typed query parameters at observability-store boundaries
+
+- Status: Proposed
+- Date: 2026-07-11
+- Deciders: Temper core maintainers
+- Related:
+  - ARN-174: ClickHouse SQL injection through string interpolation
+  - `crates/temper-observe/src/clickhouse.rs`
+  - `crates/temper-store-postgres/src/query_page.rs`
+  - `crates/temper-store-turso/src/store/query_page.rs`
+
+## Context
+
+`ClickHouseStore` expands the store-wide `$N` placeholder convention by rendering
+values into SQL text. Its string renderer doubles single quotes but does not model
+ClickHouse's backslash escapes. A value ending in a backslash can therefore escape
+the generated closing quote and allow later input to become SQL syntax.
+
+The same audit found two narrower manual literal builders for dynamic OData order
+field names in PostgreSQL and Turso. Keeping any security-sensitive SQL literal
+renderer would preserve the implementation class that caused ARN-174.
+
+## Decision
+
+ClickHouse queries will translate trusted `$N` placeholders into ClickHouse typed
+placeholders such as `{p1:String}`. The SQL remains in the multipart `query` field;
+each value is sent separately as `param_pN`. Parameter text never becomes SQL source.
+
+The translator is a single-pass scanner over trusted query templates. It recognizes
+single-, double-, and backtick-quoted regions plus line and block comments, and only
+rewrites placeholders in SQL code. Missing and zero-indexed parameters fail locally.
+`SqlParam::Null` remains the trusted SQL token `NULL`, because the cross-store enum
+does not carry the target type required for `Nullable(T)`.
+
+PostgreSQL will bind dynamic JSONB member names. Turso will use `json_each(fields)`
+and bind the exact member key rather than constructing a JSON path literal.
+
+**Why this approach**: native typed parameters delegate value encoding to the
+database protocol and eliminate a security-critical escaper instead of extending it.
+
+## Rollout Plan
+
+1. Replace interpolation and dynamic field-name literals in the three adapters.
+2. Validate the real ClickHouse multipart request against a local mock HTTP endpoint.
+3. Verify against a live ClickHouse service before merge or record that external gate
+   explicitly when no service is available locally.
+
+## Readiness Gates
+
+- Attacker-controlled parameter bytes do not occur in generated SQL.
+- The real HTTP request carries values only in `param_pN` multipart fields.
+- Quoted/comment placeholders are not rewritten.
+- PostgreSQL and Turso dynamic order fields are bound.
+- Formatting, focused tests, independent review, and live ClickHouse verification pass.
+
+## Consequences
+
+### Positive
+
+- The reported quote/backslash exploit and the entire manual-value-escaping class are removed.
+- Values stay out of routine query URLs and SQL logs.
+- All three affected adapters share the same rule: data is bound, never rendered as SQL.
+
+### Negative
+
+- ClickHouse request construction becomes multipart rather than a raw SQL body.
+- The placeholder scanner must track SQL lexical regions in trusted templates.
+
+### Risks
+
+- ClickHouse resolves response format before multipart parsing, so `default_format` remains
+  a fixed URL query parameter while SQL and values stay in the request body.
+- Null binding remains untyped until `SqlParam` carries provider-specific nullable types.
+
+### DST Compliance
+
+- These adapters are not simulation-visible. The transformation is deterministic and pure.
+
+## Non-Goals
+
+- Changing the universal store placeholder convention.
+- Adding provider-specific types to `SqlParam`.
+- Treating identifiers as values; trusted SQL structure remains in query templates.
+
+## Alternatives Considered
+
+1. **Escape backslashes before quotes** — Rejected because it retains a second ClickHouse
+   string grammar implementation and leaves future escape drift possible.
+2. **Put query parameters in the URL** — Rejected because values would appear in routine
+   proxy access logs and query length would be constrained by URL limits.
+
+## Rollback Policy
+
+Reverting restores the vulnerable interpolation path and is not permitted after release.
+If multipart compatibility fails, replace it with ClickHouse's equivalent typed parameter
+transport; do not restore value interpolation.

--- a/docs/adrs/0163-clickhouse-typed-query-parameters.md
+++ b/docs/adrs/0163-clickhouse-typed-query-parameters.md
@@ -26,9 +26,10 @@ ClickHouse queries will translate trusted `$N` placeholders into ClickHouse type
 placeholders such as `{p1:String}`. The SQL remains in the multipart `query` field;
 each value is sent separately as `param_pN`. Parameter text never becomes SQL source.
 
-The translator is a single-pass scanner over trusted query templates. It recognizes
-single-, double-, and backtick-quoted regions plus line and block comments, and only
-rewrites placeholders in SQL code. Missing and zero-indexed parameters fail locally.
+The translator is a single-pass scanner over trusted query templates. It mirrors
+ClickHouse lexical non-code regions: ASCII and Unicode quotes, heredocs, all line-comment
+forms, and nested block comments. It only rewrites placeholders in SQL code. Missing
+and zero-indexed parameters fail locally.
 `SqlParam::Null` remains the trusted SQL token `NULL`, because the cross-store enum
 does not carry the target type required for `Nullable(T)`.
 
@@ -55,7 +56,7 @@ database protocol and eliminate a security-critical escaper instead of extending
 
 - Attacker-controlled parameter bytes do not occur in generated SQL.
 - The real HTTP request carries values only in `param_pN` multipart fields.
-- Quoted/comment placeholders are not rewritten.
+- Quoted, heredoc, and comment placeholders are not rewritten.
 - PostgreSQL and Turso dynamic order fields are bound.
 - Formatting, focused tests, independent review, and live ClickHouse verification pass.
 


### PR DESCRIPTION
## ARN-174 — ClickHouse typed query parameters

Draft opened immediately after the ADR commit so ongoing implementation is visible and traceable outside bundled PR #346.

Planned scope:

- Remove ClickHouse value interpolation and use typed HTTP query parameters.
- Ensure attacker-controlled bytes never enter SQL source or routine URLs.
- Bind related dynamic JSON order-field names in PostgreSQL and Turso, removing parallel manual literal builders found by the same audit.
- Add lexical placeholder tests, real multipart request coverage, provider regressions, and live ClickHouse verification where locally available.
- Run strict formatting, Clippy, readability, focused and end-to-end tests, independent review, CI, and Greptile.

Design: `docs/adrs/0163-clickhouse-typed-query-parameters.md`.

This PR remains draft and must not be merged until implementation, local E2E, independent review, CI, and Greptile are complete.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces ClickHouse value interpolation (which was exploitable via backslash-terminated strings) with ClickHouse typed HTTP query parameters, sending SQL in the multipart `query` field and each value in a separate `param_pN` field. Parallel manual literal builders in the PostgreSQL and Turso order-by paths are also removed in favour of bound parameters.

- **ClickHouse `bind_params`**: a single-pass lexical scanner translates `$N` to `{pN:Type}` while correctly preserving placeholders inside all quoted regions, heredocs, and comments. Right-embedded tokens such as `$1suffix`, `$1_foo`, and `$1$` are detected and copied verbatim via `is_clickhouse_bareword_char`.
- **PostgreSQL**: `postgres_string_literal` is removed; dynamic JSONB member names in ORDER BY are now bound as `$N` placeholders and appended to the query's parameter list.
- **Turso**: `turso_json_path_literal` is removed; dynamic field names use `json_each(fields) WHERE key = ?N` with a bound parameter, removing the `json_extract` path-literal surface. The previously flagged `null_direction` dead variable is also cleaned up.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change cleanly eliminates a confirmed SQL injection vector in ClickHouse and two parallel literal-builder paths in Postgres and Turso, replacing all three with bound parameters. No interpolation paths remain.

The ClickHouse lexical scanner is single-pass, handles all quoted regions, heredocs, nested block comments, and the right-token boundary correctly. Attacker-controlled bytes never appear in the transformed SQL. Tests are comprehensive: unit-level injection proofs, a real TCP E2E multipart assertion, and a live libsql round-trip with metacharacter field names.

No files require special attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/temper-observe/src/clickhouse.rs | Core security fix: replaces string interpolation with typed multipart parameters. Lexical scanner correctly handles all ClickHouse non-code regions and right-embedded bareword tokens. No issues found. |
| crates/temper-observe/src/clickhouse_tests.rs | Comprehensive unit tests for bind_params covering placeholders in all quoted/comment regions, right-token boundaries (suffix, underscore, dollar continuation), multi-digit indices, type mappings, and injection rejection. |
| crates/temper-observe/tests/clickhouse_multipart.rs | End-to-end TCP test that validates the real reqwest multipart request: attack payload absent from request line and query field, present only in param_p1 field. |
| crates/temper-store-postgres/src/query_page.rs | postgres_string_literal removed; dynamic JSONB field names in ORDER BY are now bound as positional parameters. Parameter numbering and insertion order across both code paths are consistent. |
| crates/temper-store-turso/src/store/query_page.rs | turso_json_path_literal removed; json_each + bound key replaces json_extract path literals. Null-direction dead variable cleaned up. Integration test validates round-trip with metacharacter field name. |
| docs/adrs/0163-clickhouse-typed-query-parameters.md | ADR documents the vulnerability, decision rationale, rollback policy, and all three adapter changes. Covers tradeoffs and non-goals clearly. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant bind_params
    participant build_request
    participant reqwest
    participant ClickHouse

    Caller->>bind_params: sql template + SqlParam[]
    bind_params->>bind_params: scan lexical regions (quotes, heredocs, comments)
    bind_params->>bind_params: "$N in Code region to {pN:Type} in SQL"
    bind_params->>bind_params: $N in quoted/comment/heredoc copied verbatim
    bind_params->>bind_params: right-embedded tokens copied verbatim
    bind_params-->>build_request: "BoundClickHouseQuery { sql, form_params }"
    build_request->>reqwest: multipart Form with query field and param_pN fields
    reqwest->>ClickHouse: "POST /?default_format=JSONEachRow multipart/form-data"
    ClickHouse-->>reqwest: JSONEachRow response
    reqwest-->>Caller: ResultSet
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant bind_params
    participant build_request
    participant reqwest
    participant ClickHouse

    Caller->>bind_params: sql template + SqlParam[]
    bind_params->>bind_params: scan lexical regions (quotes, heredocs, comments)
    bind_params->>bind_params: "$N in Code region to {pN:Type} in SQL"
    bind_params->>bind_params: $N in quoted/comment/heredoc copied verbatim
    bind_params->>bind_params: right-embedded tokens copied verbatim
    bind_params-->>build_request: "BoundClickHouseQuery { sql, form_params }"
    build_request->>reqwest: multipart Form with query field and param_pN fields
    reqwest->>ClickHouse: "POST /?default_format=JSONEachRow multipart/form-data"
    ClickHouse-->>reqwest: JSONEachRow response
    reqwest-->>Caller: ResultSet
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `crates/temper-observe/tests/clickhouse_multipart.rs`, line 463-484 ([link](https://github.com/nerdsane/temper/blob/de97e5a9b7bb74eb06886488f89d7543286801b1/crates/temper-observe/tests/clickhouse_multipart.rs#L463-L484)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Let-chains may exceed stated MSRV**

   `if expected_len.is_none() && let Some(header_end) = ...` is a let-chain (`if bool_expr && let Some(x) = expr`). This syntax was stabilized in Rust 1.88.0, but `CLAUDE.md` declares `rust-version = "1.85"`. If CI runs with an older toolchain this test file will fail to compile. If the project's effective toolchain is already 1.88+, this is a no-op, but the `rust-version` field in the workspace `Cargo.toml` should be bumped to match.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: crates/temper-observe/tests/clickhouse_multipart.rs
   Line: 463-484

   Comment:
   **Let-chains may exceed stated MSRV**

   `if expected_len.is_none() && let Some(header_end) = ...` is a let-chain (`if bool_expr && let Some(x) = expr`). This syntax was stabilized in Rust 1.88.0, but `CLAUDE.md` declares `rust-version = "1.85"`. If CI runs with an older toolchain this test file will fail to compile. If the project's effective toolchain is already 1.88+, this is a no-op, but the `rust-version` field in the workspace `Cargo.toml` should be bumped to match.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-observe%2Ftests%2Fclickhouse_multipart.rs%0ALine%3A%20463-484%0A%0AComment%3A%0A**Let-chains%20may%20exceed%20stated%20MSRV**%0A%0A%60if%20expected_len.is_none%28%29%20%26%26%20let%20Some%28header_end%29%20%3D%20...%60%20is%20a%20let-chain%20%28%60if%20bool_expr%20%26%26%20let%20Some%28x%29%20%3D%20expr%60%29.%20This%20syntax%20was%20stabilized%20in%20Rust%201.88.0%2C%20but%20%60CLAUDE.md%60%20declares%20%60rust-version%20%3D%20%221.85%22%60.%20If%20CI%20runs%20with%20an%20older%20toolchain%20this%20test%20file%20will%20fail%20to%20compile.%20If%20the%20project's%20effective%20toolchain%20is%20already%201.88%2B%2C%20this%20is%20a%20no-op%2C%20but%20the%20%60rust-version%60%20field%20in%20the%20workspace%20%60Cargo.toml%60%20should%20be%20bumped%20to%20match.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=nerdsane%2Ftemper&pr=353&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22codex%2Farn-174-clickhouse-bindings%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Farn-174-clickhouse-bindings%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-observe%2Ftests%2Fclickhouse_multipart.rs%0ALine%3A%20463-484%0A%0AComment%3A%0A**Let-chains%20may%20exceed%20stated%20MSRV**%0A%0A%60if%20expected_len.is_none%28%29%20%26%26%20let%20Some%28header_end%29%20%3D%20...%60%20is%20a%20let-chain%20%28%60if%20bool_expr%20%26%26%20let%20Some%28x%29%20%3D%20expr%60%29.%20This%20syntax%20was%20stabilized%20in%20Rust%201.88.0%2C%20but%20%60CLAUDE.md%60%20declares%20%60rust-version%20%3D%20%221.85%22%60.%20If%20CI%20runs%20with%20an%20older%20toolchain%20this%20test%20file%20will%20fail%20to%20compile.%20If%20the%20project's%20effective%20toolchain%20is%20already%201.88%2B%2C%20this%20is%20a%20no-op%2C%20but%20the%20%60rust-version%60%20field%20in%20the%20workspace%20%60Cargo.toml%60%20should%20be%20bumped%20to%20match.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=nerdsane%2Ftemper&pr=353&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-observe%2Ftests%2Fclickhouse_multipart.rs%0ALine%3A%20463-484%0A%0AComment%3A%0A**Let-chains%20may%20exceed%20stated%20MSRV**%0A%0A%60if%20expected_len.is_none%28%29%20%26%26%20let%20Some%28header_end%29%20%3D%20...%60%20is%20a%20let-chain%20%28%60if%20bool_expr%20%26%26%20let%20Some%28x%29%20%3D%20expr%60%29.%20This%20syntax%20was%20stabilized%20in%20Rust%201.88.0%2C%20but%20%60CLAUDE.md%60%20declares%20%60rust-version%20%3D%20%221.85%22%60.%20If%20CI%20runs%20with%20an%20older%20toolchain%20this%20test%20file%20will%20fail%20to%20compile.%20If%20the%20project's%20effective%20toolchain%20is%20already%201.88%2B%2C%20this%20is%20a%20no-op%2C%20but%20the%20%60rust-version%60%20field%20in%20the%20workspace%20%60Cargo.toml%60%20should%20be%20bumped%20to%20match.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=353&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>

2. `crates/temper-observe/tests/clickhouse_multipart.rs`, line 453-486 ([link](https://github.com/nerdsane/temper/blob/de97e5a9b7bb74eb06886488f89d7543286801b1/crates/temper-observe/tests/clickhouse_multipart.rs#L453-L486)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`capture_request` loop has no timeout**

   If the request never arrives with a `Content-Length` header (e.g. a regression causes chunked transfer), `expected_len` stays `None` and the loop reads until EOF, then panics on the `assert!(read > 0)`. `#[tokio::test]` does not impose a default timeout, so a CI run would hang until the job timeout fires. Consider adding `tokio::time::timeout` wrapping the `server.await`, or at minimum a `Content-Length`-absent fallback break condition, to get a fast actionable failure.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: crates/temper-observe/tests/clickhouse_multipart.rs
   Line: 453-486

   Comment:
   **`capture_request` loop has no timeout**

   If the request never arrives with a `Content-Length` header (e.g. a regression causes chunked transfer), `expected_len` stays `None` and the loop reads until EOF, then panics on the `assert!(read > 0)`. `#[tokio::test]` does not impose a default timeout, so a CI run would hang until the job timeout fires. Consider adding `tokio::time::timeout` wrapping the `server.await`, or at minimum a `Content-Length`-absent fallback break condition, to get a fast actionable failure.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-observe%2Ftests%2Fclickhouse_multipart.rs%0ALine%3A%20453-486%0A%0AComment%3A%0A**%60capture_request%60%20loop%20has%20no%20timeout**%0A%0AIf%20the%20request%20never%20arrives%20with%20a%20%60Content-Length%60%20header%20%28e.g.%20a%20regression%20causes%20chunked%20transfer%29%2C%20%60expected_len%60%20stays%20%60None%60%20and%20the%20loop%20reads%20until%20EOF%2C%20then%20panics%20on%20the%20%60assert!%28read%20%3E%200%29%60.%20%60%23%5Btokio%3A%3Atest%5D%60%20does%20not%20impose%20a%20default%20timeout%2C%20so%20a%20CI%20run%20would%20hang%20until%20the%20job%20timeout%20fires.%20Consider%20adding%20%60tokio%3A%3Atime%3A%3Atimeout%60%20wrapping%20the%20%60server.await%60%2C%20or%20at%20minimum%20a%20%60Content-Length%60-absent%20fallback%20break%20condition%2C%20to%20get%20a%20fast%20actionable%20failure.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=nerdsane%2Ftemper&pr=353&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22codex%2Farn-174-clickhouse-bindings%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Farn-174-clickhouse-bindings%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-observe%2Ftests%2Fclickhouse_multipart.rs%0ALine%3A%20453-486%0A%0AComment%3A%0A**%60capture_request%60%20loop%20has%20no%20timeout**%0A%0AIf%20the%20request%20never%20arrives%20with%20a%20%60Content-Length%60%20header%20%28e.g.%20a%20regression%20causes%20chunked%20transfer%29%2C%20%60expected_len%60%20stays%20%60None%60%20and%20the%20loop%20reads%20until%20EOF%2C%20then%20panics%20on%20the%20%60assert!%28read%20%3E%200%29%60.%20%60%23%5Btokio%3A%3Atest%5D%60%20does%20not%20impose%20a%20default%20timeout%2C%20so%20a%20CI%20run%20would%20hang%20until%20the%20job%20timeout%20fires.%20Consider%20adding%20%60tokio%3A%3Atime%3A%3Atimeout%60%20wrapping%20the%20%60server.await%60%2C%20or%20at%20minimum%20a%20%60Content-Length%60-absent%20fallback%20break%20condition%2C%20to%20get%20a%20fast%20actionable%20failure.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=nerdsane%2Ftemper&pr=353&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-observe%2Ftests%2Fclickhouse_multipart.rs%0ALine%3A%20453-486%0A%0AComment%3A%0A**%60capture_request%60%20loop%20has%20no%20timeout**%0A%0AIf%20the%20request%20never%20arrives%20with%20a%20%60Content-Length%60%20header%20%28e.g.%20a%20regression%20causes%20chunked%20transfer%29%2C%20%60expected_len%60%20stays%20%60None%60%20and%20the%20loop%20reads%20until%20EOF%2C%20then%20panics%20on%20the%20%60assert!%28read%20%3E%200%29%60.%20%60%23%5Btokio%3A%3Atest%5D%60%20does%20not%20impose%20a%20default%20timeout%2C%20so%20a%20CI%20run%20would%20hang%20until%20the%20job%20timeout%20fires.%20Consider%20adding%20%60tokio%3A%3Atime%3A%3Atimeout%60%20wrapping%20the%20%60server.await%60%2C%20or%20at%20minimum%20a%20%60Content-Length%60-absent%20fallback%20break%20condition%2C%20to%20get%20a%20fast%20actionable%20failure.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=353&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(observe): honor clickhouse token bou..."](https://github.com/nerdsane/temper/commit/7614501626a7b76fa79b055f8f81d5cbc537fef4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43577232)</sub>

<!-- /greptile_comment -->