### PR TITLE
fix(platform): harden Genesis install against SSRF and path escape (ARN-210)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6591,6 +6591,7 @@ dependencies = [
  "axum 0.8.8",
  "base64 0.22.1",
  "chrono",
+ "futures-util",
  "hyper 1.8.1",
  "opentelemetry",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,7 @@ serial_test = "3"
 prost = "0.14"
 prost-types = "0.14"
 futures = "0.3"
+futures-util = "0.3"
 
 # Internal crates
 temper-macros = { path = "crates/temper-macros" }

--- a/crates/temper-platform/Cargo.toml
+++ b/crates/temper-platform/Cargo.toml
@@ -32,6 +32,7 @@ sha2 = { workspace = true }
 toml = { workspace = true }
 async-trait = { workspace = true }
 base64 = "0.22"
+futures-util = { workspace = true }
 
 [dev-dependencies]
 temper-codegen = { workspace = true }

--- a/crates/temper-platform/src/genesis_install.rs
+++ b/crates/temper-platform/src/genesis_install.rs
@@ -265,8 +265,23 @@ pub async fn restore_genesis_registry_cache_roots(platform: &PlatformState) -> u
         } else {
             record.registry_tenant.trim()
         };
+        // Re-validate stored registry URL on every fetch (ARN-210 defense-in-depth).
+        let registry_url = match normalize_registry_url(&record.registry_url) {
+            Ok(url) => url,
+            Err(error) => {
+                tracing::warn!(
+                    tenant = %tenant,
+                    app = %app_name,
+                    app_ref = %record.app_ref,
+                    registry_url = %record.registry_url,
+                    error = %error,
+                    "Installed app has blocked/invalid Genesis registry_url"
+                );
+                continue;
+            }
+        };
         let materialized = match materialize_registry_app_closure_via_bundle(
-            &record.registry_url,
+            &registry_url,
             registry_tenant,
             root_ref.clone(),
             &cache_root,
@@ -279,11 +294,11 @@ pub async fn restore_genesis_registry_cache_roots(platform: &PlatformState) -> u
                     tenant = %tenant,
                     app = %app_name,
                     app_ref = %record.app_ref,
-                    registry_url = %record.registry_url,
+                    registry_url = %registry_url,
                     error = %error,
                     "Genesis bundle cache recovery failed; falling back to git clone because TEMPER_GENESIS_INSTALL_GIT_FALLBACK is enabled"
                 );
-                materialize_registry_app_closure(&record.registry_url, root_ref, &cache_root).await
+                materialize_registry_app_closure(&registry_url, root_ref, &cache_root).await
             }
             Err(error) => Err(error),
         };
@@ -652,20 +667,8 @@ fn genesis_git_fallback_enabled() -> bool {
 }
 
 fn normalize_registry_url(raw: &str) -> Result<String, String> {
-    let fallback = std::env::var("TEMPER_GENESIS_REGISTRY_URL").unwrap_or_default();
-    let raw = if raw.trim().is_empty() {
-        fallback.as_str()
-    } else {
-        raw
-    };
-    let value = raw.trim().trim_end_matches('/');
-    if value.is_empty() {
-        return Err("registry_url is required for Genesis app install".to_string());
-    }
-    if !(value.starts_with("http://") || value.starts_with("https://")) {
-        return Err("registry_url must start with http:// or https://".to_string());
-    }
-    Ok(value.to_string())
+    // SSRF / supply-chain boundary — see ADR-0157 / ARN-210.
+    crate::genesis_install_security::normalize_and_validate_registry_url(raw)
 }
 
 fn follow_latest_error_update(
@@ -707,7 +710,15 @@ async fn fetch_registry_latest_version_hash(
         registry_url.trim_end_matches('/'),
         app_id.replace('\'', "''")
     );
-    let response = reqwest::Client::new()
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(
+            crate::genesis_install_security::REGISTRY_HTTP_TIMEOUT_SECS,
+        ))
+        .connect_timeout(std::time::Duration::from_secs(10))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|error| format!("build registry HTTP client: {error}"))?;
+    let response = client
         .get(&url)
         .header("X-Tenant-Id", registry_tenant)
         .send()
@@ -841,7 +852,7 @@ async fn materialize_registry_app_closure(
             continue;
         }
 
-        let app_dir = cache_root.join(&app_ref.name);
+        let app_dir = crate::genesis_install_security::join_under_cache(cache_root, &app_ref.name)?;
         let resolved_hash = materialize_git_registry_app(
             registry_url,
             &app_ref.owner,
@@ -885,7 +896,16 @@ async fn materialize_registry_app_closure_via_bundle(
         root_ref.name,
         version_hash.trim_start_matches('@')
     );
-    let response = reqwest::Client::new()
+    use crate::genesis_install_security::{
+        MAX_BUNDLE_APPS, MAX_BUNDLE_RESPONSE_BYTES, REGISTRY_HTTP_TIMEOUT_SECS, join_under_cache,
+    };
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(REGISTRY_HTTP_TIMEOUT_SECS))
+        .connect_timeout(std::time::Duration::from_secs(10))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|error| format!("build registry HTTP client: {error}"))?;
+    let response = client
         .get(&bundle_url)
         .header("X-Tenant-Id", registry_tenant)
         .send()
@@ -899,10 +919,60 @@ async fn materialize_registry_app_closure_via_bundle(
             body.trim()
         ));
     }
-    let bundle: GenesisRegistryBundleResponse = response
-        .json()
-        .await
+    // Bound response body while streaming (ARN-210 DoS — abort before OOM).
+    let bytes =
+        crate::genesis_install_security::read_body_capped(response, MAX_BUNDLE_RESPONSE_BYTES)
+            .await
+            .map_err(|error| format!("read Genesis bundle body {bundle_url}: {error}"))?;
+    let bundle: GenesisRegistryBundleResponse = serde_json::from_slice(&bytes)
         .map_err(|error| format!("decode Genesis bundle {bundle_url}: {error}"))?;
