### PR TITLE
fix(server): ban host paths from network spec ingestion (ARN-229)

### DIFF
--- a/crates/temper-server/src/api/mod.rs
+++ b/crates/temper-server/src/api/mod.rs
@@ -27,7 +27,7 @@ use crate::state::ServerState;
 /// Build the management API router (mounted at /api).
 ///
 /// Route structure:
-/// - POST   /api/specs/load-dir                        -> load specs from directory
+/// - POST   /api/specs/load-dir                        -> 410 Gone (no host paths; use load-inline)
 /// - POST   /api/specs/load-inline                     -> load specs from inline payload
 /// - POST   /api/specs/validate-ioa                    -> validate IOA source without loading it
 /// - POST   /api/wasm/modules/{module_name}            -> upload WASM module

--- a/crates/temper-server/src/observe/mod_test.rs
+++ b/crates/temper-server/src/observe/mod_test.rs
@@ -1946,44 +1946,12 @@ async fn test_load_dir_registers_specs() {
         .await
         .unwrap();
 
-    assert_eq!(response.status(), StatusCode::OK);
-    // Response is NDJSON — parse each line
-    let body = axum::body::to_bytes(response.into_body(), 10 * 1024 * 1024)
-        .await
-        .unwrap();
-    let body_str = std::str::from_utf8(&body).unwrap();
-    let lines: Vec<serde_json::Value> = body_str
-        .lines()
-        .filter(|l| !l.is_empty())
-        .map(|l| serde_json::from_str(l).unwrap())
-        .collect();
-
-    // First line: specs_loaded
-    assert_eq!(lines[0]["type"], "specs_loaded");
-    assert_eq!(lines[0]["tenant"], "test-tenant");
-    let entities = lines[0]["entities"].as_array().unwrap();
-    assert!(
-        !entities.is_empty(),
-        "should have loaded at least one entity"
-    );
-
-    // Last line: summary
-    let summary = lines.last().unwrap();
-    assert_eq!(summary["type"], "summary");
-    assert_eq!(summary["tenant"], "test-tenant");
-
-    // Verify specs are in the registry
-    let registry = state.registry.read().unwrap();
-    let tenant_id: temper_runtime::tenant::TenantId = "test-tenant".into();
-    let entity_types = registry.entity_types(&tenant_id);
-    assert!(
-        !entity_types.is_empty(),
-        "registry should have entity types for test-tenant"
-    );
+    // ARN-229: network load-dir is gone — host paths are not accepted.
+    assert_eq!(response.status(), StatusCode::GONE);
 }
 
 #[tokio::test]
-async fn test_load_dir_missing_dir_returns_error() {
+async fn test_load_dir_host_path_is_gone() {
     let system = ActorSystem::new("test-load-dir-missing");
     let registry = SpecRegistry::new();
     let state = ServerState::from_registry(system, registry);
@@ -2008,7 +1976,7 @@ async fn test_load_dir_missing_dir_returns_error() {
         .await
         .unwrap();
 
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::GONE);
 }
 
 #[tokio::test]
@@ -2066,27 +2034,8 @@ effect = "set phantom true"
 
     let _ = std::fs::remove_dir_all(&temp_specs); // determinism-ok: test-only
 
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
-        .await
-        .unwrap();
-    let body_str = std::str::from_utf8(&body).unwrap();
-    let lines: Vec<serde_json::Value> = body_str
-        .lines()
-        .filter(|l| !l.is_empty())
-        .map(|l| serde_json::from_str(l).unwrap())
-        .collect();
-
-    assert_eq!(lines[0]["type"], "specs_loaded");
-    assert!(lines.iter().any(|l| l["type"] == "lint_error"));
-    assert!(!lines.iter().any(|l| l["type"] == "verification_started"));
-
-    let registry = state.registry.read().unwrap();
-    let tenant_id: temper_runtime::tenant::TenantId = "lint-tenant".into();
-    assert!(
-        registry.get_tenant(&tenant_id).is_none(),
-        "tenant should not be registered when lint errors exist"
-    );
+    // ARN-229: network load-dir is disabled; host-path lint path is not reachable.
+    assert_eq!(response.status(), StatusCode::GONE);
 }
 
 #[tokio::test]
@@ -2126,36 +2075,9 @@ async fn test_load_dir_emits_design_time_events() {
         .await
         .unwrap();
 
-    assert_eq!(response.status(), StatusCode::OK);
-
-    // Consume entire body to wait for verification to complete
-    let _ = axum::body::to_bytes(response.into_body(), 10 * 1024 * 1024)
-        .await
-        .unwrap();
-
-    // Check that design-time events were persisted to Turso.
-    let turso = state.platform_turso_store().expect("turso configured");
-    let events = turso
-        .list_design_time_events(None, 1000)
-        .await
-        .expect("query design-time events from Turso");
-    assert!(!events.is_empty(), "design-time events should be in Turso");
-
-    // Should have spec_loaded, verify_started, and verify_done events
-    let loaded_events: Vec<_> = events.iter().filter(|e| e.kind == "spec_loaded").collect();
-    assert!(!loaded_events.is_empty(), "should have spec_loaded events");
-
-    let started_events: Vec<_> = events
-        .iter()
-        .filter(|e| e.kind == "verify_started")
-        .collect();
-    assert!(
-        !started_events.is_empty(),
-        "should have verify_started events"
-    );
-
-    let done_events: Vec<_> = events.iter().filter(|e| e.kind == "verify_done").collect();
-    assert!(!done_events.is_empty(), "should have verify_done events");
+    // ARN-229: host-path load-dir is gone. Design-time events for load-inline
+    // remain covered by inline submission paths; this test guards the network ban.
+    assert_eq!(response.status(), StatusCode::GONE);
 }
 
 #[tokio::test]

