### PR TITLE
fix(wasm): invocation-scoped stream handle capabilities (ARN-207)

### DIFF
--- a/crates/temper-server/src/git_pkt.rs
+++ b/crates/temper-server/src/git_pkt.rs
@@ -1,0 +1,55 @@
+//! Git pkt-line helpers used by HttpEndpoint action-bridge responses.
+
+use axum::body::Body;
+use axum::response::Response;
+
+pub(crate) fn sideband_channel_one(inner: Vec<u8>) -> Vec<u8> {
+    let mut response = Vec::new();
+    for chunk in inner.chunks(65_515) {
+        let mut payload = Vec::with_capacity(1 + chunk.len());
+        payload.push(0x01);
+        payload.extend_from_slice(chunk);
+        write_pkt_line(&mut response, &payload);
+    }
+    write_pkt_flush(&mut response);
+    response
+}
+
+pub(crate) fn write_pkt_line(out: &mut Vec<u8>, payload: &[u8]) {
+    let len = payload.len() + 4;
+    out.extend_from_slice(format!("{len:04x}").as_bytes());
+    out.extend_from_slice(payload);
+}
+
+pub(crate) fn write_pkt_flush(out: &mut Vec<u8>) {
+    out.extend_from_slice(b"0000");
+}
+
+pub(crate) fn sanitize_git_report_text(input: &str) -> String {
+    let mut out = input
+        .chars()
+        .map(|c| match c {
+            '\r' | '\n' | '\t' => ' ',
+            c if c.is_control() => ' ',
+            c => c,
+        })
+        .collect::<String>();
+    if out.len() > 240 {
+        out.truncate(240);
+    }
+    if out.trim().is_empty() {
+        "failed".to_string()
+    } else {
+        out
+    }
+}
+
+pub(crate) fn http_404_response(path: &str) -> Response {
+    axum::http::Response::builder()
+        .status(axum::http::StatusCode::NOT_FOUND)
+        .header("content-type", "application/json")
+        .body(Body::from(format!(
+            "{{\"error\":\"no route matches\",\"path\":\"{path}\"}}"
+        )))
+        .expect("response builder")
+}

--- a/crates/temper-server/src/http_stream_dispatch.rs
+++ b/crates/temper-server/src/http_stream_dispatch.rs
@@ -1,0 +1,48 @@
+//! HttpEndpoint stream exchange helpers (ADR-0156 / ARN-207).
+//!
+//! Keeps `router.rs` under the readability line budget while centralizing
+//! grant wiring and RAII cleanup for shared-registry stream handles.
+
+use axum::body::Body;
+use axum::response::Response;
+use temper_wasm::host_trait::ProductionWasmHost;
+use temper_wasm::http_stream::{HttpStreamRegistry, InboundExchange, StreamHandle};
+use temper_wasm::types::WasmInvocationContext;
+
+/// Open an inbound exchange or return a 503 when the global handle budget
+/// is exhausted.
+pub async fn open_inbound_exchange(
+    streams: &HttpStreamRegistry,
+) -> Result<InboundExchange, Response> {
+    match streams.open_inbound_exchange().await {
+        Ok(ex) => Ok(ex),
+        Err(e) => {
+            tracing::error!(error = %e, "HttpEndpoint: failed to open inbound stream exchange");
+            Err(axum::http::Response::builder()
+                .status(axum::http::StatusCode::SERVICE_UNAVAILABLE)
+                .header("content-type", "application/json")
+                .body(Body::from("{\"error\":\"stream handle budget exhausted\"}"))
+                .expect("response builder"))
+        }
+    }
+}
+
+/// Build a per-request host sharing `streams`, granting only guest-facing
+/// ends of the exchange (raw handles are not authority).
+pub fn host_with_inbound_grants(
+    secrets: std::collections::BTreeMap<String, String>,
+    streams: std::sync::Arc<HttpStreamRegistry>,
+    ctx: WasmInvocationContext,
+    guest_request_body: StreamHandle,
+    guest_response_body: StreamHandle,
+) -> ProductionWasmHost {
+    let host =
+        ProductionWasmHost::with_shared_streams(secrets, streams).with_invocation_context(ctx);
+    host.grant_stream_handles([guest_request_body, guest_response_body]);
+    host
+}
+
+/// Close exchange ends after timeout/failure so registry slots do not linger.
+pub async fn close_inbound_handles(streams: &HttpStreamRegistry, handles: [StreamHandle; 4]) {
+    streams.close_handles(handles).await;
+}

--- a/crates/temper-server/src/http_stream_dispatch.rs
+++ b/crates/temper-server/src/http_stream_dispatch.rs
@@ -38,7 +38,9 @@ pub fn host_with_inbound_grants(
 ) -> ProductionWasmHost {
     let host =
         ProductionWasmHost::with_shared_streams(secrets, streams).with_invocation_context(ctx);
-    host.grant_stream_handles([guest_request_body, guest_response_body]);
+    // Fresh host: grant budget is empty; two guest ends always fit.
+    host.grant_stream_handles([guest_request_body, guest_response_body])
+        .expect("fresh host must accept inbound guest grants");
     host
 }
 

--- a/crates/temper-server/src/lib.rs
+++ b/crates/temper-server/src/lib.rs
@@ -18,7 +18,9 @@ pub mod entity_actor;
 pub mod event_budget_metrics;
 pub mod events;
 pub mod eventual_invariants;
+mod git_pkt;
 pub mod http_endpoint;
+mod http_stream_dispatch;
 pub mod idempotency;
 pub mod identity;
 /// ADR-0153: declared composite-key index hashing (the negative-existence access path).

--- a/crates/temper-server/src/router.rs
+++ b/crates/temper-server/src/router.rs
@@ -13,6 +13,10 @@ use crate::odata;
 use crate::state::ServerState;
 use crate::webhooks::receiver as webhook_receiver;
 
+use crate::git_pkt::{
+    http_404_response, sanitize_git_report_text, sideband_channel_one, write_pkt_flush,
+    write_pkt_line,
+};
 use axum::body::Body;
 use axum::extract::DefaultBodyLimit;
 use axum::extract::State;
@@ -275,19 +279,16 @@ async fn dispatch_matched_route(
 
     // Open an inbound exchange on the shared registry.
     let streams = state.http_stream_registry.clone();
-    let exchange = streams.open_inbound_exchange().await;
+    let exchange = match crate::http_stream_dispatch::open_inbound_exchange(&streams).await {
+        Ok(ex) => ex,
+        Err(resp) => return resp,
+    };
     let guest_request_body = exchange.guest_request_body;
     let guest_response_body = exchange.guest_response_body;
     let kernel_request_body = exchange.kernel_request_body;
     let kernel_response_body = exchange.kernel_response_body;
 
-    // Spawn task A: axum body → kernel_request_body handle.
-    // Streaming pump: each Frame::data() chunk is forwarded as it
-    // arrives, so guests reading via the WASM SDK's request_body()
-    // see bytes the moment axum hands them over rather than after
-    // the whole request has been buffered. This is what makes the
-    // ADR-0057 inbound exchange end-to-end streaming — without it,
-    // even SDK-streaming guests are bounded by the buffered limit.
+    // Task A: stream axum body into the guest-visible request handle.
     let pump_streams = streams.clone();
     tokio::spawn(async move {
         use tokio_stream::StreamExt as _;
@@ -359,16 +360,20 @@ async fn dispatch_matched_route(
         }),
     };
 
-    // Build a per-request host that shares the registry.
+    // Per-request host: shared registry + guest-end grants only (ADR-0156).
     let secrets: std::collections::BTreeMap<String, String> = state
         .secrets_vault
         .as_ref()
         .map(|v| v.get_tenant_secrets(tenant_id.as_str()))
         .unwrap_or_default();
-    let host: std::sync::Arc<dyn temper_wasm::WasmHost> = std::sync::Arc::new(
-        temper_wasm::ProductionWasmHost::with_shared_streams(secrets, streams.clone())
-            .with_invocation_context(ctx.clone()),
-    );
+    let host: std::sync::Arc<dyn temper_wasm::WasmHost> =
+        std::sync::Arc::new(crate::http_stream_dispatch::host_with_inbound_grants(
+            secrets,
+            streams.clone(),
+            ctx.clone(),
+            guest_request_body,
+            guest_response_body,
+        ));
 
     // Spawn task B: invoke the WASM module. Runs to completion
     // (guest writes head + body via FFI; we drain on the axum side).
@@ -471,8 +476,6 @@ async fn dispatch_matched_route(
         }
     });
 