+    if bundle.apps.len() > MAX_BUNDLE_APPS {
+        return Err(format!(
+            "Genesis bundle contains {} apps; max is {MAX_BUNDLE_APPS}",
+            bundle.apps.len()
+        ));
+    }
+
+    // Stage under a private directory, then rename into place (atomic-ish).
+    let stage_root = cache_root.with_extension("staging");
+    if stage_root.exists() {
+        std::fs::remove_dir_all(&stage_root).map_err(|error| {
+            format!(
+                "clear Genesis registry bundle staging '{}': {error}",
+                stage_root.display()
+            )
+        })?;
+    }
+    std::fs::create_dir_all(&stage_root).map_err(|error| {
+        format!(
+            "create Genesis registry bundle staging '{}': {error}",
+            stage_root.display()
+        )
+    })?;
+
+    let mut refs = Vec::new();
+    for app in bundle.apps {
+        // Verify root identity when present.
+        if app.name == root_ref.name
+            && let Some(expected) = root_ref.version_hash.as_deref()
+        {
+            let got = app.version_hash.trim_start_matches('@');
+            let exp = expected.trim_start_matches('@');
+            if got != exp {
+                return Err(format!(
+                    "bundle version_hash mismatch for '{}': expected {exp}, got {got}",
+                    app.name
+                ));
+            }
+        }
+        let app_dir = join_under_cache(&stage_root, &app.name)?;
+        write_bundle_app(&app_dir, &app)?;
+        refs.push(RegistryAppRef {
+            owner: app.owner,
+            name: app.name,
+            version_hash: Some(app.version_hash),
+        });
+    }
 
     if cache_root.exists() {
         std::fs::remove_dir_all(cache_root).map_err(|error| {
@@ -912,27 +982,24 @@ async fn materialize_registry_app_closure_via_bundle(
             )
         })?;
     }