--- a/crates/temper-server/src/observe/specs.rs
+++ b/crates/temper-server/src/observe/specs.rs
@@ -12,6 +12,7 @@ use super::{ActionDetail, InvariantDetail, SpecDetail, SpecSummary, StateVarDeta
 
 mod load_dir;
 mod load_inline;
+mod path_security;
 mod types;
 mod validate_ioa;
 mod verification_stream;

--- a/crates/temper-server/src/observe/specs/load_dir.rs
+++ b/crates/temper-server/src/observe/specs/load_dir.rs
@@ -16,7 +16,7 @@ use super::types::LoadDirRequest;
 use super::verification_stream::build_verification_stream_response;
 use crate::state::ServerState;
 
-/// POST /api/specs/load-dir — **disabled for network callers** (ADR-0159 / ARN-229).
+/// POST /api/specs/load-dir — **disabled for network callers** (ADR-0162 / ARN-229).
 ///
 /// Callers must not name host directories. Use `POST /api/specs/load-inline`
 /// with an in-memory filename→content map. Internal loads after validated

--- a/crates/temper-server/src/observe/specs/load_dir.rs
+++ b/crates/temper-server/src/observe/specs/load_dir.rs
@@ -11,6 +11,7 @@ use super::super::specs_helpers::{
     build_ndjson_response, cross_lint_ndjson_line, lint_loaded_specs, lint_ndjson_line,
     to_pascal_case,
 };
+use super::path_security::is_ephemeral_inline_staging_path;
 use super::types::LoadDirRequest;
 use super::verification_stream::build_verification_stream_response;
 use crate::state::ServerState;
@@ -241,6 +242,9 @@ pub(crate) async fn load_specs_from_resolved_path(
     }
     state.rebuild_reaction_dispatcher();
 
+    // ADR-0160 / ARN-229: never durable-write ephemeral inline staging paths
+    // (`temper-inline-*`). Those dirs are deleted when InlineStagingDir drops;
+    // persisting them poisons restart reload with missing directories.
     if !state.data_dir.as_os_str().is_empty() {
         let registry_path = state.data_dir.join("specs-registry.json");
         let mut specs_registry = std::collections::BTreeMap::<String, String>::new();
@@ -252,13 +256,27 @@ pub(crate) async fn load_specs_from_resolved_path(
             {
                 for (tenant, specs_dir) in obj {
                     if let Some(specs_dir) = specs_dir.as_str() {
+                        // Scrub historically poisoned inline staging entries.
+                        if is_ephemeral_inline_staging_path(specs_dir) {
+                            continue;
+                        }
                         specs_registry.insert(tenant.clone(), specs_dir.to_string());
                     }
                 }
             }
         }
 
-        specs_registry.insert(body.tenant.clone(), body.specs_dir.clone());
+        if is_ephemeral_inline_staging_path(&body.specs_dir) {
+            // Inline load: leave any prior durable mapping for this tenant alone
+            // (or scrub if it was itself ephemeral — handled above). Do not
+            // insert the deleted staging path.
+            tracing::debug!(
+                tenant = %body.tenant,
+                "specs.registry.skip_ephemeral_inline_staging"
+            );
+        } else {
+            specs_registry.insert(body.tenant.clone(), body.specs_dir.clone());
+        }
 
         if let Ok(encoded) = serde_json::to_string_pretty(&specs_registry) {
             let _ = std::fs::create_dir_all(&state.data_dir); // determinism-ok: HTTP handler creates data dir

--- a/crates/temper-server/src/observe/specs/load_dir.rs
+++ b/crates/temper-server/src/observe/specs/load_dir.rs
@@ -15,14 +15,31 @@ use super::types::LoadDirRequest;
 use super::verification_stream::build_verification_stream_response;
 use crate::state::ServerState;
 
-/// POST /api/specs/load-dir -- hot-load specs from a directory into the running server.///
-/// Reads CSDL and IOA files from `specs_dir`, registers them under `tenant`,
-/// emits design-time SSE events for each entity, and spawns background
-/// verification tasks that stream progress via SSE.
+/// POST /api/specs/load-dir — **disabled for network callers** (ADR-0159 / ARN-229).
+///
+/// Callers must not name host directories. Use `POST /api/specs/load-inline`
+/// with an in-memory filename→content map. Internal loads after validated
+/// staging use [`load_specs_from_resolved_path`].
 #[instrument(skip_all, fields(otel.name = "POST /api/specs/load-dir"))]
 pub(crate) async fn handle_load_dir(
-    State(state): State<ServerState>,
-    Json(body): Json<LoadDirRequest>,
+    State(_state): State<ServerState>,
+    Json(_body): Json<LoadDirRequest>,
+) -> Result<axum::response::Response, (StatusCode, String)> {
+    Err((
+        StatusCode::GONE,
+        "POST /api/specs/load-dir no longer accepts host paths (ARN-229). \
+         Submit an in-memory bundle via POST /api/specs/load-inline."
+            .to_string(),
+    ))
+}
+
+/// Load specs from a kernel-resolved directory (after safe staging).
+///
+/// Not a public network contract — only called after path validation.
+#[instrument(skip_all, fields(otel.name = "specs.load_from_resolved_path"))]
+pub(crate) async fn load_specs_from_resolved_path(
+    state: ServerState,
+    body: LoadDirRequest,
 ) -> Result<axum::response::Response, (StatusCode, String)> {
     let specs_path = std::path::Path::new(&body.specs_dir);
 

--- a/crates/temper-server/src/observe/specs/load_dir.rs
+++ b/crates/temper-server/src/observe/specs/load_dir.rs
@@ -242,7 +242,7 @@ pub(crate) async fn load_specs_from_resolved_path(
     }
     state.rebuild_reaction_dispatcher();
 
-    // ADR-0160 / ARN-229: never durable-write ephemeral inline staging paths
+    // ADR-0162 / ARN-229: never durable-write ephemeral inline staging paths
     // (`temper-inline-*`). Those dirs are deleted when InlineStagingDir drops;
     // persisting them poisons restart reload with missing directories.
     if !state.data_dir.as_os_str().is_empty() {

--- a/crates/temper-server/src/observe/specs/load_inline.rs
+++ b/crates/temper-server/src/observe/specs/load_inline.rs
@@ -3,7 +3,6 @@ use std::path::{Path, PathBuf};
 use axum::extract::State;
 use axum::http::HeaderMap;
 use axum::http::StatusCode;
-use axum::response::Json;
 use serde_json::json;
 use temper_evolution::records::{
     AnalysisRecord, ObservationClass, ObservationRecord, RecordHeader, RecordType, SolutionOption,
@@ -16,7 +15,10 @@ use tracing::instrument;
 use crate::authz::{DenialInput, record_authz_denial, security_context_from_headers};
 use crate::state::{ServerState, TrajectoryEntry, TrajectorySource};
 
-use super::load_dir::handle_load_dir;
+use super::load_dir::load_specs_from_resolved_path;
+use super::path_security::{
+    create_inline_staging_dir, ensure_under_root, validate_inline_bundle, validate_inline_spec_key,
+};
 use super::types::{LoadDirRequest, LoadInlineRequest};
 
 /// POST /api/specs/load-inline -- load specs from inline content.
@@ -189,27 +191,25 @@ pub(crate) async fn handle_load_inline(
         ));
     }
 
-    // Write specs to a temp directory
-    let tmp_dir = std::env::temp_dir().join(format!("temper-inline-{}", tenant)); // determinism-ok: HTTP handler writes user specs to temp dir for loading
-    let _ = std::fs::remove_dir_all(&tmp_dir); // determinism-ok: HTTP handler cleans previous temp dir
-    std::fs::create_dir_all(&tmp_dir).map_err(|e| {
-        // determinism-ok: HTTP handler creates temp dir
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to create temp dir: {e}"),
-        )
-    })?;
-
+    // ADR-0159 / ARN-229: validate keys + budgets, then materialize into an
+    // invocation-unique staging directory (never a shared tenant temp path).
+    let validated = validate_inline_bundle(&body.specs)?;
+    let tmp_dir = create_inline_staging_dir(&tenant)?;
     let specs_root = resolve_inline_specs_root(&tmp_dir, &body.specs)?;
+    ensure_under_root(&tmp_dir, &specs_root)?;
 
-    for (filename, content) in &body.specs {
-        let path = tmp_dir.join(filename);
+    for (rel, content) in validated {
+        let path = tmp_dir.join(&rel);
+        ensure_under_root(&tmp_dir, &path)?;
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).map_err(|e| {
                 // determinism-ok: HTTP handler creates temp subdirectories for nested inline specs
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to create parent directory for {filename}: {e}"),
+                    format!(
+                        "Failed to create parent directory for {}: {e}",
+                        rel.display()
+                    ),
                 )
             })?;
         }
@@ -217,13 +217,15 @@ pub(crate) async fn handle_load_inline(
             // determinism-ok: HTTP handler writes specs
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to write {filename}: {e}"),
+                format!("Failed to write {}: {e}", rel.display()),
             )
         })?;
     }
 
     if let Some(source) = body.cross_invariants_toml.as_deref() {
-        std::fs::write(specs_root.join("cross-invariants.toml"), source).map_err(|e| {
+        let cross_path = specs_root.join("cross-invariants.toml");
+        ensure_under_root(&tmp_dir, &cross_path)?;
+        std::fs::write(&cross_path, source).map_err(|e| {
             // determinism-ok: HTTP handler writes cross-invariants
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -232,15 +234,17 @@ pub(crate) async fn handle_load_inline(
         })?;
     }
 
-    // Delegate to load-dir logic with merge=true so agent-submitted specs
-    // are added to the existing tenant config instead of replacing it.
+    // Kernel-resolved path only — never a caller-named host directory.
     let cedar_policies = body.cedar_policies.clone();
     let dir_request = LoadDirRequest {
         tenant: tenant.clone(),
         specs_dir: specs_root.to_string_lossy().to_string(),
         merge: true,
     };
-    let result = handle_load_dir(State(state.clone()), Json(dir_request)).await;
+    let result = load_specs_from_resolved_path(state.clone(), dir_request).await;
+
+    // Best-effort cleanup of this invocation's staging tree.
+    let _ = std::fs::remove_dir_all(&tmp_dir); // determinism-ok: HTTP handler cleans staging
 
     if result.is_ok()
         && let Some(ref cedar_text) = cedar_policies
@@ -382,13 +386,15 @@ fn resolve_inline_specs_root(
         ));
     }
 
-    let model_path = Path::new(model_paths[0]);
-    let relative_root = model_path.parent().unwrap_or_else(|| Path::new(""));
-    Ok(if relative_root.as_os_str().is_empty() {
+    let model_rel = validate_inline_spec_key(model_paths[0])?;
+    let relative_root = model_rel.parent().unwrap_or_else(|| Path::new(""));
+    let root = if relative_root.as_os_str().is_empty() {
         tmp_dir.to_path_buf()
     } else {
         tmp_dir.join(relative_root)
-    })
+    };
+    ensure_under_root(tmp_dir, &root)?;
+    Ok(root)
 }
 
 fn merge_inline_cedar_policy_text(existing: &str, incoming: &str) -> String {

--- a/crates/temper-server/src/observe/specs/load_inline.rs
+++ b/crates/temper-server/src/observe/specs/load_inline.rs
@@ -192,7 +192,7 @@ pub(crate) async fn handle_load_inline(
         ));
     }
 
