### PR TITLE
fix(server): route HttpEndpoint WASM through governed host (ARN-208)

### DIFF
--- a/crates/temper-server/src/http_endpoint_host.rs
+++ b/crates/temper-server/src/http_endpoint_host.rs
@@ -21,6 +21,8 @@ const STRIPPED_INBOUND_HEADERS: &[&str] = &[
     "set-cookie",
     "x-api-key",
     "x-temper-api-key",
+    // Ambient session correlation is platform context, not guest input (ARN-208).
+    "x-session-id",
 ];
 
 /// True when an inbound header must be stripped before guest delivery.
@@ -141,6 +143,7 @@ mod tests {
             ("x-temper-agent-type".into(), "claude-code".into()),
             ("x-temper-agent-role".into(), "supervisor".into()),
             ("x-api-key".into(), "k".into()),
+            ("x-session-id".into(), "sess-should-not-reach-guest".into()),
             ("accept".into(), "*/*".into()),
         ];
         let safe = guest_safe_headers(&headers);
@@ -152,8 +155,10 @@ mod tests {
         assert!(!names.iter().any(|n| n.contains("api-key")));
         assert!(!names.iter().any(|n| n.contains("agent-type")));
         assert!(!names.iter().any(|n| n.contains("agent-role")));
+        assert!(!names.iter().any(|n| n == "x-session-id"));
         assert!(!safe.iter().any(|(_, v)| v.contains("secret-token")));
         assert!(!safe.iter().any(|(_, v)| v == "admin" || v == "evil"));
+        assert!(!safe.iter().any(|(_, v)| v.contains("sess-should-not")));
     }
 
     #[test]
@@ -166,6 +171,8 @@ mod tests {
         ));
         assert!(!is_sensitive_inbound_header("content-type"));
         assert!(!is_sensitive_inbound_header("x-temper-observe-session-id"));
+        assert!(is_sensitive_inbound_header("x-session-id"));
+        assert!(is_sensitive_inbound_header("X-Session-Id"));
     }
 
     #[test]

--- a/crates/temper-server/src/http_endpoint_host.rs
+++ b/crates/temper-server/src/http_endpoint_host.rs
@@ -1,4 +1,4 @@
-//! Governed WASM host construction for HttpEndpoint (ADR-0158 / ARN-208).
+//! Governed WASM host construction for HttpEndpoint (ADR-0161 / ARN-208).
 //!
 //! Ensures the inbound endpoint path uses the same authorization envelope as
 //! entity WASM dispatch: bootstrap secrets only, gated secret resolver, and