-    std::fs::create_dir_all(cache_root).map_err(|error| {
+    std::fs::rename(&stage_root, cache_root).map_err(|error| {
         format!(
-            "create Genesis registry bundle cache '{}': {error}",
+            "promote Genesis registry bundle staging to '{}': {error}",
             cache_root.display()
         )
     })?;
-
-    let mut refs = Vec::new();
-    for app in bundle.apps {
-        let app_dir = cache_root.join(&app.name);
-        write_bundle_app(&app_dir, &app)?;
-        refs.push(RegistryAppRef {
-            owner: app.owner,
-            name: app.name,
-            version_hash: Some(app.version_hash),
-        });
-    }
     Ok(refs)
 }
 
 fn write_bundle_app(app_dir: &Path, app: &GenesisRegistryBundleApp) -> Result<(), String> {
+    use crate::genesis_install_security::{MAX_FILE_BYTES, MAX_FILES_PER_APP};
+    if app.files.len() > MAX_FILES_PER_APP {
+        return Err(format!(
+            "bundle app '{}' has {} files; max is {MAX_FILES_PER_APP}",
+            app.name,
+            app.files.len()
+        ));
+    }
     if app_dir.exists() {
         std::fs::remove_dir_all(app_dir).map_err(|error| {
             format!("clear Genesis bundle app '{}': {error}", app_dir.display())
@@ -952,6 +1019,12 @@ fn write_bundle_app(app_dir: &Path, app: &GenesisRegistryBundleApp) -> Result<()
         let bytes = base64::engine::general_purpose::STANDARD
             .decode(&file.content_base64)
             .map_err(|error| format!("decode bundle file '{}': {error}", file.path))?;
+        if bytes.len() > MAX_FILE_BYTES {
+            return Err(format!(
+                "bundle file '{}' exceeds max size {MAX_FILE_BYTES} bytes",
+                file.path
+            ));
+        }
         std::fs::write(&path, bytes)
             .map_err(|error| format!("write bundle file '{}': {error}", path.display()))?;
     }
@@ -2051,7 +2124,9 @@ fn genesis_cache_root(state: &ServerState, app_ref: &str) -> PathBuf {
     } else {
         state.data_dir.join("genesis-app-cache")
     };
-    root.join(sanitize_fragment(app_ref))
+    // Collision-resistant keys (ARN-210): lossy sanitize alone can map
+    // distinct refs onto the same directory.
+    root.join(crate::genesis_install_security::collision_resistant_cache_key(app_ref))
 }
 
 fn genesis_source_tenants() -> Vec<String> {
@@ -2388,11 +2463,7 @@ mod tests {
         assert!(genesis_source_tenants().contains(&"default".to_string()));
     }
 
-    // --- ARN-210 exploit / security contract (RED on unfixed code) ---
-    //
-    // These assert the secure post-condition. On unfixed main they fail because
-    // normalize_registry_url accepts any http(s) URL and sanitize_fragment
-    // collapses distinct refs onto the same cache key.
+    // --- ARN-210 exploit / security contract (RED on unfixed → GREEN after fix) ---
 
     #[test]
     fn arn210_private_loopback_registry_urls_must_be_rejected() {
@@ -2442,11 +2513,10 @@ mod tests {
 
     #[test]
     fn arn210_cache_key_must_not_collide_across_distinct_refs() {
-        // Lossy sanitize_fragment maps "a.b" and "a/b" onto the same key —
-        // that is a package collision hole (ARN-210). Distinct refs must
-        // produce distinct cache keys.
-        let a = sanitize_fragment("a.b");
-        let b = sanitize_fragment("a/b");
+        // Green: collision_resistant_cache_key (used by genesis_cache_root).
+        // Red history asserted the same contract against lossy sanitize_fragment.
+        let a = crate::genesis_install_security::collision_resistant_cache_key("a.b");
+        let b = crate::genesis_install_security::collision_resistant_cache_key("a/b");
         assert_ne!(
             a, b,
             "distinct app refs must not share a cache key (got both {a:?})"

--- a/crates/temper-platform/src/genesis_install.rs
+++ b/crates/temper-platform/src/genesis_install.rs
@@ -2387,4 +2387,69 @@ mod tests {
     fn source_tenants_default_to_default() {
         assert!(genesis_source_tenants().contains(&"default".to_string()));
     }
+
+    // --- ARN-210 exploit / security contract (RED on unfixed code) ---
+    //
+    // These assert the secure post-condition. On unfixed main they fail because
+    // normalize_registry_url accepts any http(s) URL and sanitize_fragment
+    // collapses distinct refs onto the same cache key.
+
+    #[test]
+    fn arn210_private_loopback_registry_urls_must_be_rejected() {
+        let result = normalize_registry_url("https://127.0.0.1/genesis");
+        assert!(
+            result.is_err(),
+            "loopback registry URL must be rejected (SSRF); got {result:?}"
+        );
+        let result = normalize_registry_url("https://10.0.0.5/registry");
+        assert!(
+            result.is_err(),
+            "private registry URL must be rejected (SSRF); got {result:?}"
+        );
+        let result = normalize_registry_url("https://169.254.169.254/latest");
+        assert!(
+            result.is_err(),
+            "link-local metadata URL must be rejected (SSRF); got {result:?}"
+        );
+    }
+
+    #[test]
+    fn arn210_localhost_hostname_must_be_rejected() {
+        let result = normalize_registry_url("https://localhost/genesis");
+        assert!(
+            result.is_err(),
+            "https://localhost must be rejected by default (SSRF); got {result:?}"
+        );
+    }
+
+    #[test]
+    fn arn210_registry_userinfo_must_be_rejected() {
+        let result = normalize_registry_url("https://user:pass@evil.example/g");
+        assert!(
+            result.is_err(),
+            "registry URLs with userinfo must be rejected; got {result:?}"
+        );
+    }
+
+    #[test]
+    fn arn210_plain_http_non_loopback_must_be_rejected() {
+        let result = normalize_registry_url("http://evil.example/registry");
+        assert!(
+            result.is_err(),
+            "plain http non-loopback registry must be rejected; got {result:?}"
+        );
+    }
+
+    #[test]
+    fn arn210_cache_key_must_not_collide_across_distinct_refs() {
+        // Lossy sanitize_fragment maps "a.b" and "a/b" onto the same key —
+        // that is a package collision hole (ARN-210). Distinct refs must
+        // produce distinct cache keys.
+        let a = sanitize_fragment("a.b");
+        let b = sanitize_fragment("a/b");
+        assert_ne!(
+            a, b,
+            "distinct app refs must not share a cache key (got both {a:?})"
+        );
+    }
 }

--- a/crates/temper-platform/src/genesis_install_security.rs
+++ b/crates/temper-platform/src/genesis_install_security.rs
@@ -1,0 +1,470 @@
+//! Genesis install security boundary (ADR-0157 / ARN-210).
+//!
+//! Hardens the registry install path against SSRF, path escape, unbounded
+//! downloads, and unauthenticated management calls.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::path::{Component, Path, PathBuf};
+
+/// Max compressed/raw bundle JSON bytes accepted from a registry.
+pub const MAX_BUNDLE_RESPONSE_BYTES: u64 = 32 * 1024 * 1024;
+
+/// Max apps in a single bundle closure.
+pub const MAX_BUNDLE_APPS: usize = 64;
+
+/// Max files across a single app package in a bundle.
+pub const MAX_FILES_PER_APP: usize = 4_096;
+
+/// Max decoded file payload size for one package file.
+pub const MAX_FILE_BYTES: usize = 8 * 1024 * 1024;
+
+/// Connect + total request timeout for registry fetches.
+pub const REGISTRY_HTTP_TIMEOUT_SECS: u64 = 30;
+
+/// Require verified platform-admin credentials for install mutations.
+///
+/// Client-supplied `X-Temper-Principal-Kind: admin` is **not** trusted by
+/// itself (ARN-210). Admin is accepted only via:
+/// 1. `Authorization: Bearer <TEMPER_PLATFORM_ADMIN_BEARER>` (preferred), or
+/// 2. `Authorization: Bearer <TEMPER_API_KEY>` when that key is configured, or
+/// 3. Explicit dev opt-in `TEMPER_GENESIS_INSTALL_DEV_ADMIN=1` **and**
+///    `X-Temper-Principal-Kind: admin` (local tests only).
+pub fn require_platform_admin(
+    headers: &axum::http::HeaderMap,
+) -> Result<(), axum::http::StatusCode> {
+    let auth = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+
+    if let Ok(expected) = std::env::var("TEMPER_PLATFORM_ADMIN_BEARER") {
+        let expected = expected.trim();
+        if !expected.is_empty() {
+            let want = format!("Bearer {expected}");
+            return if constant_time_eq(auth.as_bytes(), want.as_bytes()) {
+                Ok(())
+            } else {
+                Err(axum::http::StatusCode::UNAUTHORIZED)
+            };
+        }
+    }
+
+    if let Ok(api_key) = std::env::var("TEMPER_API_KEY") {
+        let api_key = api_key.trim();
+        if !api_key.is_empty() {
+            let want = format!("Bearer {api_key}");
+            return if constant_time_eq(auth.as_bytes(), want.as_bytes()) {
+                Ok(())
+            } else {
+                Err(axum::http::StatusCode::UNAUTHORIZED)
+            };
+        }
+    }
+
+    // Dev/test only — never the production path.
+    if matches!(
+        std::env::var("TEMPER_GENESIS_INSTALL_DEV_ADMIN")
+            .unwrap_or_default()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes"
+    ) {
+        let kind = headers
+            .get("x-temper-principal-kind")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .trim()
+            .to_ascii_lowercase();
+        if matches!(kind.as_str(), "admin" | "system" | "platform-admin") {
+            return Ok(());
+        }
+    }
+
+    Err(axum::http::StatusCode::UNAUTHORIZED)
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    // Always walk the expected secret length so timing does not leak it.
+    let mut diff = if a.len() == b.len() { 0u8 } else { 1u8 };
+    for (i, y) in b.iter().enumerate() {
+        let x = a.get(i).copied().unwrap_or(0);
+        diff |= x ^ *y;
+    }
+    diff == 0
+}
+
+/// Normalize and validate a registry base URL against the SSRF policy.
+pub fn normalize_and_validate_registry_url(raw: &str) -> Result<String, String> {
+    let fallback = std::env::var("TEMPER_GENESIS_REGISTRY_URL").unwrap_or_default();
+    let raw = if raw.trim().is_empty() {
+        fallback.as_str()
+    } else {
+        raw
+    };
+    let value = raw.trim().trim_end_matches('/');
+    if value.is_empty() {
+        return Err("registry_url is required for Genesis app install".to_string());
+    }
+
+    let parsed =
+        reqwest::Url::parse(value).map_err(|e| format!("registry_url is not a valid URL: {e}"))?;
+    let scheme = parsed.scheme();
+    if scheme != "https" && scheme != "http" {
+        return Err("registry_url must use http:// or https://".to_string());
+    }
+
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| "registry_url must include a host".to_string())?;
+
+    let allow_loopback = matches!(
+        std::env::var("TEMPER_GENESIS_ALLOW_HTTP_LOOPBACK")
+            .unwrap_or_default()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes"
+    );
+
+    // Loopback (localhost / 127.0.0.1 / ::1) is opt-in only — including https.
+    if is_loopback_host(host) {
+        if !allow_loopback {
+            return Err(
+                "registry_url loopback host is blocked (set TEMPER_GENESIS_ALLOW_HTTP_LOOPBACK for local dev)"
+                    .to_string(),
+            );
+        }
+    } else {
+        // Non-loopback: https only + block private/metadata literals + bad hostnames.
+        if scheme != "https" {
+            return Err(
+                "registry_url must use https:// (http loopback only with TEMPER_GENESIS_ALLOW_HTTP_LOOPBACK)"
+                    .to_string(),
+            );
+        }
+        if let Ok(ip) = host.parse::<IpAddr>() {
+            if is_blocked_ip(ip) {
+                return Err(format!(
+                    "registry_url host resolves to a blocked address class: {ip}"
+                ));
+            }
+        } else if is_blocked_hostname(host) {
+            return Err(format!("registry_url host '{host}' is not allowed"));
+        }
+    }
+
+    if let Some(allowlist) = registry_allowlist() {
+        let ok = allowlist
+            .iter()
+            .any(|entry| host.eq_ignore_ascii_case(entry));
+        if !ok {
+            return Err(format!(
+                "registry host '{host}' is not in TEMPER_GENESIS_REGISTRY_ALLOWLIST"
+            ));
+        }
+    }
+
+    // Reject userinfo (credential stuffing / SSRF obfuscation).
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err("registry_url must not include userinfo".to_string());
+    }
+
+    Ok(value.to_string())
+}
+
+fn registry_allowlist() -> Option<Vec<String>> {
+    let raw = std::env::var("TEMPER_GENESIS_REGISTRY_ALLOWLIST").ok()?;
+    let list: Vec<String> = raw
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(ToString::to_string)
+        .collect();
+    if list.is_empty() { None } else { Some(list) }
+}
+
+fn is_loopback_host(host: &str) -> bool {
+    host.eq_ignore_ascii_case("localhost")
+        || host == "127.0.0.1"
+        || host == "::1"
+        || host == "[::1]"
+        || host.parse::<IpAddr>().is_ok_and(|ip| match ip {
+            IpAddr::V4(v4) => v4.is_loopback(),
+            IpAddr::V6(v6) => v6.is_loopback(),
+        })
+}
+
+fn is_blocked_hostname(host: &str) -> bool {
+    let h = host.to_ascii_lowercase();
+    h == "localhost"
+        || matches!(
+            h.as_str(),
+            "metadata.google.internal"
+                | "metadata"
+                | "kubernetes.default"
+                | "kubernetes.default.svc"
+                | "kubernetes.default.svc.cluster.local"
+        )
+        || h.ends_with(".internal")
+        || h.ends_with(".local")
+        || h.ends_with(".localhost")
+}
+
+/// Blocked destination classes for SSRF (literal IPs in the URL).
+pub fn is_blocked_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => is_blocked_v4(v4),
+        IpAddr::V6(v6) => is_blocked_v6(v6),
+    }
+}
+
+fn is_blocked_v4(ip: Ipv4Addr) -> bool {
+    ip.is_loopback()
+        || ip.is_private()
+        || ip.is_link_local()
+        || ip.is_broadcast()
+        || ip.is_unspecified()
+        || ip.octets()[0] == 0
+        || (ip.octets()[0] == 100 && (ip.octets()[1] & 0xc0) == 64)
+        || (ip.octets()[0] == 198 && (ip.octets()[1] == 18 || ip.octets()[1] == 19))
+        || ip.is_multicast()
+}
+
+fn is_blocked_v6(ip: Ipv6Addr) -> bool {
+    ip.is_loopback()
+        || ip.is_unspecified()
+        || ip.is_multicast()
+        || ip.is_unique_local()
+        || ip.is_unicast_link_local()
+        || ip.to_ipv4_mapped().is_some_and(is_blocked_v4)
+}
+
+/// Validate a remote app package name before joining under the cache root.
+pub fn safe_app_package_name(name: &str) -> Result<String, String> {
+    let name = name.trim();
+    if name.is_empty() {
+        return Err("bundle app name must not be empty".to_string());
+    }
+    if name.len() > 128 {
+        return Err("bundle app name exceeds 128 characters".to_string());
+    }
+    if name == "." || name == ".." {
+        return Err("bundle app name must not be '.' or '..'".to_string());
+    }
+    if name.contains('/') || name.contains('\\') || name.contains('\0') {
+        return Err("bundle app name must not contain path separators".to_string());
+    }
+    if Path::new(name).is_absolute() {
+        return Err("bundle app name must be a relative package id".to_string());
+    }
+    for component in Path::new(name).components() {
+        match component {
+            Component::Normal(part) => {
+                let s = part.to_string_lossy();
+                if !s
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+                {
+                    return Err(format!(
+                        "bundle app name '{name}' contains forbidden characters"
+                    ));
+                }
+            }
+            _ => {
+                return Err(format!(
+                    "bundle app name '{name}' must not contain path components like '..'"
+                ));
+            }
+        }
+    }
+    Ok(name.to_string())
+}
+
+/// Join `name` under `cache_root` only if the result stays inside the root.
+pub fn join_under_cache(cache_root: &Path, name: &str) -> Result<PathBuf, String> {
+    let safe = safe_app_package_name(name)?;
+    let joined = cache_root.join(&safe);
+    let root_canon = cache_root
+        .canonicalize()
+        .unwrap_or_else(|_| cache_root.to_path_buf());
+    if !joined.starts_with(cache_root) {
+        return Err(format!(
+            "bundle app path escapes cache root: {}",
+            joined.display()
+        ));
+    }
+    if let Ok(parent) = joined.parent().unwrap_or(cache_root).canonicalize()
+        && !parent.starts_with(&root_canon)
+        && parent != root_canon
+    {
+        return Err(format!(
+            "bundle app path escapes cache root after resolution: {}",
+            joined.display()
+        ));
+    }
+    Ok(joined)
+}
+
+/// Collision-resistant cache key fragment (readable prefix + hash suffix).
+pub fn collision_resistant_cache_key(app_ref: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(app_ref.as_bytes());
+    let digest = hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect::<String>();
+    let mut readable = String::new();
+    let mut last_dash = false;
+    for ch in app_ref.chars().flat_map(char::to_lowercase) {
+        if ch.is_ascii_alphanumeric() {
+            readable.push(ch);
+            last_dash = false;
+        } else if !last_dash {
+            readable.push('-');
+            last_dash = true;
+        }
+    }
+    let readable = readable.trim_matches('-');
+    let readable = if readable.is_empty() {
+        "app"
+    } else if readable.len() > 48 {
+        &readable[..48]
+    } else {
+        readable
+    };
+    format!("{readable}-{}", &digest[..16])
+}
+
+/// Read a response body with a hard byte cap (abort before unbounded alloc).
+pub async fn read_body_capped(
+    response: reqwest::Response,
+    max_bytes: u64,
+) -> Result<Vec<u8>, String> {
+    if let Some(len) = response.content_length()
+        && len > max_bytes
+    {
+        return Err(format!(
+            "response Content-Length {len} exceeds max {max_bytes} bytes"
+        ));
+    }
+    use futures_util::StreamExt;
+    let mut stream = response.bytes_stream();
+    let mut buf = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| format!("read response body: {e}"))?;
+        let next = buf.len() as u64 + chunk.len() as u64;
+        if next > max_bytes {
+            return Err(format!(
+                "response body exceeds max {max_bytes} bytes (aborting stream)"
+            ));
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    Ok(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::{HeaderMap, HeaderValue, StatusCode};
+
+    #[test]
+    fn admin_requires_verified_bearer_not_spoofed_header() {
+        let mut headers = HeaderMap::new();
+        // No secrets configured → fail closed.
+        // SAFETY: single-threaded unit test env mutation.
+        unsafe {
+            std::env::remove_var("TEMPER_PLATFORM_ADMIN_BEARER");
+            std::env::remove_var("TEMPER_API_KEY");
+            std::env::remove_var("TEMPER_GENESIS_INSTALL_DEV_ADMIN");
+        }
+        assert_eq!(
+            require_platform_admin(&headers),
+            Err(StatusCode::UNAUTHORIZED)
+        );
+
+        // Spoofed admin header alone is denied.
+        headers.insert("x-temper-principal-kind", HeaderValue::from_static("admin"));
+        assert_eq!(
+            require_platform_admin(&headers),
+            Err(StatusCode::UNAUTHORIZED)
+        );
+
+        // Correct bearer accepted.
+        // SAFETY: test-only env mutation in single-threaded unit test.
+        unsafe {
+            std::env::set_var("TEMPER_PLATFORM_ADMIN_BEARER", "super-secret");
+        }
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer super-secret"),
+        );
+        assert_eq!(require_platform_admin(&headers), Ok(()));
+
+        // Wrong bearer denied even with admin header.
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer wrong"),
+        );
+        assert_eq!(
+            require_platform_admin(&headers),
+            Err(StatusCode::UNAUTHORIZED)
+        );
+        unsafe {
+            std::env::remove_var("TEMPER_PLATFORM_ADMIN_BEARER");
+        }
+    }
+
+    #[test]
+    fn rejects_private_metadata_and_localhost_registry_urls() {
+        // SAFETY: single-threaded unit test env mutation.
+        unsafe {
+            std::env::remove_var("TEMPER_GENESIS_ALLOW_HTTP_LOOPBACK");
+        }
+        assert!(normalize_and_validate_registry_url("https://127.0.0.1/genesis").is_err());
+        assert!(normalize_and_validate_registry_url("https://localhost/genesis").is_err());
+        assert!(normalize_and_validate_registry_url("https://10.0.0.5/g").is_err());
+        assert!(normalize_and_validate_registry_url("https://192.168.1.1/g").is_err());
+        assert!(normalize_and_validate_registry_url("https://169.254.169.254/latest").is_err());
+        assert!(normalize_and_validate_registry_url("http://evil.example/g").is_err());
+        assert!(normalize_and_validate_registry_url("https://user:pass@evil.example/g").is_err());
+    }
+
+    #[test]
+    fn accepts_public_https_registry() {
+        let url = normalize_and_validate_registry_url("https://genesis.example.com/registry/")
+            .expect("public https should be accepted");
+        assert_eq!(url, "https://genesis.example.com/registry");
+    }
+
+    #[test]
+    fn app_name_traversal_rejected() {
+        assert!(safe_app_package_name("../escape").is_err());
+        assert!(safe_app_package_name("/tmp/x").is_err());
+        assert!(safe_app_package_name("a/b").is_err());
+        assert!(safe_app_package_name("..").is_err());
+        assert_eq!(safe_app_package_name("notes-app").unwrap(), "notes-app");
+    }
+
+    #[test]
+    fn join_under_cache_blocks_escape() {
+        let root = std::env::temp_dir().join("temper-genesis-cache-test");
+        let _ = std::fs::create_dir_all(&root);
+        assert!(join_under_cache(&root, "../escape").is_err());
+        let ok = join_under_cache(&root, "notes").unwrap();
+        assert!(ok.starts_with(&root));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn cache_keys_do_not_collide_across_distinct_refs() {
+        let a = collision_resistant_cache_key("owner/app@aaaa");
+        let b = collision_resistant_cache_key("owner/app@bbbb");
+        let c = collision_resistant_cache_key("owner/app-aaaa");
+        assert_ne!(a, b);
+        assert_ne!(a, c);
+        assert!(a.contains('-'));
+        assert!(a.len() > 16);
+    }
+}

--- a/crates/temper-platform/src/lib.rs
+++ b/crates/temper-platform/src/lib.rs
@@ -10,6 +10,7 @@ pub mod bearer_auth;
 pub mod bootstrap;
 pub mod deploy;
 pub mod genesis_install;
+pub mod genesis_install_security;
 pub mod hooks;
 pub mod identity_cache;
 pub mod integration;

--- a/crates/temper-platform/src/tenant_api.rs
+++ b/crates/temper-platform/src/tenant_api.rs
@@ -363,16 +363,38 @@ pub(crate) async fn list_genesis_follow_updates(
 }
 
 /// `POST /api/genesis/apps/install` — install a pinned Genesis app into this instance.
+///
+/// Requires platform-admin principal (ARN-210 / ADR-0157). Unauthenticated
+/// callers must not drive registry fetches or cache materialization.
 pub(crate) async fn install_genesis_app(
     State(state): State<PlatformState>,
+    headers: HeaderMap,
     Json(req): Json<crate::genesis_install::GenesisRegistryInstallRequest>,
 ) -> impl IntoResponse {
+    if let Err(status) = crate::genesis_install_security::require_platform_admin(&headers) {
+        return (
+            status,
+            Json(serde_json::json!({
+                "error": "platform admin authorization required for Genesis install"
+            })),
+        );
+    }
     match crate::genesis_install::install_genesis_app_from_registry(&state, req).await {
         Ok(result) => (StatusCode::OK, Json(serde_json::json!(result))),
         Err(error) if error.contains("not found") => (
             StatusCode::NOT_FOUND,
             Json(serde_json::json!({ "error": error })),
         ),
+        Err(error)
+            if error.contains("registry_url")
+                || error.contains("blocked")
+                || error.contains("allowlist") =>
+        {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": error })),
+            )
+        }
         Err(error) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({ "error": error })),

--- a/docs/adrs/0157-genesis-install-security-boundary.md
+++ b/docs/adrs/0157-genesis-install-security-boundary.md
@@ -1,0 +1,81 @@
+# ADR-0157: Genesis install security boundary (ARN-210)
+
+- Status: Accepted
+- Date: 2026-07-11
+- Deciders: Temper core maintainers
+- Related:
+  - ARN-210: Genesis installer unauthenticated SSRF / filesystem-write / supply-chain
+  - `crates/temper-platform/src/genesis_install.rs`
+  - `crates/temper-platform/src/genesis_install_security.rs`
+  - `crates/temper-platform/src/tenant_api.rs`
+
+## Context
+
+`POST /api/genesis/apps/install` accepted unauthenticated callers, any
+`http(s)` registry URL, unbounded bundle bodies, and joined remote `app.name`
+under the cache root without package-id validation. That combination is an
+SSRF + destructive write + supply-chain boundary failure.
+
+## Decision
+
+### Sub-Decision 1: Authenticated install
+
+Client-supplied `X-Temper-Principal-Kind` is **not** trusted for install.
+Install mutations require a **verified** credential:
+
+1. `Authorization: Bearer <TEMPER_PLATFORM_ADMIN_BEARER>` (preferred), or
+2. `Authorization: Bearer <TEMPER_API_KEY>` when that platform key is set.
+
+A dev-only escape hatch (`TEMPER_GENESIS_INSTALL_DEV_ADMIN=1` plus an admin
+principal header) exists for local tests and is fail-closed when unset.
+
+### Sub-Decision 2: Registry URL policy (SSRF)
+
+- Prefer `https://`. Plain `http://` is limited to loopback when
+  `TEMPER_GENESIS_ALLOW_HTTP_LOOPBACK` is set.
+- Optional host allowlist via `TEMPER_GENESIS_REGISTRY_ALLOWLIST`.
+- Reject userinfo, blocked hostnames (metadata/internal), and literal
+  private/link-local/loopback/CGNAT IPs in the URL host.
+- Registry HTTP clients disable redirects and apply connect/total timeouts.
+
+### Sub-Decision 3: Path and package identity
+
+- Validate `app.name` as a relative package id (no separators, no `..`).
+- Join under cache only via `join_under_cache`.
+- Stage bundle materialization in `*.staging`, then rename into the cache root.
+
+### Sub-Decision 4: Budgets and integrity
+
+- Bound bundle response bytes, apps per bundle, files per app, and file size.
+- When the root app is present in the bundle, require `version_hash` match.
+- Use collision-resistant cache keys (readable prefix + content hash suffix).
+
+## Consequences
+
+### Positive
+
+- Unauthenticated install is denied.
+- Default policy blocks common SSRF targets and path escape via package name.
+- Unbounded bundle DoS is budgeted.
+
+### Negative
+
+- Local http registries need an explicit env opt-in.
+- Operators using non-allowlisted hosts must configure the allowlist when set.
+
+### Risks
+
+- DNS rebinding to a public hostname that later resolves private is not fully
+  closed without post-resolve pinning; follow-up may add connect-time IP checks.
+
+## Non-Goals
+
+- Full signed-bundle crypto verification (planned follow-up with Genesis
+  registry signing identity).
+- Changing the App.Install Cedar action model.
+
+## Alternatives Considered
+
+1. **Disable HTTP install entirely** — too restrictive for real Genesis ops.
+2. **Per-tenant allowlist only** — still needed, but base private-IP deny is
+   the fail-closed default.


### PR DESCRIPTION
## Summary

Closes ARN-210: Genesis install was an unauthenticated management surface that accepted any registry URL (SSRF), joined remote package names under the cache (path escape), and downloaded unbounded bundles.

**Root-cause fix (ADR-0157):**
1. **Auth** — `POST /api/genesis/apps/install` requires platform-admin principal.
2. **SSRF policy** — https preferred; block private/metadata/link-local/loopback literal IPs; optional allowlist; no redirects; timeouts.
3. **Path safety** — validate package names; `join_under_cache`; stage then rename.
4. **Budgets** — max bundle bytes/apps/files/file size.
5. **Integrity** — root version_hash must match when present; collision-resistant cache keys.

## Tests

```
cargo test -p temper-platform genesis_install_security
# 6 passed: admin required, private URL reject, public https accept,
# path traversal reject, join escape block, cache key non-collision

cargo test -p temper-platform genesis_install
# 23 passed (existing + security)
```

## Notes

- Branch: `claude/arn-210-genesis-installer`
- Agent: Fable
- MERGE NOTHING

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens the Genesis install surface (ARN-210) by adding platform-admin authentication, a multi-layer SSRF policy, path-escape prevention at both the app and file levels, bounded downloads, and staging-rename atomicity. The implementation is isolated in a new `genesis_install_security` module and backed by six new security-contract tests.

- **Auth**: `POST /api/genesis/apps/install` now requires a verified `Authorization: Bearer` token matched against `TEMPER_PLATFORM_ADMIN_BEARER` or `TEMPER_API_KEY`; client-supplied `X-Temper-Principal-Kind` is no longer trusted on its own.
- **SSRF & path safety**: registry URLs are validated against a blocklist of private/link-local IPs, blocked hostnames, and userinfo; app names and file paths are each validated independently before any filesystem join; the HTTP client disables redirects and applies connect + total timeouts.
- **Budgets & integrity**: bundle response is capped at 32 MB via streaming, apps-per-bundle and files-per-app are bounded, individual file payloads are capped post-decode, and the root `version_hash` is verified when present; cache keys are made collision-resistant with a SHA-256 suffix.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change is safe to merge; it closes a serious unauthenticated SSRF/path-write surface and adds no regression risk to existing authenticated paths.

All five security sub-decisions (auth, SSRF policy, path safety, budgets, integrity) are correctly implemented and covered by dedicated tests. The only open items — DNS rebinding and allowlist-port usability — are either acknowledged in the ADR or minor configuration edge cases that do not affect correctness of the security boundary.

No files require special attention. tenant_api.rs uses substring matching for error classification (pre-existing pattern), but this does not affect the auth or SSRF correctness introduced by this PR.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/temper-platform/src/genesis_install_security.rs | New security module implementing SSRF policy, path validation, budget constants, constant-time auth, and body-cap streaming — core of ARN-210 fix; logic is correct and well-tested. |
| crates/temper-platform/src/genesis_install.rs | Install path hardened: URL re-validation on cache restore, no-redirect HTTP client with timeouts, join_under_cache for app-level and safe_bundle_relative_path for file-level path isolation, staging rename, version-hash check, and collision-resistant cache keys. |
| crates/temper-platform/src/tenant_api.rs | Auth guard added at handler entry; error classification via substring matching (pre-existing concern) may misclassify internal errors as 400 BAD_REQUEST. |
| Cargo.toml | futures-util added to workspace deps to coordinate the version used by temper-platform. |
| crates/temper-platform/Cargo.toml | futures-util now references workspace pin; no floating semver. |
| docs/adrs/0157-genesis-install-security-boundary.md | ADR documents all five sub-decisions and explicitly acknowledges DNS rebinding as an open risk for a follow-up. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Handler as install_genesis_app
    participant Auth as require_platform_admin
    participant URLVal as normalize_and_validate_registry_url
    participant HTTP as reqwest no-redirect+timeout
    participant BodyCap as read_body_capped
    participant PathVal as join_under_cache+safe_bundle_path
    participant FS as Filesystem stage to rename

    Client->>Handler: POST /api/genesis/apps/install
    Handler->>Auth: check Authorization header
    alt No valid Bearer token
        Auth-->>Client: 401 UNAUTHORIZED
    end
    Auth-->>Handler: Ok
    Handler->>URLVal: validate registry_url
    note over URLVal: Reject http non-loopback, Reject private IPs, Reject blocked hostnames
    URLVal-->>Handler: Ok url or Err 400
    Handler->>HTTP: GET bundle URL 30s timeout
    HTTP->>BodyCap: stream response
    note over BodyCap: Abort if over 32 MB
    BodyCap-->>Handler: bundle bytes
    Handler->>PathVal: validate app.name and file paths
    note over PathVal: No path separators, No absolute paths, No dotdot components
    PathVal-->>Handler: safe paths
    Handler->>FS: write to staging then rename
    FS-->>Handler: Ok refs
    Handler-->>Client: 200 OK
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Handler as install_genesis_app
    participant Auth as require_platform_admin
    participant URLVal as normalize_and_validate_registry_url
    participant HTTP as reqwest no-redirect+timeout
    participant BodyCap as read_body_capped
    participant PathVal as join_under_cache+safe_bundle_path
    participant FS as Filesystem stage to rename

    Client->>Handler: POST /api/genesis/apps/install
    Handler->>Auth: check Authorization header
    alt No valid Bearer token
        Auth-->>Client: 401 UNAUTHORIZED
    end
    Auth-->>Handler: Ok
    Handler->>URLVal: validate registry_url
    note over URLVal: Reject http non-loopback, Reject private IPs, Reject blocked hostnames
    URLVal-->>Handler: Ok url or Err 400
    Handler->>HTTP: GET bundle URL 30s timeout
    HTTP->>BodyCap: stream response
    note over BodyCap: Abort if over 32 MB
    BodyCap-->>Handler: bundle bytes
    Handler->>PathVal: validate app.name and file paths
    note over PathVal: No path separators, No absolute paths, No dotdot components
    PathVal-->>Handler: safe paths
    Handler->>FS: write to staging then rename
    FS-->>Handler: Ok refs
    Handler-->>Client: 200 OK
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/temper-platform/src/tenant_api.rs`, line 777-786 ([link](https://github.com/nerdsane/temper/blob/d4d3bf2ea6e54202ba96a5e925b223d5ad83fa1a/crates/temper-platform/src/tenant_api.rs#L777-L786)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Broad keyword match can misclassify internal errors as 400.** `error.contains("blocked")` and `error.contains("registry_url")` will match any `Err` string that happens to contain those substrings, including OS-level messages (e.g. "connection blocked by firewall", "could not read registry_url from environment") that should surface as 500. Consider threading error classification through a typed `enum` or a dedicated sentinel struct rather than substring matching on the human-readable message.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: crates/temper-platform/src/tenant_api.rs
   Line: 777-786

   Comment:
   **Broad keyword match can misclassify internal errors as 400.** `error.contains("blocked")` and `error.contains("registry_url")` will match any `Err` string that happens to contain those substrings, including OS-level messages (e.g. "connection blocked by firewall", "could not read registry_url from environment") that should surface as 500. Consider threading error classification through a typed `enum` or a dedicated sentinel struct rather than substring matching on the human-readable message.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-platform%2Fsrc%2Ftenant_api.rs%0ALine%3A%20777-786%0A%0AComment%3A%0A**Broad%20keyword%20match%20can%20misclassify%20internal%20errors%20as%20400.**%20%60error.contains%28%22blocked%22%29%60%20and%20%60error.contains%28%22registry_url%22%29%60%20will%20match%20any%20%60Err%60%20string%20that%20happens%20to%20contain%20those%20substrings%2C%20including%20OS-level%20messages%20%28e.g.%20%22connection%20blocked%20by%20firewall%22%2C%20%22could%20not%20read%20registry_url%20from%20environment%22%29%20that%20should%20surface%20as%20500.%20Consider%20threading%20error%20classification%20through%20a%20typed%20%60enum%60%20or%20a%20dedicated%20sentinel%20struct%20rather%20than%20substring%20matching%20on%20the%20human-readable%20message.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=nerdsane%2Ftemper&pr=356&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22claude%2Farn-210-genesis-installer%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Farn-210-genesis-installer%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-platform%2Fsrc%2Ftenant_api.rs%0ALine%3A%20777-786%0A%0AComment%3A%0A**Broad%20keyword%20match%20can%20misclassify%20internal%20errors%20as%20400.**%20%60error.contains%28%22blocked%22%29%60%20and%20%60error.contains%28%22registry_url%22%29%60%20will%20match%20any%20%60Err%60%20string%20that%20happens%20to%20contain%20those%20substrings%2C%20including%20OS-level%20messages%20%28e.g.%20%22connection%20blocked%20by%20firewall%22%2C%20%22could%20not%20read%20registry_url%20from%20environment%22%29%20that%20should%20surface%20as%20500.%20Consider%20threading%20error%20classification%20through%20a%20typed%20%60enum%60%20or%20a%20dedicated%20sentinel%20struct%20rather%20than%20substring%20matching%20on%20the%20human-readable%20message.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=nerdsane%2Ftemper&pr=356&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-platform%2Fsrc%2Ftenant_api.rs%0ALine%3A%20777-786%0A%0AComment%3A%0A**Broad%20keyword%20match%20can%20misclassify%20internal%20errors%20as%20400.**%20%60error.contains%28%22blocked%22%29%60%20and%20%60error.contains%28%22registry_url%22%29%60%20will%20match%20any%20%60Err%60%20string%20that%20happens%20to%20contain%20those%20substrings%2C%20including%20OS-level%20messages%20%28e.g.%20%22connection%20blocked%20by%20firewall%22%2C%20%22could%20not%20read%20registry_url%20from%20environment%22%29%20that%20should%20surface%20as%20500.%20Consider%20threading%20error%20classification%20through%20a%20typed%20%60enum%60%20or%20a%20dedicated%20sentinel%20struct%20rather%20than%20substring%20matching%20on%20the%20human-readable%20message.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=356&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(platform): harden Genesis install ag..."](https://github.com/nerdsane/temper/commit/8d1e80d53f6bed155eef3283f745fe52df0cbf96) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43596717)</sub>

<!-- /greptile_comment -->