-    // ADR-0159 / ARN-229: validate keys + budgets, then materialize into an
+    // ADR-0162 / ARN-229: validate keys + budgets, then materialize into an
     // invocation-unique staging directory (never a shared tenant temp path).
     // InlineStagingDir Drop always removes the tree (success, error, panic).
     let (validated, total_bytes) = validate_inline_bundle(&body.specs)?;

--- a/crates/temper-server/src/observe/specs/load_inline.rs
+++ b/crates/temper-server/src/observe/specs/load_inline.rs
@@ -17,7 +17,8 @@ use crate::state::{ServerState, TrajectoryEntry, TrajectorySource};
 
 use super::load_dir::load_specs_from_resolved_path;
 use super::path_security::{
-    create_inline_staging_dir, ensure_under_root, validate_inline_bundle, validate_inline_spec_key,
+    create_inline_staging_dir, enforce_extra_payload_budget, ensure_under_root,
+    validate_inline_bundle, validate_inline_spec_key,
 };
 use super::types::{LoadDirRequest, LoadInlineRequest};
 
@@ -193,14 +194,16 @@ pub(crate) async fn handle_load_inline(
 
     // ADR-0159 / ARN-229: validate keys + budgets, then materialize into an
     // invocation-unique staging directory (never a shared tenant temp path).
-    let validated = validate_inline_bundle(&body.specs)?;
-    let tmp_dir = create_inline_staging_dir(&tenant)?;
-    let specs_root = resolve_inline_specs_root(&tmp_dir, &body.specs)?;
-    ensure_under_root(&tmp_dir, &specs_root)?;
+    // InlineStagingDir Drop always removes the tree (success, error, panic).
+    let (validated, total_bytes) = validate_inline_bundle(&body.specs)?;
+    let staging = create_inline_staging_dir(&tenant)?;
+    let tmp_dir = staging.path();
+    let specs_root = resolve_inline_specs_root(tmp_dir, &body.specs)?;
+    ensure_under_root(tmp_dir, &specs_root)?;
 
     for (rel, content) in validated {
         let path = tmp_dir.join(&rel);
-        ensure_under_root(&tmp_dir, &path)?;
+        ensure_under_root(tmp_dir, &path)?;
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).map_err(|e| {
                 // determinism-ok: HTTP handler creates temp subdirectories for nested inline specs
@@ -223,8 +226,9 @@ pub(crate) async fn handle_load_inline(
     }
 
     if let Some(source) = body.cross_invariants_toml.as_deref() {
+        enforce_extra_payload_budget("cross-invariants.toml", source, total_bytes)?;
         let cross_path = specs_root.join("cross-invariants.toml");
-        ensure_under_root(&tmp_dir, &cross_path)?;
+        ensure_under_root(tmp_dir, &cross_path)?;
         std::fs::write(&cross_path, source).map_err(|e| {
             // determinism-ok: HTTP handler writes cross-invariants
             (
@@ -242,9 +246,7 @@ pub(crate) async fn handle_load_inline(
         merge: true,
     };
     let result = load_specs_from_resolved_path(state.clone(), dir_request).await;
-
-    // Best-effort cleanup of this invocation's staging tree.
-    let _ = std::fs::remove_dir_all(&tmp_dir); // determinism-ok: HTTP handler cleans staging
+    // staging Drop removes the tree after files are fully read into memory.
 
     if result.is_ok()
         && let Some(ref cedar_text) = cedar_policies

--- a/crates/temper-server/src/observe/specs/path_security.rs
+++ b/crates/temper-server/src/observe/specs/path_security.rs
@@ -256,6 +256,20 @@ pub fn validate_inline_bundle(
     Ok((out, total))
 }
 
+/// True when `path` is (or contains) an ephemeral inline staging directory.
+///
+/// Staging dirs are named `temper-inline-{tenant}-{uuid}` under the process
+/// temp root and are deleted when [`InlineStagingDir`] drops. They must never
+/// be written into `specs-registry.json`.
+pub fn is_ephemeral_inline_staging_path(path: &str) -> bool {
+    std::path::Path::new(path).components().any(|c| match c {
+        std::path::Component::Normal(s) => s
+            .to_str()
+            .is_some_and(|name| name.starts_with("temper-inline-")),
+        _ => false,
+    })
+}
+
 /// Create an invocation-unique staging directory for inline specs.
 ///
 /// Uses exclusive `create_dir` so an existing path cannot be clobbered.
@@ -290,6 +304,20 @@ pub fn create_inline_staging_dir(tenant: &str) -> Result<InlineStagingDir, PathS
 mod tests {
     use super::*;
     use std::collections::BTreeMap;
+
+    #[test]
+    fn detects_ephemeral_inline_staging_paths() {
+        assert!(is_ephemeral_inline_staging_path(
+            "/tmp/temper-inline-acme-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/app"
+        ));
+        assert!(is_ephemeral_inline_staging_path(
+            "/var/folders/xx/temper-inline-t1-uuid"
+        ));
+        assert!(!is_ephemeral_inline_staging_path(
+            "/var/lib/temper/specs/acme"
+        ));
+        assert!(!is_ephemeral_inline_staging_path("/tmp/other-temper-data"));
+    }
 
     #[test]
     fn rejects_parent_and_absolute_keys() {

--- a/crates/temper-server/src/observe/specs/path_security.rs
+++ b/crates/temper-server/src/observe/specs/path_security.rs
@@ -95,13 +95,9 @@ pub fn validate_inline_spec_key(key: &str) -> Result<PathBuf, PathSecurityError>
     for component in path.components() {
         match component {
             Component::Normal(part) => {
+                // Component::Normal never yields "." / ".." (those are CurDir/ParentDir).
+                // Still reject embedded ".." tokens like "foo..bar".
                 let s = part.to_string_lossy();
-                if s == ".." || s == "." {
-                    return Err((
-                        StatusCode::BAD_REQUEST,
-                        format!("inline spec key '{key}' has forbidden component"),
-                    ));
-                }
                 if s.contains("..") {
                     return Err((
                         StatusCode::BAD_REQUEST,
@@ -152,7 +148,12 @@ pub fn ensure_under_root(root: &Path, joined: &Path) -> Result<(), PathSecurityE
     }
 
     let root_canon = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
-    if !joined.starts_with(root) && !joined.starts_with(&root_canon) {
+    // Prefer a canonical joined path when it already exists (closes symlink escapes
+    // under the staging root). Fall back to the raw path for not-yet-created targets.
+    let joined_check = joined
+        .canonicalize()
+        .unwrap_or_else(|_| joined.to_path_buf());
+    if !joined_check.starts_with(root) && !joined_check.starts_with(&root_canon) {
         return Err((
             StatusCode::BAD_REQUEST,
             format!(

--- a/crates/temper-server/src/observe/specs/path_security.rs
+++ b/crates/temper-server/src/observe/specs/path_security.rs
@@ -13,11 +13,49 @@ pub const MAX_INLINE_SPEC_FILES: usize = 256;
 /// Max bytes for a single inline file.
 pub const MAX_INLINE_FILE_BYTES: usize = 2 * 1024 * 1024;
 
-/// Max total bytes across all inline files.
+/// Max total bytes across all inline files (including optional extras).
 pub const MAX_INLINE_TOTAL_BYTES: usize = 8 * 1024 * 1024;
 
+/// Normalized relative path plus content reference from an inline map entry.
+pub type ValidatedInlineFile<'a> = (PathBuf, &'a str);
+
+/// Validated inline bundle: files and cumulative byte total.
+pub type ValidatedInlineBundle<'a> = (Vec<ValidatedInlineFile<'a>>, usize);
+
+/// Handler error pair used across path-security helpers.
+pub type PathSecurityError = (StatusCode, String);
+
+/// Invocation-unique staging directory that is removed on drop.
+///
+/// Ensures cleanup on success, error, and panic after materialization begins.
+pub struct InlineStagingDir {
+    path: PathBuf,
+    keep: bool,
+}
+
+impl InlineStagingDir {
+    /// Borrow the staging root path.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Prevent automatic removal (tests only).
+    #[cfg(test)]
+    pub fn keep_on_drop(&mut self) {
+        self.keep = true;
+    }
+}
+
+impl Drop for InlineStagingDir {
+    fn drop(&mut self) {
+        if !self.keep {
+            let _ = std::fs::remove_dir_all(&self.path); // determinism-ok: HTTP staging cleanup
+        }
+    }
+}
+
 /// Validate a single inline map key as a relative, non-escaping path.
-pub fn validate_inline_spec_key(key: &str) -> Result<PathBuf, (StatusCode, String)> {
+pub fn validate_inline_spec_key(key: &str) -> Result<PathBuf, PathSecurityError> {
     let key = key.trim();
     if key.is_empty() {
         return Err((
@@ -98,10 +136,22 @@ pub fn validate_inline_spec_key(key: &str) -> Result<PathBuf, (StatusCode, Strin
     Ok(normalized)
 }
 
-/// Ensure `joined` stays under `root` (string-prefix containment after normalize).
-pub fn ensure_under_root(root: &Path, joined: &Path) -> Result<(), (StatusCode, String)> {
+/// Ensure `joined` stays under `root` (component-prefix containment, no `..`).
+pub fn ensure_under_root(root: &Path, joined: &Path) -> Result<(), PathSecurityError> {
+    // Reject any parent-dir component in the joined path (defense in depth).
+    for component in joined.components() {
+        if matches!(component, Component::ParentDir) {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                format!(
+                    "inline path escapes staging root: {} contains '..'",
+                    joined.display()
+                ),
+            ));
+        }
+    }
+
     let root_canon = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
-    // Parent of joined may not exist yet — walk components against root.
     if !joined.starts_with(root) && !joined.starts_with(&root_canon) {
         return Err((
             StatusCode::BAD_REQUEST,
@@ -115,10 +165,40 @@ pub fn ensure_under_root(root: &Path, joined: &Path) -> Result<(), (StatusCode, 
     Ok(())
 }
 
-/// Validate entire inline map budgets and keys; return normalized relative paths.
+/// Enforce a single extra payload against the per-file and total budgets.
+pub fn enforce_extra_payload_budget(
+    label: &str,
+    content: &str,
+    used_total: usize,
+) -> Result<usize, PathSecurityError> {
+    if content.len() > MAX_INLINE_FILE_BYTES {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "inline file '{label}' exceeds size budget: {} > {}",
+                content.len(),
+                MAX_INLINE_FILE_BYTES
+            ),
+        ));
+    }
+    let total = used_total.saturating_add(content.len());
+    if total > MAX_INLINE_TOTAL_BYTES {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "inline specs exceed total byte budget: > {}",
+                MAX_INLINE_TOTAL_BYTES
+            ),
+        ));
+    }
+    Ok(total)
+}
+
+/// Validate entire inline map budgets and keys; return normalized relative paths
+/// and total byte usage (for additional payloads).
 pub fn validate_inline_bundle(
     specs: &std::collections::BTreeMap<String, String>,
-) -> Result<Vec<(PathBuf, &str)>, (StatusCode, String)> {
+) -> Result<ValidatedInlineBundle<'_>, PathSecurityError> {
     if specs.is_empty() {
         return Err((
             StatusCode::BAD_REQUEST,
@@ -172,11 +252,13 @@ pub fn validate_inline_bundle(
         out.push((rel, content.as_str()));
     }
 
-    Ok(out)
+    Ok((out, total))
 }
 
 /// Create an invocation-unique staging directory for inline specs.
-pub fn create_inline_staging_dir(tenant: &str) -> Result<PathBuf, (StatusCode, String)> {
+///
+/// Uses exclusive `create_dir` so an existing path cannot be clobbered.
+pub fn create_inline_staging_dir(tenant: &str) -> Result<InlineStagingDir, PathSecurityError> {
     let safe_tenant: String = tenant
         .chars()
         .map(|c| {
@@ -190,13 +272,17 @@ pub fn create_inline_staging_dir(tenant: &str) -> Result<PathBuf, (StatusCode, S
         .collect();
     let id = temper_runtime::scheduler::sim_uuid();
     let dir = std::env::temp_dir().join(format!("temper-inline-{safe_tenant}-{id}")); // determinism-ok: HTTP staging
-    std::fs::create_dir_all(&dir).map_err(|e| {
+    // Exclusive create — fail if the path already exists (no clobber).
+    std::fs::create_dir(&dir).map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("Failed to create staging dir: {e}"),
         )
     })?;
-    Ok(dir)
+    Ok(InlineStagingDir {
+        path: dir,
+        keep: false,
+    })
 }
 
 #[cfg(test)]
@@ -210,6 +296,8 @@ mod tests {
         assert!(validate_inline_spec_key("/etc/passwd").is_err());
         assert!(validate_inline_spec_key("foo/../../etc").is_err());
         assert!(validate_inline_spec_key("C:\\Windows\\system32").is_err());
+        assert!(validate_inline_spec_key("foo\0bar").is_err());
+        assert!(validate_inline_spec_key("").is_err());
     }
 
     #[test]
@@ -228,6 +316,25 @@ mod tests {
     }
 
     #[test]
+    fn rejects_oversize_single_file() {
+        let mut specs = BTreeMap::new();
+        specs.insert("big.ioa.toml".into(), "x".repeat(MAX_INLINE_FILE_BYTES + 1));
+        assert!(validate_inline_bundle(&specs).is_err());
+    }
+
+    #[test]
+    fn rejects_oversize_total_bytes() {
+        let mut specs = BTreeMap::new();
+        // Several files under per-file cap that sum past total.
+        let chunk = MAX_INLINE_FILE_BYTES;
+        let need = (MAX_INLINE_TOTAL_BYTES / chunk) + 1;
+        for i in 0..need {
+            specs.insert(format!("f{i}.ioa.toml"), "y".repeat(chunk));
+        }
+        assert!(validate_inline_bundle(&specs).is_err());
+    }
+
+    #[test]
     fn rejects_duplicate_normalized_keys() {
         let mut specs = BTreeMap::new();
         specs.insert("a/b.ioa.toml".into(), "1".into());
@@ -237,5 +344,52 @@ mod tests {
         // "./a/b" normalizes by skipping CurDir → same as a/b
         let err = validate_inline_bundle(&specs);
         assert!(err.is_err(), "duplicate after normalize should fail");
+    }
+
+    #[test]
+    fn extra_payload_budget_enforced() {
+        let used = MAX_INLINE_TOTAL_BYTES - 10;
+        assert!(enforce_extra_payload_budget("cross", "x".repeat(20).as_str(), used).is_err());
+        assert!(enforce_extra_payload_budget("cross", "ok", used).is_ok());
+        assert!(
+            enforce_extra_payload_budget("cross", &"z".repeat(MAX_INLINE_FILE_BYTES + 1), 0)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn ensure_under_root_rejects_parent_components() {
+        let root = PathBuf::from("/tmp/staging-root");
+        let bad = root.join("a").join("..").join("escape");
+        assert!(ensure_under_root(&root, &bad).is_err());
+        let good = root.join("a").join("b.ioa.toml");
+        assert!(ensure_under_root(&root, &good).is_ok());
+    }
+
+    #[test]
+    fn staging_dirs_are_invocation_unique_for_same_tenant() {
+        let a = create_inline_staging_dir("tenant-a").expect("a");
+        let b = create_inline_staging_dir("tenant-a").expect("b");
+        assert_ne!(a.path(), b.path());
+        assert!(a.path().exists());
+        assert!(b.path().exists());
+        // Drop cleans both.
+        let path_a = a.path().to_path_buf();
+        let path_b = b.path().to_path_buf();
+        drop(a);
+        drop(b);
+        assert!(!path_a.exists(), "staging A must be removed on drop");
+        assert!(!path_b.exists(), "staging B must be removed on drop");
+    }
+
+    #[test]
+    fn staging_create_is_exclusive() {
+        let mut first = create_inline_staging_dir("excl").expect("first");
+        first.keep_on_drop();
+        let path = first.path().to_path_buf();
+        // Manually attempt create_dir on the same path — should fail.
+        let err = std::fs::create_dir(&path);
+        assert!(err.is_err(), "exclusive create must fail when path exists");
+        let _ = std::fs::remove_dir_all(&path);
     }
 }

--- a/crates/temper-server/src/observe/specs/path_security.rs
+++ b/crates/temper-server/src/observe/specs/path_security.rs
@@ -1,4 +1,4 @@
-//! Spec ingestion path security (ADR-0159 / ARN-229).
+//! Spec ingestion path security (ADR-0162 / ARN-229).
 //!
 //! Fail-closed validation for inline spec map keys and staging under a
 //! capability-owned, invocation-unique directory.

--- a/crates/temper-server/src/observe/specs/path_security.rs
+++ b/crates/temper-server/src/observe/specs/path_security.rs
@@ -1,0 +1,241 @@
+//! Spec ingestion path security (ADR-0159 / ARN-229).
+//!
+//! Fail-closed validation for inline spec map keys and staging under a
+//! capability-owned, invocation-unique directory.
+
+use std::path::{Component, Path, PathBuf};
+
+use axum::http::StatusCode;
+
+/// Max files accepted in one inline submission.
+pub const MAX_INLINE_SPEC_FILES: usize = 256;
+
+/// Max bytes for a single inline file.
+pub const MAX_INLINE_FILE_BYTES: usize = 2 * 1024 * 1024;
+
+/// Max total bytes across all inline files.
+pub const MAX_INLINE_TOTAL_BYTES: usize = 8 * 1024 * 1024;
+
+/// Validate a single inline map key as a relative, non-escaping path.
+pub fn validate_inline_spec_key(key: &str) -> Result<PathBuf, (StatusCode, String)> {
+    let key = key.trim();
+    if key.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "inline spec key must not be empty".to_string(),
+        ));
+    }
+    if key.contains('\0') {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "inline spec key must not contain NUL".to_string(),
+        ));
+    }
+    if key.starts_with('/') || key.starts_with('\\') {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("inline spec key must be relative (got absolute '{key}')"),
+        ));
+    }
+    // Windows drive / UNC style
+    if key.len() >= 2 && key.as_bytes()[1] == b':' {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("inline spec key must not include a drive prefix ('{key}')"),
+        ));
+    }
+
+    let path = Path::new(key);
+    if path.is_absolute() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("inline spec key must be relative (got '{key}')"),
+        ));
+    }
+
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => {
+                let s = part.to_string_lossy();
+                if s == ".." || s == "." {
+                    return Err((
+                        StatusCode::BAD_REQUEST,
+                        format!("inline spec key '{key}' has forbidden component"),
+                    ));
+                }
+                if s.contains("..") {
+                    return Err((
+                        StatusCode::BAD_REQUEST,
+                        format!("inline spec key '{key}' must not embed '..'"),
+                    ));
+                }
+                normalized.push(part);
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    format!("inline spec key '{key}' must not contain '..'"),
+                ));
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    format!("inline spec key '{key}' must not be absolute"),
+                ));
+            }
+        }
+    }
+
+    if normalized.as_os_str().is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("inline spec key '{key}' normalizes to empty"),
+        ));
+    }
+
+    Ok(normalized)
+}
+
+/// Ensure `joined` stays under `root` (string-prefix containment after normalize).
+pub fn ensure_under_root(root: &Path, joined: &Path) -> Result<(), (StatusCode, String)> {
+    let root_canon = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+    // Parent of joined may not exist yet — walk components against root.
+    if !joined.starts_with(root) && !joined.starts_with(&root_canon) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "inline path escapes staging root: {} not under {}",
+                joined.display(),
+                root.display()
+            ),
+        ));
+    }
+    Ok(())
+}
+
+/// Validate entire inline map budgets and keys; return normalized relative paths.
+pub fn validate_inline_bundle(
+    specs: &std::collections::BTreeMap<String, String>,
+) -> Result<Vec<(PathBuf, &str)>, (StatusCode, String)> {
+    if specs.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "inline specs map must not be empty".to_string(),
+        ));
+    }
+    if specs.len() > MAX_INLINE_SPEC_FILES {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "inline specs exceed file budget: {} > {}",
+                specs.len(),
+                MAX_INLINE_SPEC_FILES
+            ),
+        ));
+    }
+
+    let mut total: usize = 0;
+    let mut out = Vec::with_capacity(specs.len());
+    let mut seen = std::collections::BTreeSet::new();
+
+    for (key, content) in specs {
+        if content.len() > MAX_INLINE_FILE_BYTES {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                format!(
+                    "inline file '{key}' exceeds size budget: {} > {}",
+                    content.len(),
+                    MAX_INLINE_FILE_BYTES
+                ),
+            ));
+        }
+        total = total.saturating_add(content.len());
+        if total > MAX_INLINE_TOTAL_BYTES {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                format!(
+                    "inline specs exceed total byte budget: > {}",
+                    MAX_INLINE_TOTAL_BYTES
+                ),
+            ));
+        }
+        let rel = validate_inline_spec_key(key)?;
+        let norm = rel.to_string_lossy().replace('\\', "/");
+        if !seen.insert(norm.clone()) {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                format!("duplicate normalized inline path '{norm}'"),
+            ));
+        }
+        out.push((rel, content.as_str()));
+    }
+
+    Ok(out)
+}
+
+/// Create an invocation-unique staging directory for inline specs.
+pub fn create_inline_staging_dir(tenant: &str) -> Result<PathBuf, (StatusCode, String)> {
+    let safe_tenant: String = tenant
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .take(64)
+        .collect();
+    let id = temper_runtime::scheduler::sim_uuid();
+    let dir = std::env::temp_dir().join(format!("temper-inline-{safe_tenant}-{id}")); // determinism-ok: HTTP staging
+    std::fs::create_dir_all(&dir).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to create staging dir: {e}"),
+        )
+    })?;
+    Ok(dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn rejects_parent_and_absolute_keys() {
+        assert!(validate_inline_spec_key("../etc/passwd").is_err());
+        assert!(validate_inline_spec_key("/etc/passwd").is_err());
+        assert!(validate_inline_spec_key("foo/../../etc").is_err());
+        assert!(validate_inline_spec_key("C:\\Windows\\system32").is_err());
+    }
+
+    #[test]
+    fn accepts_nested_relative_keys() {
+        let p = validate_inline_spec_key("app/model.csdl.xml").expect("ok");
+        assert_eq!(p, PathBuf::from("app/model.csdl.xml"));
+    }
+
+    #[test]
+    fn rejects_oversize_bundle() {
+        let mut specs = BTreeMap::new();
+        for i in 0..(MAX_INLINE_SPEC_FILES + 1) {
+            specs.insert(format!("f{i}.ioa.toml"), "x".into());
+        }
+        assert!(validate_inline_bundle(&specs).is_err());
+    }
+
+    #[test]
+    fn rejects_duplicate_normalized_keys() {
+        let mut specs = BTreeMap::new();
+        specs.insert("a/b.ioa.toml".into(), "1".into());
+        // Same path with redundant ./  — validate component-wise; both are distinct
+        // string keys but if one has parent dir it fails earlier.
+        specs.insert("./a/b.ioa.toml".into(), "2".into());
+        // "./a/b" normalizes by skipping CurDir → same as a/b
+        let err = validate_inline_bundle(&specs);
+        assert!(err.is_err(), "duplicate after normalize should fail");
+    }
+}

