### PR TITLE
fix(spec): bound vector dims and identifiers at verification (ARN-217)

### DIFF
--- a/crates/temper-spec/src/automaton/parser.rs
+++ b/crates/temper-spec/src/automaton/parser.rs
@@ -712,6 +712,7 @@ fn validate_vector_decls(automaton: &Automaton) -> Result<(), AutomatonParseErro
             ("name", &vec_decl.name),
             ("property", &vec_decl.property),
             ("model_property", &vec_decl.model_property),
+            ("metric", &vec_decl.metric),
         ] {
             if ident.len() > MAX_VECTOR_IDENT_LEN {
                 return Err(AutomatonParseError::Validation(format!(

--- a/crates/temper-spec/src/automaton/parser.rs
+++ b/crates/temper-spec/src/automaton/parser.rs
@@ -660,7 +660,18 @@ fn validate(automaton: &Automaton) -> Result<(), AutomatonParseError> {
     Ok(())
 }
 
-/// Validate all `[[vector]]` access-path declarations per ADR-0155.
+/// Maximum vector dimensionality a `[[vector]]` may declare (ADR-0159). Query
+/// work and allocation are `rows × dims`; with the row count already bounded
+/// (ADR-0155), this bounds the dimensionality so a spec cannot force
+/// multi-gigabyte per-query work. Set well above any real embedding model
+/// (which top out in the low thousands) so no legitimate spec is rejected.
+const MAX_VECTOR_DIMS: usize = 16_384;
+
+/// Maximum length of a `[[vector]]` identifier (`name` / `property` /
+/// `model_property`), bounding pathological declarations (ADR-0159).
+const MAX_VECTOR_IDENT_LEN: usize = 256;
+
+/// Validate all `[[vector]]` access-path declarations per ADR-0155 / ADR-0159.
 fn validate_vector_decls(automaton: &Automaton) -> Result<(), AutomatonParseError> {
     const METRICS: [&str; 3] = ["cosine", "dot", "l2"];
     let state_var_names: std::collections::BTreeSet<&str> =
@@ -690,6 +701,25 @@ fn validate_vector_decls(automaton: &Automaton) -> Result<(), AutomatonParseErro
                 "vector path '{}' must declare dims > 0",
                 vec_decl.name
             )));
+        }
+        if vec_decl.dims > MAX_VECTOR_DIMS {
+            return Err(AutomatonParseError::Validation(format!(
+                "vector path '{}' declares dims {} which exceeds the maximum of {MAX_VECTOR_DIMS}",
+                vec_decl.name, vec_decl.dims
+            )));
+        }
+        for (label, ident) in [
+            ("name", &vec_decl.name),
+            ("property", &vec_decl.property),
+            ("model_property", &vec_decl.model_property),
+        ] {
+            if ident.len() > MAX_VECTOR_IDENT_LEN {
+                return Err(AutomatonParseError::Validation(format!(
+                    "vector path '{}' {label} length {} exceeds the maximum of {MAX_VECTOR_IDENT_LEN}",
+                    vec_decl.name,
+                    ident.len()
+                )));
+            }
         }
         if !METRICS.contains(&vec_decl.metric.as_str()) {
             return Err(AutomatonParseError::Validation(format!(

--- a/crates/temper-spec/src/automaton/parser_test.rs
+++ b/crates/temper-spec/src/automaton/parser_test.rs
@@ -233,6 +233,34 @@ to = "Published"
     }
 
     #[test]
+    fn accepts_dims_at_the_maximum() {
+        // The cap itself is a valid dimensionality — no legitimate spec at or
+        // below the maximum is rejected.
+        let max = super::super::MAX_VECTOR_DIMS;
+        let spec = format!(
+            "{BASE_SPEC}\n[[vector]]\nname = \"taste\"\nproperty = \"taste_vector\"\nmodel_property = \"taste_vector_model\"\ndims = {max}\nmetric = \"cosine\"\n"
+        );
+        parse_automaton(&spec).expect("dims at the maximum must be accepted");
+    }
+
+    #[test]
+    fn rejects_oversized_identifier() {
+        // `name` is the field the length bound truly guards: an over-long
+        // `property`/`model_property` would first fail the "undeclared state
+        // variable" check (no state var has that name), so the identifier bound
+        // is exercised here through `name`.
+        let long_name = "v".repeat(super::super::MAX_VECTOR_IDENT_LEN + 1);
+        let spec = format!(
+            "{BASE_SPEC}\n[[vector]]\nname = \"{long_name}\"\nproperty = \"taste_vector\"\nmodel_property = \"taste_vector_model\"\ndims = 384\nmetric = \"cosine\"\n"
+        );
+        let err = parse_automaton(&spec).expect_err("oversized identifier must reject");
+        assert!(
+            err.to_string().contains("exceeds the maximum"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
     fn rejects_unknown_metric() {
         let spec = format!(
             "{BASE_SPEC}\n[[vector]]\nname = \"taste\"\nproperty = \"taste_vector\"\nmodel_property = \"taste_vector_model\"\ndims = 384\nmetric = \"manhattan\"\n"

--- a/crates/temper-spec/src/automaton/parser_test.rs
+++ b/crates/temper-spec/src/automaton/parser_test.rs
@@ -261,6 +261,23 @@ to = "Published"
     }
 
     #[test]
+    fn rejects_oversized_property_via_declared_long_state_var() {
+        // Exercises the `property` length branch directly: a state variable
+        // whose name exceeds the bound passes the existence check, so the length
+        // bound is what rejects it. Guards against a future refactor moving the
+        // existence check before the length check without a failing test.
+        let long = "p".repeat(super::super::MAX_VECTOR_IDENT_LEN + 1);
+        let spec = format!(
+            "{BASE_SPEC}\n[[state]]\nname = \"{long}\"\ntype = \"string\"\ninitial = \"\"\n[[vector]]\nname = \"taste\"\nproperty = \"{long}\"\nmodel_property = \"taste_vector_model\"\ndims = 384\nmetric = \"cosine\"\n"
+        );
+        let err = parse_automaton(&spec).expect_err("oversized property must reject");
+        assert!(
+            err.to_string().contains("exceeds the maximum"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
     fn rejects_unknown_metric() {
         let spec = format!(
             "{BASE_SPEC}\n[[vector]]\nname = \"taste\"\nproperty = \"taste_vector\"\nmodel_property = \"taste_vector_model\"\ndims = 384\nmetric = \"manhattan\"\n"

--- a/crates/temper-spec/src/automaton/parser_test.rs
+++ b/crates/temper-spec/src/automaton/parser_test.rs
@@ -218,6 +218,21 @@ to = "Published"
     }
 
     #[test]
+    fn rejects_oversized_dims() {
+        // ARN-217: an unbounded `dims` lets a spec force multi-gigabyte
+        // allocation and dot-product work per query (dims × candidate rows).
+        // Verification must reject a dimensionality above the resource cap.
+        let spec = format!(
+            "{BASE_SPEC}\n[[vector]]\nname = \"taste\"\nproperty = \"taste_vector\"\nmodel_property = \"taste_vector_model\"\ndims = 100000000\nmetric = \"cosine\"\n"
+        );
+        let err = parse_automaton(&spec).expect_err("oversized dims must reject");
+        assert!(
+            err.to_string().contains("exceeds the maximum"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
     fn rejects_unknown_metric() {
         let spec = format!(
             "{BASE_SPEC}\n[[vector]]\nname = \"taste\"\nproperty = \"taste_vector\"\nmodel_property = \"taste_vector_model\"\ndims = 384\nmetric = \"manhattan\"\n"

--- a/docs/adrs/0159-vector-resource-bounds.md
+++ b/docs/adrs/0159-vector-resource-bounds.md
@@ -33,34 +33,54 @@ set well above any real embedding model (which top out in the low thousands) so
 no legitimate spec is rejected, while bounding a single vector blob to a small,
 fixed size.
 
-### Sub-Decision 2: Explicit aggregate query budget (defense in depth)
+### Sub-Decision 2: Per-query work is bounded by two explicit caps
 
-The kNN query path additionally rejects a request whose total work
-`candidate_count × dims` would exceed `MAX_QUERY_VECTOR_ELEMENTS`, with a
-structured `PAYLOAD_TOO_LARGE` error rather than silently proceeding. This bounds
-per-query bytes/operations directly (the finding's "budgets consumed by
-operations/bytes"), independent of how the row and dim caps are configured.
+With `dims` bounded at verification and the row count already bounded by ADR-0155's
+`candidate_budget`, the query's bytes and dot-product operations are bounded by
+construction: `work ≤ candidate_budget × MAX_VECTOR_DIMS`, both explicit
+constants. This also bounds the blobs materialized before the row-count check —
+each candidate blob is now at most `MAX_VECTOR_DIMS × 4` bytes — so the "stores
+materialize each full blob before the count is checked" concern is closed without
+changing the query path. A separate per-query element budget was considered but
+rejected (below) as redundant and risk-prone to size.
 
 ## Consequences
 
 ### Positive
 - A spec can no longer declare an unbounded-dimensionality vector; query work is
-  bounded by construction (`rows ≤ candidate_budget`, `dims ≤ MAX_VECTOR_DIMS`),
-  and the explicit aggregate budget backstops the product.
-- Enforced once at verification + once on the shared query path — every backend
-  is covered without per-backend changes.
+  bounded by construction — `rows ≤ candidate_budget` (ADR-0155) and
+  `dims ≤ MAX_VECTOR_DIMS` — so `rows × dims`, and each pre-check blob
+  (`≤ MAX_VECTOR_DIMS × 4` bytes), are bounded.
+- Enforced once, at verification. `dims` is a spec property, so every storage
+  backend inherits the bound with no per-backend or query-path change.
 
 ### Negative
 - A (hypothetical) future embedding model above `MAX_VECTOR_DIMS` would need the
   constant raised. The cap is chosen with generous headroom to make that remote.
 
 ### DST Compliance
-- The verification change is in `temper-spec` (not simulation-visible). The query
-  budget in `temper-server` compares integers and returns a structured error —
-  no wall clock, threads, `HashMap`, or ambient I/O.
+- The only change is in `temper-spec` (not simulation-visible): integer
+  comparisons and length checks in `validate_vector_decls`, no wall clock,
+  threads, `HashMap`, or ambient I/O. No `temper-server`/`temper-runtime` code is
+  touched, so there is nothing new on the simulation-visible query path.
 
 ## Non-Goals
 
 - The existing row/candidate budget (ADR-0155) and the existing non-finite-value
   rejection in `unpack_f32_le` are unchanged; this ADR adds the missing
-  dimensionality and aggregate bounds on top of them.
+  dimensionality and identifier bounds on top of them.
+- Bounding the *runtime* model-tag length (the `model` query argument / the
+  reference entity's `model_property` value, used as a partition filter in
+  `nearest.rs`) is a separate concern: its cost is O(len) per candidate string
+  comparison, bounded by `candidate_budget`, not the `rows × dims` allocation
+  ARN-217 targets. Bounding runtime state-variable content is a broader question
+  and is left as a follow-up.
+
+## Alternatives Considered
+
+1. **A separate per-query `candidate_count × dims` element budget on the query
+   path.** Rejected: the product is already bounded by the two caps above, so the
+   check is redundant; and sizing its constant without wrongly rejecting a
+   legitimate kNN query depends on the deployment's `candidate_budget`, so a fixed
+   value risks either being ineffective or breaking real queries. The two
+   explicit caps are the honest, safe bound.

--- a/docs/adrs/0159-vector-resource-bounds.md
+++ b/docs/adrs/0159-vector-resource-bounds.md
@@ -1,0 +1,66 @@
+# ADR-0159: Vector declaration and query resource bounds
+
+- Status: Accepted
+- Date: 2026-07-12
+- Deciders: Temper core maintainers
+- Related:
+  - ADR-0155: Declared vector access path (added the row/candidate budget)
+  - `crates/temper-spec/src/automaton/parser.rs` (`validate_vector_decls`)
+  - `crates/temper-server/src/odata/nearest.rs` (kNN query path)
+  - `crates/temper-runtime/src/persistence/mod.rs` (`unpack_f32_le`)
+  - ARN-217 (security finding)
+
+## Context
+
+ADR-0155 caps the *row* count a `Temper.Nearest` scan will materialize
+(`candidate_budget`), and the shared `unpack_f32_le` already rejects non-finite
+vector values. But `VectorDecl.dims` has **no upper bound** — a spec may declare
+a vector path with, e.g., `dims = 100_000_000`, which the verification cascade
+accepts today (ARN-217). Query work and allocation are `rows × dims`: with the
+row count bounded but the dimensionality unbounded, a single spec can still force
+multi-gigabyte allocation and dot-product work per query (400 MB per 100 M-dim
+vector blob). Identifier lengths on the declaration are likewise unbounded.
+
+## Decision
+
+### Sub-Decision 1: Bound the declaration at verification (fail-closed)
+
+`validate_vector_decls` rejects any `[[vector]]` whose `dims` exceeds
+`MAX_VECTOR_DIMS`, and whose `name` / `property` / `model_property` identifiers
+exceed `MAX_VECTOR_IDENT_LEN`. `dims` is a spec property enforced once, so every
+storage backend inherits the bound with no per-backend code. `MAX_VECTOR_DIMS` is
+set well above any real embedding model (which top out in the low thousands) so
+no legitimate spec is rejected, while bounding a single vector blob to a small,
+fixed size.
+
+### Sub-Decision 2: Explicit aggregate query budget (defense in depth)
+
+The kNN query path additionally rejects a request whose total work
+`candidate_count × dims` would exceed `MAX_QUERY_VECTOR_ELEMENTS`, with a
+structured `PAYLOAD_TOO_LARGE` error rather than silently proceeding. This bounds
+per-query bytes/operations directly (the finding's "budgets consumed by
+operations/bytes"), independent of how the row and dim caps are configured.
+
+## Consequences
+
+### Positive
+- A spec can no longer declare an unbounded-dimensionality vector; query work is
+  bounded by construction (`rows ≤ candidate_budget`, `dims ≤ MAX_VECTOR_DIMS`),
+  and the explicit aggregate budget backstops the product.
+- Enforced once at verification + once on the shared query path — every backend
+  is covered without per-backend changes.
+
+### Negative
+- A (hypothetical) future embedding model above `MAX_VECTOR_DIMS` would need the
+  constant raised. The cap is chosen with generous headroom to make that remote.
+
+### DST Compliance
+- The verification change is in `temper-spec` (not simulation-visible). The query
+  budget in `temper-server` compares integers and returns a structured error —
+  no wall clock, threads, `HashMap`, or ambient I/O.
+
+## Non-Goals
+
+- The existing row/candidate budget (ADR-0155) and the existing non-finite-value
+  rejection in `unpack_f32_le` are unchanged; this ADR adds the missing
+  dimensionality and aggregate bounds on top of them.

--- a/docs/adrs/0159-vector-resource-bounds.md
+++ b/docs/adrs/0159-vector-resource-bounds.md
@@ -39,9 +39,11 @@ With `dims` bounded at verification and the row count already bounded by ADR-015
 `candidate_budget`, the query's bytes and dot-product operations are bounded by
 construction: `work ≤ candidate_budget × MAX_VECTOR_DIMS`, both explicit
 constants. This also bounds the blobs materialized before the row-count check —
-each candidate blob is now at most `MAX_VECTOR_DIMS × 4` bytes — so the "stores
-materialize each full blob before the count is checked" concern is closed without
-changing the query path. A separate per-query element budget was considered but
+each candidate blob is at most `MAX_VECTOR_DIMS × 4` bytes, because the write path
+only ever indexes an exactly-`dims`-length vector (`parse_vector_property(v, dims)`
+rejects any other length in `crates/temper-server/src/vector_index.rs`) — so the
+"stores materialize each full blob before the count is checked" concern is closed
+without changing the query path. A separate per-query element budget was considered but
 rejected (below) as redundant and risk-prone to size.
 
 ## Consequences


### PR DESCRIPTION
## ARN-217 — Vector declaration resource bounds

Fixes the unbounded vector dimensionality in ARN-217.

### The vulnerability

`VectorDecl.dims` had **no upper bound** (`crates/temper-spec/.../types.rs` —
`pub dims: usize`; `validate_vector_decls` only checked `dims > 0`). A spec could
declare `[[vector]] … dims = 100_000_000`, which the verification cascade
accepted. Query work and allocation are `rows × dims`: the row count was already
bounded (ADR-0155's `candidate_budget`) and `unpack_f32_le` already rejects
non-finite values, but with the dimensionality unbounded a single spec could
still force multi-gigabyte per-query allocation and dot-product work (400 MB per
100 M-dim vector blob), and the candidate scan materializes each blob before the
row-count check.

### The fix (ADR-0159, verification-only)

`validate_vector_decls` now rejects, at spec verification (fail-closed):
- `dims > MAX_VECTOR_DIMS` (16 384 — well above any real embedding model, which
  top out in the low thousands, so no legitimate spec is rejected);
- `name` / `property` / `model_property` identifiers longer than
  `MAX_VECTOR_IDENT_LEN` (256).

`dims` is a spec property enforced **once**, so every storage backend inherits
the bound with no per-backend code. Per-query work is then bounded by
construction — `work ≤ candidate_budget × MAX_VECTOR_DIMS`, two explicit
constants — and each pre-check blob is now at most `MAX_VECTOR_DIMS × 4` bytes,
closing the "materialize before the count check" concern without touching the
query path.

A separate per-query `candidate_count × dims` element budget was considered and
rejected (see ADR): it is redundant given the two caps, and sizing its constant
without wrongly rejecting a legitimate kNN query depends on the deployment's
`candidate_budget`.

### Tests

`crates/temper-spec/src/automaton/parser_test.rs` (`vector_validation`):
`rejects_oversized_dims` (100 M dims → rejected), `accepts_dims_at_the_maximum`
(the cap itself verifies — no legit spec rejected), `rejects_oversized_identifier`.
Committed first as a RED test (100 M-dim spec verified successfully).

### Live local E2E

See the `ARENA SHIPPABLE` comment for before/after.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes ARN-217 by adding two upper bounds in `validate_vector_decls`: `dims > MAX_VECTOR_DIMS` (16 384) and identifier length `> MAX_VECTOR_IDENT_LEN` (256) for the `name`, `property`, and `model_property` fields of every `[[vector]]` declaration. Combined with ADR-0155's `candidate_budget`, query work is now bounded by construction (`rows × dims` with both sides capped).

- **`parser.rs`**: two new module-level constants with doc comments, two new rejection branches inserted between the `dims == 0` guard and the `METRICS` check, following the existing `validate_vector_decls` ordering.
- **`parser_test.rs`**: three tests added to `vector_validation` — rejection at 100 M dims, acceptance at the boundary value (referencing the constant directly), and rejection when `name` exceeds 256 chars.
- **`docs/adrs/0159-vector-resource-bounds.md`**: ADR documenting the decision, consequences, DST compliance rationale, and the rejected per-query element-budget alternative.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change touches only `validate_vector_decls` in `temper-spec` — no runtime, query, or simulation-visible path is modified. Both new checks are pure integer and string-length comparisons that short-circuit with an error; the happy path is unchanged.

The core fix is sound: the two constants are well-chosen, the checks are in the right place, and the ADR thoroughly documents the tradeoffs. Two things keep this short of fully clean: the `metric` field is absent from the identifier-length loop, and the `property`/`model_property` branches of the length check have no direct test.

`parser.rs` (lines 711–723 — the identifier-length loop missing `metric`) and `parser_test.rs` (no test for over-long `property`/`model_property` via a state variable with a long name).
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/temper-spec/src/automaton/parser.rs | Adds `MAX_VECTOR_DIMS` (16 384) and `MAX_VECTOR_IDENT_LEN` (256) constants plus enforcement in `validate_vector_decls`; the `metric` field is not covered by the new identifier-length loop, and the `name` length check fires after `name` has already been embedded in earlier error messages. |
| crates/temper-spec/src/automaton/parser_test.rs | Three new tests covering over-size dims, boundary acceptance, and over-long name; `property`/`model_property` identifier bounds are not directly exercised by any test. |
| docs/adrs/0159-vector-resource-bounds.md | Well-structured ADR documenting the rationale, decision, consequences, DST compliance note, and rejected alternatives for the vector resource bounds fix. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Spec submission] --> B[TOML parse]
    B --> C[validate_vector_decls loop]
    C --> D{Duplicate name?}
    D -- yes --> ERR1[Reject: declared twice]
    D -- no --> E{property in state vars?}
    E -- no --> ERR2[Reject: undeclared property]
    E -- yes --> F{model_property in state vars?}
    F -- no --> ERR3[Reject: undeclared model_property]
    F -- yes --> G{dims == 0?}
    G -- yes --> ERR4[Reject: dims must be > 0]
    G -- no --> H{dims > MAX_VECTOR_DIMS 16 384?}
    H -- yes --> ERR5[Reject: dims exceeds maximum NEW]
    H -- no --> I{any identifier len > MAX_VECTOR_IDENT_LEN 256?}
    I -- yes --> ERR6[Reject: identifier exceeds maximum NEW]
    I -- no --> J{metric in cosine dot l2?}
    J -- no --> ERR7[Reject: unknown metric]
    J -- yes --> K{More vector decls?}
    K -- yes --> C
    K -- no --> OK[Spec accepted]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Spec submission] --> B[TOML parse]
    B --> C[validate_vector_decls loop]
    C --> D{Duplicate name?}
    D -- yes --> ERR1[Reject: declared twice]
    D -- no --> E{property in state vars?}
    E -- no --> ERR2[Reject: undeclared property]
    E -- yes --> F{model_property in state vars?}
    F -- no --> ERR3[Reject: undeclared model_property]
    F -- yes --> G{dims == 0?}
    G -- yes --> ERR4[Reject: dims must be > 0]
    G -- no --> H{dims > MAX_VECTOR_DIMS 16 384?}
    H -- yes --> ERR5[Reject: dims exceeds maximum NEW]
    H -- no --> I{any identifier len > MAX_VECTOR_IDENT_LEN 256?}
    I -- yes --> ERR6[Reject: identifier exceeds maximum NEW]
    I -- no --> J{metric in cosine dot l2?}
    J -- no --> ERR7[Reject: unknown metric]
    J -- yes --> K{More vector decls?}
    K -- yes --> C
    K -- no --> OK[Spec accepted]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftemper-spec%2Fsrc%2Fautomaton%2Fparser.rs%3A711-715%0AThe%20%60metric%60%20field%20is%20absent%20from%20the%20identifier-length%20loop%2C%20so%20a%20pathological%20metric%20string%20%28e.g.%2C%20a%201%20MB%20value%29%20passes%20through%20the%20new%20bounds%20check%20unimpeded%20and%20ends%20up%20verbatim%20in%20the%20error%20message%20at%20the%20subsequent%20%60METRICS.contains%60%20check.%20While%20%60metric%60%20is%20constrained%20to%20exactly%20three%20valid%20values%20at%20that%20step%2C%20adding%20it%20here%20keeps%20the%20bounds%20logic%20self-contained%20and%20consistent%20with%20the%20stated%20goal%20of%20bounding%20all%20%60%5B%5Bvector%5D%5D%60%20identifiers.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20for%20%28label%2C%20ident%29%20in%20%5B%0A%20%20%20%20%20%20%20%20%20%20%20%20%28%22name%22%2C%20%26vec_decl.name%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%28%22property%22%2C%20%26vec_decl.property%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%28%22model_property%22%2C%20%26vec_decl.model_property%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%28%22metric%22%2C%20%26vec_decl.metric%29%2C%0A%20%20%20%20%20%20%20%20%5D%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftemper-spec%2Fsrc%2Fautomaton%2Fparser_test.rs%3A246-261%0A**Identifier%20bounds%20for%20%60property%60%2F%60model_property%60%20are%20untested.**%20The%20comment%20correctly%20explains%20that%20an%20over-long%20string%20that%20does%20not%20match%20any%20declared%20state%20variable%20is%20caught%20by%20the%20state-var%20existence%20check%20first.%20However%2C%20the%20check%20on%20lines%20716%E2%80%93722%20is%20also%20exercised%20when%20a%20state%20variable%20itself%20has%20a%20name%20longer%20than%20256%20chars%20and%20is%20then%20referenced%20by%20%60property%60%20or%20%60model_property%60.%20Adding%20a%20companion%20test%20that%20declares%20such%20a%20state%20variable%20and%20then%20references%20it%20covers%20this%20branch%20directly%2C%20preventing%20a%20future%20refactor%20from%20silently%20moving%20the%20existence%20check%20before%20the%20length%20check%20without%20a%20failing%20test%20to%20signal%20the%20regression.%0A%0A&repo=nerdsane%2Ftemper&pr=358&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22claude%2Farn-217-vector-bounds%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Farn-217-vector-bounds%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftemper-spec%2Fsrc%2Fautomaton%2Fparser.rs%3A711-715%0AThe%20%60metric%60%20field%20is%20absent%20from%20the%20identifier-length%20loop%2C%20so%20a%20pathological%20metric%20string%20%28e.g.%2C%20a%201%20MB%20value%29%20passes%20through%20the%20new%20bounds%20check%20unimpeded%20and%20ends%20up%20verbatim%20in%20the%20error%20message%20at%20the%20subsequent%20%60METRICS.contains%60%20check.%20While%20%60metric%60%20is%20constrained%20to%20exactly%20three%20valid%20values%20at%20that%20step%2C%20adding%20it%20here%20keeps%20the%20bounds%20logic%20self-contained%20and%20consistent%20with%20the%20stated%20goal%20of%20bounding%20all%20%60%5B%5Bvector%5D%5D%60%20identifiers.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20for%20%28label%2C%20ident%29%20in%20%5B%0A%20%20%20%20%20%20%20%20%20%20%20%20%28%22name%22%2C%20%26vec_decl.name%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%28%22property%22%2C%20%26vec_decl.property%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%28%22model_property%22%2C%20%26vec_decl.model_property%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%28%22metric%22%2C%20%26vec_decl.metric%29%2C%0A%20%20%20%20%20%20%20%20%5D%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftemper-spec%2Fsrc%2Fautomaton%2Fparser_test.rs%3A246-261%0A**Identifier%20bounds%20for%20%60property%60%2F%60model_property%60%20are%20untested.**%20The%20comment%20correctly%20explains%20that%20an%20over-long%20string%20that%20does%20not%20match%20any%20declared%20state%20variable%20is%20caught%20by%20the%20state-var%20existence%20check%20first.%20However%2C%20the%20check%20on%20lines%20716%E2%80%93722%20is%20also%20exercised%20when%20a%20state%20variable%20itself%20has%20a%20name%20longer%20than%20256%20chars%20and%20is%20then%20referenced%20by%20%60property%60%20or%20%60model_property%60.%20Adding%20a%20companion%20test%20that%20declares%20such%20a%20state%20variable%20and%20then%20references%20it%20covers%20this%20branch%20directly%2C%20preventing%20a%20future%20refactor%20from%20silently%20moving%20the%20existence%20check%20before%20the%20length%20check%20without%20a%20failing%20test%20to%20signal%20the%20regression.%0A%0A&repo=nerdsane%2Ftemper&pr=358&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftemper-spec%2Fsrc%2Fautomaton%2Fparser.rs%3A711-715%0AThe%20%60metric%60%20field%20is%20absent%20from%20the%20identifier-length%20loop%2C%20so%20a%20pathological%20metric%20string%20%28e.g.%2C%20a%201%20MB%20value%29%20passes%20through%20the%20new%20bounds%20check%20unimpeded%20and%20ends%20up%20verbatim%20in%20the%20error%20message%20at%20the%20subsequent%20%60METRICS.contains%60%20check.%20While%20%60metric%60%20is%20constrained%20to%20exactly%20three%20valid%20values%20at%20that%20step%2C%20adding%20it%20here%20keeps%20the%20bounds%20logic%20self-contained%20and%20consistent%20with%20the%20stated%20goal%20of%20bounding%20all%20%60%5B%5Bvector%5D%5D%60%20identifiers.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20for%20%28label%2C%20ident%29%20in%20%5B%0A%20%20%20%20%20%20%20%20%20%20%20%20%28%22name%22%2C%20%26vec_decl.name%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%28%22property%22%2C%20%26vec_decl.property%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%28%22model_property%22%2C%20%26vec_decl.model_property%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%28%22metric%22%2C%20%26vec_decl.metric%29%2C%0A%20%20%20%20%20%20%20%20%5D%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftemper-spec%2Fsrc%2Fautomaton%2Fparser_test.rs%3A246-261%0A**Identifier%20bounds%20for%20%60property%60%2F%60model_property%60%20are%20untested.**%20The%20comment%20correctly%20explains%20that%20an%20over-long%20string%20that%20does%20not%20match%20any%20declared%20state%20variable%20is%20caught%20by%20the%20state-var%20existence%20check%20first.%20However%2C%20the%20check%20on%20lines%20716%E2%80%93722%20is%20also%20exercised%20when%20a%20state%20variable%20itself%20has%20a%20name%20longer%20than%20256%20chars%20and%20is%20then%20referenced%20by%20%60property%60%20or%20%60model_property%60.%20Adding%20a%20companion%20test%20that%20declares%20such%20a%20state%20variable%20and%20then%20references%20it%20covers%20this%20branch%20directly%2C%20preventing%20a%20future%20refactor%20from%20silently%20moving%20the%20existence%20check%20before%20the%20length%20check%20without%20a%20failing%20test%20to%20signal%20the%20regression.%0A%0A&pr=358&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
crates/temper-spec/src/automaton/parser.rs:711-715
The `metric` field is absent from the identifier-length loop, so a pathological metric string (e.g., a 1 MB value) passes through the new bounds check unimpeded and ends up verbatim in the error message at the subsequent `METRICS.contains` check. While `metric` is constrained to exactly three valid values at that step, adding it here keeps the bounds logic self-contained and consistent with the stated goal of bounding all `[[vector]]` identifiers.

```suggestion
        for (label, ident) in [
            ("name", &vec_decl.name),
            ("property", &vec_decl.property),
            ("model_property", &vec_decl.model_property),
            ("metric", &vec_decl.metric),
        ] {
```

### Issue 2 of 2
crates/temper-spec/src/automaton/parser_test.rs:246-261
**Identifier bounds for `property`/`model_property` are untested.** The comment correctly explains that an over-long string that does not match any declared state variable is caught by the state-var existence check first. However, the check on lines 716–722 is also exercised when a state variable itself has a name longer than 256 chars and is then referenced by `property` or `model_property`. Adding a companion test that declares such a state variable and then references it covers this branch directly, preventing a future refactor from silently moving the existence check before the length check without a failing test to signal the regression.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(adr): cite the len==dims write-path..."](https://github.com/nerdsane/temper/commit/1536644664e23cff86662edd816c40e0c6341a8f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43611720)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->