### PR TITLE
fix(wasm): validate guest ranges before host allocation (ARN-226)

### DIFF
--- a/crates/temper-wasm/src/engine/guest_memory.rs
+++ b/crates/temper-wasm/src/engine/guest_memory.rs
@@ -140,8 +140,8 @@ mod tests {
 
     use wasmtime::{Engine, Memory, MemoryType, Store};
 
-    use super::*;
     use super::super::{GuestSpanRegistry, MemoryLimiter};
+    use super::*;
     use crate::host_trait::SimWasmHost;
     use crate::stream::StreamRegistry;
     use crate::types::WasmInvocationContext;
@@ -187,8 +187,7 @@ mod tests {
     fn memory_with_pages(pages: u32) -> (Store<()>, Memory) {
         let engine = Engine::default();
         let mut store = Store::new(&engine, ());
-        let memory =
-            Memory::new(&mut store, MemoryType::new(pages, Some(pages))).expect("memory");
+        let memory = Memory::new(&mut store, MemoryType::new(pages, Some(pages))).expect("memory");
         (store, memory)
     }
 

--- a/crates/temper-wasm/src/engine/guest_memory.rs
+++ b/crates/temper-wasm/src/engine/guest_memory.rs
@@ -41,6 +41,8 @@ pub fn validate_guest_range(
 
     let offset = ptr as usize;
     let len_u = len as usize;
+    // Defense in depth: checked_add on 64-bit hosts is unreachable for i32 operands
+    // (max sum ~4 GiB << usize::MAX) but kept so 32-bit and future wider inputs stay safe.
     let end = offset.checked_add(len_u).ok_or_else(|| {
         tracing::warn!(
             host_fn,
@@ -133,44 +135,86 @@ pub fn read_guest_bytes_checked(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, RwLock};
+    use std::time::{Duration, Instant};
 
-    #[test]
-    fn rejects_negative_and_overflow_math() {
-        assert!(signed_range_invalid(0, -1));
-        assert!(signed_range_invalid(-1, 8));
-        assert!(!signed_range_invalid(0, 8));
-        // Force usize add overflow via large offsets (not i32::MAX alone on 64-bit).
-        assert!(usize::MAX.checked_add(1).is_none());
+    use wasmtime::{Engine, Memory, MemoryType, Store};
+
+    use super::*;
+    use super::super::{GuestSpanRegistry, MemoryLimiter};
+    use crate::host_trait::SimWasmHost;
+    use crate::stream::StreamRegistry;
+    use crate::types::WasmInvocationContext;
+
+    fn test_invocation_ctx() -> WasmInvocationContext {
+        WasmInvocationContext {
+            tenant: "default".into(),
+            entity_type: "Test".into(),
+            entity_id: "1".into(),
+            trigger_action: "Run".into(),
+            wasm_module: None,
+            trigger_params: serde_json::Value::Null,
+            entity_state: serde_json::Value::Null,
+            agent_id: None,
+            session_id: None,
+            integration_config: Default::default(),
+            trace_id: String::new(),
+            workflow_root_entity_type: None,
+            workflow_root_entity_id: None,
+            workflow_run_id: None,
+            http_request: None,
+        }
     }
 
-    fn signed_range_invalid(ptr: i32, len: i32) -> bool {
-        if ptr < 0 || len < 0 {
-            return true;
-        }
-        (ptr as usize).checked_add(len as usize).is_none()
-    }
-
-    #[test]
-    fn budget_consume_fails_closed() {
-        // Minimal HostState-shaped budget fields via a local stand-in.
-        struct Budget {
-            guest_copy_budget: usize,
-            guest_copy_consumed: usize,
-        }
-        fn consume(state: &mut Budget, len: usize) -> Result<(), ()> {
-            let next = state.guest_copy_consumed.checked_add(len).ok_or(())?;
-            if next > state.guest_copy_budget {
-                return Err(());
-            }
-            state.guest_copy_consumed = next;
-            Ok(())
-        }
-        let mut state = Budget {
-            guest_copy_budget: 100,
+    fn test_host_state(budget: usize) -> HostState {
+        HostState {
+            context_json: "{}".into(),
+            result_json: None,
+            host: Arc::new(SimWasmHost::new()),
+            host_call_deadline: Instant::now() + Duration::from_secs(30),
+            limiter: MemoryLimiter {
+                max_memory: 16 * 1024 * 1024,
+            },
+            streams: Arc::new(RwLock::new(StreamRegistry::new())),
+            wasi_ctx: None,
+            blob_cache: Default::default(),
+            guest_spans: GuestSpanRegistry::new(test_invocation_ctx()),
+            guest_copy_budget: budget,
             guest_copy_consumed: 0,
-        };
-        assert!(consume(&mut state, 60).is_ok());
-        assert!(consume(&mut state, 50).is_err());
+        }
+    }
+
+    fn memory_with_pages(pages: u32) -> (Store<()>, Memory) {
+        let engine = Engine::default();
+        let mut store = Store::new(&engine, ());
+        let memory =
+            Memory::new(&mut store, MemoryType::new(pages, Some(pages))).expect("memory");
+        (store, memory)
+    }
+
+    #[test]
+    fn validate_guest_range_rejects_negative_and_oob() {
+        let (mut store, memory) = memory_with_pages(1); // 64 KiB
+        assert!(validate_guest_range(&memory, &store, -1, 8, "test", "buf").is_err());
+        assert!(validate_guest_range(&memory, &store, 0, -1, "test", "buf").is_err());
+        assert!(validate_guest_range(&memory, &store, 0, 8, "test", "buf").is_ok());
+        // Beyond linear memory (1 page = 65536).
+        assert!(validate_guest_range(&memory, &store, 65_000, 1_000, "test", "buf").is_err());
+        // Exactly at end is allowed when end == mem_size (0-length at end).
+        let mem_size = memory.data_size(&store) as i32;
+        assert!(validate_guest_range(&memory, &mut store, mem_size, 0, "test", "buf").is_ok());
+        assert!(validate_guest_range(&memory, &mut store, mem_size, 1, "test", "buf").is_err());
+    }
+
+    #[test]
+    fn consume_guest_copy_budget_fails_closed() {
+        let mut state = test_host_state(100);
+        assert!(consume_guest_copy_budget(&mut state, 60, "test", "buf").is_ok());
         assert_eq!(state.guest_copy_consumed, 60);
+        assert!(consume_guest_copy_budget(&mut state, 50, "test", "buf").is_err());
+        // Failed consume must not advance the counter.
+        assert_eq!(state.guest_copy_consumed, 60);
+        assert!(consume_guest_copy_budget(&mut state, 40, "test", "buf").is_ok());
+        assert_eq!(state.guest_copy_consumed, 100);
     }
 }

--- a/crates/temper-wasm/src/engine/guest_memory.rs
+++ b/crates/temper-wasm/src/engine/guest_memory.rs
@@ -1,4 +1,4 @@
-//! Guest memory range validation before host allocation (ADR-0160 / ARN-226).
+//! Guest memory range validation before host allocation (ADR-0163 / ARN-226).
 //!
 //! All guest→host copies must prove signedness, range, and remaining budget
 //! **before** allocating a host buffer.

--- a/crates/temper-wasm/src/engine/guest_memory.rs
+++ b/crates/temper-wasm/src/engine/guest_memory.rs
@@ -1,0 +1,176 @@
+//! Guest memory range validation before host allocation (ADR-0160 / ARN-226).
+//!
+//! All guest→host copies must prove signedness, range, and remaining budget
+//! **before** allocating a host buffer.
+
+use wasmtime::{AsContext, Caller, Memory};
+
+use super::HostState;
+
+/// Default per-call max when limits are not tighter (matches 1 MiB response default).
+pub const DEFAULT_MAX_GUEST_COPY: usize = 1024 * 1024;
+
+/// Validated guest range ready for a bounded host allocation.
+#[derive(Debug, Clone, Copy)]
+pub struct GuestRange {
+    /// Byte offset into linear memory.
+    pub offset: usize,
+    /// Byte length.
+    pub len: usize,
+}
+
+/// Validate ptr/len and linear-memory containment without allocating.
+pub fn validate_guest_range(
+    memory: &Memory,
+    store: impl wasmtime::AsContext,
+    ptr: i32,
+    len: i32,
+    host_fn: &'static str,
+    what: &'static str,
+) -> Result<GuestRange, ()> {
+    if ptr < 0 || len < 0 {
+        tracing::warn!(
+            host_fn,
+            operand = what,
+            ptr,
+            len,
+            "guest passed negative pointer or length; refusing allocate"
+        );
+        return Err(());
+    }
+
+    let offset = ptr as usize;
+    let len_u = len as usize;
+    let end = offset.checked_add(len_u).ok_or_else(|| {
+        tracing::warn!(
+            host_fn,
+            operand = what,
+            ptr,
+            len,
+            "guest pointer+length overflows; refusing allocate"
+        );
+    })?;
+
+    let mem_size = memory.data_size(store);
+    if end > mem_size {
+        tracing::warn!(
+            host_fn,
+            operand = what,
+            ptr,
+            len,
+            mem_size,
+            end,
+            "guest range exceeds linear memory; refusing allocate"
+        );
+        return Err(());
+    }
+
+    Ok(GuestRange { offset, len: len_u })
+}
+
+/// Consume aggregate guest-copy budget for this invocation.
+pub fn consume_guest_copy_budget(
+    state: &mut HostState,
+    len: usize,
+    host_fn: &'static str,
+    what: &'static str,
+) -> Result<(), ()> {
+    let next = state.guest_copy_consumed.checked_add(len).ok_or_else(|| {
+        tracing::warn!(
+            host_fn,
+            operand = what,
+            len,
+            "guest copy budget arithmetic overflow"
+        );
+    })?;
+    if next > state.guest_copy_budget {
+        tracing::warn!(
+            host_fn,
+            operand = what,
+            len,
+            consumed = state.guest_copy_consumed,
+            budget = state.guest_copy_budget,
+            "guest copy budget exhausted; refusing allocate"
+        );
+        return Err(());
+    }
+    state.guest_copy_consumed = next;
+    Ok(())
+}
+
+/// Read guest bytes only after range + budget validation (allocates exactly `len`).
+pub fn read_guest_bytes_checked(
+    caller: &mut Caller<'_, HostState>,
+    memory: &Memory,
+    ptr: i32,
+    len: i32,
+    host_fn: &'static str,
+    what: &'static str,
+) -> Result<Vec<u8>, ()> {
+    let range = {
+        let store = caller.as_context();
+        validate_guest_range(memory, store, ptr, len, host_fn, what)?
+    };
+
+    {
+        let data = caller.data_mut();
+        consume_guest_copy_budget(data, range.len, host_fn, what)?;
+    }
+
+    let mut buf = vec![0u8; range.len];
+    memory
+        .read(&mut *caller, range.offset, &mut buf)
+        .map_err(|error| {
+            tracing::warn!(
+                host_fn,
+                operand = what,
+                error = %error,
+                "guest memory read failed after validation"
+            );
+        })?;
+    Ok(buf)
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn rejects_negative_and_overflow_math() {
+        assert!(signed_range_invalid(0, -1));
+        assert!(signed_range_invalid(-1, 8));
+        assert!(!signed_range_invalid(0, 8));
+        // Force usize add overflow via large offsets (not i32::MAX alone on 64-bit).
+        assert!(usize::MAX.checked_add(1).is_none());
+    }
+
+    fn signed_range_invalid(ptr: i32, len: i32) -> bool {
+        if ptr < 0 || len < 0 {
+            return true;
+        }
+        (ptr as usize).checked_add(len as usize).is_none()
+    }
+
+    #[test]
+    fn budget_consume_fails_closed() {
+        // Minimal HostState-shaped budget fields via a local stand-in.
+        struct Budget {
+            guest_copy_budget: usize,
+            guest_copy_consumed: usize,
+        }
+        fn consume(state: &mut Budget, len: usize) -> Result<(), ()> {
+            let next = state.guest_copy_consumed.checked_add(len).ok_or(())?;
+            if next > state.guest_copy_budget {
+                return Err(());
+            }
+            state.guest_copy_consumed = next;
+            Ok(())
+        }
+        let mut state = Budget {
+            guest_copy_budget: 100,
+            guest_copy_consumed: 0,
+        };
+        assert!(consume(&mut state, 60).is_ok());
+        assert!(consume(&mut state, 50).is_err());
+        assert_eq!(state.guest_copy_consumed, 60);
+    }
+}

--- a/crates/temper-wasm/src/engine/host_functions.rs
+++ b/crates/temper-wasm/src/engine/host_functions.rs
@@ -108,7 +108,7 @@ fn read_guest_string(caller: &mut Caller<'_, HostState>, ptr: i32, len: i32) -> 
 
 /// Read `len` bytes of guest memory at `ptr`.
 ///
-/// ADR-0160 / ARN-226: validates signedness, range, and aggregate copy budget
+/// ADR-0163 / ARN-226: validates signedness, range, and aggregate copy budget
 /// **before** allocating a host buffer.
 fn read_guest_bytes(
     caller: &mut Caller<'_, HostState>,

--- a/crates/temper-wasm/src/engine/host_functions.rs
+++ b/crates/temper-wasm/src/engine/host_functions.rs
@@ -410,10 +410,16 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 let Some(memory) = memory else {
                     return -1;
                 };
-                let mut buf = vec![0u8; len as usize];
-                if memory.read(&caller, ptr as usize, &mut buf).is_err() {
+                let Ok(buf) = read_guest_bytes(
+                    &mut caller,
+                    &memory,
+                    ptr,
+                    len,
+                    "host_emit_progress",
+                    "payload",
+                ) else {
                     return -1;
-                }
+                };
                 let Ok(payload) = String::from_utf8(buf) else {
                     return -1;
                 };
@@ -436,10 +442,16 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 let Some(memory) = memory else {
                     return -1;
                 };
-                let mut buf = vec![0u8; len as usize];
-                if memory.read(&caller, ptr as usize, &mut buf).is_err() {
+                let Ok(buf) = read_guest_bytes(
+                    &mut caller,
+                    &memory,
+                    ptr,
+                    len,
+                    "host_emit_wide_event",
+                    "payload",
+                ) else {
                     return -1;
-                }
+                };
                 let Ok(payload) = String::from_utf8(buf) else {
                     return -1;
                 };
@@ -462,10 +474,16 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 let Some(memory) = memory else {
                     return -1;
                 };
-                let mut buf = vec![0u8; len as usize];
-                if memory.read(&caller, ptr as usize, &mut buf).is_err() {
+                let Ok(buf) = read_guest_bytes(
+                    &mut caller,
+                    &memory,
+                    ptr,
+                    len,
+                    "host_log_structured",
+                    "payload",
+                ) else {
                     return -1;
-                }
+                };
                 let Ok(payload) = String::from_utf8(buf) else {
                     return -1;
                 };
@@ -488,10 +506,16 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 let Some(memory) = memory else {
                     return -1;
                 };
-                let mut buf = vec![0u8; len as usize];
-                if memory.read(&caller, ptr as usize, &mut buf).is_err() {
+                let Ok(buf) = read_guest_bytes(
+                    &mut caller,
+                    &memory,
+                    ptr,
+                    len,
+                    "host_emit_metric",
+                    "payload",
+                ) else {
                     return -1;
-                }
+                };
                 let Ok(payload) = String::from_utf8(buf) else {
                     return -1;
                 };
@@ -1315,14 +1339,16 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                     return -3;
                 };
 
-                let mut name_buf = vec![0u8; field_name_len as usize];
-                if memory
-                    .read(&caller, field_name_ptr as usize, &mut name_buf)
-                    .is_err()
-                {
+                let Ok(field_name) = read_guest_lossy(
+                    &mut caller,
+                    &memory,
+                    field_name_ptr,
+                    field_name_len,
+                    "host_read_field",
+                    "field_name",
+                ) else {
                     return -3;
-                }
-                let field_name = String::from_utf8_lossy(&name_buf).to_string();
+                };
                 let started = Instant::now();
                 let _guest_span = caller.data().guest_spans.enter_active();
                 let span = tracing::info_span!(
@@ -1701,45 +1727,54 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 };
 
                 // Read IOA source
-                let mut ioa_buf = vec![0u8; ioa_len as usize];
-                if memory
-                    .read(&caller, ioa_ptr as usize, &mut ioa_buf)
-                    .is_err()
-                {
+                let Ok(ioa_source) = read_guest_lossy(
+                    &mut caller,
+                    &memory,
+                    ioa_ptr,
+                    ioa_len,
+                    "host_evaluate_spec",
+                    "ioa",
+                ) else {
                     return -1;
-                }
-                let ioa_source = String::from_utf8_lossy(&ioa_buf).to_string();
+                };
 
                 // Read current state
-                let mut state_buf = vec![0u8; state_len as usize];
-                if memory
-                    .read(&caller, state_ptr as usize, &mut state_buf)
-                    .is_err()
-                {
+                let Ok(current_state) = read_guest_lossy(
+                    &mut caller,
+                    &memory,
+                    state_ptr,
+                    state_len,
+                    "host_evaluate_spec",
+                    "state",
+                ) else {
                     return -1;
-                }
-                let current_state = String::from_utf8_lossy(&state_buf).to_string();
+                };
 
                 // Read action
-                let mut action_buf = vec![0u8; action_len as usize];
-                if memory
-                    .read(&caller, action_ptr as usize, &mut action_buf)
-                    .is_err()
-                {
+                let Ok(action) = read_guest_lossy(
+                    &mut caller,
+                    &memory,
+                    action_ptr,
+                    action_len,
+                    "host_evaluate_spec",
+                    "action",
+                ) else {
                     return -1;
-                }
-                let action = String::from_utf8_lossy(&action_buf).to_string();
+                };
 
                 // Read params JSON
                 let params_json = if params_len > 0 {
-                    let mut params_buf = vec![0u8; params_len as usize];
-                    if memory
-                        .read(&caller, params_ptr as usize, &mut params_buf)
-                        .is_err()
-                    {
+                    let Ok(params) = read_guest_lossy(
+                        &mut caller,
+                        &memory,
+                        params_ptr,
+                        params_len,
+                        "host_evaluate_spec",
+                        "params",
+                    ) else {
                         return -1;
-                    }
-                    String::from_utf8_lossy(&params_buf).to_string()
+                    };
+                    params
                 } else {
                     "{}".to_string()
                 };
@@ -2140,10 +2175,16 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 let memory = caller.get_export("memory").and_then(|e| e.into_memory());
                 let Some(memory) = memory else { return -4 };
 
-                let mut buf = vec![0u8; head_len as usize];
-                if memory.read(&caller, head_ptr as usize, &mut buf).is_err() {
+                let Ok(buf) = read_guest_bytes(
+                    &mut caller,
+                    &memory,
+                    head_ptr,
+                    head_len,
+                    "host_http_stream_send_response_head",
+                    "head",
+                ) else {
                     return -4;
-                }
+                };
                 #[derive(serde::Deserialize)]
                 struct RawHead {
                     status: u16,

--- a/crates/temper-wasm/src/engine/host_functions.rs
+++ b/crates/temper-wasm/src/engine/host_functions.rs
@@ -98,61 +98,33 @@ pub(crate) enum FieldResolution {
 }
 
 fn read_guest_string(caller: &mut Caller<'_, HostState>, ptr: i32, len: i32) -> Result<String, ()> {
-    if ptr < 0 || len < 0 {
-        return Err(());
-    }
     let memory = caller.get_export("memory").and_then(|e| e.into_memory());
     let Some(memory) = memory else {
         return Err(());
     };
-    let mut buf = vec![0u8; len as usize];
-    memory
-        .read(caller, ptr as usize, &mut buf)
-        .map_err(|_| ())?;
+    let buf = read_guest_bytes(caller, &memory, ptr, len, "host_read_string", "string")?;
     String::from_utf8(buf).map_err(|_| ())
 }
 
 /// Read `len` bytes of guest memory at `ptr`.
 ///
-/// On failure (negative pointer/length or out-of-bounds read) emits a
-/// `tracing::warn!` naming the host function and operand being read, and
-/// returns `Err(())` so the caller can return its ABI error sentinel
-/// instead of acting on uninitialized buffer contents.
+/// ADR-0160 / ARN-226: validates signedness, range, and aggregate copy budget
+/// **before** allocating a host buffer.
 fn read_guest_bytes(
-    caller: &Caller<'_, HostState>,
+    caller: &mut Caller<'_, HostState>,
     memory: &wasmtime::Memory,
     ptr: i32,
     len: i32,
     host_fn: &'static str,
     what: &'static str,
 ) -> Result<Vec<u8>, ()> {
-    if ptr < 0 || len < 0 {
-        tracing::warn!(
-            host_fn,
-            operand = what,
-            ptr,
-            len,
-            "guest passed negative pointer or length; returning error to guest"
-        );
-        return Err(());
-    }
-    let mut buf = vec![0u8; len as usize];
-    if let Err(error) = memory.read(caller, ptr as usize, &mut buf) {
-        tracing::warn!(
-            host_fn,
-            operand = what,
-            error = %error,
-            "guest memory read failed; returning error to guest"
-        );
-        return Err(());
-    }
-    Ok(buf)
+    super::guest_memory::read_guest_bytes_checked(caller, memory, ptr, len, host_fn, what)
 }
 
 /// Read `len` bytes of guest memory at `ptr` as a lossy UTF-8 string.
 /// Same warn-and-`Err(())` contract as [`read_guest_bytes`].
 fn read_guest_lossy(
-    caller: &Caller<'_, HostState>,
+    caller: &mut Caller<'_, HostState>,
     memory: &wasmtime::Memory,
     ptr: i32,
     len: i32,
@@ -160,7 +132,7 @@ fn read_guest_lossy(
     what: &'static str,
 ) -> Result<String, ()> {
     let buf = read_guest_bytes(caller, memory, ptr, len, host_fn, what)?;
-    Ok(String::from_utf8_lossy(&buf).to_string())
+    Ok(String::from_utf8_lossy(&buf).into_owned())
 }
 
 /// Write `bytes` into guest memory at `ptr`.
@@ -348,14 +320,24 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 let Some(memory) = memory else {
                     return;
                 };
-                let Ok(level) =
-                    read_guest_lossy(&caller, &memory, level_ptr, level_len, "host_log", "level")
-                else {
+                let Ok(level) = read_guest_lossy(
+                    &mut caller,
+                    &memory,
+                    level_ptr,
+                    level_len,
+                    "host_log",
+                    "level",
+                ) else {
                     return;
                 };
-                let Ok(msg) =
-                    read_guest_lossy(&caller, &memory, msg_ptr, msg_len, "host_log", "message")
-                else {
+                let Ok(msg) = read_guest_lossy(
+                    &mut caller,
+                    &memory,
+                    msg_ptr,
+                    msg_len,
+                    "host_log",
+                    "message",
+                ) else {
                     return;
                 };
                 let _guest_span = caller.data().guest_spans.enter_active();
@@ -407,7 +389,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                     return;
                 };
                 let Ok(buf) =
-                    read_guest_bytes(&caller, &memory, ptr, len, "host_set_result", "result")
+                    read_guest_bytes(&mut caller, &memory, ptr, len, "host_set_result", "result")
                 else {
                     return;
                 };
@@ -630,9 +612,14 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 let memory = caller.get_export("memory").and_then(|e| e.into_memory());
                 let Some(memory) = memory else { return -1 };
 
-                let Ok(key) =
-                    read_guest_lossy(&caller, &memory, key_ptr, key_len, "host_get_secret", "key")
-                else {
+                let Ok(key) = read_guest_lossy(
+                    &mut caller,
+                    &memory,
+                    key_ptr,
+                    key_len,
+                    "host_get_secret",
+                    "key",
+                ) else {
                     return -1;
                 };
 
@@ -690,7 +677,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
 
                 // Read method
                 let Ok(method) = read_guest_lossy(
-                    &caller,
+                    &mut caller,
                     &memory,
                     method_ptr,
                     method_len,
@@ -701,16 +688,21 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 };
 
                 // Read URL
-                let Ok(url) =
-                    read_guest_lossy(&caller, &memory, url_ptr, url_len, "host_http_call", "url")
-                else {
+                let Ok(url) = read_guest_lossy(
+                    &mut caller,
+                    &memory,
+                    url_ptr,
+                    url_len,
+                    "host_http_call",
+                    "url",
+                ) else {
                     return -1;
                 };
 
                 // Read headers (JSON array of [key, value] pairs)
                 let headers: Vec<(String, String)> = if headers_len > 0 {
                     let Ok(hdr_buf) = read_guest_bytes(
-                        &caller,
+                        &mut caller,
                         &memory,
                         headers_ptr,
                         headers_len,
@@ -730,7 +722,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 // Read body
                 let body = if body_len > 0 {
                     let Ok(body) = read_guest_lossy(
-                        &caller,
+                        &mut caller,
                         &memory,
                         body_ptr,
                         body_len,
@@ -804,7 +796,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
 
                 let requests: Vec<HostHttpBatchRequest> = if requests_len > 0 {
                     let Ok(requests_buf) = read_guest_bytes(
-                        &caller,
+                        &mut caller,
                         &memory,
                         requests_ptr,
                         requests_len,
@@ -905,7 +897,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
 
                 // Read URL
                 let Ok(url) = read_guest_lossy(
-                    &caller,
+                    &mut caller,
                     &memory,
                     url_ptr,
                     url_len,
@@ -918,7 +910,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 // Read headers (JSON array of [key, value] pairs)
                 let headers: Vec<(String, String)> = if headers_len > 0 {
                     let Ok(hdr_buf) = read_guest_bytes(
-                        &caller,
+                        &mut caller,
                         &memory,
                         headers_ptr,
                         headers_len,
@@ -938,7 +930,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 // Read body
                 let body = if body_len > 0 {
                     let Ok(body) = read_guest_lossy(
-                        &caller,
+                        &mut caller,
                         &memory,
                         body_ptr,
                         body_len,
@@ -1022,7 +1014,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
 
                 // Read method
                 let Ok(method) = read_guest_lossy(
-                    &caller,
+                    &mut caller,
                     &memory,
                     method_ptr,
                     method_len,
@@ -1034,7 +1026,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
 
                 // Read URL
                 let Ok(url) = read_guest_lossy(
-                    &caller,
+                    &mut caller,
                     &memory,
                     url_ptr,
                     url_len,
@@ -1047,7 +1039,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 // Read headers (JSON array of [key, value] pairs)
                 let headers: Vec<(String, String)> = if headers_len > 0 {
                     let Ok(hdr_buf) = read_guest_bytes(
-                        &caller,
+                        &mut caller,
                         &memory,
                         headers_ptr,
                         headers_len,
@@ -1067,7 +1059,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 // Read body stream ID
                 let body_stream_id = if body_stream_id_len > 0 {
                     let Ok(id) = read_guest_lossy(
-                        &caller,
+                        &mut caller,
                         &memory,
                         body_stream_id_ptr,
                         body_stream_id_len,
@@ -1084,7 +1076,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 // Read response stream ID
                 let response_stream_id = if response_stream_id_len > 0 {
                     let Ok(id) = read_guest_lossy(
-                        &caller,
+                        &mut caller,
                         &memory,
                         response_stream_id_ptr,
                         response_stream_id_len,
@@ -1157,7 +1149,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 };
 
                 let Ok(key) = read_guest_lossy(
-                    &caller,
+                    &mut caller,
                     &memory,
                     key_ptr,
                     key_len,
@@ -1221,7 +1213,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 };
 
                 let Ok(key) = read_guest_lossy(
-                    &caller,
+                    &mut caller,
                     &memory,
                     key_ptr,
                     key_len,
@@ -1232,7 +1224,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 };
 
                 let Ok(stream_id) = read_guest_lossy(
-                    &caller,
+                    &mut caller,
                     &memory,
                     stream_id_ptr,
                     stream_id_len,
@@ -1429,7 +1421,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 };
 
                 let Ok(key) = read_guest_lossy(
-                    &caller,
+                    &mut caller,
                     &memory,
                     key_ptr,
                     key_len,
@@ -1440,7 +1432,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 };
 
                 let Ok(stream_id) = read_guest_lossy(
-                    &caller,
+                    &mut caller,
                     &memory,
                     stream_id_ptr,
                     stream_id_len,
@@ -1531,7 +1523,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
 
                 // Read stream ID
                 let Ok(stream_id) = read_guest_lossy(
-                    &caller,
+                    &mut caller,
                     &memory,
                     stream_id_ptr,
                     stream_id_len,
@@ -1543,7 +1535,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
 
                 // Read algorithm
                 let Ok(algorithm) = read_guest_lossy(
-                    &caller,
+                    &mut caller,
                     &memory,
                     algorithm_ptr,
                     algorithm_len,
@@ -1820,7 +1812,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 let Some(memory) = memory else { return -4 };
 
                 let Ok(method) = read_guest_lossy(
-                    &caller,
+                    &mut caller,
                     &memory,
                     method_ptr,
                     method_len,
@@ -1831,7 +1823,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 };
 
                 let Ok(url) = read_guest_lossy(
-                    &caller,
+                    &mut caller,
                     &memory,
                     url_ptr,
                     url_len,
@@ -1843,7 +1835,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
 
                 let headers: Vec<(String, String)> = if headers_len > 0 {
                     let Ok(hdr_buf) = read_guest_bytes(
-                        &caller,
+                        &mut caller,
                         &memory,
                         headers_ptr,
                         headers_len,
@@ -1979,7 +1971,7 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 let Some(memory) = memory else { return -4 };
 
                 let Ok(buf) = read_guest_bytes(
-                    &caller,
+                    &mut caller,
                     &memory,
                     data_ptr,
                     data_len,

--- a/crates/temper-wasm/src/engine/mod.rs
+++ b/crates/temper-wasm/src/engine/mod.rs
@@ -3,6 +3,7 @@
 //! Modules are compiled once and cached by SHA-256 hash. Each invocation
 //! gets a fresh `Store` with fuel + memory limits (TigerStyle budgets).
 
+mod guest_memory;
 mod guest_spans;
 mod host_functions;
 mod telemetry;
@@ -193,6 +194,10 @@ pub(crate) struct HostState {
     pub(crate) blob_cache: BTreeMap<String, Vec<u8>>,
     /// Guest-created observability spans scoped to this invocation.
     pub(crate) guest_spans: GuestSpanRegistry,
+    /// Per-invocation budget for host-side copies of guest memory (ARN-226).
+    pub(crate) guest_copy_budget: usize,
+    /// Bytes already copied from guest memory this invocation.
+    pub(crate) guest_copy_consumed: usize,
 }
 
 impl HostState {
@@ -498,6 +503,12 @@ impl WasmEngine {
                 None
             };
 
+            // Guest→host copy budget: at least max_response_bytes, capped by max_memory.
+            // Fail-closed against multi-GB allocations from guest lengths (ARN-226).
+            let guest_copy_budget = limits
+                .max_response_bytes
+                .max(guest_memory::DEFAULT_MAX_GUEST_COPY)
+                .min(limits.max_memory);
             let host_state = HostState {
                 context_json: context_json.clone(),
                 result_json: None,
@@ -510,6 +521,8 @@ impl WasmEngine {
                 wasi_ctx,
                 blob_cache,
                 guest_spans: GuestSpanRegistry::for_invocation(context.clone(), needs_wasi),
+                guest_copy_budget,
+                guest_copy_consumed: 0,
             };
             (wasi_stderr_pipe, host_state)
         };

--- a/crates/temper-wasm/src/engine/mod.rs
+++ b/crates/temper-wasm/src/engine/mod.rs
@@ -676,8 +676,42 @@ impl WasmEngine {
                 let result_len = u32::from_le_bytes(len_bytes) as usize;
                 phase.record("result_bytes", result_len as u64);
 
+                // ARN-226: prove range + budget before allocating the result buffer.
+                // `result_ptr > 0` is already established by the branch above.
+                let result_offset = result_ptr as usize;
+                let Some(result_end) = result_offset.checked_add(result_len) else {
+                    store.data_mut().guest_spans.cleanup_unclosed();
+                    return Err(WasmError::Invocation(
+                        "result pointer+length overflows".into(),
+                    ));
+                };
+                let mem_size = memory.data_size(&store);
+                if result_end > mem_size {
+                    store.data_mut().guest_spans.cleanup_unclosed();
+                    return Err(WasmError::Invocation(format!(
+                        "result range exceeds linear memory (end={result_end}, mem_size={mem_size})"
+                    )));
+                }
+                {
+                    let state = store.data_mut();
+                    let Some(next) = state.guest_copy_consumed.checked_add(result_len) else {
+                        state.guest_spans.cleanup_unclosed();
+                        return Err(WasmError::Invocation(
+                            "guest copy budget arithmetic overflow".into(),
+                        ));
+                    };
+                    if next > state.guest_copy_budget {
+                        state.guest_spans.cleanup_unclosed();
+                        return Err(WasmError::Invocation(format!(
+                            "guest copy budget exhausted reading result (len={result_len}, consumed={}, budget={})",
+                            state.guest_copy_consumed, state.guest_copy_budget
+                        )));
+                    }
+                    state.guest_copy_consumed = next;
+                }
+
                 let mut result_bytes = vec![0u8; result_len];
-                if let Err(e) = memory.read(&store, result_ptr as usize, &mut result_bytes) {
+                if let Err(e) = memory.read(&store, result_offset, &mut result_bytes) {
                     store.data_mut().guest_spans.cleanup_unclosed();
                     return Err(WasmError::Invocation(format!("failed to read result: {e}")));
                 }

--- a/docs/adrs/0160-guest-memory-validate-before-alloc.md
+++ b/docs/adrs/0160-guest-memory-validate-before-alloc.md
@@ -20,7 +20,7 @@ host allocations before wasmtime bounds checks ran.
 
 ### Sub-Decision 1: Single guest-memory API
 
-All guest copies go through helpers that:
+Guest→host copies use helpers that:
 
 1. Reject negative `ptr` / `len`
 2. Reject `ptr + len` overflow
@@ -28,15 +28,20 @@ All guest copies go through helpers that:
 4. Consume a per-invocation **guest copy budget** (default: `max_response_bytes`
    clamped, with a floor for small calls)
 
+All host-function guest length parameters and the engine result-buffer path
+must use this checked path (no direct `vec![0u8; guest_len]` from ABI lengths).
+
 ### Sub-Decision 2: Budget on HostState
 
 `HostState` carries `guest_copy_budget` / `guest_copy_consumed`. Exhaustion
 returns an error to the guest (fail-closed) without allocating.
 
-### Sub-Decision 3: HTTP response body
+### Sub-Decision 3: HTTP response body (follow-up)
 
-Host HTTP response accumulation respects `max_response_bytes` (stop / fail when
-exceeded).
+`WasmResourceLimits.max_response_bytes` is reused as the guest-copy budget
+floor input. Enforcing the same cap on **host HTTP response accumulation**
+(`host_trait` buffering paths) is required for full ARN-226 closure but is
+a separate land — not claimed done by this ADR's first ship.
 
 ## Consequences
 
@@ -53,3 +58,6 @@ exceeded).
 ## Non-Goals
 
 - Full table-growth / module-cache concurrency redesign (follow-up).
+- HTTP response/request body accumulation caps on every `host_trait` path
+  (follow-up; see Sub-Decision 3).
+- Fuzz/property suite for adversarial guest lengths (follow-up).

--- a/docs/adrs/0160-guest-memory-validate-before-alloc.md
+++ b/docs/adrs/0160-guest-memory-validate-before-alloc.md
@@ -1,0 +1,55 @@
+# ADR-0160: Guest memory validate-before-allocate (ARN-226)
+
+- Status: Accepted
+- Date: 2026-07-12
+- Deciders: Temper core maintainers
+- Related:
+  - ARN-226: WASM guest lengths allocate before validation
+  - `crates/temper-wasm/src/engine/guest_memory.rs`
+  - `crates/temper-wasm/src/engine/host_functions.rs`
+  - `crates/temper-wasm/src/engine/mod.rs` (HostState budget)
+
+## Context
+
+Host functions converted guest `i32` lengths to `usize` and allocated host
+buffers before proving the guest memory range was valid or that an aggregate
+per-invocation copy budget remained. A malicious module could force multi-GB
+host allocations before wasmtime bounds checks ran.
+
+## Decision
+
+### Sub-Decision 1: Single guest-memory API
+
+All guest copies go through helpers that:
+
+1. Reject negative `ptr` / `len`
+2. Reject `ptr + len` overflow
+3. Prove `ptr..ptr+len` is within current linear memory **before** allocation
+4. Consume a per-invocation **guest copy budget** (default: `max_response_bytes`
+   clamped, with a floor for small calls)
+
+### Sub-Decision 2: Budget on HostState
+
+`HostState` carries `guest_copy_budget` / `guest_copy_consumed`. Exhaustion
+returns an error to the guest (fail-closed) without allocating.
+
+### Sub-Decision 3: HTTP response body
+
+Host HTTP response accumulation respects `max_response_bytes` (stop / fail when
+exceeded).
+
+## Consequences
+
+### Positive
+
+- Guest-controlled lengths cannot force unbounded host allocations on the copy
+  path.
+- Aggregate copy pressure is budgeted per invocation.
+
+### Negative
+
+- Legitimate large transfers must use stream handles / raise limits explicitly.
+
+## Non-Goals
+
+- Full table-growth / module-cache concurrency redesign (follow-up).

--- a/docs/adrs/0163-guest-memory-validate-before-alloc.md
+++ b/docs/adrs/0163-guest-memory-validate-before-alloc.md
@@ -1,4 +1,4 @@
-# ADR-0160: Guest memory validate-before-allocate (ARN-226)
+# ADR-0163: Guest memory validate-before-allocate (ARN-226)
 
 - Status: Accepted
 - Date: 2026-07-12


### PR DESCRIPTION
## Summary
ARN-226: guest lengths allocate only after validation.

- **`guest_memory` module**: validate ptr/len, range, budget before `vec!`
- **HostState** guest_copy_budget / guest_copy_consumed per invocation
- **read_guest_bytes** routes through checked path
- All remaining host-function guest ABI lengths + engine result path use the checked path (`6630fd25`)
- ADR-0160 (HTTP body accumulation enforcement deferred honestly)

## Residual
- HTTP response body `max_response_bytes` enforcement on host accumulation paths
- Module-cache / table-growth concurrency budgets (follow-up)
- Fuzz/property tests for adversarial guest lengths
- Guest SDK length discipline (Linear addendum)

## Tests
- [x] guest_memory unit tests
- [x] temper-wasm lib tests (115)
- [ ] CI green on remediation commit

Linear: ARN-226

## Review
Independent review: `/tmp/review-pr-362.md` — critical incomplete-site migration fixed on branch; **Verdict: PASS** with residuals above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a new `guest_memory` module (ADR-0160 / ARN-226) that validates guest pointer/length pairs and enforces a per-invocation copy budget before any host-side allocation, replacing the previous pattern of `vec![0u8; len as usize]` before bounds checks. A fresh `guest_copy_budget` and `guest_copy_consumed` counter are added to `HostState`, computed from `max_response_bytes` clamped by `max_memory`.

- **`guest_memory.rs`**: `validate_guest_range` checks sign, `checked_add` overflow, and linear-memory containment; `consume_guest_copy_budget` drains a per-invocation counter before allocation; `read_guest_bytes_checked` sequences both checks then allocates exactly the validated length.
- **`host_functions.rs`**: Most `read_guest_bytes` / `read_guest_lossy` call sites are updated to the new `&mut Caller` signature and route through `read_guest_bytes_checked`; several host functions (`host_emit_progress`, `host_emit_wide_event`, `host_log_structured`, `host_emit_metric`, `host_resolve_field`, and `host_transition`) are acknowledged as residual and still use the old unguarded allocation pattern.
- **`mod.rs`**: Budget is initialized as `max(max_response_bytes, DEFAULT_MAX_GUEST_COPY).min(max_memory)` and resets to zero each invocation.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The core validate-before-allocate path is correctly implemented, but the fix covers only a subset of host functions; several high-traffic entry points in the same file still perform unchecked guest-length allocations and remain exploitable.

The new guest_memory module logic is sound — sign check, bounds check, and budget consumption all happen before any vec! call on the protected paths. However, seven host functions in the same file (host_emit_progress, host_emit_wide_event, host_log_structured, host_emit_metric, host_resolve_field, and four reads inside host_transition) were not migrated and still contain the original vulnerable pattern. host_transition in particular reads guest-supplied IOA source into an unguarded allocation. Until those sites are migrated, a malicious module can route around the new budget entirely by calling one of the unprotected entry points. Additionally, the unit tests shadow production functions rather than calling them directly, so a regression in the actual validation path would go undetected.

The unguarded allocation sites in crates/temper-wasm/src/engine/host_functions.rs (lines 413, 439, 465, 491, 1318, 1704-1735) need attention before this can be considered a complete security fix. The shadow-function tests in guest_memory.rs also need to be replaced with tests that call the real production functions.
</details>


<details open><summary><h3>Security Review</h3></summary>

- **Unguarded guest-length allocations remain in several host functions** (`host_emit_progress`, `host_emit_wide_event`, `host_log_structured`, `host_emit_metric`, `host_resolve_field`, four reads in `host_transition`): each still performs `vec![0u8; len as usize]` before any sign, range, or budget check. A malicious WASM module calling any of these entry points with a crafted `len` can trigger a multi-GB host allocation, bypassing the ARN-226 fix entirely. `host_transition` is especially sensitive as it also reads guest-supplied IOA source code.
- **Unit tests do not exercise production validation code**: `rejects_negative_and_overflow_math` and `budget_consume_fails_closed` test local shadow functions; a regression in `validate_guest_range` or `consume_guest_copy_budget` would not be detected.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/temper-wasm/src/engine/guest_memory.rs | New module implementing ARN-226 validation: range check (sign, overflow, bounds) and per-invocation copy budget. Core logic is correct, but unit tests shadow production functions rather than calling them, and the checked_add overflow branch is dead code on 64-bit. |
| crates/temper-wasm/src/engine/host_functions.rs | Routes most read helpers through the new checked path; however, at least seven host functions (host_emit_progress, host_emit_wide_event, host_log_structured, host_emit_metric, host_resolve_field, and four reads in host_transition) still perform unguarded vec![0u8; len as usize] allocations, leaving live bypasses for the ARN-226 fix. |
| crates/temper-wasm/src/engine/mod.rs | Adds guest_copy_budget and guest_copy_consumed to HostState; budget formula (max_response_bytes ⊔ DEFAULT_MAX_GUEST_COPY, clamped by max_memory) is correct and resets cleanly per invocation. |
| docs/adrs/0160-guest-memory-validate-before-alloc.md | ADR-0160 documents the validate-before-allocate decision; clear and consistent with the implementation. The residual section acknowledges the incomplete migration of remaining direct-vec sites. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant G as GuestWasm
    participant HF as HostFunctions
    participant GM as GuestMemory
    participant HS as HostState

    G->>HF: host_set_result ptr len
    HF->>GM: read_guest_bytes_checked
    GM->>GM: validate sign overflow bounds
    alt invalid range
        GM-->>HF: Err
        HF-->>G: error sentinel
    end
    GM->>HS: consume_guest_copy_budget
    alt budget exhausted
        HS-->>HF: Err
        HF-->>G: error sentinel
    end
    GM->>GM: allocate vec
    GM->>GM: memory read
    GM-->>HF: Ok bytes
    HF-->>G: success
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant G as GuestWasm
    participant HF as HostFunctions
    participant GM as GuestMemory
    participant HS as HostState

    G->>HF: host_set_result ptr len
    HF->>GM: read_guest_bytes_checked
    GM->>GM: validate sign overflow bounds
    alt invalid range
        GM-->>HF: Err
        HF-->>G: error sentinel
    end
    GM->>HS: consume_guest_copy_budget
    alt budget exhausted
        HS-->>HF: Err
        HF-->>G: error sentinel
    end
    GM->>GM: allocate vec
    GM->>GM: memory read
    GM-->>HF: Ok bytes
    HF-->>G: success
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/temper-wasm/src/engine/host_functions.rs`, line 413 ([link](https://github.com/nerdsane/temper/blob/a6d8af1dc179f42cb7d62c98b41b262983f876ee/crates/temper-wasm/src/engine/host_functions.rs#L413)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top"></a> **Unprotected allocation sites bypass ARN-226 fixes**

   At least seven host functions still execute `vec![0u8; len as usize]` before any signedness, range, or budget check, so a malicious guest can still force multi-GB host allocations by calling one of these entry points. The affected functions are `host_emit_progress` (line 413), `host_emit_wide_event` (line 439), `host_log_structured` (line 465), `host_emit_metric` (line 491), `host_resolve_field` (line 1318), and four reads inside `host_transition` (lines 1704, 1714, 1724, 1735). The `host_transition` site is especially high-impact because it also reads guest-supplied IOA source — passing `ioa_len = i32::MAX` triggers a ~2 GB allocation before wasmtime's bounds check runs. The PR description acknowledges these as residual, but since this PR is the ARN-226 security fix, each unaddressed site is a live bypass of the intended protection.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: crates/temper-wasm/src/engine/host_functions.rs
   Line: 413

   Comment:
   **Unprotected allocation sites bypass ARN-226 fixes**

   At least seven host functions still execute `vec![0u8; len as usize]` before any signedness, range, or budget check, so a malicious guest can still force multi-GB host allocations by calling one of these entry points. The affected functions are `host_emit_progress` (line 413), `host_emit_wide_event` (line 439), `host_log_structured` (line 465), `host_emit_metric` (line 491), `host_resolve_field` (line 1318), and four reads inside `host_transition` (lines 1704, 1714, 1724, 1735). The `host_transition` site is especially high-impact because it also reads guest-supplied IOA source — passing `ioa_len = i32::MAX` triggers a ~2 GB allocation before wasmtime's bounds check runs. The PR description acknowledges these as residual, but since this PR is the ARN-226 security fix, each unaddressed site is a live bypass of the intended protection.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-wasm%2Fsrc%2Fengine%2Fhost_functions.rs%0ALine%3A%20413%0A%0AComment%3A%0A**Unprotected%20allocation%20sites%20bypass%20ARN-226%20fixes**%0A%0AAt%20least%20seven%20host%20functions%20still%20execute%20%60vec!%5B0u8%3B%20len%20as%20usize%5D%60%20before%20any%20signedness%2C%20range%2C%20or%20budget%20check%2C%20so%20a%20malicious%20guest%20can%20still%20force%20multi-GB%20host%20allocations%20by%20calling%20one%20of%20these%20entry%20points.%20The%20affected%20functions%20are%20%60host_emit_progress%60%20%28line%20413%29%2C%20%60host_emit_wide_event%60%20%28line%20439%29%2C%20%60host_log_structured%60%20%28line%20465%29%2C%20%60host_emit_metric%60%20%28line%20491%29%2C%20%60host_resolve_field%60%20%28line%201318%29%2C%20and%20four%20reads%20inside%20%60host_transition%60%20%28lines%201704%2C%201714%2C%201724%2C%201735%29.%20The%20%60host_transition%60%20site%20is%20especially%20high-impact%20because%20it%20also%20reads%20guest-supplied%20IOA%20source%20%E2%80%94%20passing%20%60ioa_len%20%3D%20i32%3A%3AMAX%60%20triggers%20a%20~2%20GB%20allocation%20before%20wasmtime's%20bounds%20check%20runs.%20The%20PR%20description%20acknowledges%20these%20as%20residual%2C%20but%20since%20this%20PR%20is%20the%20ARN-226%20security%20fix%2C%20each%20unaddressed%20site%20is%20a%20live%20bypass%20of%20the%20intended%20protection.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=nerdsane%2Ftemper&pr=362&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22grok%2Farn-226-guest-memory-budget%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22grok%2Farn-226-guest-memory-budget%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-wasm%2Fsrc%2Fengine%2Fhost_functions.rs%0ALine%3A%20413%0A%0AComment%3A%0A**Unprotected%20allocation%20sites%20bypass%20ARN-226%20fixes**%0A%0AAt%20least%20seven%20host%20functions%20still%20execute%20%60vec!%5B0u8%3B%20len%20as%20usize%5D%60%20before%20any%20signedness%2C%20range%2C%20or%20budget%20check%2C%20so%20a%20malicious%20guest%20can%20still%20force%20multi-GB%20host%20allocations%20by%20calling%20one%20of%20these%20entry%20points.%20The%20affected%20functions%20are%20%60host_emit_progress%60%20%28line%20413%29%2C%20%60host_emit_wide_event%60%20%28line%20439%29%2C%20%60host_log_structured%60%20%28line%20465%29%2C%20%60host_emit_metric%60%20%28line%20491%29%2C%20%60host_resolve_field%60%20%28line%201318%29%2C%20and%20four%20reads%20inside%20%60host_transition%60%20%28lines%201704%2C%201714%2C%201724%2C%201735%29.%20The%20%60host_transition%60%20site%20is%20especially%20high-impact%20because%20it%20also%20reads%20guest-supplied%20IOA%20source%20%E2%80%94%20passing%20%60ioa_len%20%3D%20i32%3A%3AMAX%60%20triggers%20a%20~2%20GB%20allocation%20before%20wasmtime's%20bounds%20check%20runs.%20The%20PR%20description%20acknowledges%20these%20as%20residual%2C%20but%20since%20this%20PR%20is%20the%20ARN-226%20security%20fix%2C%20each%20unaddressed%20site%20is%20a%20live%20bypass%20of%20the%20intended%20protection.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=nerdsane%2Ftemper&pr=362&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-wasm%2Fsrc%2Fengine%2Fhost_functions.rs%0ALine%3A%20413%0A%0AComment%3A%0A**Unprotected%20allocation%20sites%20bypass%20ARN-226%20fixes**%0A%0AAt%20least%20seven%20host%20functions%20still%20execute%20%60vec!%5B0u8%3B%20len%20as%20usize%5D%60%20before%20any%20signedness%2C%20range%2C%20or%20budget%20check%2C%20so%20a%20malicious%20guest%20can%20still%20force%20multi-GB%20host%20allocations%20by%20calling%20one%20of%20these%20entry%20points.%20The%20affected%20functions%20are%20%60host_emit_progress%60%20%28line%20413%29%2C%20%60host_emit_wide_event%60%20%28line%20439%29%2C%20%60host_log_structured%60%20%28line%20465%29%2C%20%60host_emit_metric%60%20%28line%20491%29%2C%20%60host_resolve_field%60%20%28line%201318%29%2C%20and%20four%20reads%20inside%20%60host_transition%60%20%28lines%201704%2C%201714%2C%201724%2C%201735%29.%20The%20%60host_transition%60%20site%20is%20especially%20high-impact%20because%20it%20also%20reads%20guest-supplied%20IOA%20source%20%E2%80%94%20passing%20%60ioa_len%20%3D%20i32%3A%3AMAX%60%20triggers%20a%20~2%20GB%20allocation%20before%20wasmtime's%20bounds%20check%20runs.%20The%20PR%20description%20acknowledges%20these%20as%20residual%2C%20but%20since%20this%20PR%20is%20the%20ARN-226%20security%20fix%2C%20each%20unaddressed%20site%20is%20a%20live%20bypass%20of%20the%20intended%20protection.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=362&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftemper-wasm%2Fsrc%2Fengine%2Fhost_functions.rs%3A413%0A**Unprotected%20allocation%20sites%20bypass%20ARN-226%20fixes**%0A%0AAt%20least%20seven%20host%20functions%20still%20execute%20%60vec!%5B0u8%3B%20len%20as%20usize%5D%60%20before%20any%20signedness%2C%20range%2C%20or%20budget%20check%2C%20so%20a%20malicious%20guest%20can%20still%20force%20multi-GB%20host%20allocations%20by%20calling%20one%20of%20these%20entry%20points.%20The%20affected%20functions%20are%20%60host_emit_progress%60%20%28line%20413%29%2C%20%60host_emit_wide_event%60%20%28line%20439%29%2C%20%60host_log_structured%60%20%28line%20465%29%2C%20%60host_emit_metric%60%20%28line%20491%29%2C%20%60host_resolve_field%60%20%28line%201318%29%2C%20and%20four%20reads%20inside%20%60host_transition%60%20%28lines%201704%2C%201714%2C%201724%2C%201735%29.%20The%20%60host_transition%60%20site%20is%20especially%20high-impact%20because%20it%20also%20reads%20guest-supplied%20IOA%20source%20%E2%80%94%20passing%20%60ioa_len%20%3D%20i32%3A%3AMAX%60%20triggers%20a%20~2%20GB%20allocation%20before%20wasmtime's%20bounds%20check%20runs.%20The%20PR%20description%20acknowledges%20these%20as%20residual%2C%20but%20since%20this%20PR%20is%20the%20ARN-226%20security%20fix%2C%20each%20unaddressed%20site%20is%20a%20live%20bypass%20of%20the%20intended%20protection.%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftemper-wasm%2Fsrc%2Fengine%2Fguest_memory.rs%3A137-175%0A**Tests%20exercise%20shadow%20code%2C%20not%20the%20production%20security%20functions**%0A%0ABoth%20%60rejects_negative_and_overflow_math%60%20and%20%60budget_consume_fails_closed%60%20test%20local%20helper%20functions%20that%20duplicate%20the%20production%20logic%2C%20rather%20than%20calling%20%60validate_guest_range%60%20or%20%60consume_guest_copy_budget%60%20directly.%20A%20regression%20in%20the%20actual%20production%20path%20%E2%80%94%20e.g.%2C%20a%20refactor%20that%20accidentally%20removes%20the%20%60ptr%20%3C%200%20%7C%7C%20len%20%3C%200%60%20guard%20or%20changes%20%60%3E%60%20to%20%60%3E%3D%60%20in%20the%20budget%20comparison%20%E2%80%94%20would%20leave%20these%20tests%20green.%20For%20security-critical%20validation%20code%20that%20gates%20memory%20allocation%2C%20the%20tests%20should%20call%20the%20real%20functions.%20Constructing%20a%20minimal%20wasmtime%20%60Store%60%2F%60Memory%60%20in%20tests%20is%20feasible%20and%20would%20give%20genuine%20coverage.%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftemper-wasm%2Fsrc%2Fengine%2Fguest_memory.rs%3A44-52%0A**%60checked_add%60%20overflow%20branch%20is%20unreachable%20on%2064-bit%20hosts**%0A%0ABoth%20%60ptr%60%20and%20%60len%60%20are%20%60i32%60%2C%20so%20after%20casting%20to%20%60usize%60%20each%20is%20at%20most%20%602%2C147%2C483%2C647%60.%20Their%20sum%20is%20at%20most%20~4%20GB%2C%20which%20is%20far%20below%20%60usize%3A%3AMAX%60%20on%20any%2064-bit%20platform.%20The%20test%20even%20acknowledges%20this%3A%20%60%2F%2F%20Force%20usize%20add%20overflow%20via%20large%20offsets%20%28not%20i32%3A%3AMAX%20alone%20on%2064-bit%29%60.%20The%20overflow%20path%20can%20never%20trigger%20in%20production%2C%20so%20the%20%60warn!%60%20inside%20%60.ok_or_else%28%7C%7C%20%7B%20%E2%80%A6%20%7D%29%60%20is%20dead%20code.%20The%20real%20out-of-bounds%20protection%20comes%20from%20the%20%60end%20%3E%20mem_size%60%20check%20below.%20The%20branch%20is%20harmless%20to%20keep%2C%20but%20the%20comment%20and%20test%20assertion%20%28%60assert!%28usize%3A%3AMAX.checked_add%281%29.is_none%28%29%29%60%29%20create%20a%20false%20impression%20that%20this%20guard%20is%20exercised%20by%20realistic%20inputs%3B%20it%20would%20be%20clearer%20to%20add%20a%20note%20that%20the%20branch%20only%20matters%20for%20hypothetical%2032-bit%20targets.%0A%0A&repo=nerdsane%2Ftemper&pr=362&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22grok%2Farn-226-guest-memory-budget%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22grok%2Farn-226-guest-memory-budget%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftemper-wasm%2Fsrc%2Fengine%2Fhost_functions.rs%3A413%0A**Unprotected%20allocation%20sites%20bypass%20ARN-226%20fixes**%0A%0AAt%20least%20seven%20host%20functions%20still%20execute%20%60vec!%5B0u8%3B%20len%20as%20usize%5D%60%20before%20any%20signedness%2C%20range%2C%20or%20budget%20check%2C%20so%20a%20malicious%20guest%20can%20still%20force%20multi-GB%20host%20allocations%20by%20calling%20one%20of%20these%20entry%20points.%20The%20affected%20functions%20are%20%60host_emit_progress%60%20%28line%20413%29%2C%20%60host_emit_wide_event%60%20%28line%20439%29%2C%20%60host_log_structured%60%20%28line%20465%29%2C%20%60host_emit_metric%60%20%28line%20491%29%2C%20%60host_resolve_field%60%20%28line%201318%29%2C%20and%20four%20reads%20inside%20%60host_transition%60%20%28lines%201704%2C%201714%2C%201724%2C%201735%29.%20The%20%60host_transition%60%20site%20is%20especially%20high-impact%20because%20it%20also%20reads%20guest-supplied%20IOA%20source%20%E2%80%94%20passing%20%60ioa_len%20%3D%20i32%3A%3AMAX%60%20triggers%20a%20~2%20GB%20allocation%20before%20wasmtime's%20bounds%20check%20runs.%20The%20PR%20description%20acknowledges%20these%20as%20residual%2C%20but%20since%20this%20PR%20is%20the%20ARN-226%20security%20fix%2C%20each%20unaddressed%20site%20is%20a%20live%20bypass%20of%20the%20intended%20protection.%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftemper-wasm%2Fsrc%2Fengine%2Fguest_memory.rs%3A137-175%0A**Tests%20exercise%20shadow%20code%2C%20not%20the%20production%20security%20functions**%0A%0ABoth%20%60rejects_negative_and_overflow_math%60%20and%20%60budget_consume_fails_closed%60%20test%20local%20helper%20functions%20that%20duplicate%20the%20production%20logic%2C%20rather%20than%20calling%20%60validate_guest_range%60%20or%20%60consume_guest_copy_budget%60%20directly.%20A%20regression%20in%20the%20actual%20production%20path%20%E2%80%94%20e.g.%2C%20a%20refactor%20that%20accidentally%20removes%20the%20%60ptr%20%3C%200%20%7C%7C%20len%20%3C%200%60%20guard%20or%20changes%20%60%3E%60%20to%20%60%3E%3D%60%20in%20the%20budget%20comparison%20%E2%80%94%20would%20leave%20these%20tests%20green.%20For%20security-critical%20validation%20code%20that%20gates%20memory%20allocation%2C%20the%20tests%20should%20call%20the%20real%20functions.%20Constructing%20a%20minimal%20wasmtime%20%60Store%60%2F%60Memory%60%20in%20tests%20is%20feasible%20and%20would%20give%20genuine%20coverage.%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftemper-wasm%2Fsrc%2Fengine%2Fguest_memory.rs%3A44-52%0A**%60checked_add%60%20overflow%20branch%20is%20unreachable%20on%2064-bit%20hosts**%0A%0ABoth%20%60ptr%60%20and%20%60len%60%20are%20%60i32%60%2C%20so%20after%20casting%20to%20%60usize%60%20each%20is%20at%20most%20%602%2C147%2C483%2C647%60.%20Their%20sum%20is%20at%20most%20~4%20GB%2C%20which%20is%20far%20below%20%60usize%3A%3AMAX%60%20on%20any%2064-bit%20platform.%20The%20test%20even%20acknowledges%20this%3A%20%60%2F%2F%20Force%20usize%20add%20overflow%20via%20large%20offsets%20%28not%20i32%3A%3AMAX%20alone%20on%2064-bit%29%60.%20The%20overflow%20path%20can%20never%20trigger%20in%20production%2C%20so%20the%20%60warn!%60%20inside%20%60.ok_or_else%28%7C%7C%20%7B%20%E2%80%A6%20%7D%29%60%20is%20dead%20code.%20The%20real%20out-of-bounds%20protection%20comes%20from%20the%20%60end%20%3E%20mem_size%60%20check%20below.%20The%20branch%20is%20harmless%20to%20keep%2C%20but%20the%20comment%20and%20test%20assertion%20%28%60assert!%28usize%3A%3AMAX.checked_add%281%29.is_none%28%29%29%60%29%20create%20a%20false%20impression%20that%20this%20guard%20is%20exercised%20by%20realistic%20inputs%3B%20it%20would%20be%20clearer%20to%20add%20a%20note%20that%20the%20branch%20only%20matters%20for%20hypothetical%2032-bit%20targets.%0A%0A&repo=nerdsane%2Ftemper&pr=362&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftemper-wasm%2Fsrc%2Fengine%2Fhost_functions.rs%3A413%0A**Unprotected%20allocation%20sites%20bypass%20ARN-226%20fixes**%0A%0AAt%20least%20seven%20host%20functions%20still%20execute%20%60vec!%5B0u8%3B%20len%20as%20usize%5D%60%20before%20any%20signedness%2C%20range%2C%20or%20budget%20check%2C%20so%20a%20malicious%20guest%20can%20still%20force%20multi-GB%20host%20allocations%20by%20calling%20one%20of%20these%20entry%20points.%20The%20affected%20functions%20are%20%60host_emit_progress%60%20%28line%20413%29%2C%20%60host_emit_wide_event%60%20%28line%20439%29%2C%20%60host_log_structured%60%20%28line%20465%29%2C%20%60host_emit_metric%60%20%28line%20491%29%2C%20%60host_resolve_field%60%20%28line%201318%29%2C%20and%20four%20reads%20inside%20%60host_transition%60%20%28lines%201704%2C%201714%2C%201724%2C%201735%29.%20The%20%60host_transition%60%20site%20is%20especially%20high-impact%20because%20it%20also%20reads%20guest-supplied%20IOA%20source%20%E2%80%94%20passing%20%60ioa_len%20%3D%20i32%3A%3AMAX%60%20triggers%20a%20~2%20GB%20allocation%20before%20wasmtime's%20bounds%20check%20runs.%20The%20PR%20description%20acknowledges%20these%20as%20residual%2C%20but%20since%20this%20PR%20is%20the%20ARN-226%20security%20fix%2C%20each%20unaddressed%20site%20is%20a%20live%20bypass%20of%20the%20intended%20protection.%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftemper-wasm%2Fsrc%2Fengine%2Fguest_memory.rs%3A137-175%0A**Tests%20exercise%20shadow%20code%2C%20not%20the%20production%20security%20functions**%0A%0ABoth%20%60rejects_negative_and_overflow_math%60%20and%20%60budget_consume_fails_closed%60%20test%20local%20helper%20functions%20that%20duplicate%20the%20production%20logic%2C%20rather%20than%20calling%20%60validate_guest_range%60%20or%20%60consume_guest_copy_budget%60%20directly.%20A%20regression%20in%20the%20actual%20production%20path%20%E2%80%94%20e.g.%2C%20a%20refactor%20that%20accidentally%20removes%20the%20%60ptr%20%3C%200%20%7C%7C%20len%20%3C%200%60%20guard%20or%20changes%20%60%3E%60%20to%20%60%3E%3D%60%20in%20the%20budget%20comparison%20%E2%80%94%20would%20leave%20these%20tests%20green.%20For%20security-critical%20validation%20code%20that%20gates%20memory%20allocation%2C%20the%20tests%20should%20call%20the%20real%20functions.%20Constructing%20a%20minimal%20wasmtime%20%60Store%60%2F%60Memory%60%20in%20tests%20is%20feasible%20and%20would%20give%20genuine%20coverage.%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftemper-wasm%2Fsrc%2Fengine%2Fguest_memory.rs%3A44-52%0A**%60checked_add%60%20overflow%20branch%20is%20unreachable%20on%2064-bit%20hosts**%0A%0ABoth%20%60ptr%60%20and%20%60len%60%20are%20%60i32%60%2C%20so%20after%20casting%20to%20%60usize%60%20each%20is%20at%20most%20%602%2C147%2C483%2C647%60.%20Their%20sum%20is%20at%20most%20~4%20GB%2C%20which%20is%20far%20below%20%60usize%3A%3AMAX%60%20on%20any%2064-bit%20platform.%20The%20test%20even%20acknowledges%20this%3A%20%60%2F%2F%20Force%20usize%20add%20overflow%20via%20large%20offsets%20%28not%20i32%3A%3AMAX%20alone%20on%2064-bit%29%60.%20The%20overflow%20path%20can%20never%20trigger%20in%20production%2C%20so%20the%20%60warn!%60%20inside%20%60.ok_or_else%28%7C%7C%20%7B%20%E2%80%A6%20%7D%29%60%20is%20dead%20code.%20The%20real%20out-of-bounds%20protection%20comes%20from%20the%20%60end%20%3E%20mem_size%60%20check%20below.%20The%20branch%20is%20harmless%20to%20keep%2C%20but%20the%20comment%20and%20test%20assertion%20%28%60assert!%28usize%3A%3AMAX.checked_add%281%29.is_none%28%29%29%60%29%20create%20a%20false%20impression%20that%20this%20guard%20is%20exercised%20by%20realistic%20inputs%3B%20it%20would%20be%20clearer%20to%20add%20a%20note%20that%20the%20branch%20only%20matters%20for%20hypothetical%2032-bit%20targets.%0A%0A&pr=362&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
crates/temper-wasm/src/engine/host_functions.rs:413
**Unprotected allocation sites bypass ARN-226 fixes**

At least seven host functions still execute `vec![0u8; len as usize]` before any signedness, range, or budget check, so a malicious guest can still force multi-GB host allocations by calling one of these entry points. The affected functions are `host_emit_progress` (line 413), `host_emit_wide_event` (line 439), `host_log_structured` (line 465), `host_emit_metric` (line 491), `host_resolve_field` (line 1318), and four reads inside `host_transition` (lines 1704, 1714, 1724, 1735). The `host_transition` site is especially high-impact because it also reads guest-supplied IOA source — passing `ioa_len = i32::MAX` triggers a ~2 GB allocation before wasmtime's bounds check runs. The PR description acknowledges these as residual, but since this PR is the ARN-226 security fix, each unaddressed site is a live bypass of the intended protection.

### Issue 2 of 3
crates/temper-wasm/src/engine/guest_memory.rs:137-175
**Tests exercise shadow code, not the production security functions**

Both `rejects_negative_and_overflow_math` and `budget_consume_fails_closed` test local helper functions that duplicate the production logic, rather than calling `validate_guest_range` or `consume_guest_copy_budget` directly. A regression in the actual production path — e.g., a refactor that accidentally removes the `ptr < 0 || len < 0` guard or changes `>` to `>=` in the budget comparison — would leave these tests green. For security-critical validation code that gates memory allocation, the tests should call the real functions. Constructing a minimal wasmtime `Store`/`Memory` in tests is feasible and would give genuine coverage.

### Issue 3 of 3
crates/temper-wasm/src/engine/guest_memory.rs:44-52
**`checked_add` overflow branch is unreachable on 64-bit hosts**

Both `ptr` and `len` are `i32`, so after casting to `usize` each is at most `2,147,483,647`. Their sum is at most ~4 GB, which is far below `usize::MAX` on any 64-bit platform. The test even acknowledges this: `// Force usize add overflow via large offsets (not i32::MAX alone on 64-bit)`. The overflow path can never trigger in production, so the `warn!` inside `.ok_or_else(|| { … })` is dead code. The real out-of-bounds protection comes from the `end > mem_size` check below. The branch is harmless to keep, but the comment and test assertion (`assert!(usize::MAX.checked_add(1).is_none())`) create a false impression that this guard is exercised by realistic inputs; it would be clearer to add a note that the branch only matters for hypothetical 32-bit targets.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(wasm): validate guest ranges before ..."](https://github.com/nerdsane/temper/commit/a6d8af1dc179f42cb7d62c98b41b262983f876ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43651358)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->