--- a/docs/adrs/0159-spec-ingestion-no-host-paths.md
+++ b/docs/adrs/0159-spec-ingestion-no-host-paths.md
@@ -1,0 +1,63 @@
+# ADR-0159: Spec ingestion without host paths (ARN-229)
+
+- Status: Accepted
+- Date: 2026-07-12
+- Deciders: Temper core maintainers
+- Related:
+  - ARN-229: Spec ingestion exposes arbitrary host filesystem
+  - `crates/temper-server/src/observe/specs/load_dir.rs`
+  - `crates/temper-server/src/observe/specs/load_inline.rs`
+  - `crates/temper-server/src/observe/specs/path_security.rs`
+
+## Context
+
+`POST /api/specs/load-dir` accepted an arbitrary server path and read CSDL/IOA
+from it without a handler-level auth gate. `load-inline` staged into a
+tenant-named shared temp directory and joined caller keys without rejecting
+`..` / absolute paths, enabling path escape and concurrent clobbering.
+
+## Decision
+
+### Sub-Decision 1: No network-named host directories
+
+The HTTP `load-dir` endpoint **rejects** caller-supplied server paths
+(status `410 Gone` / clear error). Specs enter the network API only as an
+in-memory filename→content map (`load-inline`).
+
+Internal loading from a resolved path remains available only after the kernel
+itself materializes a validated staging directory (used by load-inline).
+
+### Sub-Decision 2: Strict relative keys for inline bundles
+
+Every map key must be a relative path:
+
+- No absolute paths, drive prefixes, or `..` components
+- No null bytes or empty segments
+- Normalized containment under the staging root after join
+- Budgets: max files, max total bytes, max single file size
+
+### Sub-Decision 3: Invocation-unique staging
+
+Staging directories are `temper-inline-{tenant}-{uuid}` (not tenant-only), so
+concurrent submissions cannot delete each other's trees.
+
+### Sub-Decision 4: Auth on load-inline remains required
+
+Cedar `submit_specs` continues to gate load-inline. load-dir no longer accepts
+network callers.
+
+## Consequences
+
+### Positive
+
+- Network callers cannot name host directories.
+- Path traversal and shared-temp races are closed for inline submission.
+
+### Negative
+
+- Local operators who scripted `load-dir` with filesystem paths must switch to
+  load-inline or an out-of-band install path.
+
+## Non-Goals
+
+- Full multipart archive format (zip) — in-memory map is sufficient for now.