@@ -30,7 +30,7 @@ const STRIPPED_INBOUND_HEADERS: &[&str] = &[
 /// Exact denylist covers classic credential carriers. Prefix rules cover
 /// ambient platform identity (`x-temper-principal*`, `x-temper-agent-*`)
 /// so guests cannot inherit authority material from request headers
-/// (ADR-0158 / ARN-208).
+/// (ADR-0161 / ARN-208).
 pub fn is_sensitive_inbound_header(name: &str) -> bool {
     let lower = name.to_ascii_lowercase();
     if STRIPPED_INBOUND_HEADERS.contains(&lower.as_str()) {

--- a/crates/temper-server/src/http_endpoint_host.rs
+++ b/crates/temper-server/src/http_endpoint_host.rs
@@ -30,9 +30,7 @@ const STRIPPED_INBOUND_HEADERS: &[&str] = &[
 /// True when an inbound header must be stripped before guest delivery.
 pub fn is_sensitive_inbound_header(name: &str) -> bool {
     let lower = name.to_ascii_lowercase();
-    STRIPPED_INBOUND_HEADERS
-        .iter()
-        .any(|blocked| *blocked == lower.as_str())
+    STRIPPED_INBOUND_HEADERS.contains(&lower.as_str())
 }
 
 /// Filter inbound headers for guest `HttpDispatchContext` delivery.

--- a/crates/temper-server/src/http_endpoint_host.rs
+++ b/crates/temper-server/src/http_endpoint_host.rs
@@ -1,0 +1,169 @@
+//! Governed WASM host construction for HttpEndpoint (ADR-0158 / ARN-208).
+//!
+//! Ensures the inbound endpoint path uses the same authorization envelope as
+//! entity WASM dispatch: bootstrap secrets only, gated secret resolver, and
+//! `AuthorizedWasmHost` — never a raw production host with a full secret map.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use temper_runtime::tenant::TenantId;
+use temper_wasm::http_stream::HttpStreamRegistry;
+use temper_wasm::types::{WasmAuthzContext, WasmInvocationContext};
+use temper_wasm::{AuthorizedWasmHost, ProductionWasmHost, WasmHost};
+
+use crate::state::ServerState;
+
+/// Header names that must never be delivered to endpoint guests.
+const STRIPPED_INBOUND_HEADERS: &[&str] = &[
+    "authorization",
+    "proxy-authorization",
+    "cookie",
+    "set-cookie",
+    "x-api-key",
+    "x-temper-api-key",
+    "x-temper-principal-id",
+    "x-temper-principal-kind",
+    "x-temper-principal-scopes",
+];
+
+/// True when an inbound header must be stripped before guest delivery.
+pub fn is_sensitive_inbound_header(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    STRIPPED_INBOUND_HEADERS
+        .iter()
+        .any(|blocked| *blocked == lower.as_str())
+}
+
+/// Filter inbound headers for guest `HttpDispatchContext` delivery.
+pub fn guest_safe_headers(headers: &[(String, String)]) -> Vec<(String, String)> {
+    headers
+        .iter()
+        .filter(|(k, _)| !is_sensitive_inbound_header(k))
+        .cloned()
+        .collect()
+}
+
+/// Build the governed host used for an HttpEndpoint WASM invocation.
+pub fn build_httpendpoint_wasm_host(
+    state: &ServerState,
+    tenant: &TenantId,
+    module_name: &str,
+    streams: Arc<HttpStreamRegistry>,
+    invocation_ctx: WasmInvocationContext,
+) -> Arc<dyn WasmHost> {
+    let gate = state.wasm_authz_gate();
+    let authz_ctx = WasmAuthzContext {
+        tenant: tenant.as_str().to_string(),
+        module_name: module_name.to_string(),
+        agent_id: None,
+        session_id: None,
+        entity_type: "HttpEndpoint".to_string(),
+        trigger_action: "HandleHttp".to_string(),
+    };
+
+    // Bootstrap only — never clone the full tenant secret map (ARN-208).
+    let bootstrap_secrets =
+        state.get_authorized_wasm_host_bootstrap_secrets(tenant, &*gate, &authz_ctx);
+    let secret_resolver =
+        state.authorized_wasm_secret_resolver(tenant, Arc::clone(&gate), authz_ctx.clone());
+
+    let mut production = ProductionWasmHost::with_shared_streams(bootstrap_secrets, streams)
+        .with_invocation_context(invocation_ctx);
+    if let Some(resolver) = secret_resolver {
+        production = production.with_secret_resolver(resolver);
+    }
+
+    let inner: Arc<dyn WasmHost> = Arc::new(production);
+    Arc::new(AuthorizedWasmHost::new(inner, gate, authz_ctx))
+}
+
+/// Empty secret map proof helper for tests and diagnostics.
+pub fn empty_secret_map() -> BTreeMap<String, String> {
+    BTreeMap::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_authorization_and_principal_headers() {
+        let headers = vec![
+            ("content-type".into(), "application/json".into()),
+            ("authorization".into(), "Bearer secret-token".into()),
+            ("X-Temper-Principal-Kind".into(), "admin".into()),
+            ("x-temper-principal-id".into(), "evil".into()),
+            ("x-api-key".into(), "k".into()),
+            ("accept".into(), "*/*".into()),
+        ];
+        let safe = guest_safe_headers(&headers);
+        let names: Vec<_> = safe.iter().map(|(k, _)| k.to_ascii_lowercase()).collect();
+        assert!(names.contains(&"content-type".to_string()));
+        assert!(names.contains(&"accept".to_string()));
+        assert!(!names.iter().any(|n| n.contains("authorization")));
+        assert!(!names.iter().any(|n| n.contains("principal")));
+        assert!(!names.iter().any(|n| n.contains("api-key")));
+        assert!(!safe.iter().any(|(_, v)| v.contains("secret-token")));
+    }
+
+    #[test]
+    fn sensitive_header_match_is_case_insensitive() {
+        assert!(is_sensitive_inbound_header("Authorization"));
+        assert!(is_sensitive_inbound_header("COOKIE"));
+        assert!(!is_sensitive_inbound_header("content-type"));
+    }
+
+    #[test]
+    fn build_httpendpoint_host_does_not_require_full_secret_map() {
+        use crate::registry::SpecRegistry;
+        use crate::secrets::SecretsVault;
+        use temper_runtime::ActorSystem;
+        use temper_wasm::types::WasmInvocationContext;
+
+        let vault = SecretsVault::new(&[9u8; 32]);
+        vault
+            .cache_secret(
+                "default",
+                "LEAKED_TENANT_SECRET",
+                "should-not-be-eager".to_string(),
+            )
+            .expect("cache");
+        let system = ActorSystem::new("httpendpoint-host-test");
+        let state =
+            ServerState::from_registry(system, SpecRegistry::new()).with_secrets_vault(vault);
+        // Default ServerState uses a permissive authz engine for local/dev.
+        // Force empty Cedar policies so access_secret is default-deny (ARN-208).
+        state
+            .authz
+            .reload_policies("")
+            .expect("empty policy set should parse");
+        let tenant = TenantId::default();
+        let streams = Arc::new(HttpStreamRegistry::new());
+        let inv = WasmInvocationContext {
+            tenant: "default".into(),
+            entity_type: "HttpEndpoint".into(),
+            entity_id: "ep-1".into(),
+            trigger_action: "HandleHttp".into(),
+            wasm_module: Some("mod".into()),
+            trigger_params: serde_json::Value::Null,
+            entity_state: serde_json::Value::Null,
+            agent_id: None,
+            session_id: None,
+            integration_config: BTreeMap::new(),
+            trace_id: String::new(),
+            workflow_root_entity_type: None,
+            workflow_root_entity_id: None,
+            workflow_run_id: None,
+            http_request: None,
+        };
+        let host = build_httpendpoint_wasm_host(&state, &tenant, "mod", streams, inv);
+        // Host is constructed; secret lookups for non-bootstrap keys go through
+        // the gated resolver and fail closed without Cedar permit.
+        let err = host.get_secret("LEAKED_TENANT_SECRET");
+        assert!(
+            err.is_err(),
+            "unauthorized secret must not be readable via endpoint host: {err:?}"
+        );
+    }
+}

--- a/crates/temper-server/src/http_endpoint_host.rs
+++ b/crates/temper-server/src/http_endpoint_host.rs
@@ -4,7 +4,6 @@
 //! entity WASM dispatch: bootstrap secrets only, gated secret resolver, and
 //! `AuthorizedWasmHost` — never a raw production host with a full secret map.
 
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use temper_runtime::tenant::TenantId;
@@ -14,7 +13,7 @@ use temper_wasm::{AuthorizedWasmHost, ProductionWasmHost, WasmHost};
 
 use crate::state::ServerState;
 
-/// Header names that must never be delivered to endpoint guests.
+/// Exact header names that must never be delivered to endpoint guests.
 const STRIPPED_INBOUND_HEADERS: &[&str] = &[
     "authorization",
     "proxy-authorization",
@@ -22,15 +21,20 @@ const STRIPPED_INBOUND_HEADERS: &[&str] = &[
     "set-cookie",
     "x-api-key",
     "x-temper-api-key",
-    "x-temper-principal-id",
-    "x-temper-principal-kind",
-    "x-temper-principal-scopes",
 ];
 
 /// True when an inbound header must be stripped before guest delivery.
+///
+/// Exact denylist covers classic credential carriers. Prefix rules cover
+/// ambient platform identity (`x-temper-principal*`, `x-temper-agent-*`)
+/// so guests cannot inherit authority material from request headers
+/// (ADR-0158 / ARN-208).
 pub fn is_sensitive_inbound_header(name: &str) -> bool {
     let lower = name.to_ascii_lowercase();
-    STRIPPED_INBOUND_HEADERS.contains(&lower.as_str())
+    if STRIPPED_INBOUND_HEADERS.contains(&lower.as_str()) {
+        return true;
+    }
+    lower.starts_with("x-temper-principal") || lower.starts_with("x-temper-agent-")
 }
 
 /// Filter inbound headers for guest `HttpDispatchContext` delivery.
@@ -76,49 +80,17 @@ pub fn build_httpendpoint_wasm_host(
     Arc::new(AuthorizedWasmHost::new(inner, gate, authz_ctx))
 }
 
-/// Empty secret map proof helper for tests and diagnostics.
-pub fn empty_secret_map() -> BTreeMap<String, String> {
-    BTreeMap::new()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
 
-    #[test]
-    fn strips_authorization_and_principal_headers() {
-        let headers = vec![
-            ("content-type".into(), "application/json".into()),
-            ("authorization".into(), "Bearer secret-token".into()),
-            ("X-Temper-Principal-Kind".into(), "admin".into()),
-            ("x-temper-principal-id".into(), "evil".into()),
-            ("x-api-key".into(), "k".into()),
-            ("accept".into(), "*/*".into()),
-        ];
-        let safe = guest_safe_headers(&headers);
-        let names: Vec<_> = safe.iter().map(|(k, _)| k.to_ascii_lowercase()).collect();
-        assert!(names.contains(&"content-type".to_string()));
-        assert!(names.contains(&"accept".to_string()));
-        assert!(!names.iter().any(|n| n.contains("authorization")));
-        assert!(!names.iter().any(|n| n.contains("principal")));
-        assert!(!names.iter().any(|n| n.contains("api-key")));
-        assert!(!safe.iter().any(|(_, v)| v.contains("secret-token")));
-    }
+    use crate::registry::SpecRegistry;
+    use crate::secrets::SecretsVault;
+    use temper_runtime::ActorSystem;
+    use temper_wasm::types::WasmInvocationContext;
 
-    #[test]
-    fn sensitive_header_match_is_case_insensitive() {
-        assert!(is_sensitive_inbound_header("Authorization"));
-        assert!(is_sensitive_inbound_header("COOKIE"));
-        assert!(!is_sensitive_inbound_header("content-type"));
-    }
-
-    #[test]
-    fn build_httpendpoint_host_does_not_require_full_secret_map() {
-        use crate::registry::SpecRegistry;
-        use crate::secrets::SecretsVault;
-        use temper_runtime::ActorSystem;
-        use temper_wasm::types::WasmInvocationContext;
-
+    fn deny_all_state_with_leaked_secret() -> ServerState {
         let vault = SecretsVault::new(&[9u8; 32]);
         vault
             .cache_secret(
@@ -130,15 +102,16 @@ mod tests {
         let system = ActorSystem::new("httpendpoint-host-test");
         let state =
             ServerState::from_registry(system, SpecRegistry::new()).with_secrets_vault(vault);
-        // Default ServerState uses a permissive authz engine for local/dev.
-        // Force empty Cedar policies so access_secret is default-deny (ARN-208).
+        // Force empty Cedar policies so host ops are default-deny (ARN-208).
         state
             .authz
             .reload_policies("")
             .expect("empty policy set should parse");
-        let tenant = TenantId::default();
-        let streams = Arc::new(HttpStreamRegistry::new());
-        let inv = WasmInvocationContext {
+        state
+    }
+
+    fn sample_invocation_ctx() -> WasmInvocationContext {
+        WasmInvocationContext {
             tenant: "default".into(),
             entity_type: "HttpEndpoint".into(),
             entity_id: "ep-1".into(),
@@ -154,14 +127,85 @@ mod tests {
             workflow_root_entity_id: None,
             workflow_run_id: None,
             http_request: None,
-        };
-        let host = build_httpendpoint_wasm_host(&state, &tenant, "mod", streams, inv);
+        }
+    }
+
+    #[test]
+    fn strips_authorization_and_principal_headers() {
+        let headers = vec![
+            ("content-type".into(), "application/json".into()),
+            ("authorization".into(), "Bearer secret-token".into()),
+            ("X-Temper-Principal-Kind".into(), "admin".into()),
+            ("x-temper-principal-id".into(), "evil".into()),
+            ("x-temper-principal-scopes".into(), "admin".into()),
+            ("x-temper-agent-type".into(), "claude-code".into()),
+            ("x-temper-agent-role".into(), "supervisor".into()),
+            ("x-api-key".into(), "k".into()),
+            ("accept".into(), "*/*".into()),
+        ];
+        let safe = guest_safe_headers(&headers);
+        let names: Vec<_> = safe.iter().map(|(k, _)| k.to_ascii_lowercase()).collect();
+        assert!(names.contains(&"content-type".to_string()));
+        assert!(names.contains(&"accept".to_string()));
+        assert!(!names.iter().any(|n| n.contains("authorization")));
+        assert!(!names.iter().any(|n| n.contains("principal")));
+        assert!(!names.iter().any(|n| n.contains("api-key")));
+        assert!(!names.iter().any(|n| n.contains("agent-type")));
+        assert!(!names.iter().any(|n| n.contains("agent-role")));
+        assert!(!safe.iter().any(|(_, v)| v.contains("secret-token")));
+        assert!(!safe.iter().any(|(_, v)| v == "admin" || v == "evil"));
+    }
+
+    #[test]
+    fn sensitive_header_match_is_case_insensitive() {
+        assert!(is_sensitive_inbound_header("Authorization"));
+        assert!(is_sensitive_inbound_header("COOKIE"));
+        assert!(is_sensitive_inbound_header("X-Temper-Agent-Type"));
+        assert!(is_sensitive_inbound_header(
+            "x-temper-principal-attr-region"
+        ));
+        assert!(!is_sensitive_inbound_header("content-type"));
+        assert!(!is_sensitive_inbound_header("x-temper-observe-session-id"));
+    }
+
+    #[test]
+    fn build_httpendpoint_host_does_not_require_full_secret_map() {
+        let state = deny_all_state_with_leaked_secret();
+        let tenant = TenantId::default();
+        let streams = Arc::new(HttpStreamRegistry::new());
+        let host =
+            build_httpendpoint_wasm_host(&state, &tenant, "mod", streams, sample_invocation_ctx());
         // Host is constructed; secret lookups for non-bootstrap keys go through
         // the gated resolver and fail closed without Cedar permit.
         let err = host.get_secret("LEAKED_TENANT_SECRET");
         assert!(
             err.is_err(),
             "unauthorized secret must not be readable via endpoint host: {err:?}"
+        );
+        let msg = err.expect_err("denied");
+        assert!(
+            msg.contains("authorization denied"),
+            "expected Cedar denial via AuthorizedWasmHost, got: {msg}"
+        );
+    }
+
+    /// Proves the outer envelope is `AuthorizedWasmHost`: empty Cedar policies
+    /// deny outbound HTTP. A bare `ProductionWasmHost` would attempt the call
+    /// and fail with a network/client error instead of an authorization denial.
+    #[tokio::test]
+    async fn build_httpendpoint_host_gates_outbound_http() {
+        let state = deny_all_state_with_leaked_secret();
+        let tenant = TenantId::default();
+        let streams = Arc::new(HttpStreamRegistry::new());
+        let host =
+            build_httpendpoint_wasm_host(&state, &tenant, "mod", streams, sample_invocation_ctx());
+        let err = host
+            .http_call("GET", "https://evil.example.com/ssrf", &[], "")
+            .await
+            .expect_err("outbound HTTP must be Cedar-gated");
+        assert!(
+            err.contains("authorization denied"),
+            "expected AuthorizedWasmHost denial, got: {err}"
         );
     }
 }

--- a/crates/temper-server/src/lib.rs
+++ b/crates/temper-server/src/lib.rs
@@ -19,6 +19,7 @@ pub mod event_budget_metrics;
 pub mod events;
 pub mod eventual_invariants;
 pub mod http_endpoint;
+pub mod http_endpoint_host;
 pub mod idempotency;
 pub mod identity;
 /// ADR-0153: declared composite-key index hashing (the negative-existence access path).

--- a/crates/temper-server/src/router.rs
+++ b/crates/temper-server/src/router.rs
@@ -315,7 +315,7 @@ async fn dispatch_matched_route(
     });
 
     // Build the invocation context. Strip credential/principal headers so
-    // guests never receive ambient authority material (ADR-0158 / ARN-208).
+    // guests never receive ambient authority material (ADR-0161 / ARN-208).
     let header_pairs: Vec<(String, String)> = headers
         .iter()
         .filter_map(|(k, v)| {
@@ -361,7 +361,7 @@ async fn dispatch_matched_route(
         }),
     };
 
-    // ADR-0158 / ARN-208: governed host (AuthorizedWasmHost + bootstrap
+    // ADR-0161 / ARN-208: governed host (AuthorizedWasmHost + bootstrap
     // secrets + gated resolver). Never attach the full tenant secret map.
     let host = crate::http_endpoint_host::build_httpendpoint_wasm_host(
         &state,

--- a/crates/temper-server/src/router.rs
+++ b/crates/temper-server/src/router.rs
@@ -314,7 +314,8 @@ async fn dispatch_matched_route(
         let _ = pump_streams.close(kernel_request_body).await;
     });
 
-    // Build the invocation context.
+    // Build the invocation context. Strip credential/principal headers so
+    // guests never receive ambient authority material (ADR-0158 / ARN-208).
     let header_pairs: Vec<(String, String)> = headers
         .iter()
         .filter_map(|(k, v)| {
@@ -323,6 +324,7 @@ async fn dispatch_matched_route(
                 .map(|s| (k.as_str().to_string(), s.to_string()))
         })
         .collect();
+    let header_pairs = crate::http_endpoint_host::guest_safe_headers(&header_pairs);
     let route_params = git_route_params_for_http_dispatch(
         &route.route.integration_module,
         uri.path(),
@@ -359,15 +361,14 @@ async fn dispatch_matched_route(
         }),
     };
 
-    // Build a per-request host that shares the registry.
-    let secrets: std::collections::BTreeMap<String, String> = state
-        .secrets_vault
-        .as_ref()
-        .map(|v| v.get_tenant_secrets(tenant_id.as_str()))
-        .unwrap_or_default();
-    let host: std::sync::Arc<dyn temper_wasm::WasmHost> = std::sync::Arc::new(
-        temper_wasm::ProductionWasmHost::with_shared_streams(secrets, streams.clone())
-            .with_invocation_context(ctx.clone()),
+    // ADR-0158 / ARN-208: governed host (AuthorizedWasmHost + bootstrap
+    // secrets + gated resolver). Never attach the full tenant secret map.
+    let host = crate::http_endpoint_host::build_httpendpoint_wasm_host(
+        &state,
+        &tenant_id,
+        &route.route.integration_module,
+        streams.clone(),
+        ctx.clone(),
     );
 
     // Spawn task B: invoke the WASM module. Runs to completion

--- a/docs/adrs/0158-httpendpoint-governed-host.md
+++ b/docs/adrs/0158-httpendpoint-governed-host.md
@@ -1,0 +1,83 @@
+# ADR-0158: HttpEndpoint uses one governed WASM host (ARN-208)
+
+- Status: Accepted
+- Date: 2026-07-12
+- Deciders: Temper core maintainers
+- Related:
+  - ARN-208: HttpEndpoint WASM bypasses the governed host
+  - ADR-0156: Native adapter sandbox boundary (parallel trust edge)
+  - `crates/temper-server/src/router.rs` (HttpEndpoint dispatch)
+  - `crates/temper-server/src/http_endpoint_host.rs`
+  - `crates/temper-server/src/state/dispatch/wasm.rs` (entity dispatch path)
+  - `crates/temper-wasm/src/authorized_host.rs`
+
+## Context
+
+Entity WASM dispatch builds `AuthorizedWasmHost` around `ProductionWasmHost`
+with Cedar-gated HTTP and secret access, and only bootstrap secrets up front.
+
+The inbound `HttpEndpoint` fallback in the router constructed a raw
+`ProductionWasmHost` with the **full tenant secret map** and forwarded every
+inbound header (including `Authorization` / principal headers) into the guest
+context. That is a second production invocation path that skips the trust
+boundary.
+
+## Decision
+
+### Sub-Decision 1: One governed factory for HttpEndpoint
+
+HttpEndpoint invocations must use the same authorization envelope as entity
+dispatch:
+
+1. Bootstrap secrets only (`get_authorized_wasm_host_bootstrap_secrets`)
+2. Lazy secret resolver gated by `WasmAuthzGate`
+3. Outer `AuthorizedWasmHost` with `WasmAuthzContext` for the endpoint module
+
+Raw `ProductionWasmHost::with_shared_streams(...)` is not called from the
+router without that envelope.
+
+### Sub-Decision 2: Strip inbound auth material before guest delivery
+
+Before building `HttpDispatchContext.headers`, drop:
+
+- `authorization`
+- `cookie` / `set-cookie`
+- `x-temper-principal-id` / `x-temper-principal-kind` / `x-temper-principal-scopes`
+- `x-api-key` and similar credential carriers
+
+Guests never receive ambient platform credentials from the inbound request.
+
+### Sub-Decision 3: Principal for host ops
+
+Host authorization context is bound to the **integration module** and tenant
+(module as Cedar principal), not to guest-supplied principal headers. Action
+bridge auth remains separate (existing `requires_auth` path).
+
+## Consequences
+
+### Positive
+
+- Endpoint guests cannot read arbitrary tenant secrets or perform ungated
+  outbound HTTP.
+- Auth headers are not reflected into guest code.
+- One consistent production host construction story.
+
+### Negative
+
+- Endpoint modules need Cedar permits for secrets/HTTP they legitimately use
+  (same as entity integrations).
+
+### Risks
+
+- Policies that only covered entity dispatch may need endpoint module entries;
+  fail-closed is intentional.
+
+## Non-Goals
+
+- Redesigning HttpEndpoint routing table semantics.
+- Full Class-A auth rewrite (ARN-170) for the HTTP surface.
+
+## Alternatives Considered
+
+1. **Disable HttpEndpoint entirely** — too blunt for git/webhook surfaces.
+2. **Only strip secrets, leave raw host** — still skips Cedar HTTP gate.

--- a/docs/adrs/0158-httpendpoint-governed-host.md
+++ b/docs/adrs/0158-httpendpoint-governed-host.md
@@ -40,12 +40,15 @@ router without that envelope.
 
 Before building `HttpDispatchContext.headers`, drop:
 
-- `authorization`
+- `authorization` / `proxy-authorization`
 - `cookie` / `set-cookie`
-- `x-temper-principal-id` / `x-temper-principal-kind` / `x-temper-principal-scopes`
-- `x-api-key` and similar credential carriers
+- `x-api-key` / `x-temper-api-key`
+- any header whose name starts with `x-temper-principal` (id, kind, scopes, attrs)
+- any header whose name starts with `x-temper-agent-` (type, role, …)
 
-Guests never receive ambient platform credentials from the inbound request.
+Guests never receive ambient platform credentials or identity carriers from
+the inbound request. Kernel-side action-bridge auth still reads the raw
+request headers.
 
 ### Sub-Decision 3: Principal for host ops
 

--- a/docs/adrs/0161-httpendpoint-governed-host.md
+++ b/docs/adrs/0161-httpendpoint-governed-host.md
@@ -1,4 +1,4 @@
-# ADR-0158: HttpEndpoint uses one governed WASM host (ARN-208)
+# ADR-0161: HttpEndpoint uses one governed WASM host (ARN-208)
 
 - Status: Accepted
 - Date: 2026-07-12

--- a/docs/adrs/0161-httpendpoint-governed-host.md
+++ b/docs/adrs/0161-httpendpoint-governed-host.md
@@ -5,7 +5,7 @@
 - Deciders: Temper core maintainers
 - Related:
   - ARN-208: HttpEndpoint WASM bypasses the governed host
-  - ADR-0156: Native adapter sandbox boundary (parallel trust edge)
+  - ADR-0160: Native adapter sandbox boundary (parallel trust edge)
   - `crates/temper-server/src/router.rs` (HttpEndpoint dispatch)
   - `crates/temper-server/src/http_endpoint_host.rs`
   - `crates/temper-server/src/state/dispatch/wasm.rs` (entity dispatch path)
@@ -18,7 +18,7 @@ with Cedar-gated HTTP and secret access, and only bootstrap secrets up front.
 
 The inbound `HttpEndpoint` fallback in the router constructed a raw
 `ProductionWasmHost` with the **full tenant secret map** and forwarded every
-inbound header (including `Authorization` / principal headers) into the guest
+inbound header (including `Authorization`, `x-session-id`, and principal headers) into the guest
 context. That is a second production invocation path that skips the trust
 boundary.
 
@@ -43,6 +43,7 @@ Before building `HttpDispatchContext.headers`, drop:
 - `authorization` / `proxy-authorization`
 - `cookie` / `set-cookie`
 - `x-api-key` / `x-temper-api-key`
+- `x-session-id`
 - any header whose name starts with `x-temper-principal` (id, kind, scopes, attrs)
 - any header whose name starts with `x-temper-agent-` (type, role, …)
 


### PR DESCRIPTION
## Summary
Closes the ARN-208 parallel trust boundary for inbound HttpEndpoint WASM.

- **Governed host factory** (`http_endpoint_host.rs`): `AuthorizedWasmHost` + bootstrap secrets + Cedar-gated secret resolver (same envelope as entity dispatch)
- **No full tenant secret map** on endpoint host construction
- **Strip inbound auth/principal headers** before guest `HttpDispatchContext`
- **ADR-0158** documents the decision

## Tests
- [x] `cargo test -p temper-server --lib http_endpoint_host` (3 passed)
- [ ] CI green

Linear: ARN-208

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes the ARN-208 trust boundary gap where `HttpEndpoint` WASM invocations bypassed the governed host by constructing a raw `ProductionWasmHost` with the full tenant secret map and unfiltered inbound headers.

- **Governed host factory** (`http_endpoint_host.rs`): introduces `build_httpendpoint_wasm_host`, which wraps `ProductionWasmHost` in `AuthorizedWasmHost` using bootstrap-only secrets and a Cedar-gated lazy secret resolver — matching the envelope already used by entity dispatch.
- **Header stripping** (`router.rs` + `http_endpoint_host.rs`): `guest_safe_headers` removes `authorization`, `cookie`, `x-api-key`, all `x-temper-principal-*` headers, and `proxy-authorization` from the `HttpDispatchContext` before the WASM guest sees it; the action-bridge path correctly retains the original `HeaderMap` for kernel-side auth per ADR-0138.
- **ADR-0158** documents all three sub-decisions with clear consequences and alternatives.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The core change correctly closes the raw-host / full-secret-map bypass; the new governed factory and header strip function look sound and are well-tested.

The implementation matches the ADR's stated intent and the three unit tests verify the key invariants. The open questions around x-session-id in the strip list and empty_secret_map visibility are worth resolving before merge but do not represent current defects in the governed-host path itself.

crates/temper-server/src/http_endpoint_host.rs — the STRIPPED_INBOUND_HEADERS list and empty_secret_map visibility are the two spots worth a second look.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/temper-server/src/http_endpoint_host.rs | New governed host factory for HttpEndpoint WASM; header strip logic and tests look correct, but empty_secret_map is unnecessarily public and x-session-id is absent from the strip list |
| crates/temper-server/src/router.rs | Correctly threads guest_safe_headers and build_httpendpoint_wasm_host into the dispatch path; action bridge retains original headers for kernel-side auth (intentional per ADR-0138) |
| crates/temper-server/src/lib.rs | Adds pub module declaration for http_endpoint_host; trivial one-line change |
| docs/adrs/0158-httpendpoint-governed-host.md | ADR documents all three sub-decisions accurately; consequences and alternatives are clearly reasoned |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Router as router.rs (fallback)
    participant Table as HttpEndpointTable
    participant HeaderFilter as guest_safe_headers()
    participant HostFactory as build_httpendpoint_wasm_host()
    participant AuthGate as WasmAuthzGate (Cedar)
    participant ProdHost as ProductionWasmHost
    participant AuthHost as AuthorizedWasmHost
    participant WASM as WASM Guest

    Client->>Router: HTTP request (with auth/principal headers)
    Router->>Table: match_request(method, path)
    Table-->>Router: MatchedRoute

    Router->>HeaderFilter: guest_safe_headers(header_pairs)
    Note over HeaderFilter: Strips: authorization, cookie, x-api-key,<br/>x-temper-principal-*, x-temper-api-key, proxy-authorization
    HeaderFilter-->>Router: stripped header_pairs

    Router->>HostFactory: build_httpendpoint_wasm_host(state, tenant, module, streams, ctx)
    HostFactory->>AuthGate: get_authorized_wasm_host_bootstrap_secrets()
    AuthGate-->>HostFactory: bootstrap_secrets (Cedar-gated)
    HostFactory->>AuthGate: authorized_wasm_secret_resolver()
    AuthGate-->>HostFactory: lazy_resolver
    HostFactory->>ProdHost: ProductionWasmHost::with_shared_streams(bootstrap_secrets, streams)
    ProdHost-->>HostFactory: production_host
    HostFactory->>AuthHost: AuthorizedWasmHost::new(production_host, gate, authz_ctx)
    AuthHost-->>HostFactory: governed_host
    HostFactory-->>Router: "Arc<dyn WasmHost> (governed)"

    Router->>WASM: engine.invoke_with_blobs(hash, ctx_stripped_headers, governed_host, ...)
    Note over WASM: Sees only stripped headers<br/>Secret access Cedar-gated per module+tenant
    WASM-->>Router: WasmInvocationResult (streaming response)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Router as router.rs (fallback)
    participant Table as HttpEndpointTable
    participant HeaderFilter as guest_safe_headers()
    participant HostFactory as build_httpendpoint_wasm_host()
    participant AuthGate as WasmAuthzGate (Cedar)
    participant ProdHost as ProductionWasmHost
    participant AuthHost as AuthorizedWasmHost
    participant WASM as WASM Guest

    Client->>Router: HTTP request (with auth/principal headers)
    Router->>Table: match_request(method, path)
    Table-->>Router: MatchedRoute

    Router->>HeaderFilter: guest_safe_headers(header_pairs)
    Note over HeaderFilter: Strips: authorization, cookie, x-api-key,<br/>x-temper-principal-*, x-temper-api-key, proxy-authorization
    HeaderFilter-->>Router: stripped header_pairs

    Router->>HostFactory: build_httpendpoint_wasm_host(state, tenant, module, streams, ctx)
    HostFactory->>AuthGate: get_authorized_wasm_host_bootstrap_secrets()
    AuthGate-->>HostFactory: bootstrap_secrets (Cedar-gated)
    HostFactory->>AuthGate: authorized_wasm_secret_resolver()
    AuthGate-->>HostFactory: lazy_resolver
    HostFactory->>ProdHost: ProductionWasmHost::with_shared_streams(bootstrap_secrets, streams)
    ProdHost-->>HostFactory: production_host
    HostFactory->>AuthHost: AuthorizedWasmHost::new(production_host, gate, authz_ctx)
    AuthHost-->>HostFactory: governed_host
    HostFactory-->>Router: "Arc<dyn WasmHost> (governed)"

    Router->>WASM: engine.invoke_with_blobs(hash, ctx_stripped_headers, governed_host, ...)
    Note over WASM: Sees only stripped headers<br/>Secret access Cedar-gated per module+tenant
    WASM-->>Router: WasmInvocationResult (streaming response)
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftemper-server%2Fsrc%2Fhttp_endpoint_host.rs%3A79-82%0A%60empty_secret_map%60%20is%20documented%20as%20a%20%22test%20and%20diagnostics%22%20helper%20but%20is%20%60pub%60%2C%20making%20it%20part%20of%20the%20crate's%20public%20API%20surface.%20Any%20caller%20could%20pass%20the%20result%20to%20%60ProductionWasmHost%3A%3Awith_shared_streams%28empty_secret_map%28%29%2C%20...%29%60%20and%20construct%20an%20ungoverned%20host%20%E2%80%94%20exactly%20the%20pattern%20ARN-208%20closes.%20Restricting%20visibility%20to%20%60pub%28crate%29%60%20prevents%20that%20from%20being%20done%20accidentally%20in%20future%20code%20paths.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20Empty%20secret%20map%20proof%20helper%20for%20tests%20and%20diagnostics.%0Apub%28crate%29%20fn%20empty_secret_map%28%29%20-%3E%20BTreeMap%3CString%2C%20String%3E%20%7B%0A%20%20%20%20BTreeMap%3A%3Anew%28%29%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftemper-server%2Fsrc%2Fhttp_endpoint_host.rs%3A18-27%0A%60x-session-id%60%20is%20absent%20from%20%60STRIPPED_INBOUND_HEADERS%60%20but%20is%20an%20explicitly%20CORS-allowed%20header%20%28see%20%60router.rs%60%20%60allow_headers%60%29%2C%20so%20browser%20clients%20can%20send%20it%20to%20any%20HttpEndpoint%20route.%20The%20ADR-0158%20strip%20list%20focuses%20on%20auth%2Fprincipal%20headers%2C%20so%20this%20may%20be%20intentional%20%E2%80%94%20but%20a%20session%20ID%20does%20constitute%20ambient%20caller%20context.%20If%20%60x-session-id%60%20can%20be%20used%20by%20the%20platform%20to%20tie%20actions%20to%20a%20user%20session%2C%20a%20WASM%20endpoint%20module%20that%20reads%20it%20could%20infer%20platform-side%20session%20state%20it%20shouldn't%20see.%20Worth%20a%20deliberate%20decision%20either%20way.%0A%0A&repo=nerdsane%2Ftemper&pr=360&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22grok%2Farn-208-httpendpoint-host%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22grok%2Farn-208-httpendpoint-host%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftemper-server%2Fsrc%2Fhttp_endpoint_host.rs%3A79-82%0A%60empty_secret_map%60%20is%20documented%20as%20a%20%22test%20and%20diagnostics%22%20helper%20but%20is%20%60pub%60%2C%20making%20it%20part%20of%20the%20crate's%20public%20API%20surface.%20Any%20caller%20could%20pass%20the%20result%20to%20%60ProductionWasmHost%3A%3Awith_shared_streams%28empty_secret_map%28%29%2C%20...%29%60%20and%20construct%20an%20ungoverned%20host%20%E2%80%94%20exactly%20the%20pattern%20ARN-208%20closes.%20Restricting%20visibility%20to%20%60pub%28crate%29%60%20prevents%20that%20from%20being%20done%20accidentally%20in%20future%20code%20paths.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20Empty%20secret%20map%20proof%20helper%20for%20tests%20and%20diagnostics.%0Apub%28crate%29%20fn%20empty_secret_map%28%29%20-%3E%20BTreeMap%3CString%2C%20String%3E%20%7B%0A%20%20%20%20BTreeMap%3A%3Anew%28%29%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftemper-server%2Fsrc%2Fhttp_endpoint_host.rs%3A18-27%0A%60x-session-id%60%20is%20absent%20from%20%60STRIPPED_INBOUND_HEADERS%60%20but%20is%20an%20explicitly%20CORS-allowed%20header%20%28see%20%60router.rs%60%20%60allow_headers%60%29%2C%20so%20browser%20clients%20can%20send%20it%20to%20any%20HttpEndpoint%20route.%20The%20ADR-0158%20strip%20list%20focuses%20on%20auth%2Fprincipal%20headers%2C%20so%20this%20may%20be%20intentional%20%E2%80%94%20but%20a%20session%20ID%20does%20constitute%20ambient%20caller%20context.%20If%20%60x-session-id%60%20can%20be%20used%20by%20the%20platform%20to%20tie%20actions%20to%20a%20user%20session%2C%20a%20WASM%20endpoint%20module%20that%20reads%20it%20could%20infer%20platform-side%20session%20state%20it%20shouldn't%20see.%20Worth%20a%20deliberate%20decision%20either%20way.%0A%0A&repo=nerdsane%2Ftemper&pr=360&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftemper-server%2Fsrc%2Fhttp_endpoint_host.rs%3A79-82%0A%60empty_secret_map%60%20is%20documented%20as%20a%20%22test%20and%20diagnostics%22%20helper%20but%20is%20%60pub%60%2C%20making%20it%20part%20of%20the%20crate's%20public%20API%20surface.%20Any%20caller%20could%20pass%20the%20result%20to%20%60ProductionWasmHost%3A%3Awith_shared_streams%28empty_secret_map%28%29%2C%20...%29%60%20and%20construct%20an%20ungoverned%20host%20%E2%80%94%20exactly%20the%20pattern%20ARN-208%20closes.%20Restricting%20visibility%20to%20%60pub%28crate%29%60%20prevents%20that%20from%20being%20done%20accidentally%20in%20future%20code%20paths.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20Empty%20secret%20map%20proof%20helper%20for%20tests%20and%20diagnostics.%0Apub%28crate%29%20fn%20empty_secret_map%28%29%20-%3E%20BTreeMap%3CString%2C%20String%3E%20%7B%0A%20%20%20%20BTreeMap%3A%3Anew%28%29%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftemper-server%2Fsrc%2Fhttp_endpoint_host.rs%3A18-27%0A%60x-session-id%60%20is%20absent%20from%20%60STRIPPED_INBOUND_HEADERS%60%20but%20is%20an%20explicitly%20CORS-allowed%20header%20%28see%20%60router.rs%60%20%60allow_headers%60%29%2C%20so%20browser%20clients%20can%20send%20it%20to%20any%20HttpEndpoint%20route.%20The%20ADR-0158%20strip%20list%20focuses%20on%20auth%2Fprincipal%20headers%2C%20so%20this%20may%20be%20intentional%20%E2%80%94%20but%20a%20session%20ID%20does%20constitute%20ambient%20caller%20context.%20If%20%60x-session-id%60%20can%20be%20used%20by%20the%20platform%20to%20tie%20actions%20to%20a%20user%20session%2C%20a%20WASM%20endpoint%20module%20that%20reads%20it%20could%20infer%20platform-side%20session%20state%20it%20shouldn't%20see.%20Worth%20a%20deliberate%20decision%20either%20way.%0A%0A&pr=360&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
crates/temper-server/src/http_endpoint_host.rs:79-82
`empty_secret_map` is documented as a "test and diagnostics" helper but is `pub`, making it part of the crate's public API surface. Any caller could pass the result to `ProductionWasmHost::with_shared_streams(empty_secret_map(), ...)` and construct an ungoverned host — exactly the pattern ARN-208 closes. Restricting visibility to `pub(crate)` prevents that from being done accidentally in future code paths.

```suggestion
/// Empty secret map proof helper for tests and diagnostics.
pub(crate) fn empty_secret_map() -> BTreeMap<String, String> {
    BTreeMap::new()
}
```

### Issue 2 of 2
crates/temper-server/src/http_endpoint_host.rs:18-27
`x-session-id` is absent from `STRIPPED_INBOUND_HEADERS` but is an explicitly CORS-allowed header (see `router.rs` `allow_headers`), so browser clients can send it to any HttpEndpoint route. The ADR-0158 strip list focuses on auth/principal headers, so this may be intentional — but a session ID does constitute ambient caller context. If `x-session-id` can be used by the platform to tie actions to a user session, a WASM endpoint module that reads it could infer platform-side session state it shouldn't see. Worth a deliberate decision either way.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use contains for sensitive header c..."](https://github.com/nerdsane/temper/commit/1f61f9e577aa309fc36808f47132575d30b0279c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43651353)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->