-    // Await the guest's response head — bounded by the route's
-    // configured timeout so a bad guest doesn't wedge the request.
     let head_timeout = std::time::Duration::from_secs(route.route.timeout_secs as u64);
     let head_result = tokio::time::timeout(
         head_timeout,
@@ -484,6 +487,16 @@ async fn dispatch_matched_route(
         Ok(Err(e)) => {
             tracing::warn!(error = %e, "HttpEndpoint: guest did not submit response head");
             invoke_task.abort();
+            crate::http_stream_dispatch::close_inbound_handles(
+                &streams,
+                [
+                    guest_request_body,
+                    guest_response_body,
+                    kernel_request_body,
+                    kernel_response_body,
+                ],
+            )
+            .await;
             return axum::http::Response::builder()
                 .status(axum::http::StatusCode::BAD_GATEWAY)
                 .body(Body::from(format!(
@@ -497,6 +510,16 @@ async fn dispatch_matched_route(
                 "HttpEndpoint: guest timed out before submitting response head"
             );
             invoke_task.abort();
+            crate::http_stream_dispatch::close_inbound_handles(
+                &streams,
+                [
+                    guest_request_body,
+                    guest_response_body,
+                    kernel_request_body,
+                    kernel_response_body,
+                ],
+            )
+            .await;
             return axum::http::Response::builder()
                 .status(axum::http::StatusCode::GATEWAY_TIMEOUT)
                 .body(Body::from(
@@ -939,57 +962,6 @@ fn git_receive_pack_response(refs: &[String], sideband: bool, error: Option<&str
         .header("content-type", "application/x-git-receive-pack-result")
         .header("cache-control", "no-cache")
         .body(Body::from(body))
-        .expect("response builder")
-}
-
-fn sideband_channel_one(inner: Vec<u8>) -> Vec<u8> {
-    let mut response = Vec::new();
-    for chunk in inner.chunks(65_515) {
-        let mut payload = Vec::with_capacity(1 + chunk.len());
-        payload.push(0x01);
-        payload.extend_from_slice(chunk);
-        write_pkt_line(&mut response, &payload);
-    }
-    write_pkt_flush(&mut response);
-    response
-}
-
-fn write_pkt_line(out: &mut Vec<u8>, payload: &[u8]) {
-    let len = payload.len() + 4;
-    out.extend_from_slice(format!("{len:04x}").as_bytes());
-    out.extend_from_slice(payload);
-}
-
-fn write_pkt_flush(out: &mut Vec<u8>) {
-    out.extend_from_slice(b"0000");
-}
-
-fn sanitize_git_report_text(input: &str) -> String {
-    let mut out = input
-        .chars()
-        .map(|c| match c {
-            '\r' | '\n' | '\t' => ' ',
-            c if c.is_control() => ' ',
-            c => c,
-        })
-        .collect::<String>();
-    if out.len() > 240 {
-        out.truncate(240);
-    }
-    if out.trim().is_empty() {
-        "failed".to_string()
-    } else {
-        out
-    }
-}
-
-fn http_404_response(path: &str) -> Response {
-    axum::http::Response::builder()
-        .status(axum::http::StatusCode::NOT_FOUND)
-        .header("content-type", "application/json")
-        .body(Body::from(format!(
-            "{{\"error\":\"no route matches\",\"path\":\"{path}\"}}"
-        )))
         .expect("response builder")
 }
 

--- a/crates/temper-server/src/state/mod.rs
+++ b/crates/temper-server/src/state/mod.rs
@@ -532,6 +532,10 @@ pub struct ServerState {
     /// WASM invocation. Per-request ProductionWasmHost instances
     /// receive a clone of this Arc via `with_shared_streams` so
     /// FFI calls from the guest resolve to the same handle IDs.
+    ///
+    /// Sharing the registry is intentional; authority is not. Guest
+    /// ops require invocation-scoped grants (ADR-0156 / ARN-207) —
+    /// raw handle integers alone never authorize stream access.
     pub http_stream_registry: Arc<temper_wasm::http_stream::HttpStreamRegistry>,
     /// Long-lived workflow root spans keyed by workflow.run_id.
     pub(crate) workflow_spans: Arc<crate::workflow_tracing::WorkflowSpanRegistry>,

--- a/crates/temper-wasm/src/host_trait.rs
+++ b/crates/temper-wasm/src/host_trait.rs
@@ -352,8 +352,12 @@ pub struct ProductionWasmHost {
     /// Invocation context for auto-enriching guest telemetry.
     invocation_context: Option<WasmInvocationContext>,
     /// Registry of active streaming HTTP exchanges (ADR-0057).
-    /// One per host instance; handle IDs are unique within the host.
+    /// May be shared process-wide; handle IDs are opaque and not
+    /// authority-bearing (ADR-0156 / ARN-207).
     http_streams: Arc<crate::http_stream::HttpStreamRegistry>,
+    /// Invocation-scoped grants: guest stream ops require membership
+    /// in this set. Fail closed when empty (ARN-207).
+    stream_grants: Arc<std::sync::Mutex<std::collections::BTreeSet<u32>>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -531,6 +535,64 @@ impl ProductionWasmHost {
             text_http_interceptor: None,
             invocation_context: None,
             http_streams: Arc::new(crate::http_stream::HttpStreamRegistry::new()),
+            stream_grants: Arc::new(std::sync::Mutex::new(std::collections::BTreeSet::new())),
+        }
+    }
+
+    /// Grant guest-facing stream handles to this invocation host.
+    ///
+    /// Used by the HttpEndpoint dispatcher after minting an inbound
+    /// exchange so the guest may operate only on those ends (ADR-0156).
+    /// Fails closed beyond [`crate::http_stream::MAX_STREAM_GRANTS_PER_INVOCATION`].
+    pub fn grant_stream_handles(
+        &self,
+        handles: impl IntoIterator<Item = crate::http_stream::StreamHandle>,
+    ) {
+        let mut grants = self.stream_grants.lock().unwrap_or_else(|e| e.into_inner());
+        for handle in handles {
+            if grants.len() >= crate::http_stream::MAX_STREAM_GRANTS_PER_INVOCATION {
+                tracing::warn!(
+                    handle = handle.0,
+                    "stream grant budget exhausted; refusing additional grant"
+                );
+                break;
+            }
+            grants.insert(handle.0);
+        }
+    }
+
+    /// Whether this host holds a grant for `handle`.
+    pub fn has_stream_grant(&self, handle: crate::http_stream::StreamHandle) -> bool {
+        self.stream_grants
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .contains(&handle.0)
+    }
+
+    fn require_stream_grant(
+        &self,
+        handle: crate::http_stream::StreamHandle,
+    ) -> Result<(), crate::http_stream::StreamError> {
+        if self.has_stream_grant(handle) {
+            Ok(())
+        } else {
+            Err(crate::http_stream::StreamError::InvalidHandle)
+        }
+    }
+
+    /// Close and revoke every granted stream handle (request end cleanup).
+    pub async fn close_granted_streams(&self) {
+        let granted: Vec<crate::http_stream::StreamHandle> = {
+            let grants = self.stream_grants.lock().unwrap_or_else(|e| e.into_inner());
+            grants
+                .iter()
+                .copied()
+                .map(crate::http_stream::StreamHandle)
+                .collect()
+        };
+        self.http_streams.close_handles(granted).await;
+        if let Ok(mut grants) = self.stream_grants.lock() {
+            grants.clear();
         }
     }
 
@@ -1593,8 +1655,14 @@ impl WasmHost for ProductionWasmHost {
         use futures_util::StreamExt;
         use tracing::Instrument;
 
-        let exchange = self.http_streams.open_outbound_exchange().await;
+        let exchange = self
+            .http_streams
+            .open_outbound_exchange()
+            .await
+            .map_err(|e| e.to_string())?;
         let guest = exchange.guest_handles();
+        // Invocation-scoped grants: only these ends are guest-operable.
+        self.grant_stream_handles([guest.request_body, guest.response_body]);
         let bridge_req = exchange.bridge_request_body;
         let bridge_resp = exchange.bridge_response_body;
         let head_tx = exchange.bridge_head_sender;
@@ -1750,6 +1818,7 @@ impl WasmHost for ProductionWasmHost {
         &self,
         handle: crate::http_stream::StreamHandle,
     ) -> Result<Vec<u8>, crate::http_stream::StreamError> {
+        self.require_stream_grant(handle)?;
         self.http_streams.read(handle).await
     }
 
@@ -1758,6 +1827,7 @@ impl WasmHost for ProductionWasmHost {
         handle: crate::http_stream::StreamHandle,
         max_bytes: usize,
     ) -> Result<Vec<u8>, crate::http_stream::StreamError> {
+        self.require_stream_grant(handle)?;
         self.http_streams.read_bounded(handle, max_bytes).await
     }
 
@@ -1766,6 +1836,7 @@ impl WasmHost for ProductionWasmHost {
         handle: crate::http_stream::StreamHandle,
         chunk: Vec<u8>,
     ) -> Result<usize, crate::http_stream::StreamError> {
+        self.require_stream_grant(handle)?;
         self.http_streams.try_write(handle, chunk).await
     }
 
@@ -1773,6 +1844,7 @@ impl WasmHost for ProductionWasmHost {
         &self,
         handle: crate::http_stream::StreamHandle,
     ) -> Result<(), crate::http_stream::StreamError> {
+        self.require_stream_grant(handle)?;
         self.http_streams.close(handle).await
     }
 
@@ -1780,6 +1852,8 @@ impl WasmHost for ProductionWasmHost {
         &self,
         response_body: crate::http_stream::StreamHandle,
     ) -> Result<crate::http_stream::HttpResponseHead, String> {
+        self.require_stream_grant(response_body)
+            .map_err(|e| e.to_string())?;
         self.http_streams
             .await_response_head(response_body)
             .await
@@ -1791,6 +1865,7 @@ impl WasmHost for ProductionWasmHost {
         response_body: crate::http_stream::StreamHandle,
         head: crate::http_stream::HttpResponseHead,
     ) -> Result<(), crate::http_stream::StreamError> {
+        self.require_stream_grant(response_body)?;
         self.http_streams
             .submit_inbound_response_head(response_body, head)
             .await

--- a/crates/temper-wasm/src/host_trait.rs
+++ b/crates/temper-wasm/src/host_trait.rs
@@ -603,9 +603,10 @@ impl ProductionWasmHost {
                 .collect()
         };
         self.http_streams.close_handles(granted).await;
-        if let Ok(mut grants) = self.stream_grants.lock() {
-            grants.clear();
-        }
+        // Recover from a poisoned lock so teardown always clears grants
+        // (same pattern as grant/require/revoke — Greptile ARN-207).
+        let mut grants = self.stream_grants.lock().unwrap_or_else(|e| e.into_inner());
+        grants.clear();
     }
 
     /// Create with a spec evaluator for `host_evaluate_spec` support.

--- a/crates/temper-wasm/src/host_trait.rs
+++ b/crates/temper-wasm/src/host_trait.rs
@@ -543,22 +543,26 @@ impl ProductionWasmHost {
     ///
     /// Used by the HttpEndpoint dispatcher after minting an inbound
     /// exchange so the guest may operate only on those ends (ADR-0156).
-    /// Fails closed beyond [`crate::http_stream::MAX_STREAM_GRANTS_PER_INVOCATION`].
+    /// Returns `Err` when the per-invocation grant budget would be
+    /// exceeded so callers can roll back registry allocation.
     pub fn grant_stream_handles(
         &self,
         handles: impl IntoIterator<Item = crate::http_stream::StreamHandle>,
-    ) {
+    ) -> Result<(), crate::http_stream::StreamError> {
         let mut grants = self.stream_grants.lock().unwrap_or_else(|e| e.into_inner());
-        for handle in handles {
-            if grants.len() >= crate::http_stream::MAX_STREAM_GRANTS_PER_INVOCATION {
-                tracing::warn!(
-                    handle = handle.0,
-                    "stream grant budget exhausted; refusing additional grant"
-                );
-                break;
-            }
+        let incoming: Vec<_> = handles.into_iter().collect();
+        let new_unique = incoming.iter().filter(|h| !grants.contains(&h.0)).count();
+        if grants.len().saturating_add(new_unique)
+            > crate::http_stream::MAX_STREAM_GRANTS_PER_INVOCATION
+        {
+            return Err(crate::http_stream::StreamError::Aborted(
+                "stream grant budget exhausted".into(),
+            ));
+        }
+        for handle in incoming {
             grants.insert(handle.0);
         }
+        Ok(())
     }
 
     /// Whether this host holds a grant for `handle`.
@@ -580,7 +584,14 @@ impl ProductionWasmHost {
         }
     }
 
-    /// Close and revoke every granted stream handle (request end cleanup).
+    fn revoke_stream_grant(&self, handle: crate::http_stream::StreamHandle) {
+        if let Ok(mut grants) = self.stream_grants.lock() {
+            grants.remove(&handle.0);
+        }
+    }
+
+    /// Close every still-granted stream handle and clear the grant set.
+    /// Used on request-end teardown (cancel / dispatcher abort).
     pub async fn close_granted_streams(&self) {
         let granted: Vec<crate::http_stream::StreamHandle> = {
             let grants = self.stream_grants.lock().unwrap_or_else(|e| e.into_inner());
@@ -1662,7 +1673,19 @@ impl WasmHost for ProductionWasmHost {
             .map_err(|e| e.to_string())?;
         let guest = exchange.guest_handles();
         // Invocation-scoped grants: only these ends are guest-operable.
-        self.grant_stream_handles([guest.request_body, guest.response_body]);
+        // If the grant budget is exhausted, roll back the exchange so we
+        // do not leave unusable registry slots behind.
+        if let Err(e) = self.grant_stream_handles([guest.request_body, guest.response_body]) {
+            self.http_streams
+                .close_handles([
+                    guest.request_body,
+                    guest.response_body,
+                    exchange.bridge_request_body,
+                    exchange.bridge_response_body,
+                ])
+                .await;
+            return Err(e.to_string());
+        }
         let bridge_req = exchange.bridge_request_body;
         let bridge_resp = exchange.bridge_response_body;
         let head_tx = exchange.bridge_head_sender;
@@ -1845,7 +1868,11 @@ impl WasmHost for ProductionWasmHost {
         handle: crate::http_stream::StreamHandle,
     ) -> Result<(), crate::http_stream::StreamError> {
         self.require_stream_grant(handle)?;
-        self.http_streams.close(handle).await
+        self.http_streams.close(handle).await?;
+        // Drop capability after successful close so a later ID reuse
+        // in the same host cannot resurrect authority.
+        self.revoke_stream_grant(handle);
+        Ok(())
     }
 
     async fn http_stream_response_head(

--- a/crates/temper-wasm/src/host_trait.rs
+++ b/crates/temper-wasm/src/host_trait.rs
@@ -585,9 +585,10 @@ impl ProductionWasmHost {
     }
 
     fn revoke_stream_grant(&self, handle: crate::http_stream::StreamHandle) {
-        if let Ok(mut grants) = self.stream_grants.lock() {
-            grants.remove(&handle.0);
-        }
+        // Match grant/require paths: recover from a poisoned lock so a
+        // prior panic cannot leave a stale capability in place.
+        let mut grants = self.stream_grants.lock().unwrap_or_else(|e| e.into_inner());
+        grants.remove(&handle.0);
     }
 
     /// Close every still-granted stream handle and clear the grant set.

--- a/crates/temper-wasm/src/http_stream.rs
+++ b/crates/temper-wasm/src/http_stream.rs
@@ -18,10 +18,18 @@
 //! Capacity: 64 chunks × 16 KiB = 1 MiB per handle for SDK-originated
 //! writes. Host-originated chunks can be larger; bounded reads split
 //! those chunks across guest buffers while preserving stream order.
+//!
+//! ## Authority (ADR-0156 / ARN-207)
+//!
+//! Handle IDs are opaque and unguessable. Guest authority is **not** the
+//! integer itself: `ProductionWasmHost` holds an invocation-scoped grant
+//! table, and guest-facing ops require a grant. Kernel/bridge code uses
+//! the privileged registry methods with the exact ends it created.
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use tokio::sync::{Mutex, mpsc, oneshot};
+use uuid::Uuid;
 
 /// Chunk size used by SDK adapters when splitting writes. A single
 /// SDK-originated chunk may be smaller (short writes), but never larger.
@@ -32,9 +40,18 @@ pub const STREAM_CHUNK_BYTES: usize = 16 * 1024;
 /// 1 MiB per handle, 2 MiB per bidirectional exchange.
 pub const STREAM_CHANNEL_CAPACITY: usize = 64;
 
+/// Maximum live handles in one process-global registry (DoS bound).
+pub const MAX_STREAM_HANDLES_GLOBAL: usize = 16_384;
+
+/// Maximum guest stream grants per invocation host (DoS bound).
+pub const MAX_STREAM_GRANTS_PER_INVOCATION: usize = 64;
+
 /// Opaque handle identifying one end of a streaming channel. Passed
 /// from guest to host via FFI; host-side lookups go through
 /// [`HttpStreamRegistry`].
+///
+/// The raw `u32` is **not** an authority-bearing capability (ADR-0156).
+/// Guests may only operate on handles granted to their invocation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct StreamHandle(pub u32);
 
@@ -159,15 +176,15 @@ enum ChannelEnd {
 }
 
 /// Registry of active stream handles. Lives on `ProductionWasmHost`
-/// (and any other host that implements streaming). One registry per
-/// host instance; handle IDs are unique within a host but not across
-/// hosts — they're opaque u32s.
+/// (and any other host that implements streaming). One registry may be
+/// shared process-wide (`ServerState.http_stream_registry`); handle IDs
+/// are opaque unguessable `u32`s and are **not** authority by themselves
+/// (ADR-0156 / ARN-207).
 pub struct HttpStreamRegistry {
     inner: Mutex<RegistryState>,
 }
 
 struct RegistryState {
-    next_id: u32,
     handles: BTreeMap<u32, ChannelEnd>,
     /// Outbound: oneshot receivers keyed on response-body handle ID.
     /// Bridge task holds the Sender and fires once the HTTP response
@@ -182,11 +199,43 @@ struct RegistryState {
     pending_reads: BTreeMap<u32, Vec<u8>>,
 }
 
+impl RegistryState {
+    /// Allocate an unguessable free handle id. Not sequential — raw
+    /// integers must not be enumerable capabilities (ARN-207).
+    ///
+    /// `// determinism-ok: production host I/O path; not SimActor scheduling.`
+    fn alloc_id(&mut self) -> Result<u32, StreamError> {
+        if self.handles.len() >= MAX_STREAM_HANDLES_GLOBAL {
+            return Err(StreamError::Aborted(
+                "stream handle budget exhausted".into(),
+            ));
+        }
+        // determinism-ok: production host I/O path; not SimActor scheduling.
+        for _ in 0..64 {
+            let id = (Uuid::new_v4().as_u128() as u32) | 1; // never zero
+            if !self.handles.contains_key(&id) {
+                return Ok(id);
+            }
+        }
+        // Extremely unlikely: fall back to a linear probe from a fresh seed.
+        // determinism-ok: production host I/O path; not SimActor scheduling.
+        let mut probe = (Uuid::new_v4().as_u128() as u32) | 1;
+        for _ in 0..1024 {
+            if probe != 0 && !self.handles.contains_key(&probe) {
+                return Ok(probe);
+            }
+            probe = probe.wrapping_add(1).max(1);
+        }
+        Err(StreamError::Aborted(
+            "failed to allocate stream handle id".into(),
+        ))
+    }
+}
+
 impl HttpStreamRegistry {
     pub fn new() -> Self {
         Self {
             inner: Mutex::new(RegistryState {
-                next_id: 1,
                 handles: BTreeMap::new(),
                 response_head_receivers: BTreeMap::new(),
                 inbound_head_senders: BTreeMap::new(),
@@ -199,18 +248,30 @@ impl HttpStreamRegistry {
     /// Allocate a new paired (sender, receiver) channel. Returns
     /// (write_handle, read_handle) — guests write into the first,
     /// the other end reads from the second.
-    pub async fn create_pair(&self) -> (StreamHandle, StreamHandle) {
+    pub async fn create_pair(&self) -> Result<(StreamHandle, StreamHandle), StreamError> {
         let (tx, rx) = mpsc::channel::<Vec<u8>>(STREAM_CHANNEL_CAPACITY);
         let mut state = self.inner.lock().await;
-        let write_id = state.next_id;
-        state.next_id += 1;
-        let read_id = state.next_id;
-        state.next_id += 1;
+        // Need room for two ends.
+        if state.handles.len() + 2 > MAX_STREAM_HANDLES_GLOBAL {
+            return Err(StreamError::Aborted(
+                "stream handle budget exhausted".into(),
+            ));
+        }
+        let write_id = state.alloc_id()?;
+        // Temporarily insert a placeholder so the second alloc cannot collide
+        // with write_id (alloc_id only checks `handles`).
         state.handles.insert(write_id, ChannelEnd::Sender(tx));
+        let read_id = match state.alloc_id() {
+            Ok(id) => id,
+            Err(e) => {
+                state.handles.remove(&write_id);
+                return Err(e);
+            }
+        };
         state
             .handles
             .insert(read_id, ChannelEnd::Receiver(Arc::new(Mutex::new(rx))));
-        (StreamHandle(write_id), StreamHandle(read_id))
+        Ok((StreamHandle(write_id), StreamHandle(read_id)))
     }
 
     /// Write `chunk` to the handle's channel. Suspends if the
@@ -291,21 +352,29 @@ impl HttpStreamRegistry {
     /// is kept on the bridge task until the HTTP response arrives; the
     /// receiver is stored in the registry and handed to the guest on
     /// its first `await_response_head(response_body)` call.
-    pub async fn open_outbound_exchange(&self) -> OutboundExchange {
-        let (req_writer, req_reader) = self.create_pair().await;
-        let (resp_writer, resp_reader) = self.create_pair().await;
+    pub async fn open_outbound_exchange(&self) -> Result<OutboundExchange, StreamError> {
+        let (req_writer, req_reader) = self.create_pair().await?;
+        let (resp_writer, resp_reader) = match self.create_pair().await {
+            Ok(pair) => pair,
+            Err(e) => {
+                // Best-effort cleanup of the first pair on budget failure.
+                let _ = self.close(req_writer).await;
+                let _ = self.close(req_reader).await;
+                return Err(e);
+            }
+        };
         let (head_tx, head_rx) = oneshot::channel();
         {
             let mut state = self.inner.lock().await;
             state.response_head_receivers.insert(resp_reader.0, head_rx);
         }
-        OutboundExchange {
+        Ok(OutboundExchange {
             guest_request_body: req_writer,
             guest_response_body: resp_reader,
             bridge_request_body: req_reader,
             bridge_response_body: resp_writer,
             bridge_head_sender: head_tx,
-        }
+        })
     }
 
     /// Await the response head for the given response-body handle.
@@ -335,9 +404,16 @@ impl HttpStreamRegistry {
     /// `kernel_response_body`. Guest fires the response head with
     /// `submit_inbound_response_head`; kernel awaits it via
     /// `await_inbound_response_head`.
-    pub async fn open_inbound_exchange(&self) -> InboundExchange {
-        let (kern_req_writer, guest_req_reader) = self.create_pair().await;
-        let (guest_resp_writer, kern_resp_reader) = self.create_pair().await;
+    pub async fn open_inbound_exchange(&self) -> Result<InboundExchange, StreamError> {
+        let (kern_req_writer, guest_req_reader) = self.create_pair().await?;
+        let (guest_resp_writer, kern_resp_reader) = match self.create_pair().await {
+            Ok(pair) => pair,
+            Err(e) => {
+                let _ = self.close(kern_req_writer).await;
+                let _ = self.close(guest_req_reader).await;
+                return Err(e);
+            }
+        };
         let (head_tx, head_rx) = oneshot::channel();
         {
             let mut state = self.inner.lock().await;
@@ -348,12 +424,20 @@ impl HttpStreamRegistry {
                 .inbound_head_receivers
                 .insert(guest_resp_writer.0, head_rx);
         }
-        InboundExchange {
+        Ok(InboundExchange {
             guest_request_body: guest_req_reader,
             guest_response_body: guest_resp_writer,
             kernel_request_body: kern_req_writer,
             kernel_response_body: kern_resp_reader,
             kernel_head_receiver_slot: guest_resp_writer,
+        })
+    }
+
+    /// Close every listed handle that still exists. Used for RAII-style
+    /// cleanup on timeout / cancel / request end (ARN-207).
+    pub async fn close_handles(&self, handles: impl IntoIterator<Item = StreamHandle>) {
+        for handle in handles {
+            let _ = self.close(handle).await;
         }
     }
 
@@ -465,7 +549,7 @@ mod tests {
     #[tokio::test]
     async fn create_pair_returns_distinct_ids() {
         let reg = HttpStreamRegistry::new();
-        let (w, r) = reg.create_pair().await;
+        let (w, r) = reg.create_pair().await.unwrap();
         assert_ne!(w.0, r.0);
         assert_eq!(reg.handle_count().await, 2);
     }
@@ -473,7 +557,7 @@ mod tests {
     #[tokio::test]
     async fn write_then_read_roundtrips_chunk() {
         let reg = HttpStreamRegistry::new();
-        let (w, r) = reg.create_pair().await;
+        let (w, r) = reg.create_pair().await.unwrap();
         let n = reg.write(w, b"hello".to_vec()).await.unwrap();
         assert_eq!(n, 5);
         let chunk = reg.read(r).await.unwrap();
@@ -483,7 +567,7 @@ mod tests {
     #[tokio::test]
     async fn bounded_read_splits_oversized_chunk_and_preserves_order() {
         let reg = HttpStreamRegistry::new();
-        let (w, r) = reg.create_pair().await;
+        let (w, r) = reg.create_pair().await.unwrap();
         reg.write(w, b"abcdefghij".to_vec()).await.unwrap();
         reg.write(w, b"next".to_vec()).await.unwrap();
 
@@ -501,7 +585,7 @@ mod tests {
     #[tokio::test]
     async fn write_into_receiver_handle_is_invalid() {
         let reg = HttpStreamRegistry::new();
-        let (_w, r) = reg.create_pair().await;
+        let (_w, r) = reg.create_pair().await.unwrap();
         let err = reg.write(r, b"hi".to_vec()).await.unwrap_err();
         assert_eq!(err, StreamError::InvalidHandle);
     }
@@ -509,7 +593,7 @@ mod tests {
     #[tokio::test]
     async fn read_from_sender_handle_is_invalid() {
         let reg = HttpStreamRegistry::new();
-        let (w, _r) = reg.create_pair().await;
+        let (w, _r) = reg.create_pair().await.unwrap();
         let err = reg.read(w).await.unwrap_err();
         assert_eq!(err, StreamError::InvalidHandle);
     }
@@ -517,7 +601,7 @@ mod tests {
     #[tokio::test]
     async fn try_write_returns_wouldblock_when_full() {
         let reg = HttpStreamRegistry::new();
-        let (w, _r) = reg.create_pair().await;
+        let (w, _r) = reg.create_pair().await.unwrap();
         // Fill the channel to capacity.
         for _ in 0..STREAM_CHANNEL_CAPACITY {
             reg.try_write(w, vec![0u8; 8]).await.unwrap();
@@ -530,7 +614,7 @@ mod tests {
     #[tokio::test]
     async fn close_sender_causes_receiver_eof() {
         let reg = HttpStreamRegistry::new();
-        let (w, r) = reg.create_pair().await;
+        let (w, r) = reg.create_pair().await.unwrap();
         reg.write(w, b"first".to_vec()).await.unwrap();
         reg.close(w).await.unwrap();
         // Drain buffered chunk then EOF.
@@ -543,7 +627,7 @@ mod tests {
     #[tokio::test]
     async fn write_after_receiver_close_returns_closed() {
         let reg = HttpStreamRegistry::new();
-        let (w, r) = reg.create_pair().await;
+        let (w, r) = reg.create_pair().await.unwrap();
         reg.close(r).await.unwrap();
         let err = reg.write(w, b"x".to_vec()).await.unwrap_err();
         assert_eq!(err, StreamError::Closed);
@@ -559,7 +643,7 @@ mod tests {
     #[tokio::test]
     async fn inbound_exchange_roundtrips_head_and_body() {
         let reg = HttpStreamRegistry::new();
-        let exchange = reg.open_inbound_exchange().await;
+        let exchange = reg.open_inbound_exchange().await.unwrap();
 
         // Kernel pushes request body.
         reg.write(
@@ -619,12 +703,29 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn handle_ids_monotonic_within_registry() {
+    async fn handle_ids_are_unique_and_non_zero() {
         let reg = HttpStreamRegistry::new();
-        let (w1, r1) = reg.create_pair().await;
-        let (w2, r2) = reg.create_pair().await;
-        assert!(w1.0 < r1.0);
-        assert!(r1.0 < w2.0);
-        assert!(w2.0 < r2.0);
+        let (w1, r1) = reg.create_pair().await.unwrap();
+        let (w2, r2) = reg.create_pair().await.unwrap();
+        let ids = [w1.0, r1.0, w2.0, r2.0];
+        assert!(ids.iter().all(|&id| id != 0));
+        let set: std::collections::BTreeSet<_> = ids.into_iter().collect();
+        assert_eq!(set.len(), 4, "handle ids must be unique");
+    }
+
+    #[tokio::test]
+    async fn handle_ids_are_not_dense_low_integers() {
+        // Sequential allocation made 1..=N guessable. Opaque IDs must not
+        // land in a tiny low range that enumeration can cover cheaply.
+        let reg = HttpStreamRegistry::new();
+        let (w, r) = reg.create_pair().await.unwrap();
+        // Probabilistically: two random u32s both < 256 is vanishingly rare.
+        // If both are small, something regressed to sequential allocation.
+        let both_tiny = w.0 < 256 && r.0 < 256;
+        assert!(
+            !both_tiny,
+            "expected unguessable handle ids, got w={} r={}",
+            w.0, r.0
+        );
     }
 }

--- a/crates/temper-wasm/src/http_stream.rs
+++ b/crates/temper-wasm/src/http_stream.rs
@@ -211,8 +211,10 @@ impl RegistryState {
             ));
         }
         // determinism-ok: production host I/O path; not SimActor scheduling.
+        // ~31 bits of unguessability (low bit forced 1 so id is never 0).
+        // Grants remain the authority boundary; opacity is defense-in-depth.
         for _ in 0..64 {
-            let id = (Uuid::new_v4().as_u128() as u32) | 1; // never zero
+            let id = (Uuid::new_v4().as_u128() as u32) | 1;
             if !self.handles.contains_key(&id) {
                 return Ok(id);
             }

--- a/crates/temper-wasm/tests/http_stream_capability_isolation.rs
+++ b/crates/temper-wasm/tests/http_stream_capability_isolation.rs
@@ -1,0 +1,116 @@
+//! ARN-207: process-global enumerable WASM stream handles must not be
+//! authority-bearing capabilities.
+//!
+//! ServerState shares one `HttpStreamRegistry` across tenants. Handles
+//! were sequential `u32` values, and guest-facing `ProductionWasmHost`
+//! stream ops validated only that the raw handle existed. A malicious
+//! guest can therefore enumerate another tenant's active handle and
+//! read, inject, or close foreign request/response bodies.
+//!
+//! These tests document the secure contract. On unfixed code they fail
+//! (RED) because the exploit currently succeeds; after the capability
+//! fix they pass (GREEN).
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use temper_wasm::WasmHost;
+use temper_wasm::host_trait::ProductionWasmHost;
+use temper_wasm::http_stream::{HttpStreamRegistry, StreamError, StreamHandle};
+
+/// Shared-registry layout mirrors `ServerState.http_stream_registry`.
+fn shared_registry() -> Arc<HttpStreamRegistry> {
+    Arc::new(HttpStreamRegistry::new())
+}
+
+#[tokio::test]
+async fn cross_tenant_guest_cannot_read_foreign_request_body() {
+    let registry = shared_registry();
+
+    // Victim tenant opens an inbound exchange (HttpEndpoint path).
+    let victim = registry.open_inbound_exchange().await;
+    registry
+        .write(victim.kernel_request_body, b"SECRET-TENANT-A-BODY".to_vec())
+        .await
+        .unwrap();
+
+    // Attacker tenant: separate host, same process-global registry.
+    let attacker = ProductionWasmHost::with_shared_streams(BTreeMap::new(), registry.clone());
+
+    let result = attacker.http_stream_read(victim.guest_request_body).await;
+
+    assert!(
+        matches!(result, Err(StreamError::InvalidHandle)),
+        "cross-tenant stream read must be denied; got {result:?}"
+    );
+
+    // Victim body must remain intact for the legitimate owner path.
+    let still_there = registry.read(victim.guest_request_body).await.unwrap();
+    assert_eq!(&still_there, b"SECRET-TENANT-A-BODY");
+}
+
+#[tokio::test]
+async fn cross_tenant_guest_cannot_write_foreign_response_body() {
+    let registry = shared_registry();
+    let victim = registry.open_inbound_exchange().await;
+
+    let attacker = ProductionWasmHost::with_shared_streams(BTreeMap::new(), registry.clone());
+    let result = attacker
+        .http_stream_try_write(victim.guest_response_body, b"injected-by-attacker".to_vec())
+        .await;
+
+    assert!(
+        matches!(result, Err(StreamError::InvalidHandle)),
+        "cross-tenant stream write must be denied; got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn cross_tenant_guest_cannot_close_foreign_handle() {
+    let registry = shared_registry();
+    let victim = registry.open_inbound_exchange().await;
+
+    let attacker = ProductionWasmHost::with_shared_streams(BTreeMap::new(), registry.clone());
+    let result = attacker.http_stream_close(victim.guest_request_body).await;
+
+    assert!(
+        matches!(result, Err(StreamError::InvalidHandle)),
+        "cross-tenant stream close must be denied; got {result:?}"
+    );
+
+    // Handle still usable after the denied close.
+    registry
+        .write(victim.kernel_request_body, b"still-open".to_vec())
+        .await
+        .unwrap();
+    let chunk = registry.read(victim.guest_request_body).await.unwrap();
+    assert_eq!(&chunk, b"still-open");
+}
+
+#[tokio::test]
+async fn sequential_handle_enumeration_cannot_steal_body() {
+    let registry = shared_registry();
+    let victim = registry.open_inbound_exchange().await;
+    registry
+        .write(victim.kernel_request_body, b"secret-payload".to_vec())
+        .await
+        .unwrap();
+
+    let attacker = ProductionWasmHost::with_shared_streams(BTreeMap::new(), registry.clone());
+
+    let mut stolen = false;
+    for id in 1u32..=128 {
+        match attacker.http_stream_read(StreamHandle(id)).await {
+            Ok(chunk) if chunk == b"secret-payload" => {
+                stolen = true;
+                break;
+            }
+            Ok(_) | Err(_) => {}
+        }
+    }
+
+    assert!(
+        !stolen,
+        "sequential handle enumeration must not yield a foreign stream body"
+    );
+}

--- a/crates/temper-wasm/tests/http_stream_capability_isolation.rs
+++ b/crates/temper-wasm/tests/http_stream_capability_isolation.rs
@@ -28,7 +28,7 @@ async fn cross_tenant_guest_cannot_read_foreign_request_body() {
     let registry = shared_registry();
 
     // Victim tenant opens an inbound exchange (HttpEndpoint path).
-    let victim = registry.open_inbound_exchange().await;
+    let victim = registry.open_inbound_exchange().await.unwrap();
     registry
         .write(victim.kernel_request_body, b"SECRET-TENANT-A-BODY".to_vec())
         .await
@@ -52,7 +52,7 @@ async fn cross_tenant_guest_cannot_read_foreign_request_body() {
 #[tokio::test]
 async fn cross_tenant_guest_cannot_write_foreign_response_body() {
     let registry = shared_registry();
-    let victim = registry.open_inbound_exchange().await;
+    let victim = registry.open_inbound_exchange().await.unwrap();
 
     let attacker = ProductionWasmHost::with_shared_streams(BTreeMap::new(), registry.clone());
     let result = attacker
@@ -68,7 +68,7 @@ async fn cross_tenant_guest_cannot_write_foreign_response_body() {
 #[tokio::test]
 async fn cross_tenant_guest_cannot_close_foreign_handle() {
     let registry = shared_registry();
-    let victim = registry.open_inbound_exchange().await;
+    let victim = registry.open_inbound_exchange().await.unwrap();
 
     let attacker = ProductionWasmHost::with_shared_streams(BTreeMap::new(), registry.clone());
     let result = attacker.http_stream_close(victim.guest_request_body).await;
@@ -90,7 +90,7 @@ async fn cross_tenant_guest_cannot_close_foreign_handle() {
 #[tokio::test]
 async fn sequential_handle_enumeration_cannot_steal_body() {
     let registry = shared_registry();
-    let victim = registry.open_inbound_exchange().await;
+    let victim = registry.open_inbound_exchange().await.unwrap();
     registry
         .write(victim.kernel_request_body, b"secret-payload".to_vec())
         .await
@@ -113,4 +113,97 @@ async fn sequential_handle_enumeration_cannot_steal_body() {
         !stolen,
         "sequential handle enumeration must not yield a foreign stream body"
     );
+}
+
+#[tokio::test]
+async fn legitimate_owner_can_use_granted_inbound_handles() {
+    let registry = shared_registry();
+    let exchange = registry.open_inbound_exchange().await.unwrap();
+    registry
+        .write(exchange.kernel_request_body, b"hello-owner".to_vec())
+        .await
+        .unwrap();
+
+    let owner = ProductionWasmHost::with_shared_streams(BTreeMap::new(), registry.clone());
+    owner.grant_stream_handles([exchange.guest_request_body, exchange.guest_response_body]);
+
+    let body = owner
+        .http_stream_read(exchange.guest_request_body)
+        .await
+        .expect("owner must read granted request body");
+    assert_eq!(&body, b"hello-owner");
+
+    let n = owner
+        .http_stream_try_write(exchange.guest_response_body, b"reply".to_vec())
+        .await
+        .expect("owner must write granted response body");
+    assert_eq!(n, 5);
+
+    let drained = registry.read(exchange.kernel_response_body).await.unwrap();
+    assert_eq!(&drained, b"reply");
+}
+
+#[tokio::test]
+async fn guest_cannot_operate_on_kernel_side_handles_even_when_guessed() {
+    let registry = shared_registry();
+    let exchange = registry.open_inbound_exchange().await.unwrap();
+
+    let owner = ProductionWasmHost::with_shared_streams(BTreeMap::new(), registry.clone());
+    // Grant only guest ends — mirrors HttpEndpoint dispatcher.
+    owner.grant_stream_handles([exchange.guest_request_body, exchange.guest_response_body]);
+
+    let kernel_read = owner.http_stream_read(exchange.kernel_request_body).await;
+    assert!(
+        matches!(kernel_read, Err(StreamError::InvalidHandle)),
+        "guest must not read kernel-side handle; got {kernel_read:?}"
+    );
+
+    let kernel_write = owner
+        .http_stream_try_write(exchange.kernel_response_body, b"nope".to_vec())
+        .await;
+    assert!(
+        matches!(kernel_write, Err(StreamError::InvalidHandle)),
+        "guest must not write kernel-side handle; got {kernel_write:?}"
+    );
+}
+
+#[tokio::test]
+async fn concurrent_tenants_cannot_cross_read_shared_registry() {
+    let registry = shared_registry();
+
+    let a = registry.open_inbound_exchange().await.unwrap();
+    let b = registry.open_inbound_exchange().await.unwrap();
+    registry
+        .write(a.kernel_request_body, b"tenant-a".to_vec())
+        .await
+        .unwrap();
+    registry
+        .write(b.kernel_request_body, b"tenant-b".to_vec())
+        .await
+        .unwrap();
+
+    let host_a = ProductionWasmHost::with_shared_streams(BTreeMap::new(), registry.clone());
+    host_a.grant_stream_handles([a.guest_request_body, a.guest_response_body]);
+    let host_b = ProductionWasmHost::with_shared_streams(BTreeMap::new(), registry.clone());
+    host_b.grant_stream_handles([b.guest_request_body, b.guest_response_body]);
+
+    // Each owner reads only its own body.
+    assert_eq!(
+        host_a.http_stream_read(a.guest_request_body).await.unwrap(),
+        b"tenant-a"
+    );
+    assert_eq!(
+        host_b.http_stream_read(b.guest_request_body).await.unwrap(),
+        b"tenant-b"
+    );
+
+    // Cross-tenant reads denied.
+    assert!(matches!(
+        host_a.http_stream_read(b.guest_request_body).await,
+        Err(StreamError::InvalidHandle)
+    ));
+    assert!(matches!(
+        host_b.http_stream_read(a.guest_request_body).await,
+        Err(StreamError::InvalidHandle)
+    ));
 }

--- a/crates/temper-wasm/tests/http_stream_capability_isolation.rs
+++ b/crates/temper-wasm/tests/http_stream_capability_isolation.rs
@@ -125,7 +125,9 @@ async fn legitimate_owner_can_use_granted_inbound_handles() {
         .unwrap();
 
     let owner = ProductionWasmHost::with_shared_streams(BTreeMap::new(), registry.clone());
-    owner.grant_stream_handles([exchange.guest_request_body, exchange.guest_response_body]);
+    owner
+        .grant_stream_handles([exchange.guest_request_body, exchange.guest_response_body])
+        .unwrap();
 
     let body = owner
         .http_stream_read(exchange.guest_request_body)
@@ -150,7 +152,9 @@ async fn guest_cannot_operate_on_kernel_side_handles_even_when_guessed() {
 
     let owner = ProductionWasmHost::with_shared_streams(BTreeMap::new(), registry.clone());
     // Grant only guest ends — mirrors HttpEndpoint dispatcher.
-    owner.grant_stream_handles([exchange.guest_request_body, exchange.guest_response_body]);
+    owner
+        .grant_stream_handles([exchange.guest_request_body, exchange.guest_response_body])
+        .unwrap();
 
     let kernel_read = owner.http_stream_read(exchange.kernel_request_body).await;
     assert!(
@@ -164,6 +168,61 @@ async fn guest_cannot_operate_on_kernel_side_handles_even_when_guessed() {
     assert!(
         matches!(kernel_write, Err(StreamError::InvalidHandle)),
         "guest must not write kernel-side handle; got {kernel_write:?}"
+    );
+}
+
+#[tokio::test]
+async fn cross_tenant_guest_cannot_send_or_await_foreign_response_head() {
+    let registry = shared_registry();
+    let victim = registry.open_inbound_exchange().await.unwrap();
+
+    let attacker = ProductionWasmHost::with_shared_streams(BTreeMap::new(), registry.clone());
+
+    let send = attacker
+        .http_stream_send_response_head(
+            victim.guest_response_body,
+            temper_wasm::http_stream::HttpResponseHead {
+                status: 200,
+                headers: vec![],
+            },
+        )
+        .await;
+    assert!(
+        matches!(send, Err(StreamError::InvalidHandle)),
+        "cross-tenant send_response_head must be denied; got {send:?}"
+    );
+
+    // Outbound head await on a foreign inbound response handle is also denied.
+    let await_head = attacker
+        .http_stream_response_head(victim.guest_response_body)
+        .await;
+    assert!(
+        await_head.is_err(),
+        "cross-tenant response_head await must be denied; got {await_head:?}"
+    );
+}
+
+#[tokio::test]
+async fn close_revokes_grant_so_handle_cannot_be_reused() {
+    let registry = shared_registry();
+    let exchange = registry.open_inbound_exchange().await.unwrap();
+    let owner = ProductionWasmHost::with_shared_streams(BTreeMap::new(), registry.clone());
+    owner
+        .grant_stream_handles([exchange.guest_request_body, exchange.guest_response_body])
+        .unwrap();
+
+    owner
+        .http_stream_close(exchange.guest_response_body)
+        .await
+        .unwrap();
+    assert!(
+        !owner.has_stream_grant(exchange.guest_response_body),
+        "successful close must revoke the grant"
+    );
+    let reclose = owner.http_stream_close(exchange.guest_response_body).await;
+    assert!(
+        matches!(reclose, Err(StreamError::InvalidHandle)),
+        "revoked grant must deny further ops; got {reclose:?}"
     );
 }
 
@@ -183,9 +242,13 @@ async fn concurrent_tenants_cannot_cross_read_shared_registry() {
         .unwrap();
 
     let host_a = ProductionWasmHost::with_shared_streams(BTreeMap::new(), registry.clone());
-    host_a.grant_stream_handles([a.guest_request_body, a.guest_response_body]);
+    host_a
+        .grant_stream_handles([a.guest_request_body, a.guest_response_body])
+        .unwrap();
     let host_b = ProductionWasmHost::with_shared_streams(BTreeMap::new(), registry.clone());
-    host_b.grant_stream_handles([b.guest_request_body, b.guest_response_body]);
+    host_b
+        .grant_stream_handles([b.guest_request_body, b.guest_response_body])
+        .unwrap();
 
     // Each owner reads only its own body.
     assert_eq!(
@@ -206,4 +269,19 @@ async fn concurrent_tenants_cannot_cross_read_shared_registry() {
         host_b.http_stream_read(a.guest_request_body).await,
         Err(StreamError::InvalidHandle)
     ));
+}
+
+#[tokio::test]
+async fn close_granted_streams_clears_all_grants() {
+    let registry = shared_registry();
+    let exchange = registry.open_inbound_exchange().await.unwrap();
+    let owner = ProductionWasmHost::with_shared_streams(BTreeMap::new(), registry.clone());
+    owner
+        .grant_stream_handles([exchange.guest_request_body, exchange.guest_response_body])
+        .unwrap();
+    owner.close_granted_streams().await;
+    assert!(!owner.has_stream_grant(exchange.guest_request_body));
+    assert!(!owner.has_stream_grant(exchange.guest_response_body));
+    let read = owner.http_stream_read(exchange.guest_request_body).await;
+    assert!(matches!(read, Err(StreamError::InvalidHandle)));
 }

--- a/docs/adrs/0156-invocation-scoped-http-stream-capabilities.md
+++ b/docs/adrs/0156-invocation-scoped-http-stream-capabilities.md
@@ -60,9 +60,16 @@ when it knows the ID from a leak.
 ### Sub-Decision 4: Budgets and cleanup
 
 - Global registry handle budget and per-invocation grant budget bound resource
-  use (concurrent streams / DoS).
-- `close_granted_streams` / dispatcher cleanup closes granted guest ends on
-  success, failure, timeout, and cancellation so entries do not retain forever.
+  use (concurrent streams / DoS). Grant insertion is fallible: if the budget
+  is exhausted, the open/begin path rolls back registry allocation rather than
+  handing the guest unusable handles.
+- Dispatcher cleanup closes all four exchange ends on **head failure and head
+  timeout** (the paths where the guest never completed a normal stream).
+  Successful exchanges still rely on channel EOF and peer close (existing
+  ADR-0057 semantics). Hosts also revoke a grant on successful
+  `http_stream_close` so the capability does not outlive the handle.
+- `close_granted_streams` is available for request-end teardown when a host
+  must drop every remaining grant (cancel / dispatcher abort).
 
 ### Sub-Decision 5: Kernel path stays privileged
 

--- a/docs/adrs/0156-invocation-scoped-http-stream-capabilities.md
+++ b/docs/adrs/0156-invocation-scoped-http-stream-capabilities.md
@@ -1,0 +1,124 @@
+# ADR-0156: Invocation-scoped HTTP stream capabilities (ARN-207)
+
+- Status: Accepted
+- Date: 2026-07-11
+- Deciders: Temper core maintainers
+- Related:
+  - ARN-207: Global enumerable WASM stream handles permit cross-tenant theft
+  - ADR-0069: HttpEndpoint inbound path-prefix routing
+  - `crates/temper-wasm/src/http_stream.rs`
+  - `crates/temper-wasm/src/host_trait.rs`
+  - `crates/temper-server/src/router.rs`
+
+## Context
+
+`ServerState` shares one `HttpStreamRegistry` across all tenants and requests.
+Handles were sequential `u32` values. Guest-facing `ProductionWasmHost` stream
+ops (`read` / `try_write` / `close` / head delivery) validated only that the
+raw handle existed in the registry. A process-global integer was therefore an
+authority-bearing capability: a malicious guest could enumerate another
+tenant's active handle, read its request body, inject or close its response,
+and leave leaked entries after timeouts.
+
+## Decision
+
+### Sub-Decision 1: Invocation-local capability table (fail closed)
+
+Each `ProductionWasmHost` carries an invocation-scoped **grant set** of stream
+handle IDs. Guest-facing stream operations require the handle to be present in
+that set; otherwise they return `StreamError::InvalidHandle` with no further
+registry interaction.
+
+Grants are issued only by:
+
+1. `http_stream_begin_outbound` — automatically grants the guest request/response
+   handles of the newly opened exchange.
+2. `grant_stream_handles` — used by the HttpEndpoint dispatcher when minting an
+   inbound exchange so the guest may use the handles published in
+   `HttpDispatchContext`.
+
+A host with no grants cannot operate on any stream. Sharing a registry is no
+longer sufficient to act on another invocation's handles.
+
+**Why this approach**: The authority is the capability table, not the integer.
+This matches least privilege and keeps the WASM ABI (`u32` handles) stable.
+
+### Sub-Decision 2: Opaque non-enumerable handle IDs
+
+Handle IDs are allocated from unguessable `u32` material (UUID-v4 bits), not
+a global sequential counter. Enumeration of low IDs cannot discover live
+handles. Ownership still fails closed even under collision (collision → next
+ID).
+
+### Sub-Decision 3: Direction stays structural
+
+Each registry slot remains a sender or receiver end. Wrong-direction ops still
+return `InvalidHandle`. Kernel-side ends of an exchange are never granted to
+the guest, so the guest cannot close or write the kernel pump handles even
+when it knows the ID from a leak.
+
+### Sub-Decision 4: Budgets and cleanup
+
+- Global registry handle budget and per-invocation grant budget bound resource
+  use (concurrent streams / DoS).
+- `close_granted_streams` / dispatcher cleanup closes granted guest ends on
+  success, failure, timeout, and cancellation so entries do not retain forever.
+
+### Sub-Decision 5: Kernel path stays privileged
+
+Bridge and axum pump tasks continue to use registry `read` / `write` / `close`
+directly with the exact handles they created. They never accept guest-supplied
+handle IDs.
+
+## Rollout Plan
+
+1. **Phase 0 (this PR)** — grant table + opaque IDs + budgets + cleanup hooks +
+   exploit regressions + live local E2E.
+2. **Phase 1 (optional follow-up)** — richer endpoint/direction tags on grants
+   for observability; per-tenant stream metrics in Observe.
+
+## Consequences
+
+### Positive
+
+- Cross-tenant and cross-invocation stream theft/injection is denied by
+  construction.
+- Sequential handle guessing no longer yields foreign bodies.
+- Working inbound/outbound streaming paths remain intact for granted handles.
+
+### Negative
+
+- Guests and hosts must obtain handles via begin/grant; tests that assumed
+  global raw-handle authority need grants.
+
+### Risks
+
+- Missing a `grant_stream_handles` call on a new dispatcher path fails closed
+  (guest sees InvalidHandle). Prefer that over open-by-default.
+
+### DST Compliance
+
+- Core registry lives in `temper-wasm` (I/O host path). `temper-server` router
+  wiring is production-async; handle allocation uses UUID (annotated
+  `// determinism-ok` where required). Concurrent isolation is covered by
+  deterministic unit/integration tests, not wall-clock races.
+
+## Non-Goals
+
+- Changing the guest WASM ABI away from `u32` handles.
+- Per-chunk encryption of stream payloads.
+- Removing the shared registry (sharing is fine; authority is not shared).
+
+## Alternatives Considered
+
+1. **Per-tenant registries only** — blocks cross-tenant theft but not
+   same-tenant cross-invocation; still leaves sequential guessability.
+2. **Cedar policy on every stream op** — heavier and still needs a handle
+   capability object; grants are the capability.
+3. **Invocation-local indices remapped at the FFI boundary** — stronger
+   non-addressability but larger ABI/engine change; deferred.
+
+## Rollback Policy
+
+Revert the PR: grants become unused, sequential IDs return. Do not partial-roll
+grants without restoring deny-by-default — that would re-open the hole.


### PR DESCRIPTION
## Summary

Closes the ARN-207 security hole where process-global enumerable WASM stream handles were treated as authority-bearing capabilities. A shared `HttpStreamRegistry` across tenants + sequential `u32` IDs + ungated guest stream ops let a malicious guest read, write, or close another tenant's request/response body.

**Root-cause fix (ADR-0156):**
- **Fail-closed invocation grants** on `ProductionWasmHost`: guest stream ops require membership in an invocation-local grant set.
- **HttpEndpoint dispatch** grants only guest-facing ends of the inbound exchange.
- **Opaque unguessable handle IDs** (UUID-derived `u32`) — not sequential counters.
- **Global + per-invocation budgets** on handle count; grant insertion is fallible with begin_outbound rollback.
- **RAII cleanup** of exchange ends on head timeout/failure; grants revoked on successful close.
- Kernel/bridge paths keep privileged registry access with the exact ends they created.

## Commits

1. `test(wasm): red exploit for cross-tenant stream handle theft` — fails on unfixed code (steal succeeds).
2. `fix(wasm): invocation-scoped stream handle capabilities` — green fix + ADR-0156.
3. `fix(wasm): address ARN-207 review P2s` — fallible grants, revoke-on-close, head-path exploit tests.

## Live local E2E

Real entry point: `ProductionWasmHost` stream ops on a shared registry (mirrors `ServerState.http_stream_registry`).

```
cargo test -p temper-wasm --test http_stream_capability_isolation -- --nocapture
```

**Before (RED commit):** cross-tenant read returned `Ok(SECRET-TENANT-A-BODY)`; write/close succeeded; sequential enumeration stole body.

**After (GREEN):**
```
running 10 tests
test cross_tenant_guest_cannot_read_foreign_request_body ... ok
test cross_tenant_guest_cannot_write_foreign_response_body ... ok
test cross_tenant_guest_cannot_close_foreign_handle ... ok
test sequential_handle_enumeration_cannot_steal_body ... ok
test legitimate_owner_can_use_granted_inbound_handles ... ok
test guest_cannot_operate_on_kernel_side_handles_even_when_guessed ... ok
test concurrent_tenants_cannot_cross_read_shared_registry ... ok
test cross_tenant_guest_cannot_send_or_await_foreign_response_head ... ok
test close_revokes_grant_so_handle_cannot_be_reused ... ok
test close_granted_streams_clears_all_grants ... ok
test result: ok. 10 passed
```

Legitimate outbound streaming still works:
```
cargo test -p temper-wasm --test http_stream_outbound
# 4 passed (echo, 1MiB, auth headers, span-hint strip)
```

## Test plan

- [x] RED exploit tests fail for stated reason (cross-tenant theft)
- [x] GREEN exploit + owner + concurrent isolation + head paths pass
- [x] Outbound streaming integration tests pass
- [x] `cargo fmt --check`, clippy `-D warnings` on temper-wasm/temper-server
- [x] Readability ratchet (router under 1000 lines)
- [x] Dedicated Fable reviewer PASS (re-review after P2s): https://github.com/nerdsane/temper/pull/354#issuecomment-4950087857
- [ ] Greptile after reviewer PASS
- [ ] CI green on head

## Notes for judge

- Branch: `claude/arn-207-wasm-stream-handles`
- Agent: Fable (Claude Code)
- MERGE NOTHING — leave open for arena adjudication
- Linear: ARN-207

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes ARN-207, a cross-tenant stream handle theft vulnerability where process-global sequential `u32` handle IDs in a shared `HttpStreamRegistry` were treated as authority-bearing capabilities. The fix introduces a fail-closed invocation-scoped grant table on `ProductionWasmHost`, replaces sequential IDs with UUID-derived opaque handles, adds global and per-invocation handle budgets with rollback on exhaustion, and adds RAII cleanup in the head-timeout/failure paths of the HttpEndpoint dispatcher.

- **Capability table** (`stream_grants`): all six guest-facing stream ops now gate on `require_stream_grant`; a host with no grants cannot touch any stream regardless of the integer value of a handle ID.
- **Opaque IDs**: `alloc_id` derives `u32` values from `Uuid::new_v4()` bits (low bit forced to 1, non-zero, 64-attempt loop before a linear fallback probe), replacing the previous monotonic counter.
- **Fallible exchange open + cleanup**: `open_inbound_exchange` / `open_outbound_exchange` now return `Result`, and both the dispatcher and `begin_outbound` roll back all four exchange handles when the grant budget is exhausted.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The capability-table fix is correct and complete across all guest-facing stream paths; two if let Ok mutex patterns in host_trait.rs leave grant revocation and grant clearing potentially skipped on a poisoned mutex, inconsistent with the recover-on-poison style used everywhere else in the same file.

The fix correctly addresses the stated vulnerability across all guest-facing stream paths, the exchange-open rollback on budget exhaustion is complete, and the test suite covers cross-tenant, enumeration, concurrent, head-path, and revoke-on-close scenarios. The two inconsistent if let Ok lock patterns in host_trait.rs are the only issues; they do not affect normal operation but represent a defensive-programming gap in security-critical code.

crates/temper-wasm/src/host_trait.rs — revoke_stream_grant and the clear step of close_granted_streams should use unwrap_or_else(|e| e.into_inner()) to match the recovery style of the surrounding grant API.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/temper-wasm/src/host_trait.rs | Adds stream_grants (invocation-scoped Arc<Mutex<BTreeSet<u32>>>) and gates all six guest-facing stream ops behind require_stream_grant. Two minor inconsistencies: revoke_stream_grant and the grant-clear step of close_granted_streams use if let Ok rather than unwrap_or_else, which silently skips on a poisoned mutex while every other lock site recovers. |
| crates/temper-wasm/src/http_stream.rs | Core security fix: replaces sequential next_id counter with UUID-derived opaque u32 IDs, makes create_pair/open_inbound_exchange/open_outbound_exchange fallible with budget bounds, adds close_handles batch helper. |
| crates/temper-server/src/http_stream_dispatch.rs | New helper module isolating the inbound exchange lifecycle: open_inbound_exchange wraps the fallible registry call into a 503, host_with_inbound_grants wires guest-end grants on a fresh host, close_inbound_handles provides RAII batch close. |
| crates/temper-server/src/router.rs | Switches to fallible open_inbound_exchange, replaces direct host construction with host_with_inbound_grants, adds close_inbound_handles in both head-error and head-timeout paths. |
| crates/temper-server/src/git_pkt.rs | Mechanical extraction of git pkt-line helpers from router.rs into a new pub(crate) module. No logic changes. |
| crates/temper-wasm/tests/http_stream_capability_isolation.rs | Ten isolation tests covering cross-tenant denial, sequential enumeration resistance, legitimate owner access, kernel-side handle protection, concurrent tenant isolation, revoke-on-close, and close_granted_streams teardown. |
| docs/adrs/0156-invocation-scoped-http-stream-capabilities.md | Well-structured ADR documenting all five sub-decisions with rollback policy and DST compliance notes. |
| crates/temper-server/src/state/mod.rs | Documentation update only: clarifies that http_stream_registry sharing is intentional and authority requires invocation-scoped grants per ADR-0156/ARN-207. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Axum as Axum Router
    participant Dispatch as http_stream_dispatch
    participant Registry as HttpStreamRegistry
    participant Host as ProductionWasmHost
    participant Guest as WASM Guest

    Axum->>Dispatch: open_inbound_exchange
    Dispatch->>Registry: open_inbound_exchange()
    Registry-->>Dispatch: Ok(InboundExchange) [opaque UUID IDs]
    Dispatch-->>Axum: Ok(exchange)
    Axum->>Dispatch: host_with_inbound_grants(...)
    Dispatch->>Host: grant_stream_handles([guest_req, guest_resp])
    Note over Host: stream_grants = {guest_req.id, guest_resp.id}
    Axum->>Host: invoke WASM
    Guest->>Host: http_stream_read(handle)
    Host->>Host: require_stream_grant(handle)
    alt NOT in stream_grants
        Host-->>Guest: Err(InvalidHandle)
    else in stream_grants
        Host->>Registry: read(handle)
        Host-->>Guest: Ok(chunk)
    end
    Guest->>Host: http_stream_close(handle)
    Host->>Registry: close(handle)
    Host->>Host: revoke_stream_grant(handle)
    alt Head timeout
        Axum->>Registry: close_handles([all 4])
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Axum as Axum Router
    participant Dispatch as http_stream_dispatch
    participant Registry as HttpStreamRegistry
    participant Host as ProductionWasmHost
    participant Guest as WASM Guest

    Axum->>Dispatch: open_inbound_exchange
    Dispatch->>Registry: open_inbound_exchange()
    Registry-->>Dispatch: Ok(InboundExchange) [opaque UUID IDs]
    Dispatch-->>Axum: Ok(exchange)
    Axum->>Dispatch: host_with_inbound_grants(...)
    Dispatch->>Host: grant_stream_handles([guest_req, guest_resp])
    Note over Host: stream_grants = {guest_req.id, guest_resp.id}
    Axum->>Host: invoke WASM
    Guest->>Host: http_stream_read(handle)
    Host->>Host: require_stream_grant(handle)
    alt NOT in stream_grants
        Host-->>Guest: Err(InvalidHandle)
    else in stream_grants
        Host->>Registry: read(handle)
        Host-->>Guest: Ok(chunk)
    end
    Guest->>Host: http_stream_close(handle)
    Host->>Registry: close(handle)
    Host->>Host: revoke_stream_grant(handle)
    alt Head timeout
        Axum->>Registry: close_handles([all 4])
    end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/temper-wasm/src/host_trait.rs`, line 403-406 ([link](https://github.com/nerdsane/temper/blob/a6bc328ccfe61edffcba3b16a5530a4c2c3f4a46/crates/temper-wasm/src/host_trait.rs#L403-L406)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Silent skip on poison leaves grants uncleared after `close_granted_streams`**

   The second mutex acquisition in `close_granted_streams` (the `grants.clear()` step) uses `if let Ok(...)` and silently skips clearing grants on a poisoned mutex, while the first acquisition uses `unwrap_or_else(|e| e.into_inner())`. If the clear is skipped, subsequent `require_stream_grant` calls on the same host would still succeed for handles that have already been physically closed in the registry. This should use `unwrap_or_else(|e| e.into_inner())` to be consistent with the rest of the grant API.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: crates/temper-wasm/src/host_trait.rs
   Line: 403-406

   Comment:
   **Silent skip on poison leaves grants uncleared after `close_granted_streams`**

   The second mutex acquisition in `close_granted_streams` (the `grants.clear()` step) uses `if let Ok(...)` and silently skips clearing grants on a poisoned mutex, while the first acquisition uses `unwrap_or_else(|e| e.into_inner())`. If the clear is skipped, subsequent `require_stream_grant` calls on the same host would still succeed for handles that have already been physically closed in the registry. This should use `unwrap_or_else(|e| e.into_inner())` to be consistent with the rest of the grant API.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-wasm%2Fsrc%2Fhost_trait.rs%0ALine%3A%20403-406%0A%0AComment%3A%0A**Silent%20skip%20on%20poison%20leaves%20grants%20uncleared%20after%20%60close_granted_streams%60**%0A%0AThe%20second%20mutex%20acquisition%20in%20%60close_granted_streams%60%20%28the%20%60grants.clear%28%29%60%20step%29%20uses%20%60if%20let%20Ok%28...%29%60%20and%20silently%20skips%20clearing%20grants%20on%20a%20poisoned%20mutex%2C%20while%20the%20first%20acquisition%20uses%20%60unwrap_or_else%28%7Ce%7C%20e.into_inner%28%29%29%60.%20If%20the%20clear%20is%20skipped%2C%20subsequent%20%60require_stream_grant%60%20calls%20on%20the%20same%20host%20would%20still%20succeed%20for%20handles%20that%20have%20already%20been%20physically%20closed%20in%20the%20registry.%20This%20should%20use%20%60unwrap_or_else%28%7Ce%7C%20e.into_inner%28%29%29%60%20to%20be%20consistent%20with%20the%20rest%20of%20the%20grant%20API.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=nerdsane%2Ftemper&pr=354&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22claude%2Farn-207-wasm-stream-handles%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Farn-207-wasm-stream-handles%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-wasm%2Fsrc%2Fhost_trait.rs%0ALine%3A%20403-406%0A%0AComment%3A%0A**Silent%20skip%20on%20poison%20leaves%20grants%20uncleared%20after%20%60close_granted_streams%60**%0A%0AThe%20second%20mutex%20acquisition%20in%20%60close_granted_streams%60%20%28the%20%60grants.clear%28%29%60%20step%29%20uses%20%60if%20let%20Ok%28...%29%60%20and%20silently%20skips%20clearing%20grants%20on%20a%20poisoned%20mutex%2C%20while%20the%20first%20acquisition%20uses%20%60unwrap_or_else%28%7Ce%7C%20e.into_inner%28%29%29%60.%20If%20the%20clear%20is%20skipped%2C%20subsequent%20%60require_stream_grant%60%20calls%20on%20the%20same%20host%20would%20still%20succeed%20for%20handles%20that%20have%20already%20been%20physically%20closed%20in%20the%20registry.%20This%20should%20use%20%60unwrap_or_else%28%7Ce%7C%20e.into_inner%28%29%29%60%20to%20be%20consistent%20with%20the%20rest%20of%20the%20grant%20API.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=nerdsane%2Ftemper&pr=354&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-wasm%2Fsrc%2Fhost_trait.rs%0ALine%3A%20403-406%0A%0AComment%3A%0A**Silent%20skip%20on%20poison%20leaves%20grants%20uncleared%20after%20%60close_granted_streams%60**%0A%0AThe%20second%20mutex%20acquisition%20in%20%60close_granted_streams%60%20%28the%20%60grants.clear%28%29%60%20step%29%20uses%20%60if%20let%20Ok%28...%29%60%20and%20silently%20skips%20clearing%20grants%20on%20a%20poisoned%20mutex%2C%20while%20the%20first%20acquisition%20uses%20%60unwrap_or_else%28%7Ce%7C%20e.into_inner%28%29%29%60.%20If%20the%20clear%20is%20skipped%2C%20subsequent%20%60require_stream_grant%60%20calls%20on%20the%20same%20host%20would%20still%20succeed%20for%20handles%20that%20have%20already%20been%20physically%20closed%20in%20the%20registry.%20This%20should%20use%20%60unwrap_or_else%28%7Ce%7C%20e.into_inner%28%29%29%60%20to%20be%20consistent%20with%20the%20rest%20of%20the%20grant%20API.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=354&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftemper-wasm%2Fsrc%2Fhost_trait.rs%3A587-591%0A**Inconsistent%20poison-recovery%20in%20%60revoke_stream_grant%60%20vs.%20all%20other%20grant%20methods**%0A%0A%60revoke_stream_grant%60%20uses%20%60if%20let%20Ok%28mut%20grants%29%20%3D%20self.stream_grants.lock%28%29%60%20and%20silently%20skips%20the%20removal%20when%20the%20mutex%20is%20poisoned.%20Every%20other%20method%20on%20this%20struct%20that%20touches%20%60stream_grants%60%20uses%20%60unwrap_or_else%28%7Ce%7C%20e.into_inner%28%29%29%60%20to%20recover%20the%20guard%20from%20a%20poisoned%20mutex.%20If%20the%20mutex%20is%20poisoned%20and%20the%20revocation%20is%20skipped%2C%20the%20grant%20outlives%20a%20successful%20%60http_stream_close%60.%20Should%20a%20handle%20ID%20be%20reallocated%20%28UUID-v4%20odds%20make%20this%20extremely%20improbable%29%2C%20the%20stale%20grant%20would%20authorize%20access%20to%20the%20new%20handle%20without%20an%20explicit%20%60grant_stream_handles%60%20call.%20The%20second%20%60if%20let%20Ok%60%20in%20%60close_granted_streams%60%20%28the%20clear%20step%29%20has%20the%20same%20problem.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftemper-wasm%2Fsrc%2Fhost_trait.rs%3A403-406%0A**Silent%20skip%20on%20poison%20leaves%20grants%20uncleared%20after%20%60close_granted_streams%60**%0A%0AThe%20second%20mutex%20acquisition%20in%20%60close_granted_streams%60%20%28the%20%60grants.clear%28%29%60%20step%29%20uses%20%60if%20let%20Ok%28...%29%60%20and%20silently%20skips%20clearing%20grants%20on%20a%20poisoned%20mutex%2C%20while%20the%20first%20acquisition%20uses%20%60unwrap_or_else%28%7Ce%7C%20e.into_inner%28%29%29%60.%20If%20the%20clear%20is%20skipped%2C%20subsequent%20%60require_stream_grant%60%20calls%20on%20the%20same%20host%20would%20still%20succeed%20for%20handles%20that%20have%20already%20been%20physically%20closed%20in%20the%20registry.%20This%20should%20use%20%60unwrap_or_else%28%7Ce%7C%20e.into_inner%28%29%29%60%20to%20be%20consistent%20with%20the%20rest%20of%20the%20grant%20API.%0A%0A&repo=nerdsane%2Ftemper&pr=354&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22claude%2Farn-207-wasm-stream-handles%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Farn-207-wasm-stream-handles%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftemper-wasm%2Fsrc%2Fhost_trait.rs%3A587-591%0A**Inconsistent%20poison-recovery%20in%20%60revoke_stream_grant%60%20vs.%20all%20other%20grant%20methods**%0A%0A%60revoke_stream_grant%60%20uses%20%60if%20let%20Ok%28mut%20grants%29%20%3D%20self.stream_grants.lock%28%29%60%20and%20silently%20skips%20the%20removal%20when%20the%20mutex%20is%20poisoned.%20Every%20other%20method%20on%20this%20struct%20that%20touches%20%60stream_grants%60%20uses%20%60unwrap_or_else%28%7Ce%7C%20e.into_inner%28%29%29%60%20to%20recover%20the%20guard%20from%20a%20poisoned%20mutex.%20If%20the%20mutex%20is%20poisoned%20and%20the%20revocation%20is%20skipped%2C%20the%20grant%20outlives%20a%20successful%20%60http_stream_close%60.%20Should%20a%20handle%20ID%20be%20reallocated%20%28UUID-v4%20odds%20make%20this%20extremely%20improbable%29%2C%20the%20stale%20grant%20would%20authorize%20access%20to%20the%20new%20handle%20without%20an%20explicit%20%60grant_stream_handles%60%20call.%20The%20second%20%60if%20let%20Ok%60%20in%20%60close_granted_streams%60%20%28the%20clear%20step%29%20has%20the%20same%20problem.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftemper-wasm%2Fsrc%2Fhost_trait.rs%3A403-406%0A**Silent%20skip%20on%20poison%20leaves%20grants%20uncleared%20after%20%60close_granted_streams%60**%0A%0AThe%20second%20mutex%20acquisition%20in%20%60close_granted_streams%60%20%28the%20%60grants.clear%28%29%60%20step%29%20uses%20%60if%20let%20Ok%28...%29%60%20and%20silently%20skips%20clearing%20grants%20on%20a%20poisoned%20mutex%2C%20while%20the%20first%20acquisition%20uses%20%60unwrap_or_else%28%7Ce%7C%20e.into_inner%28%29%29%60.%20If%20the%20clear%20is%20skipped%2C%20subsequent%20%60require_stream_grant%60%20calls%20on%20the%20same%20host%20would%20still%20succeed%20for%20handles%20that%20have%20already%20been%20physically%20closed%20in%20the%20registry.%20This%20should%20use%20%60unwrap_or_else%28%7Ce%7C%20e.into_inner%28%29%29%60%20to%20be%20consistent%20with%20the%20rest%20of%20the%20grant%20API.%0A%0A&repo=nerdsane%2Ftemper&pr=354&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftemper-wasm%2Fsrc%2Fhost_trait.rs%3A587-591%0A**Inconsistent%20poison-recovery%20in%20%60revoke_stream_grant%60%20vs.%20all%20other%20grant%20methods**%0A%0A%60revoke_stream_grant%60%20uses%20%60if%20let%20Ok%28mut%20grants%29%20%3D%20self.stream_grants.lock%28%29%60%20and%20silently%20skips%20the%20removal%20when%20the%20mutex%20is%20poisoned.%20Every%20other%20method%20on%20this%20struct%20that%20touches%20%60stream_grants%60%20uses%20%60unwrap_or_else%28%7Ce%7C%20e.into_inner%28%29%29%60%20to%20recover%20the%20guard%20from%20a%20poisoned%20mutex.%20If%20the%20mutex%20is%20poisoned%20and%20the%20revocation%20is%20skipped%2C%20the%20grant%20outlives%20a%20successful%20%60http_stream_close%60.%20Should%20a%20handle%20ID%20be%20reallocated%20%28UUID-v4%20odds%20make%20this%20extremely%20improbable%29%2C%20the%20stale%20grant%20would%20authorize%20access%20to%20the%20new%20handle%20without%20an%20explicit%20%60grant_stream_handles%60%20call.%20The%20second%20%60if%20let%20Ok%60%20in%20%60close_granted_streams%60%20%28the%20clear%20step%29%20has%20the%20same%20problem.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftemper-wasm%2Fsrc%2Fhost_trait.rs%3A403-406%0A**Silent%20skip%20on%20poison%20leaves%20grants%20uncleared%20after%20%60close_granted_streams%60**%0A%0AThe%20second%20mutex%20acquisition%20in%20%60close_granted_streams%60%20%28the%20%60grants.clear%28%29%60%20step%29%20uses%20%60if%20let%20Ok%28...%29%60%20and%20silently%20skips%20clearing%20grants%20on%20a%20poisoned%20mutex%2C%20while%20the%20first%20acquisition%20uses%20%60unwrap_or_else%28%7Ce%7C%20e.into_inner%28%29%29%60.%20If%20the%20clear%20is%20skipped%2C%20subsequent%20%60require_stream_grant%60%20calls%20on%20the%20same%20host%20would%20still%20succeed%20for%20handles%20that%20have%20already%20been%20physically%20closed%20in%20the%20registry.%20This%20should%20use%20%60unwrap_or_else%28%7Ce%7C%20e.into_inner%28%29%29%60%20to%20be%20consistent%20with%20the%20rest%20of%20the%20grant%20API.%0A%0A&pr=354&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
crates/temper-wasm/src/host_trait.rs:587-591
**Inconsistent poison-recovery in `revoke_stream_grant` vs. all other grant methods**

`revoke_stream_grant` uses `if let Ok(mut grants) = self.stream_grants.lock()` and silently skips the removal when the mutex is poisoned. Every other method on this struct that touches `stream_grants` uses `unwrap_or_else(|e| e.into_inner())` to recover the guard from a poisoned mutex. If the mutex is poisoned and the revocation is skipped, the grant outlives a successful `http_stream_close`. Should a handle ID be reallocated (UUID-v4 odds make this extremely improbable), the stale grant would authorize access to the new handle without an explicit `grant_stream_handles` call. The second `if let Ok` in `close_granted_streams` (the clear step) has the same problem.

### Issue 2 of 2
crates/temper-wasm/src/host_trait.rs:403-406
**Silent skip on poison leaves grants uncleared after `close_granted_streams`**

The second mutex acquisition in `close_granted_streams` (the `grants.clear()` step) uses `if let Ok(...)` and silently skips clearing grants on a poisoned mutex, while the first acquisition uses `unwrap_or_else(|e| e.into_inner())`. If the clear is skipped, subsequent `require_stream_grant` calls on the same host would still succeed for handles that have already been physically closed in the registry. This should use `unwrap_or_else(|e| e.into_inner())` to be consistent with the rest of the grant API.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(wasm): address ARN-207 review P2s fo..."](https://github.com/nerdsane/temper/commit/a6bc328ccfe61edffcba3b16a5530a4c2c3f4a46) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43593850)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->