--- a/docs/adrs/0159-spec-ingestion-no-host-paths.md
+++ b/docs/adrs/0159-spec-ingestion-no-host-paths.md
@@ -41,6 +41,12 @@ Every map key must be a relative path:
 Staging directories are `temper-inline-{tenant}-{uuid}` (not tenant-only), so
 concurrent submissions cannot delete each other's trees.
 
+### Sub-Decision 3b: No durable registry for ephemeral staging
+
+`specs-registry.json` must not record `temper-inline-*` paths. Staging is
+deleted when the request finishes; writing those paths would poison restart
+reload. Existing poisoned entries are scrubbed on the next registry rewrite.
+
 ### Sub-Decision 4: Auth on load-inline remains required
 
 Cedar `submit_specs` continues to gate load-inline. load-dir no longer accepts

--- a/docs/adrs/0162-spec-ingestion-no-host-paths.md
+++ b/docs/adrs/0162-spec-ingestion-no-host-paths.md
@@ -1,4 +1,4 @@
-# ADR-0159: Spec ingestion without host paths (ARN-229)
+# ADR-0162: Spec ingestion without host paths (ARN-229)
 
 - Status: Accepted
 - Date: 2026-07-12


### PR DESCRIPTION
## Summary
ARN-229: close host-filesystem exposure on the network spec surface.

