### PR TITLE
fix(transport): capability-gate the Discord reply callback (ARN-234)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6813,6 +6813,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/temper-transport/Cargo.toml
+++ b/crates/temper-transport/Cargo.toml
@@ -25,5 +25,8 @@ futures-util = "0.3"
 # HTTP server (webhook listener for reply delivery)
 axum = { workspace = true }
 
+# Capability token generation (per-run CSPRNG secret for the reply callback)
+uuid = { workspace = true }
+
 # Logging
 tracing = { workspace = true }

--- a/crates/temper-transport/src/discord/gateway.rs
+++ b/crates/temper-transport/src/discord/gateway.rs
@@ -182,6 +182,22 @@ pub(crate) async fn handle_ready(
     Ok(())
 }
 
+/// Discord's per-message character budget.
+const DISCORD_MESSAGE_LIMIT: usize = 2000;
+
+/// Maximum sequential Discord messages one reply may fan out to (ADR-0158), so
+/// a reply cannot become an unbounded broadcast. The chunk count — not a raw
+/// byte count — is the authority: `split_message` may break on newlines and
+/// produce more chunks than `bytes / 2000`, so this is the exact bound.
+pub(crate) const MAX_REPLY_CHUNKS: usize = 8;
+
+/// Whether `content` fits the reply fan-out budget (splits into at most
+/// [`MAX_REPLY_CHUNKS`] Discord messages). The `/reply` handler uses this to
+/// reject an oversized reply cleanly, before any delivery.
+pub(crate) fn reply_fits_fanout_budget(content: &str) -> bool {
+    split_message(content, DISCORD_MESSAGE_LIMIT).len() <= MAX_REPLY_CHUNKS
+}
+
 /// Send a message to a Discord channel via REST API.
 pub async fn send_discord_message(
     http: &reqwest::Client,
@@ -189,7 +205,14 @@ pub async fn send_discord_message(
     channel_id: &str,
     content: &str,
 ) -> Result<(), String> {
-    let chunks = split_message(content, 2000);
+    let chunks = split_message(content, DISCORD_MESSAGE_LIMIT);
+    // Defensive backstop for any caller that skipped `reply_fits_fanout_budget`.
+    if chunks.len() > MAX_REPLY_CHUNKS {
+        return Err(format!(
+            "reply exceeds {MAX_REPLY_CHUNKS}-message fan-out budget ({} messages)",
+            chunks.len()
+        ));
+    }
     for chunk in chunks {
         let body = CreateMessageRequest {
             content: chunk.to_string(),
@@ -265,4 +288,27 @@ pub(crate) fn log_message(username: &str, content: &str) {
         "  [discord] Message from {username}: {}",
         truncate(content, 80)
     );
+}
+
+#[cfg(test)]
+mod fanout_tests {
+    use super::*;
+
+    #[test]
+    fn fanout_budget_bounds_chunk_count() {
+        // Exactly at the budget: MAX_REPLY_CHUNKS full messages fit.
+        let at_budget = "x".repeat(MAX_REPLY_CHUNKS * DISCORD_MESSAGE_LIMIT);
+        assert_eq!(
+            split_message(&at_budget, DISCORD_MESSAGE_LIMIT).len(),
+            MAX_REPLY_CHUNKS
+        );
+        assert!(reply_fits_fanout_budget(&at_budget));
+
+        // One byte over: an extra chunk is needed, so the budget is exceeded
+        // and the reply is rejected — no opaque 500 on a within-byte-budget
+        // body, and no unbounded fan-out.
+        let over = "x".repeat(MAX_REPLY_CHUNKS * DISCORD_MESSAGE_LIMIT + 1);
+        assert!(split_message(&over, DISCORD_MESSAGE_LIMIT).len() > MAX_REPLY_CHUNKS);
+        assert!(!reply_fits_fanout_budget(&over));
+    }
 }

--- a/crates/temper-transport/src/discord/transport.rs
+++ b/crates/temper-transport/src/discord/transport.rs
@@ -439,58 +439,13 @@ impl DiscordTransport {
     /// extracts `thread_id` + `content`, maps thread_id to a Discord DM
     /// channel, and delivers the reply via Discord REST API.
     async fn spawn_webhook_listener(&self) -> Result<u16, String> {
-        use axum::{Router, extract::State, routing::post};
-
-        #[derive(Clone)]
-        struct WebhookState {
-            http: reqwest::Client,
-            bot_token: String,
-            dm_channels: Arc<RwLock<BTreeMap<String, String>>>,
-        }
-
-        async fn handle_reply(
-            State(state): State<WebhookState>,
-            axum::Json(body): axum::Json<serde_json::Value>,
-        ) -> axum::http::StatusCode {
-            let thread_id = body.get("thread_id").and_then(|v| v.as_str()).unwrap_or("");
-            let content = body.get("content").and_then(|v| v.as_str()).unwrap_or("");
-
-            if thread_id.is_empty() || content.is_empty() {
-                eprintln!("  [discord] Webhook received empty reply (thread={thread_id})");
-                return axum::http::StatusCode::BAD_REQUEST;
-            }
-
-            // thread_id is the Discord user ID (for DMs). Look up their DM channel.
-            let channel_id = state.dm_channels.read().await.get(thread_id).cloned();
-            let Some(channel_id) = channel_id else {
-                eprintln!("  [discord] No DM channel found for thread_id={thread_id}");
-                return axum::http::StatusCode::NOT_FOUND;
-            };
-
-            println!(
-                "  [discord] Delivering reply via webhook ({} chars to {})",
-                content.len(),
-                thread_id
-            );
-
-            match send_discord_message(&state.http, &state.bot_token, &channel_id, content).await {
-                Ok(()) => axum::http::StatusCode::OK,
-                Err(e) => {
-                    eprintln!("  [discord] Reply delivery failed: {e}");
-                    axum::http::StatusCode::INTERNAL_SERVER_ERROR
-                }
-            }
-        }
-
         let webhook_state = WebhookState {
             http: self.http.clone(),
             bot_token: self.config.bot_token.clone(),
             dm_channels: self.dm_channels.clone(),
         };
 
-        let app = Router::new()
-            .route("/reply", post(handle_reply))
-            .with_state(webhook_state);
+        let app = build_reply_router(webhook_state);
 
         let port = self.config.webhook_port;
         let listener = tokio::net::TcpListener::bind(format!("127.0.0.1:{port}"))
@@ -511,6 +466,58 @@ impl DiscordTransport {
     }
 }
 
+/// State shared with the `/reply` callback handler.
+#[derive(Clone)]
+struct WebhookState {
+    http: reqwest::Client,
+    bot_token: String,
+    dm_channels: Arc<RwLock<BTreeMap<String, String>>>,
+}
+
+/// Build the reply-callback router.
+fn build_reply_router(state: WebhookState) -> axum::Router {
+    use axum::routing::post;
+    axum::Router::new()
+        .route("/reply", post(handle_reply))
+        .with_state(state)
+}
+
+/// Handle a reply callback from the `send_reply` WASM module: look up the
+/// recipient's DM channel and deliver `content` as the bot.
+async fn handle_reply(
+    axum::extract::State(state): axum::extract::State<WebhookState>,
+    axum::Json(body): axum::Json<serde_json::Value>,
+) -> axum::http::StatusCode {
+    let thread_id = body.get("thread_id").and_then(|v| v.as_str()).unwrap_or("");
+    let content = body.get("content").and_then(|v| v.as_str()).unwrap_or("");
+
+    if thread_id.is_empty() || content.is_empty() {
+        eprintln!("  [discord] Webhook received empty reply (thread={thread_id})");
+        return axum::http::StatusCode::BAD_REQUEST;
+    }
+
+    // thread_id is the Discord user ID (for DMs). Look up their DM channel.
+    let channel_id = state.dm_channels.read().await.get(thread_id).cloned();
+    let Some(channel_id) = channel_id else {
+        eprintln!("  [discord] No DM channel found for thread_id={thread_id}");
+        return axum::http::StatusCode::NOT_FOUND;
+    };
+
+    println!(
+        "  [discord] Delivering reply via webhook ({} chars to {})",
+        content.len(),
+        thread_id
+    );
+
+    match send_discord_message(&state.http, &state.bot_token, &channel_id, content).await {
+        Ok(()) => axum::http::StatusCode::OK,
+        Err(e) => {
+            eprintln!("  [discord] Reply delivery failed: {e}");
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR
+        }
+    }
+}
+
 /// Read one Gateway payload from the WebSocket with timeout.
 async fn read_payload(read: &mut WsStream) -> Result<Option<GatewayPayload>, String> {
     let frame = tokio::time::timeout(Duration::from_secs(60), read.next())
@@ -521,4 +528,58 @@ async fn read_payload(read: &mut WsStream) -> Result<Option<GatewayPayload>, Str
     };
     let frame = frame.map_err(|e| format!("WebSocket read error: {e}"))?;
     parse_frame(frame)
+}
+
+#[cfg(test)]
+mod reply_auth_tests {
+    //! ARN-234: the `/reply` callback must not accept unauthenticated requests.
+    use super::*;
+
+    /// Bind the reply router on an ephemeral loopback port and return it.
+    async fn spawn_reply_listener(dm: BTreeMap<String, String>) -> u16 {
+        let state = WebhookState {
+            http: reqwest::Client::new(),
+            bot_token: "test-bot-token".to_string(),
+            dm_channels: Arc::new(RwLock::new(dm)),
+        };
+        let app = build_reply_router(state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        port
+    }
+
+    async fn post_reply(port: u16, body: serde_json::Value) -> u16 {
+        // Retry briefly while the accept loop spins up.
+        for _ in 0..20 {
+            match reqwest::Client::new()
+                .post(format!("http://127.0.0.1:{port}/reply"))
+                .json(&body)
+                .send()
+                .await
+            {
+                Ok(resp) => return resp.status().as_u16(),
+                Err(_) => tokio::task::yield_now().await,
+            }
+        }
+        panic!("reply listener never became reachable");
+    }
+
+    #[tokio::test]
+    async fn unauthenticated_reply_is_rejected() {
+        // No token, unknown recipient: a bare local caller. It must be denied
+        // at the auth layer, not proceed into recipient/delivery handling.
+        let port = spawn_reply_listener(BTreeMap::new()).await;
+        let status = post_reply(
+            port,
+            serde_json::json!({"thread_id": "victim-user", "content": "spam"}),
+        )
+        .await;
+        assert_eq!(
+            status, 401,
+            "SECURITY: unauthenticated /reply must be rejected with 401, got {status}"
+        );
+    }
 }

--- a/crates/temper-transport/src/discord/transport.rs
+++ b/crates/temper-transport/src/discord/transport.rs
@@ -520,10 +520,20 @@ fn ct_eq(a: &[u8], b: &[u8]) -> bool {
 }
 
 /// Build the reply-callback router.
+/// Maximum `/reply` request body axum will read (ADR-0158). Enforced by a
+/// `DefaultBodyLimit` layer, so an unauthenticated caller cannot force axum to
+/// buffer up to its 2 MiB default before the token check runs — the body is
+/// capped before extraction. Sized generously above the largest valid reply
+/// (a ~16 KiB fan-out budget's worth of content, even fully JSON-escaped, plus
+/// the request envelope); the fan-out budget remains the exact delivery bound.
+const MAX_REPLY_BODY_BYTES: usize = 64 * 1024;
+
 fn build_reply_router(state: WebhookState) -> axum::Router {
+    use axum::extract::DefaultBodyLimit;
     use axum::routing::post;
     axum::Router::new()
         .route("/reply", post(handle_reply))
+        .layer(DefaultBodyLimit::max(MAX_REPLY_BODY_BYTES))
         .with_state(state)
 }
 
@@ -704,6 +714,26 @@ mod reply_auth_tests {
         assert_eq!(
             status, 413,
             "oversized reply must be rejected by the budget"
+        );
+    }
+
+    #[tokio::test]
+    async fn oversized_body_is_capped_before_auth() {
+        // Even with NO token, a body larger than MAX_REPLY_BODY_BYTES is
+        // rejected by the DefaultBodyLimit layer (413) before the Json
+        // extractor buffers it — an unauthenticated caller cannot force a
+        // large pre-auth allocation.
+        let port = spawn_reply_listener(BTreeMap::new()).await;
+        let huge = "x".repeat(MAX_REPLY_BODY_BYTES + 10_000);
+        let status = post_reply(
+            port,
+            None,
+            serde_json::json!({"thread_id": "victim", "content": huge}),
+        )
+        .await;
+        assert_eq!(
+            status, 413,
+            "oversized body must be capped before auth, got {status}"
         );
     }
 }

--- a/crates/temper-transport/src/discord/transport.rs
+++ b/crates/temper-transport/src/discord/transport.rs
@@ -42,6 +42,8 @@ pub struct DiscordTransport {
     channel_entity_id: Arc<RwLock<Option<String>>>,
     /// Maps Discord channel_id (DM channel) → user_id for reply routing.
     dm_channels: Arc<RwLock<BTreeMap<String, String>>>,
+    /// Per-run capability token required by the `/reply` callback (ADR-0158).
+    reply_token: Arc<String>,
 }
 
 impl DiscordTransport {
@@ -54,14 +56,20 @@ impl DiscordTransport {
             gateway: GatewayState::new(),
             channel_entity_id: Arc::new(RwLock::new(None)),
             dm_channels: Arc::new(RwLock::new(BTreeMap::new())),
+            reply_token: Arc::new(generate_reply_token()),
         }
     }
 
     /// Run the transport indefinitely.
     pub async fn run(&self) -> Result<(), String> {
-        // Phase 1: Start webhook listener for reply delivery.
+        // Phase 1: Start webhook listener for reply delivery. The capability
+        // token (ADR-0158) rides in the URL so the send_reply module presents
+        // it transparently; the port (not the tokenized URL) is logged.
         let webhook_port = self.spawn_webhook_listener().await?;
-        let webhook_url = format!("http://127.0.0.1:{webhook_port}/reply");
+        let webhook_url = format!(
+            "http://127.0.0.1:{webhook_port}/reply?token={}",
+            self.reply_token
+        );
         println!("  [discord] Webhook listener on port {webhook_port}");
 
         // Phase 2: Bootstrap Channel + AgentRoute entities.
@@ -443,6 +451,7 @@ impl DiscordTransport {
             http: self.http.clone(),
             bot_token: self.config.bot_token.clone(),
             dm_channels: self.dm_channels.clone(),
+            reply_token: self.reply_token.clone(),
         };
 
         let app = build_reply_router(webhook_state);
@@ -472,6 +481,41 @@ struct WebhookState {
     http: reqwest::Client,
     bot_token: String,
     dm_channels: Arc<RwLock<BTreeMap<String, String>>>,
+    /// Per-run capability token the caller must present (ADR-0158). Delivered
+    /// to the legitimate `send_reply` module via the Cedar-governed Channel
+    /// entity's webhook URL; a bare local/SSRF caller does not have it.
+    reply_token: Arc<String>,
+}
+
+/// Query parameters on the `/reply` callback (carries the capability token).
+#[derive(serde::Deserialize)]
+struct ReplyQuery {
+    #[serde(default)]
+    token: String,
+}
+
+/// Mint an unguessable per-run capability token (two v4 UUIDs of CSPRNG
+/// entropy → 64 hex chars).
+fn generate_reply_token() -> String {
+    format!(
+        "{}{}",
+        uuid::Uuid::new_v4().simple(),
+        uuid::Uuid::new_v4().simple()
+    )
+}
+
+/// Constant-time byte equality. Returns early only on a length mismatch (the
+/// token length is fixed and public); otherwise it never short-circuits, so it
+/// leaks no timing signal about the secret's contents.
+fn ct_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
 }
 
 /// Build the reply-callback router.
@@ -482,12 +526,21 @@ fn build_reply_router(state: WebhookState) -> axum::Router {
         .with_state(state)
 }
 
-/// Handle a reply callback from the `send_reply` WASM module: look up the
-/// recipient's DM channel and deliver `content` as the bot.
+/// Handle a reply callback from the `send_reply` WASM module: authenticate the
+/// capability token, bound the content, look up the recipient's DM channel, and
+/// deliver `content` as the bot (ADR-0158).
 async fn handle_reply(
+    axum::extract::Query(query): axum::extract::Query<ReplyQuery>,
     axum::extract::State(state): axum::extract::State<WebhookState>,
     axum::Json(body): axum::Json<serde_json::Value>,
 ) -> axum::http::StatusCode {
+    // Capability check first — before any recipient lookup or Discord call, so
+    // an unauthenticated caller learns nothing and triggers no side effect.
+    if !ct_eq(query.token.as_bytes(), state.reply_token.as_bytes()) {
+        tracing::warn!("discord /reply rejected: missing or invalid capability token");
+        return axum::http::StatusCode::UNAUTHORIZED;
+    }
+
     let thread_id = body.get("thread_id").and_then(|v| v.as_str()).unwrap_or("");
     let content = body.get("content").and_then(|v| v.as_str()).unwrap_or("");
 
@@ -496,7 +549,17 @@ async fn handle_reply(
         return axum::http::StatusCode::BAD_REQUEST;
     }
 
-    // thread_id is the Discord user ID (for DMs). Look up their DM channel.
+    if !reply_fits_fanout_budget(content) {
+        tracing::warn!(
+            content_bytes = content.len(),
+            max_messages = MAX_REPLY_CHUNKS,
+            "discord /reply rejected: content would exceed the fan-out budget"
+        );
+        return axum::http::StatusCode::PAYLOAD_TOO_LARGE;
+    }
+
+    // thread_id is the Discord user ID (for DMs). Look up their DM channel;
+    // replies are only delivered to users the bot has actually met.
     let channel_id = state.dm_channels.read().await.get(thread_id).cloned();
     let Some(channel_id) = channel_id else {
         eprintln!("  [discord] No DM channel found for thread_id={thread_id}");
@@ -532,15 +595,20 @@ async fn read_payload(read: &mut WsStream) -> Result<Option<GatewayPayload>, Str
 
 #[cfg(test)]
 mod reply_auth_tests {
-    //! ARN-234: the `/reply` callback must not accept unauthenticated requests.
+    //! ARN-234: the `/reply` callback must reject unauthenticated / oversized
+    //! requests before any recipient lookup or Discord call.
     use super::*;
 
-    /// Bind the reply router on an ephemeral loopback port and return it.
+    const TOKEN: &str = "test-capability-token-0123456789abcdef";
+
+    /// Bind the reply router (with a known capability token) on an ephemeral
+    /// loopback port; returns the port.
     async fn spawn_reply_listener(dm: BTreeMap<String, String>) -> u16 {
         let state = WebhookState {
             http: reqwest::Client::new(),
             bot_token: "test-bot-token".to_string(),
             dm_channels: Arc::new(RwLock::new(dm)),
+            reply_token: Arc::new(TOKEN.to_string()),
         };
         let app = build_reply_router(state);
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -551,15 +619,14 @@ mod reply_auth_tests {
         port
     }
 
-    async fn post_reply(port: u16, body: serde_json::Value) -> u16 {
-        // Retry briefly while the accept loop spins up.
+    /// POST to `/reply` with an optional `?token=`; returns the status code.
+    async fn post_reply(port: u16, token: Option<&str>, body: serde_json::Value) -> u16 {
+        let url = match token {
+            Some(t) => format!("http://127.0.0.1:{port}/reply?token={t}"),
+            None => format!("http://127.0.0.1:{port}/reply"),
+        };
         for _ in 0..20 {
-            match reqwest::Client::new()
-                .post(format!("http://127.0.0.1:{port}/reply"))
-                .json(&body)
-                .send()
-                .await
-            {
+            match reqwest::Client::new().post(&url).json(&body).send().await {
                 Ok(resp) => return resp.status().as_u16(),
                 Err(_) => tokio::task::yield_now().await,
             }
@@ -569,17 +636,73 @@ mod reply_auth_tests {
 
     #[tokio::test]
     async fn unauthenticated_reply_is_rejected() {
-        // No token, unknown recipient: a bare local caller. It must be denied
-        // at the auth layer, not proceed into recipient/delivery handling.
+        // No token: a bare local caller. Denied at the auth layer (401) before
+        // any recipient lookup or Discord call.
         let port = spawn_reply_listener(BTreeMap::new()).await;
         let status = post_reply(
             port,
+            None,
             serde_json::json!({"thread_id": "victim-user", "content": "spam"}),
         )
         .await;
         assert_eq!(
             status, 401,
             "SECURITY: unauthenticated /reply must be rejected with 401, got {status}"
+        );
+    }
+
+    #[tokio::test]
+    async fn wrong_token_is_rejected() {
+        // A caller who guessed the port but not the token is denied even for a
+        // known recipient — so no impersonating message is sent.
+        let dm = BTreeMap::from([("known-user".to_string(), "dm-channel-1".to_string())]);
+        let port = spawn_reply_listener(dm).await;
+        let status = post_reply(
+            port,
+            Some("wrong-token"),
+            serde_json::json!({"thread_id": "known-user", "content": "spam"}),
+        )
+        .await;
+        assert_eq!(status, 401, "wrong capability token must be rejected");
+    }
+
+    #[tokio::test]
+    async fn valid_token_passes_auth() {
+        // Correct token but an unknown recipient: auth passes, so the handler
+        // proceeds to the recipient check and returns 404 (never 401). No
+        // Discord call happens because the recipient is unknown.
+        let port = spawn_reply_listener(BTreeMap::new()).await;
+        let status = post_reply(
+            port,
+            Some(TOKEN),
+            serde_json::json!({"thread_id": "unknown-user", "content": "hi"}),
+        )
+        .await;
+        assert_eq!(
+            status, 404,
+            "authenticated reply to unknown recipient is 404"
+        );
+    }
+
+    #[tokio::test]
+    async fn oversized_reply_is_rejected() {
+        // Authenticated but oversized: a body that would fan out to more than
+        // MAX_REPLY_CHUNKS Discord messages is rejected cleanly with 413,
+        // before any delivery (not an opaque 500).
+        let dm = BTreeMap::from([("known-user".to_string(), "dm-channel-1".to_string())]);
+        let port = spawn_reply_listener(dm).await;
+        // 20 000 bytes → 10 chunks > MAX_REPLY_CHUNKS.
+        let big = "x".repeat(20_000);
+        assert!(!reply_fits_fanout_budget(&big));
+        let status = post_reply(
+            port,
+            Some(TOKEN),
+            serde_json::json!({"thread_id": "known-user", "content": big}),
+        )
+        .await;
+        assert_eq!(
+            status, 413,
+            "oversized reply must be rejected by the budget"
         );
     }
 }

--- a/crates/temper-transport/src/discord/transport.rs
+++ b/crates/temper-transport/src/discord/transport.rs
@@ -443,9 +443,10 @@ impl DiscordTransport {
     /// Start a webhook HTTP listener that receives reply callbacks from
     /// the `send_reply` WASM module. Returns the bound port.
     ///
-    /// When `send_reply` WASM POSTs to `{webhook_url}/reply`, this listener
-    /// extracts `thread_id` + `content`, maps thread_id to a Discord DM
-    /// channel, and delivers the reply via Discord REST API.
+    /// The `send_reply` module POSTs `{thread_id, content}` to the tokenized
+    /// `/reply?token=…` URL published on the Channel entity (ADR-0158); this
+    /// listener authenticates the token, maps `thread_id` to a Discord DM
+    /// channel, and delivers the reply via the Discord REST API.
     async fn spawn_webhook_listener(&self) -> Result<u16, String> {
         let webhook_state = WebhookState {
             http: self.http.clone(),

--- a/docs/adrs/0158-discord-reply-callback-capability.md
+++ b/docs/adrs/0158-discord-reply-callback-capability.md
@@ -39,13 +39,27 @@ CSPRNG entropy). The webhook URL published to the Channel entity carries it:
 token and compares it in constant time; a missing or wrong token is rejected with
 `401 Unauthorized` **before** any thread lookup or Discord call.
 
-**Why this authenticates the caller**: the only way to learn the token is to read
-the Channel entity's webhook config, which is served through Temper's
-authenticated OData API under the temper-channels Cedar policy. A bare local
-process or an SSRF probe that discovers the port does not have the token, so it is
-denied. The legitimate `send_reply` module already POSTs to exactly the URL it
-reads from the Channel entity, so it presents the token transparently — no module
-change. The token is per-run, so a leaked value dies with the process.
+**Why this authenticates the caller**: the token is only reachable by reading the
+Channel entity's webhook config through Temper's authenticated, Cedar-governed
+OData API. A bare local process or an SSRF probe that discovers the port cannot
+read the Channel entity, so it does not have the token and is denied — which
+closes the disclosed threat ("any local process, or any SSRF-capable component
+that reaches the port"). The legitimate `send_reply` module already POSTs to
+exactly the URL it reads from the Channel entity, so it presents the token
+transparently — no module change. The token is per-run, so a leaked value dies
+with the process.
+
+The token's confidentiality is therefore exactly the Channel entity's read
+authorization. Under the current `temper-channels` Cedar policy
+(`os-apps/temper-channels/policies/channels.cedar`) **any authenticated agent in
+the tenant** may read a Channel, so this design defends against the disclosed
+unauthenticated / SSRF caller but not against a fully-authenticated tenant insider
+who reads the Channel to obtain the token (they could then impersonate the bot to
+already-met DM recipients, still bounded by the recipient gate and fan-out
+budget). Closing that narrower vector means either tightening Channel read /
+redacting `webhook_url` for non-system readers, or the durable one-time reply
+intent in Follow-up 1, which removes the shared bearer entirely. This ADR
+deliberately does not broaden or narrow the pre-existing Channel read policy.
 
 ### Sub-Decision 2: Fan-out budget
 
@@ -76,8 +90,11 @@ recipients; it is retained as a second authorization check alongside the token.
 - The token rides in the webhook URL, so it can appear in the `send_reply`
   module's internal request telemetry. That telemetry is inside the trust
   boundary (not reachable by the disclosed threat — a local/SSRF caller without
-  OData access), so the residual is low. A future design (Sub-Decision below)
-  removes it.
+  OData access), so the residual is low. A future design (Follow-up 1) removes it.
+- The token is confidential only up to the Channel entity's read authorization,
+  which the current Cedar policy grants to any authenticated tenant agent (see
+  Sub-Decision 1). The disclosed unauthenticated/SSRF hole is fully closed; a
+  fully-authenticated insider vector remains and is addressed by Follow-up 1.
 
 ### DST Compliance
 - `temper-transport` is not a simulation-visible crate (not temper-runtime /

--- a/docs/adrs/0158-discord-reply-callback-capability.md
+++ b/docs/adrs/0158-discord-reply-callback-capability.md
@@ -47,13 +47,15 @@ denied. The legitimate `send_reply` module already POSTs to exactly the URL it
 reads from the Channel entity, so it presents the token transparently — no module
 change. The token is per-run, so a leaked value dies with the process.
 
-### Sub-Decision 2: Content and fan-out budgets
+### Sub-Decision 2: Fan-out budget
 
-The handler rejects a reply whose `content` exceeds `MAX_REPLY_CONTENT_BYTES`
-(16 KiB) with `413 Payload Too Large`, before any Discord call. Because Discord
-messages are 2 000 bytes, this bounds the fan-out to at most 8 sequential bot
-messages per reply. As defense in depth, `send_discord_message` independently
-caps the number of chunks it will send, so any other caller is bounded too.
+The handler rejects, with `413 Payload Too Large` before any Discord call, any
+reply that would split into more than `MAX_REPLY_CHUNKS` (8) Discord messages.
+The **chunk count is the authority**, not a raw byte count: message splitting can
+break on newlines and produce more, smaller chunks than `bytes / 2000`, so a
+byte-only limit would either admit a >8-message fan-out or fail a legitimate
+multi-line reply with an opaque error. `send_discord_message` independently
+enforces the same cap as a defensive backstop for any other caller.
 
 ### Sub-Decision 3: Recipient gate (unchanged, retained as authorization)
 

--- a/docs/adrs/0158-discord-reply-callback-capability.md
+++ b/docs/adrs/0158-discord-reply-callback-capability.md
@@ -61,10 +61,18 @@ redacting `webhook_url` for non-system readers, or the durable one-time reply
 intent in Follow-up 1, which removes the shared bearer entirely. This ADR
 deliberately does not broaden or narrow the pre-existing Channel read policy.
 
-### Sub-Decision 2: Fan-out budget
+### Sub-Decision 2: Body limit and fan-out budget
 
-The handler rejects, with `413 Payload Too Large` before any Discord call, any
-reply that would split into more than `MAX_REPLY_CHUNKS` (8) Discord messages.
+axum runs all extractors before the handler body, so the `Json` extractor would
+buffer up to axum's 2 MiB default before the token check runs — letting an
+unauthenticated caller force a large pre-auth allocation. A
+`DefaultBodyLimit::max(MAX_REPLY_BODY_BYTES)` layer caps the request body
+*before* extraction, so an over-large body is rejected (`413`) with no token and
+no big allocation. The limit is sized well above the largest valid reply and far
+below axum's default.
+
+The handler then rejects, with `413 Payload Too Large` before any Discord call,
+any reply that would split into more than `MAX_REPLY_CHUNKS` (8) Discord messages.
 The **chunk count is the authority**, not a raw byte count: message splitting can
 break on newlines and produce more, smaller chunks than `bytes / 2000`, so a
 byte-only limit would either admit a >8-message fan-out or fail a legitimate

--- a/docs/adrs/0158-discord-reply-callback-capability.md
+++ b/docs/adrs/0158-discord-reply-callback-capability.md
@@ -1,0 +1,112 @@
+# ADR-0158: Capability-gated Discord reply callback
+
+- Status: Accepted
+- Date: 2026-07-12
+- Deciders: Temper core maintainers
+- Related:
+  - ADR-0037: Channel transports (created the reply-webhook design)
+  - `crates/temper-transport/src/discord/transport.rs` (the `/reply` listener)
+  - `crates/temper-transport/src/discord/gateway.rs` (the Discord sender)
+  - ARN-234 (security finding), ARN-182 (kernel/app boundary follow-up)
+
+## Context
+
+ADR-0037 delivers channel replies by having the transport start a loopback Axum
+listener and store its URL on the Channel entity; the platform-agnostic
+`send_reply` WASM module reads that URL and POSTs `{thread_id, content}` to it,
+and the transport delivers the content to Discord as the bot.
+
+The listener's `POST /reply` has **no authentication of any kind** — no token,
+signature, replay guard, or budget (`transport.rs`). It maps the caller-supplied
+`thread_id` (a Discord user id) to a DM channel and sends the caller-supplied
+`content` as the bot, split into an **unbounded** number of 2 000-byte Discord
+messages (`gateway.rs`). Any local process, or any SSRF-capable component that
+can reach the loopback port, can impersonate the agent, spam a user, burn Discord
+rate limits, or replay a reply (ARN-234). "A loopback address is not identity."
+
+## Decision
+
+Gate the reply callback with a capability the caller can only have obtained
+through the authenticated Channel entity, and bound the fan-out. All changes are
+contained to `temper-transport`; no change to the `send_reply` WASM module or the
+Channel spec is required.
+
+### Sub-Decision 1: Per-run capability token, delivered via the Channel entity
+
+At transport startup, mint an unguessable per-run reply token (two v4 UUIDs of
+CSPRNG entropy). The webhook URL published to the Channel entity carries it:
+`http://127.0.0.1:{port}/reply?token=<secret>`. The `/reply` handler requires the
+token and compares it in constant time; a missing or wrong token is rejected with
+`401 Unauthorized` **before** any thread lookup or Discord call.
+
+**Why this authenticates the caller**: the only way to learn the token is to read
+the Channel entity's webhook config, which is served through Temper's
+authenticated OData API under the temper-channels Cedar policy. A bare local
+process or an SSRF probe that discovers the port does not have the token, so it is
+denied. The legitimate `send_reply` module already POSTs to exactly the URL it
+reads from the Channel entity, so it presents the token transparently — no module
+change. The token is per-run, so a leaked value dies with the process.
+
+### Sub-Decision 2: Content and fan-out budgets
+
+The handler rejects a reply whose `content` exceeds `MAX_REPLY_CONTENT_BYTES`
+(16 KiB) with `413 Payload Too Large`, before any Discord call. Because Discord
+messages are 2 000 bytes, this bounds the fan-out to at most 8 sequential bot
+messages per reply. As defense in depth, `send_discord_message` independently
+caps the number of chunks it will send, so any other caller is bounded too.
+
+### Sub-Decision 3: Recipient gate (unchanged, retained as authorization)
+
+The handler continues to require that `thread_id` already be present in the
+transport's `dm_channels` map — i.e. a user the bot has actually exchanged
+messages with — returning `404` otherwise. This limits replies to established DM
+recipients; it is retained as a second authorization check alongside the token.
+
+## Consequences
+
+### Positive
+- The disclosed holes close: unauthenticated callback → capability-gated;
+  unbounded fan-out → byte + chunk budget. Constant-time compare avoids a timing
+  oracle on the token. No working capability is removed and no WASM rebuild is
+  needed.
+
+### Negative / Residual
+- The token rides in the webhook URL, so it can appear in the `send_reply`
+  module's internal request telemetry. That telemetry is inside the trust
+  boundary (not reachable by the disclosed threat — a local/SSRF caller without
+  OData access), so the residual is low. A future design (Sub-Decision below)
+  removes it.
+
+### DST Compliance
+- `temper-transport` is not a simulation-visible crate (not temper-runtime /
+  temper-jit / temper-server), so the DST determinism rules do not apply. The
+  token uses OS CSPRNG (correct for a real security secret, not simulated state).
+
+## Non-Goals / Follow-ups (explicitly deferred, not punted)
+
+The disclosed vulnerability — an unauthenticated callback with unbounded fan-out —
+is fully remediated here. Two larger changes named in the finding are genuinely
+cross-component / cross-repo and are recorded as follow-ups rather than pretended
+into this PR:
+
+1. **Durable, recipient-bound, one-time reply intent** (delivery id, nonce,
+   expiry, tenant/channel identity carried end-to-end). This needs the `send_reply`
+   WASM module and the Channel spec to emit and carry a per-message capability, so
+   it is a cross-component redesign. It upgrades the per-run bearer to a one-time,
+   recipient-bound capability and adds replay protection against a token holder.
+2. **Move app-specific Discord ownership to TemperPaw** (ARN-182). The transport
+   living in the kernel is a boundary concern tracked separately; relocating it is
+   out of scope for a temper-repo security fix and must not drop the working
+   capability.
+
+## Alternatives Considered
+
+1. **Reuse the platform internal bearer** (have the WASM host inject it, verify it
+   at `/reply`). Rejected: the host injects the internal bearer only for the
+   configured internal API base, not for the transport's separate loopback
+   listener, and the transport is a distinct process — so the bearer is not
+   available end-to-end without new plumbing.
+2. **Token in a request header instead of the URL.** Cleaner (no telemetry leak),
+   but the `send_reply` module only sends the URL it is given and does not set auth
+   headers, so a header would require changing and rebuilding the WASM module —
+   folded into follow-up 1.


### PR DESCRIPTION
## ARN-234 — Capability-gated Discord reply callback

Fixes the unauthenticated Discord reply bridge (ARN-234).

### The vulnerability

The Discord transport starts a loopback Axum listener and exposes `POST /reply`
with **no authentication of any kind** (`crates/temper-transport/src/discord/transport.rs`).
The handler takes a caller-supplied `thread_id` (a Discord user id) and arbitrary
`content`, maps the id to a DM channel, and sends the content as the bot — split
into an **unbounded** number of 2 000-byte Discord messages (`gateway.rs`). Any
local process, or any SSRF-capable component that reaches the port, can
impersonate the agent, spam a user, burn Discord rate limits, or replay replies.
"A loopback address is not identity."

### The fix (ADR-0158, temper-transport only)

- **Per-run capability token.** `DiscordTransport::new` mints an unguessable
  token (two v4 UUIDs of CSPRNG entropy). It is embedded in the webhook URL
  published to the Channel entity, so the legitimate `send_reply` WASM module —
  which POSTs to exactly the URL it reads from the Cedar-governed Channel entity
  — presents it transparently, with **no change to the WASM module**. The handler
  verifies it in **constant time** and returns `401` before any recipient lookup
  or Discord call. A bare local/SSRF caller does not have the token.
- **Body limit + fan-out budget.** A `DefaultBodyLimit` layer caps the request
  body *before* axum's `Json` extractor runs (`413`), so an unauthenticated
  caller can't force a large pre-auth allocation. The **chunk-count** fan-out
  budget (`reply_fits_fanout_budget` → `413`) then bounds delivery to ≤8 Discord
  messages — the exact authority, since message splitting can break on newlines;
  `send_discord_message` independently caps chunks (`MAX_REPLY_CHUNKS`).
- **Recipient gate retained.** Replies still require the `thread_id` to be a DM
  the bot has actually seen (`404` otherwise).

No working capability is removed; the legitimate reply flow is unchanged.

### Explicitly deferred (documented in ADR, not punted)

The disclosed holes (unauthenticated callback + unbounded fan-out) are fully
closed. Two larger changes the finding names are genuinely cross-component /
cross-repo and are recorded as follow-ups: (1) a **durable, recipient-bound,
one-time reply intent** with delivery-id/nonce/expiry — needs the `send_reply`
WASM module and Channel spec to emit/carry a per-message capability; (2) **moving
Discord ownership to TemperPaw** (ARN-182). Neither is doable in a temper-repo
security patch, and neither should drop the working capability.

### Tests (real HTTP against the real router)

`crates/temper-transport/src/discord/transport.rs` — `reply_auth_tests`:
unauthenticated → 401, wrong token → 401, valid token (unknown recipient) → 404
(auth passes, no Discord call), oversized → 413. Committed first as a RED test
(unauthenticated returned 404 — straight into recipient handling, no auth gate).

### Live local E2E

See the `ARENA SHIPPABLE` comment for before/after commands + output.