- **HTTP `load-dir` returns 410** — no network-named host directories
- **load-inline** validates relative keys (no `..`/absolute), budgets files/bytes, stages under `temper-inline-{tenant}-{uuid}`, cleans up after load
- **ADR-0159**

## Tests
- [x] path_security unit tests (4)
- [x] load-dir network ban tests (4)
- [ ] CI green

Linear: ARN-229

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes ARN-229 by banning caller-supplied host paths from the network spec ingestion surface: `POST /api/specs/load-dir` now returns `410 Gone`, and `load-inline` gains path-traversal guards, per-file byte budgets, and UUID-named staging directories that are cleaned up after every request.

- `path_security.rs` (new): rejects `..`, absolute, NUL-containing, and drive-prefixed keys; enforces 256-file / 2 MiB-per-file / 8 MiB-total budgets; issues invocation-unique staging dirs via `temper-inline-{tenant}-{uuid}`.
- `load_inline.rs`: wires through `validate_inline_bundle` + `create_inline_staging_dir` + `ensure_under_root` before writing any file, then calls `load_specs_from_resolved_path` for the actual load.
- `load_dir.rs`: the HTTP handler returns `410`; real loading logic moves to `load_specs_from_resolved_path` — but it still writes the transient staging path into `specs-registry.json`, which will be stale as soon as cleanup runs.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The path-traversal and host-filesystem exposure fixes are correct and well-structured, but every inline spec submission now writes a stale entry to `specs-registry.json` that points to a deleted staging directory, which would silently break any restart-based spec reload for inline-submitted tenants.

The core security changes work as intended. The registry persistence bug is a current behavioral regression: every inline spec submission now produces a stale entry in `specs-registry.json`, and since `load-dir` is no longer available as a network option, inline-submitted tenants would not survive a server restart if the file-based registry is the reload source.

`crates/temper-server/src/observe/specs/load_dir.rs` lines 261–266 — the `specs-registry.json` write inside `load_specs_from_resolved_path` should skip or tombstone the entry when the path is a transient staging directory.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/temper-server/src/observe/specs/path_security.rs | New module enforcing key validation, byte budgets, and UUID staging. Logic is sound; minor hardening gaps in `ensure_under_root` and a dead-code branch in the Normal component arm. |
| crates/temper-server/src/observe/specs/load_dir.rs | HTTP handler now returns 410. Correctness issue: `load_specs_from_resolved_path` writes the transient staging path to `specs-registry.json`, leaving stale entries after cleanup. |
| crates/temper-server/src/observe/specs/load_inline.rs | Correctly wires validation + UUID staging + ensure_under_root before writes. Cleanup is safe since file data is fully in-memory before the response is returned. |
| crates/temper-server/src/observe/mod_test.rs | load-dir tests updated to assert 410; four network-ban tests added. Previous load-logic coverage replaced with GONE assertions. |
| crates/temper-server/src/observe/specs.rs | Adds `mod path_security;` only. |
| docs/adrs/0159-spec-ingestion-no-host-paths.md | New ADR documenting the four sub-decisions. Accurate and matches the implementation. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant handle_load_dir
    participant handle_load_inline
    participant path_security
    participant load_specs_from_resolved_path
    participant FS as Filesystem
    participant Registry

    Client->>handle_load_dir: POST /api/specs/load-dir
    handle_load_dir-->>Client: 410 Gone (ARN-229)

    Client->>handle_load_inline: POST /api/specs/load-inline
    handle_load_inline->>handle_load_inline: Cedar authz gate
    handle_load_inline->>path_security: validate_inline_bundle(specs)
    path_security-->>handle_load_inline: Vec normalized paths
    handle_load_inline->>path_security: create_inline_staging_dir(tenant)
    path_security->>FS: create /tmp/temper-inline-tenant-uuid
    path_security-->>handle_load_inline: tmp_dir
    handle_load_inline->>path_security: resolve_inline_specs_root + ensure_under_root
    loop per validated file
        handle_load_inline->>path_security: ensure_under_root(tmp_dir, path)
        handle_load_inline->>FS: write tmp_dir/rel
    end
    handle_load_inline->>load_specs_from_resolved_path: state + LoadDirRequest
    load_specs_from_resolved_path->>FS: read csdl + ioa.toml into memory
    load_specs_from_resolved_path->>Registry: register specs
    load_specs_from_resolved_path->>FS: write specs-registry.json (stale transient path)
    load_specs_from_resolved_path-->>handle_load_inline: streaming Response
    handle_load_inline->>FS: remove_dir_all(tmp_dir)
    handle_load_inline-->>Client: NDJSON verification stream
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant handle_load_dir
    participant handle_load_inline
    participant path_security
    participant load_specs_from_resolved_path
    participant FS as Filesystem
    participant Registry

    Client->>handle_load_dir: POST /api/specs/load-dir
    handle_load_dir-->>Client: 410 Gone (ARN-229)

    Client->>handle_load_inline: POST /api/specs/load-inline
    handle_load_inline->>handle_load_inline: Cedar authz gate
    handle_load_inline->>path_security: validate_inline_bundle(specs)
    path_security-->>handle_load_inline: Vec normalized paths
    handle_load_inline->>path_security: create_inline_staging_dir(tenant)
    path_security->>FS: create /tmp/temper-inline-tenant-uuid
    path_security-->>handle_load_inline: tmp_dir
    handle_load_inline->>path_security: resolve_inline_specs_root + ensure_under_root
    loop per validated file
        handle_load_inline->>path_security: ensure_under_root(tmp_dir, path)
        handle_load_inline->>FS: write tmp_dir/rel
    end
    handle_load_inline->>load_specs_from_resolved_path: state + LoadDirRequest
    load_specs_from_resolved_path->>FS: read csdl + ioa.toml into memory
    load_specs_from_resolved_path->>Registry: register specs
    load_specs_from_resolved_path->>FS: write specs-registry.json (stale transient path)
    load_specs_from_resolved_path-->>handle_load_inline: streaming Response
    handle_load_inline->>FS: remove_dir_all(tmp_dir)
    handle_load_inline-->>Client: NDJSON verification stream
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/temper-server/src/observe/specs/load_dir.rs`, line 261-266 ([link](https://github.com/nerdsane/temper/blob/1c9d54f47a7ef8438f595eb9538a607464af9af8/crates/temper-server/src/observe/specs/load_dir.rs#L261-L266)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Stale path written to `specs-registry.json`**

   `load_specs_from_resolved_path` unconditionally writes `body.specs_dir` (the transient staging path, e.g. `/tmp/temper-inline-tenant-uuid/…`) to `specs-registry.json`. The staging directory is deleted by `handle_load_inline` immediately after this function returns. On any server restart that reads `specs-registry.json` to reload specs, every inline-submitted tenant will point to a path that no longer exists, silently breaking the registry-based reload. Since `load-dir` is now gone as a direct network option (this PR), inline is the primary ingestion path — making this persistence gap more impactful than before.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: crates/temper-server/src/observe/specs/load_dir.rs
   Line: 261-266

   Comment:
   **Stale path written to `specs-registry.json`**

   `load_specs_from_resolved_path` unconditionally writes `body.specs_dir` (the transient staging path, e.g. `/tmp/temper-inline-tenant-uuid/…`) to `specs-registry.json`. The staging directory is deleted by `handle_load_inline` immediately after this function returns. On any server restart that reads `specs-registry.json` to reload specs, every inline-submitted tenant will point to a path that no longer exists, silently breaking the registry-based reload. Since `load-dir` is now gone as a direct network option (this PR), inline is the primary ingestion path — making this persistence gap more impactful than before.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-server%2Fsrc%2Fobserve%2Fspecs%2Fload_dir.rs%0ALine%3A%20261-266%0A%0AComment%3A%0A**Stale%20path%20written%20to%20%60specs-registry.json%60**%0A%0A%60load_specs_from_resolved_path%60%20unconditionally%20writes%20%60body.specs_dir%60%20%28the%20transient%20staging%20path%2C%20e.g.%20%60%2Ftmp%2Ftemper-inline-tenant-uuid%2F%E2%80%A6%60%29%20to%20%60specs-registry.json%60.%20The%20staging%20directory%20is%20deleted%20by%20%60handle_load_inline%60%20immediately%20after%20this%20function%20returns.%20On%20any%20server%20restart%20that%20reads%20%60specs-registry.json%60%20to%20reload%20specs%2C%20every%20inline-submitted%20tenant%20will%20point%20to%20a%20path%20that%20no%20longer%20exists%2C%20silently%20breaking%20the%20registry-based%20reload.%20Since%20%60load-dir%60%20is%20now%20gone%20as%20a%20direct%20network%20option%20%28this%20PR%29%2C%20inline%20is%20the%20primary%20ingestion%20path%20%E2%80%94%20making%20this%20persistence%20gap%20more%20impactful%20than%20before.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=nerdsane%2Ftemper&pr=361&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22grok%2Farn-229-spec-ingestion%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22grok%2Farn-229-spec-ingestion%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-server%2Fsrc%2Fobserve%2Fspecs%2Fload_dir.rs%0ALine%3A%20261-266%0A%0AComment%3A%0A**Stale%20path%20written%20to%20%60specs-registry.json%60**%0A%0A%60load_specs_from_resolved_path%60%20unconditionally%20writes%20%60body.specs_dir%60%20%28the%20transient%20staging%20path%2C%20e.g.%20%60%2Ftmp%2Ftemper-inline-tenant-uuid%2F%E2%80%A6%60%29%20to%20%60specs-registry.json%60.%20The%20staging%20directory%20is%20deleted%20by%20%60handle_load_inline%60%20immediately%20after%20this%20function%20returns.%20On%20any%20server%20restart%20that%20reads%20%60specs-registry.json%60%20to%20reload%20specs%2C%20every%20inline-submitted%20tenant%20will%20point%20to%20a%20path%20that%20no%20longer%20exists%2C%20silently%20breaking%20the%20registry-based%20reload.%20Since%20%60load-dir%60%20is%20now%20gone%20as%20a%20direct%20network%20option%20%28this%20PR%29%2C%20inline%20is%20the%20primary%20ingestion%20path%20%E2%80%94%20making%20this%20persistence%20gap%20more%20impactful%20than%20before.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=nerdsane%2Ftemper&pr=361&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-server%2Fsrc%2Fobserve%2Fspecs%2Fload_dir.rs%0ALine%3A%20261-266%0A%0AComment%3A%0A**Stale%20path%20written%20to%20%60specs-registry.json%60**%0A%0A%60load_specs_from_resolved_path%60%20unconditionally%20writes%20%60body.specs_dir%60%20%28the%20transient%20staging%20path%2C%20e.g.%20%60%2Ftmp%2Ftemper-inline-tenant-uuid%2F%E2%80%A6%60%29%20to%20%60specs-registry.json%60.%20The%20staging%20directory%20is%20deleted%20by%20%60handle_load_inline%60%20immediately%20after%20this%20function%20returns.%20On%20any%20server%20restart%20that%20reads%20%60specs-registry.json%60%20to%20reload%20specs%2C%20every%20inline-submitted%20tenant%20will%20point%20to%20a%20path%20that%20no%20longer%20exists%2C%20silently%20breaking%20the%20registry-based%20reload.%20Since%20%60load-dir%60%20is%20now%20gone%20as%20a%20direct%20network%20option%20%28this%20PR%29%2C%20inline%20is%20the%20primary%20ingestion%20path%20%E2%80%94%20making%20this%20persistence%20gap%20more%20impactful%20than%20before.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=361&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftemper-server%2Fsrc%2Fobserve%2Fspecs%2Fload_dir.rs%3A261-266%0A**Stale%20path%20written%20to%20%60specs-registry.json%60**%0A%0A%60load_specs_from_resolved_path%60%20unconditionally%20writes%20%60body.specs_dir%60%20%28the%20transient%20staging%20path%2C%20e.g.%20%60%2Ftmp%2Ftemper-inline-tenant-uuid%2F%E2%80%A6%60%29%20to%20%60specs-registry.json%60.%20The%20staging%20directory%20is%20deleted%20by%20%60handle_load_inline%60%20immediately%20after%20this%20function%20returns.%20On%20any%20server%20restart%20that%20reads%20%60specs-registry.json%60%20to%20reload%20specs%2C%20every%20inline-submitted%20tenant%20will%20point%20to%20a%20path%20that%20no%20longer%20exists%2C%20silently%20breaking%20the%20registry-based%20reload.%20Since%20%60load-dir%60%20is%20now%20gone%20as%20a%20direct%20network%20option%20%28this%20PR%29%2C%20inline%20is%20the%20primary%20ingestion%20path%20%E2%80%94%20making%20this%20persistence%20gap%20more%20impactful%20than%20before.%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftemper-server%2Fsrc%2Fobserve%2Fspecs%2Fpath_security.rs%3A59-67%0A**Dead-code%20guard%20inside%20%60Component%3A%3ANormal%60%20arm**%0A%0A%60Component%3A%3ANormal%60%20is%20never%20yielded%20for%20%60%22.%22%60%20or%20%60%22..%22%60%20%E2%80%94%20Rust's%20path%20parser%20emits%20those%20as%20%60Component%3A%3ACurDir%60%20and%20%60Component%3A%3AParentDir%60%2C%20handled%20by%20their%20own%20match%20arms.%20The%20%60s%20%3D%3D%20%22..%22%60%20and%20%60s%20%3D%3D%20%22.%22%60%20checks%20can%20never%20be%20true%20and%20may%20mislead%20a%20future%20reviewer%20into%20thinking%20the%20%60ParentDir%60%2F%60CurDir%60%20arms%20are%20optional.%20The%20%60s.contains%28%22..%22%29%60%20check%20below%20%28catching%20embedded%20double-dots%20like%20%60foo..bar%60%29%20remains%20valid%20and%20should%20be%20kept.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20Component%3A%3ANormal%28part%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20s%20%3D%20part.to_string_lossy%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20s.contains%28%22..%22%29%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftemper-server%2Fsrc%2Fobserve%2Fspecs%2Fpath_security.rs%3A101-116%0A**%60ensure_under_root%60%20checks%20only%20the%20raw%20%28non-canonicalized%29%20%60joined%60%20path**%0A%0A%60root_canon%60%20is%20produced%20by%20%60canonicalize%60%2C%20but%20%60joined%60%20is%20never%20canonicalized%20before%20the%20%60starts_with%60%20checks.%20If%20a%20subdirectory%20inside%20the%20staging%20dir%20contains%20a%20symlink%20pointing%20outside%20%60tmp_dir%60%2C%20%60ensure_under_root%60%20would%20approve%20the%20pre-symlink%20raw%20path%20while%20the%20actual%20write%20resolves%20elsewhere.%20Given%20the%20UUID-named%20fresh%20directory%20this%20is%20practically%20unexploitable%20today%2C%20but%20canonicalizing%20%60joined%60%20%28falling%20back%20to%20raw%20if%20the%20target%20does%20not%20yet%20exist%29%20would%20close%20the%20gap.%0A%0A&repo=nerdsane%2Ftemper&pr=361&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22grok%2Farn-229-spec-ingestion%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22grok%2Farn-229-spec-ingestion%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftemper-server%2Fsrc%2Fobserve%2Fspecs%2Fload_dir.rs%3A261-266%0A**Stale%20path%20written%20to%20%60specs-registry.json%60**%0A%0A%60load_specs_from_resolved_path%60%20unconditionally%20writes%20%60body.specs_dir%60%20%28the%20transient%20staging%20path%2C%20e.g.%20%60%2Ftmp%2Ftemper-inline-tenant-uuid%2F%E2%80%A6%60%29%20to%20%60specs-registry.json%60.%20The%20staging%20directory%20is%20deleted%20by%20%60handle_load_inline%60%20immediately%20after%20this%20function%20returns.%20On%20any%20server%20restart%20that%20reads%20%60specs-registry.json%60%20to%20reload%20specs%2C%20every%20inline-submitted%20tenant%20will%20point%20to%20a%20path%20that%20no%20longer%20exists%2C%20silently%20breaking%20the%20registry-based%20reload.%20Since%20%60load-dir%60%20is%20now%20gone%20as%20a%20direct%20network%20option%20%28this%20PR%29%2C%20inline%20is%20the%20primary%20ingestion%20path%20%E2%80%94%20making%20this%20persistence%20gap%20more%20impactful%20than%20before.%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftemper-server%2Fsrc%2Fobserve%2Fspecs%2Fpath_security.rs%3A59-67%0A**Dead-code%20guard%20inside%20%60Component%3A%3ANormal%60%20arm**%0A%0A%60Component%3A%3ANormal%60%20is%20never%20yielded%20for%20%60%22.%22%60%20or%20%60%22..%22%60%20%E2%80%94%20Rust's%20path%20parser%20emits%20those%20as%20%60Component%3A%3ACurDir%60%20and%20%60Component%3A%3AParentDir%60%2C%20handled%20by%20their%20own%20match%20arms.%20The%20%60s%20%3D%3D%20%22..%22%60%20and%20%60s%20%3D%3D%20%22.%22%60%20checks%20can%20never%20be%20true%20and%20may%20mislead%20a%20future%20reviewer%20into%20thinking%20the%20%60ParentDir%60%2F%60CurDir%60%20arms%20are%20optional.%20The%20%60s.contains%28%22..%22%29%60%20check%20below%20%28catching%20embedded%20double-dots%20like%20%60foo..bar%60%29%20remains%20valid%20and%20should%20be%20kept.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20Component%3A%3ANormal%28part%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20s%20%3D%20part.to_string_lossy%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20s.contains%28%22..%22%29%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftemper-server%2Fsrc%2Fobserve%2Fspecs%2Fpath_security.rs%3A101-116%0A**%60ensure_under_root%60%20checks%20only%20the%20raw%20%28non-canonicalized%29%20%60joined%60%20path**%0A%0A%60root_canon%60%20is%20produced%20by%20%60canonicalize%60%2C%20but%20%60joined%60%20is%20never%20canonicalized%20before%20the%20%60starts_with%60%20checks.%20If%20a%20subdirectory%20inside%20the%20staging%20dir%20contains%20a%20symlink%20pointing%20outside%20%60tmp_dir%60%2C%20%60ensure_under_root%60%20would%20approve%20the%20pre-symlink%20raw%20path%20while%20the%20actual%20write%20resolves%20elsewhere.%20Given%20the%20UUID-named%20fresh%20directory%20this%20is%20practically%20unexploitable%20today%2C%20but%20canonicalizing%20%60joined%60%20%28falling%20back%20to%20raw%20if%20the%20target%20does%20not%20yet%20exist%29%20would%20close%20the%20gap.%0A%0A&repo=nerdsane%2Ftemper&pr=361&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftemper-server%2Fsrc%2Fobserve%2Fspecs%2Fload_dir.rs%3A261-266%0A**Stale%20path%20written%20to%20%60specs-registry.json%60**%0A%0A%60load_specs_from_resolved_path%60%20unconditionally%20writes%20%60body.specs_dir%60%20%28the%20transient%20staging%20path%2C%20e.g.%20%60%2Ftmp%2Ftemper-inline-tenant-uuid%2F%E2%80%A6%60%29%20to%20%60specs-registry.json%60.%20The%20staging%20directory%20is%20deleted%20by%20%60handle_load_inline%60%20immediately%20after%20this%20function%20returns.%20On%20any%20server%20restart%20that%20reads%20%60specs-registry.json%60%20to%20reload%20specs%2C%20every%20inline-submitted%20tenant%20will%20point%20to%20a%20path%20that%20no%20longer%20exists%2C%20silently%20breaking%20the%20registry-based%20reload.%20Since%20%60load-dir%60%20is%20now%20gone%20as%20a%20direct%20network%20option%20%28this%20PR%29%2C%20inline%20is%20the%20primary%20ingestion%20path%20%E2%80%94%20making%20this%20persistence%20gap%20more%20impactful%20than%20before.%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftemper-server%2Fsrc%2Fobserve%2Fspecs%2Fpath_security.rs%3A59-67%0A**Dead-code%20guard%20inside%20%60Component%3A%3ANormal%60%20arm**%0A%0A%60Component%3A%3ANormal%60%20is%20never%20yielded%20for%20%60%22.%22%60%20or%20%60%22..%22%60%20%E2%80%94%20Rust's%20path%20parser%20emits%20those%20as%20%60Component%3A%3ACurDir%60%20and%20%60Component%3A%3AParentDir%60%2C%20handled%20by%20their%20own%20match%20arms.%20The%20%60s%20%3D%3D%20%22..%22%60%20and%20%60s%20%3D%3D%20%22.%22%60%20checks%20can%20never%20be%20true%20and%20may%20mislead%20a%20future%20reviewer%20into%20thinking%20the%20%60ParentDir%60%2F%60CurDir%60%20arms%20are%20optional.%20The%20%60s.contains%28%22..%22%29%60%20check%20below%20%28catching%20embedded%20double-dots%20like%20%60foo..bar%60%29%20remains%20valid%20and%20should%20be%20kept.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20Component%3A%3ANormal%28part%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20s%20%3D%20part.to_string_lossy%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20s.contains%28%22..%22%29%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftemper-server%2Fsrc%2Fobserve%2Fspecs%2Fpath_security.rs%3A101-116%0A**%60ensure_under_root%60%20checks%20only%20the%20raw%20%28non-canonicalized%29%20%60joined%60%20path**%0A%0A%60root_canon%60%20is%20produced%20by%20%60canonicalize%60%2C%20but%20%60joined%60%20is%20never%20canonicalized%20before%20the%20%60starts_with%60%20checks.%20If%20a%20subdirectory%20inside%20the%20staging%20dir%20contains%20a%20symlink%20pointing%20outside%20%60tmp_dir%60%2C%20%60ensure_under_root%60%20would%20approve%20the%20pre-symlink%20raw%20path%20while%20the%20actual%20write%20resolves%20elsewhere.%20Given%20the%20UUID-named%20fresh%20directory%20this%20is%20practically%20unexploitable%20today%2C%20but%20canonicalizing%20%60joined%60%20%28falling%20back%20to%20raw%20if%20the%20target%20does%20not%20yet%20exist%29%20would%20close%20the%20gap.%0A%0A&pr=361&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
crates/temper-server/src/observe/specs/load_dir.rs:261-266
**Stale path written to `specs-registry.json`**

`load_specs_from_resolved_path` unconditionally writes `body.specs_dir` (the transient staging path, e.g. `/tmp/temper-inline-tenant-uuid/…`) to `specs-registry.json`. The staging directory is deleted by `handle_load_inline` immediately after this function returns. On any server restart that reads `specs-registry.json` to reload specs, every inline-submitted tenant will point to a path that no longer exists, silently breaking the registry-based reload. Since `load-dir` is now gone as a direct network option (this PR), inline is the primary ingestion path — making this persistence gap more impactful than before.

### Issue 2 of 3
crates/temper-server/src/observe/specs/path_security.rs:59-67
**Dead-code guard inside `Component::Normal` arm**

`Component::Normal` is never yielded for `"."` or `".."` — Rust's path parser emits those as `Component::CurDir` and `Component::ParentDir`, handled by their own match arms. The `s == ".."` and `s == "."` checks can never be true and may mislead a future reviewer into thinking the `ParentDir`/`CurDir` arms are optional. The `s.contains("..")` check below (catching embedded double-dots like `foo..bar`) remains valid and should be kept.

```suggestion
            Component::Normal(part) => {
                let s = part.to_string_lossy();
                if s.contains("..") {
```

### Issue 3 of 3
crates/temper-server/src/observe/specs/path_security.rs:101-116
**`ensure_under_root` checks only the raw (non-canonicalized) `joined` path**

`root_canon` is produced by `canonicalize`, but `joined` is never canonicalized before the `starts_with` checks. If a subdirectory inside the staging dir contains a symlink pointing outside `tmp_dir`, `ensure_under_root` would approve the pre-symlink raw path while the actual write resolves elsewhere. Given the UUID-named fresh directory this is practically unexploitable today, but canonicalizing `joined` (falling back to raw if the target does not yet exist) would close the gap.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(server): ban host paths from network..."](https://github.com/nerdsane/temper/commit/1c9d54f47a7ef8438f595eb9538a607464af9af8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43651356)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->