### PR TITLE
fix(actor-runtime): require namespace grant for cross-namespace persistence (ARN-215)

### DIFF
--- a/crates/temper-actor-runtime/src/actor.rs
+++ b/crates/temper-actor-runtime/src/actor.rs
@@ -97,6 +97,10 @@ pub enum ActorError {
 
     #[error("internal error: {0}")]
     Internal(String),
+
+    /// Cross-namespace persistence denied (ARN-215).
+    #[error("namespace capability denied: {0}")]
+    NamespaceDenied(String),
 }
 
 /// The actor's interface to the system. Passed to `handle()`.
@@ -111,6 +115,9 @@ pub struct ActorContext {
     pub(crate) mailbox: Option<std::sync::Arc<dyn crate::mailbox::Mailbox>>,
     /// Pool for spawn/lookup operations.
     pub(crate) pool: Option<deadpool_postgres::Pool>,
+    /// Explicit grants for cross-namespace load/upsert (ADR-0161 / ARN-215).
+    /// Own namespace is always allowed without a grant.
+    cross_namespace_grants: std::sync::Mutex<std::collections::BTreeSet<String>>,
 }
 
 impl ActorContext {
@@ -125,6 +132,17 @@ impl ActorContext {
             pending_tells: Mutex::new(Vec::new()),
             mailbox,
             pool,
+            cross_namespace_grants: std::sync::Mutex::new(std::collections::BTreeSet::new()),
+        }
+    }
+
+    /// Grant cross-namespace load/upsert for the named namespaces (ARN-215).
+    ///
+    /// Own namespace is always allowed. Grants are additive and must be set by
+    /// the runtime/tool layer before cross-namespace access — not by guest data.
+    pub fn grant_cross_namespace(&self, namespace: impl Into<String>) {
+        if let Ok(mut grants) = self.cross_namespace_grants.lock() {
+            grants.insert(namespace.into());
         }
     }
 
@@ -133,12 +151,34 @@ impl ActorContext {
         &self.self_handle
     }
 
+    /// Fail closed unless `namespace` is self or explicitly granted (ARN-215).
+    fn require_namespace_access(&self, namespace: &str) -> Result<(), ActorError> {
+        if namespace == self.self_handle.namespace {
+            return Ok(());
+        }
+        let granted = self
+            .cross_namespace_grants
+            .lock()
+            .map(|g| g.contains(namespace))
+            .unwrap_or(false);
+        if granted {
+            return Ok(());
+        }
+        Err(ActorError::NamespaceDenied(format!(
+            "actor '{}' cannot access namespace '{}' without an explicit grant",
+            self.self_handle.namespace, namespace
+        )))
+    }
+
     /// Load raw state bytes for an actor instance.
+    ///
+    /// Cross-namespace reads require a prior [`grant_cross_namespace`].
     pub async fn load_actor_state(
         &self,
         namespace: &str,
         actor_type: &str,
     ) -> Result<Option<Vec<u8>>, ActorError> {
+        self.require_namespace_access(namespace)?;
         let Some(pool) = &self.pool else {
             return Err(ActorError::Internal("no pool in ActorContext".into()));
         };
@@ -158,12 +198,15 @@ impl ActorContext {
 
     /// Best-effort spawn/update of an actor instance with explicit state bytes.
     /// Used by integrations to persist auxiliary entities (e.g. Message).
+    ///
+    /// Cross-namespace writes require a prior [`grant_cross_namespace`].
     pub async fn upsert_actor_state(
         &self,
         namespace: &str,
         actor_type: &str,
         state: Vec<u8>,
     ) -> Result<(), ActorError> {
+        self.require_namespace_access(namespace)?;
         let Some(pool) = &self.pool else {
             return Err(ActorError::Internal("no pool in ActorContext".into()));
         };
@@ -332,4 +375,29 @@ pub trait Actor: Send + Sync + 'static {
         state: &mut Vec<u8>,
         message: &Message,
     ) -> Result<(), ActorError>;
+}
+
+#[cfg(test)]
+mod namespace_cap_tests {
+    use super::*;
+
+    #[test]
+    fn same_namespace_allowed_without_grant() {
+        let ctx = ActorContext::new(ActorHandle::new("ns-a", "Process"), None, None);
+        assert!(ctx.require_namespace_access("ns-a").is_ok());
+    }
+
+    #[test]
+    fn cross_namespace_denied_without_grant() {
+        let ctx = ActorContext::new(ActorHandle::new("ns-a", "Process"), None, None);
+        let err = ctx.require_namespace_access("ns-b").unwrap_err();
+        assert!(matches!(err, ActorError::NamespaceDenied(_)));
+    }
+
+    #[test]
+    fn cross_namespace_allowed_after_grant() {
+        let ctx = ActorContext::new(ActorHandle::new("ns-a", "Process"), None, None);
+        ctx.grant_cross_namespace("ns-b");
+        assert!(ctx.require_namespace_access("ns-b").is_ok());
+    }
 }

--- a/crates/temper-actor-runtime/src/actor.rs
+++ b/crates/temper-actor-runtime/src/actor.rs
@@ -136,24 +136,53 @@ impl ActorContext {
         }
     }
 
-    /// Grant cross-namespace load/upsert for the named namespaces (ARN-215).
+    /// Grant cross-namespace load/upsert for a same-tenant namespace (ARN-215).
     ///
-    /// Own namespace is always allowed. Grants are additive.
+    /// Own namespace is always allowed without a grant. Grants are additive.
     ///
     /// # Security contract
     ///
-    /// Callers must only grant namespaces that have already been validated as
-    /// in-tenant and free of path traversal. Untrusted payload strings (e.g.
-    /// user-supplied `process_id`) must be validated before calling this method
-    /// — see `temper-agents` process-id checks. This is a trusted runtime/tool
-    /// privilege, not a guest-facing capability; handlers must never pass
-    /// attacker-controlled namespace strings through without validation.
-    pub fn grant_cross_namespace(&self, namespace: impl Into<String>) {
+    /// Grants are **type-enforced to the caller's tenant root** (first path
+    /// segment of `self_handle.namespace`). A handler cannot self-grant into
+    /// another tenant's namespace tree. Path separators, `..`, NUL, and empty
+    /// strings are rejected. Untrusted payload segments (e.g. `process_id`)
+    /// must still be validated by the caller before composition — see
+    /// `temper-agents` process-id checks.
+    ///
+    /// Returns [`ActorError::NamespaceDenied`] when the grant would cross
+    /// tenant roots or fails structural validation.
+    pub fn grant_cross_namespace(&self, namespace: impl Into<String>) -> Result<(), ActorError> {
+        let ns = namespace.into();
+        self.validate_grant_target(&ns)?;
         // Recover poison so a prior panic does not silently drop later grants.
         self.cross_namespace_grants
             .lock()
             .unwrap_or_else(|e| e.into_inner())
-            .insert(namespace.into());
+            .insert(ns);
+        Ok(())
+    }
+
+    /// Reject grants outside the actor's tenant root or with path traversal.
+    fn validate_grant_target(&self, namespace: &str) -> Result<(), ActorError> {
+        if namespace.is_empty()
+            || namespace.contains('\0')
+            || namespace.contains('\\')
+            || namespace.contains("..")
+            || namespace.starts_with('/')
+        {
+            return Err(ActorError::NamespaceDenied(format!(
+                "invalid grant namespace '{namespace}'"
+            )));
+        }
+        let self_root = self.self_handle.namespace.split('/').next().unwrap_or("");
+        let grant_root = namespace.split('/').next().unwrap_or("");
+        if self_root.is_empty() || grant_root != self_root {
+            return Err(ActorError::NamespaceDenied(format!(
+                "actor '{}' cannot grant namespace '{}' outside tenant root '{}'",
+                self.self_handle.namespace, namespace, self_root
+            )));
+        }
+        Ok(())
     }
 
     /// This actor's own address.
@@ -405,9 +434,26 @@ mod namespace_cap_tests {
     }
 
     #[test]
-    fn cross_namespace_allowed_after_grant() {
+    fn same_tenant_child_allowed_after_grant() {
         let ctx = ActorContext::new(ActorHandle::new("ns-a", "Process"), None, None);
-        ctx.grant_cross_namespace("ns-b");
-        assert!(ctx.require_namespace_access("ns-b").is_ok());
+        ctx.grant_cross_namespace("ns-a/child")
+            .expect("same-tenant child grant");
+        assert!(ctx.require_namespace_access("ns-a/child").is_ok());
+    }
+
+    #[test]
+    fn grant_rejects_other_tenant_root() {
+        let ctx = ActorContext::new(ActorHandle::new("ns-a", "Process"), None, None);
+        let err = ctx.grant_cross_namespace("ns-b").unwrap_err();
+        assert!(matches!(err, ActorError::NamespaceDenied(_)));
+        assert!(ctx.require_namespace_access("ns-b").is_err());
+    }
+
+    #[test]
+    fn grant_rejects_path_traversal() {
+        let ctx = ActorContext::new(ActorHandle::new("tenant/proc", "Process"), None, None);
+        assert!(ctx.grant_cross_namespace("tenant/../other").is_err());
+        assert!(ctx.grant_cross_namespace("").is_err());
+        assert!(ctx.grant_cross_namespace("/tenant/x").is_err());
     }
 }

--- a/crates/temper-actor-runtime/src/actor.rs
+++ b/crates/temper-actor-runtime/src/actor.rs
@@ -115,7 +115,7 @@ pub struct ActorContext {
     pub(crate) mailbox: Option<std::sync::Arc<dyn crate::mailbox::Mailbox>>,
     /// Pool for spawn/lookup operations.
     pub(crate) pool: Option<deadpool_postgres::Pool>,
-    /// Explicit grants for cross-namespace load/upsert (ADR-0161 / ARN-215).
+    /// Explicit grants for cross-namespace load/upsert (ADR-0164 / ARN-215).
     /// Own namespace is always allowed without a grant.
     cross_namespace_grants: std::sync::Mutex<std::collections::BTreeSet<String>>,
 }

--- a/crates/temper-actor-runtime/src/actor.rs
+++ b/crates/temper-actor-runtime/src/actor.rs
@@ -138,12 +138,22 @@ impl ActorContext {
 
     /// Grant cross-namespace load/upsert for the named namespaces (ARN-215).
     ///
-    /// Own namespace is always allowed. Grants are additive and must be set by
-    /// the runtime/tool layer before cross-namespace access — not by guest data.
+    /// Own namespace is always allowed. Grants are additive.
+    ///
+    /// # Security contract
+    ///
+    /// Callers must only grant namespaces that have already been validated as
+    /// in-tenant and free of path traversal. Untrusted payload strings (e.g.
+    /// user-supplied `process_id`) must be validated before calling this method
+    /// — see `temper-agents` process-id checks. This is a trusted runtime/tool
+    /// privilege, not a guest-facing capability; handlers must never pass
+    /// attacker-controlled namespace strings through without validation.
     pub fn grant_cross_namespace(&self, namespace: impl Into<String>) {
-        if let Ok(mut grants) = self.cross_namespace_grants.lock() {
-            grants.insert(namespace.into());
-        }
+        // Recover poison so a prior panic does not silently drop later grants.
+        self.cross_namespace_grants
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(namespace.into());
     }
 
     /// This actor's own address.
@@ -159,8 +169,8 @@ impl ActorContext {
         let granted = self
             .cross_namespace_grants
             .lock()
-            .map(|g| g.contains(namespace))
-            .unwrap_or(false);
+            .unwrap_or_else(|e| e.into_inner())
+            .contains(namespace);
         if granted {
             return Ok(());
         }

--- a/crates/temper-agents/src/common.rs
+++ b/crates/temper-agents/src/common.rs
@@ -70,6 +70,8 @@ pub async fn append_message(
         fields,
     };
     if let Ok(bytes) = serde_json::to_vec(&state) {
+        // ARN-215: Message rows live under a child namespace; grant before write.
+        ctx.grant_cross_namespace(message_namespace.clone());
         let _ = ctx
             .upsert_actor_state(&message_namespace, "Message", bytes)
             .await;

--- a/crates/temper-agents/src/common.rs
+++ b/crates/temper-agents/src/common.rs
@@ -71,9 +71,11 @@ pub async fn append_message(
     };
     if let Ok(bytes) = serde_json::to_vec(&state) {
         // ARN-215: Message rows live under a child namespace; grant before write.
-        ctx.grant_cross_namespace(message_namespace.clone());
-        let _ = ctx
-            .upsert_actor_state(&message_namespace, "Message", bytes)
-            .await;
+        // Same-tenant root is enforced inside grant_cross_namespace.
+        if ctx.grant_cross_namespace(message_namespace.clone()).is_ok() {
+            let _ = ctx
+                .upsert_actor_state(&message_namespace, "Message", bytes)
+                .await;
+        }
     }
 }

--- a/crates/temper-agents/src/tool_executor.rs
+++ b/crates/temper-agents/src/tool_executor.rs
@@ -258,8 +258,11 @@ async fn dispatch_builtin(
 
             // If the caller provided a child_id, check child state directly first.
             if let Some(child_id) = input["child_id"].as_str().filter(|s| !s.is_empty()) {
+                if let Err(msg) = validate_process_id(child_id) {
+                    return format!("error: {msg}");
+                }
                 let child_ns = format!("{tenant}/{child_id}");
-                // ARN-215: sibling Process rows require an explicit namespace grant.
+                // ARN-215: only after validating id is a single path segment under self tenant.
                 ctx.grant_cross_namespace(child_ns.clone());
                 if let Some(child_state) = ctx
                     .load_actor_state(&child_ns, "Process")
@@ -356,11 +359,39 @@ async fn dispatch_builtin(
     }
 }
 
+/// Reject path traversal / multi-segment process ids before any grant (ARN-215).
+///
+/// Cross-namespace access is only granted for `{self_tenant}/{process_id}` where
+/// `process_id` is a single non-empty segment (no `/`, `\`, or `..`).
+fn validate_process_id(process_id: &str) -> Result<(), String> {
+    if process_id.is_empty() {
+        return Err("process_id must not be empty".to_string());
+    }
+    if process_id.contains('/') || process_id.contains('\\') || process_id.contains("..") {
+        return Err("process_id must not contain path separators or '..'".to_string());
+    }
+    if !process_id
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+    {
+        return Err("process_id has invalid characters".to_string());
+    }
+    Ok(())
+}
+
 async fn get_process_state(ctx: &ActorContext, process_id: &str, output_only: bool) -> String {
+    if let Err(msg) = validate_process_id(process_id) {
+        return format!("error: {msg}");
+    }
     let ns = ctx.self_handle().namespace.clone();
     let tenant = ns.split('/').next().unwrap_or("default");
+    // Always bind to the caller's tenant prefix — never accept a foreign tenant.
     let target_ns = format!("{tenant}/{process_id}");
-    // ARN-215: cross-namespace Process read requires an explicit grant.
+    debug_assert!(
+        target_ns.starts_with(&format!("{tenant}/")) && !target_ns[tenant.len() + 1..].contains('/'),
+        "target namespace must be a direct child of self tenant"
+    );
+    // ARN-215: grant only after validation; capability is same-tenant process lookup.
     ctx.grant_cross_namespace(target_ns.clone());
     let Some(state) = ctx
         .load_actor_state(&target_ns, "Process")

--- a/crates/temper-agents/src/tool_executor.rs
+++ b/crates/temper-agents/src/tool_executor.rs
@@ -259,6 +259,8 @@ async fn dispatch_builtin(
             // If the caller provided a child_id, check child state directly first.
             if let Some(child_id) = input["child_id"].as_str().filter(|s| !s.is_empty()) {
                 let child_ns = format!("{tenant}/{child_id}");
+                // ARN-215: sibling Process rows require an explicit namespace grant.
+                ctx.grant_cross_namespace(child_ns.clone());
                 if let Some(child_state) = ctx
                     .load_actor_state(&child_ns, "Process")
                     .await
@@ -358,6 +360,8 @@ async fn get_process_state(ctx: &ActorContext, process_id: &str, output_only: bo
     let ns = ctx.self_handle().namespace.clone();
     let tenant = ns.split('/').next().unwrap_or("default");
     let target_ns = format!("{tenant}/{process_id}");
+    // ARN-215: cross-namespace Process read requires an explicit grant.
+    ctx.grant_cross_namespace(target_ns.clone());
     let Some(state) = ctx
         .load_actor_state(&target_ns, "Process")
         .await

--- a/crates/temper-agents/src/tool_executor.rs
+++ b/crates/temper-agents/src/tool_executor.rs
@@ -379,8 +379,6 @@ fn validate_process_id(process_id: &str) -> Result<(), String> {
     Ok(())
 }
 
-
-
 async fn get_process_state(ctx: &ActorContext, process_id: &str, output_only: bool) -> String {
     if let Err(msg) = validate_process_id(process_id) {
         return format!("error: {msg}");
@@ -390,7 +388,8 @@ async fn get_process_state(ctx: &ActorContext, process_id: &str, output_only: bo
     // Always bind to the caller's tenant prefix — never accept a foreign tenant.
     let target_ns = format!("{tenant}/{process_id}");
     debug_assert!(
-        target_ns.starts_with(&format!("{tenant}/")) && !target_ns[tenant.len() + 1..].contains('/'),
+        target_ns.starts_with(&format!("{tenant}/"))
+            && !target_ns[tenant.len() + 1..].contains('/'),
         "target namespace must be a direct child of self tenant"
     );
     // ARN-215: grant only after validation; capability is same-tenant process lookup.

--- a/crates/temper-agents/src/tool_executor.rs
+++ b/crates/temper-agents/src/tool_executor.rs
@@ -379,6 +379,8 @@ fn validate_process_id(process_id: &str) -> Result<(), String> {
     Ok(())
 }
 
+
+
 async fn get_process_state(ctx: &ActorContext, process_id: &str, output_only: bool) -> String {
     if let Err(msg) = validate_process_id(process_id) {
         return format!("error: {msg}");

--- a/crates/temper-agents/src/tool_executor.rs
+++ b/crates/temper-agents/src/tool_executor.rs
@@ -263,7 +263,9 @@ async fn dispatch_builtin(
                 }
                 let child_ns = format!("{tenant}/{child_id}");
                 // ARN-215: only after validating id is a single path segment under self tenant.
-                ctx.grant_cross_namespace(child_ns.clone());
+                if let Err(e) = ctx.grant_cross_namespace(child_ns.clone()) {
+                    return format!("error: {e}");
+                }
                 if let Some(child_state) = ctx
                     .load_actor_state(&child_ns, "Process")
                     .await
@@ -393,7 +395,10 @@ async fn get_process_state(ctx: &ActorContext, process_id: &str, output_only: bo
         "target namespace must be a direct child of self tenant"
     );
     // ARN-215: grant only after validation; capability is same-tenant process lookup.
-    ctx.grant_cross_namespace(target_ns.clone());
+    // Tenant-root bound is enforced inside grant_cross_namespace.
+    if let Err(e) = ctx.grant_cross_namespace(target_ns.clone()) {
+        return format!("error: {e}");
+    }
     let Some(state) = ctx
         .load_actor_state(&target_ns, "Process")
         .await

--- a/docs/adrs/0161-actor-namespace-capability.md
+++ b/docs/adrs/0161-actor-namespace-capability.md
@@ -1,0 +1,46 @@
+# ADR-0161: ActorContext namespace capability (ARN-215)
+
+- Status: Accepted
+- Date: 2026-07-12
+- Deciders: Temper core maintainers
+- Related:
+  - ARN-215: ActorContext grants arbitrary cross-namespace persistence
+  - `crates/temper-actor-runtime/src/actor.rs`
+
+## Context
+
+`load_actor_state` / `upsert_actor_state` accepted any namespace string, so a
+compromised or buggy handler could read/overwrite arbitrary actor rows outside
+its activation namespace.
+
+## Decision
+
+### Sub-Decision 1: Default bind to self namespace
+
+Access to `namespace == self_handle.namespace` is always allowed.
+
+### Sub-Decision 2: Explicit grant for cross-namespace
+
+Any other namespace requires a prior `grant_cross_namespace` on the context.
+Grants are set only by runtime/tool code, not by untrusted message payload.
+
+### Sub-Decision 3: Fail closed
+
+Missing grant → `ActorError::NamespaceDenied`.
+
+## Consequences
+
+### Positive
+
+- Cross-namespace persistence is capability-gated.
+- Same-namespace integrations keep working unchanged.
+
+### Negative
+
+- Callers that intentionally touch sibling namespaces (e.g. child Process) must
+  grant those namespaces before load/upsert.
+
+## Non-Goals
+
+- Full Cedar policy evaluation for each row (follow-up).
+- Mailbox retention redesign (separate).

--- a/docs/adrs/0161-actor-namespace-capability.md
+++ b/docs/adrs/0161-actor-namespace-capability.md
@@ -19,14 +19,19 @@ its activation namespace.
 
 Access to `namespace == self_handle.namespace` is always allowed.
 
-### Sub-Decision 2: Explicit grant for cross-namespace
+### Sub-Decision 2: Explicit grant for cross-namespace (same tenant root)
 
 Any other namespace requires a prior `grant_cross_namespace` on the context.
-Grants are set only by runtime/tool code, not by untrusted message payload.
+Grants are **restricted to the caller's tenant root** (first `/`-separated
+segment of `self_handle.namespace`). A handler cannot self-grant into another
+tenant's namespace tree. Path traversal, empty, absolute, and backslash
+namespaces are rejected at grant time. Callers still validate untrusted path
+segments (e.g. `process_id`) before composing the namespace string.
 
 ### Sub-Decision 3: Fail closed
 
-Missing grant → `ActorError::NamespaceDenied`.
+Missing grant → `ActorError::NamespaceDenied`. Invalid grant targets also
+return `NamespaceDenied` (no silent accept).
 
 ## Consequences
 

--- a/docs/adrs/0164-actor-namespace-capability.md
+++ b/docs/adrs/0164-actor-namespace-capability.md
@@ -1,4 +1,4 @@
-# ADR-0161: ActorContext namespace capability (ARN-215)
+# ADR-0164: ActorContext namespace capability (ARN-215)
 
 - Status: Accepted
 - Date: 2026-07-12


### PR DESCRIPTION
## Summary
ARN-215: ActorContext no longer allows arbitrary cross-namespace load/upsert.

- Default: only `self_handle.namespace`
- Cross-namespace: `grant_cross_namespace` then load/upsert
- `ActorError::NamespaceDenied` fail-closed
- ADR-0161; agents updated for Message + child Process grants

## Tests
- [x] namespace_cap unit tests (3)
- [ ] CI green

Linear: ARN-215

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a namespace capability guard to `ActorContext::load_actor_state` and `upsert_actor_state`: access to namespaces other than the actor's own now requires a prior `grant_cross_namespace` call, failing closed with `ActorError::NamespaceDenied`. The `temper-agents` call sites (`append_message`, `wait_child`, `get_process_state`) are updated to issue grants before their cross-namespace operations.

- **Core check (`actor.rs`)**: The `require_namespace_access` guard and `BTreeSet`-backed grant set are correct in isolation, and the three unit tests cover the basic allow/deny/grant cases.
- **Public visibility gap**: `grant_cross_namespace` is `pub`, so any `Actor::handle()` implementation receiving the same `&ActorContext` can self-grant arbitrary namespaces — the ADR's \"runtime-only grant\" rule is a documentation convention, not a type-system guarantee.
- **Co-located grant pattern (`tool_executor.rs`)**: `grant_cross_namespace(target_ns)` is called immediately before `load_actor_state(&target_ns, …)` for user-supplied `process_id` and `child_id` values, making the capability check a no-op at those sites; the granted namespace is never validated against a tenant boundary before the grant is issued.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The namespace guard introduced here does not hold the boundary it advertises — the public grant method is accessible to every actor handler, and the tool-executor callers unconditionally self-grant whatever namespace the user provides. The change is safe to merge as a documentation and defense-in-depth step, but should not be treated as a completed security control until the visibility and co-located grant issues are resolved.

Two related defects exist on the security-critical path: grant_cross_namespace is reachable from untrusted handler code, and the tool-executor sites bypass the check by granting user-controlled namespace strings immediately before access. Together these mean the capability model does not prevent cross-namespace reads that the ADR intends to block.

crates/temper-actor-runtime/src/actor.rs (grant visibility) and crates/temper-agents/src/tool_executor.rs (co-located grant + user-controlled namespace) need the most attention before this can be considered a hardened boundary.
</details>

<details open><summary><h3>Security Review</h3></summary>

- **`grant_cross_namespace` public visibility** (`actor.rs:143`): Any `Actor::handle()` implementation can call `ctx.grant_cross_namespace(namespace_from_payload)` to self-grant access to arbitrary namespaces, bypassing the capability boundary described in ADR-0161. The protection is convention-only, not enforced by the type system.
- **Unconditional grant before user-controlled load** (`tool_executor.rs:362-365`, `tool_executor.rs:262-263`): `process_id` and `child_id` are taken from user-supplied tool-call JSON and used verbatim to construct a namespace that is immediately granted and read. No tenant-boundary validation occurs before the grant is issued, meaning a crafted `process_id` containing path separators (e.g. `other-user/secret`) will receive an automatic grant and succeed.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/temper-actor-runtime/src/actor.rs | Adds namespace capability check to load_actor_state/upsert_actor_state via a BTreeSet of grants; grant_cross_namespace is pub which allows any actor handler to self-grant arbitrary namespaces, undermining the intended security boundary. |
| crates/temper-agents/src/tool_executor.rs | Issues grant_cross_namespace immediately before load_actor_state for user-supplied process_id/child_id values, making the capability check a no-op for these call sites; any peer namespace within the tenant can be read. |
| crates/temper-agents/src/common.rs | append_message now calls grant_cross_namespace before upsert_actor_state for Message rows; the co-located grant is legitimate here since the message namespace is constructed internally, not from untrusted input. |
| docs/adrs/0161-actor-namespace-capability.md | New ADR documenting the namespace capability design; security claim that grants are only set by runtime/tool code is stated but not enforced by the implementation. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Handler as Actor::handle()
    participant Ctx as ActorContext
    participant Check as require_namespace_access()
    participant DB as PostgreSQL

    Note over Handler,DB: Same-namespace access (always allowed)
    Handler->>Ctx: load_actor_state("ns-a", "Process")
    Ctx->>Check: "namespace == self_handle.namespace?"
    Check-->>Ctx: Ok(())
    Ctx->>DB: "SELECT state WHERE namespace='ns-a'"
    DB-->>Handler: Ok(Some(bytes))

    Note over Handler,DB: Cross-namespace tool executor path
    Handler->>Ctx: grant_cross_namespace("tenant/child-id")
    Ctx->>Ctx: grants.insert("tenant/child-id")
    Handler->>Ctx: load_actor_state("tenant/child-id", "Process")
    Ctx->>Check: grants.contains("tenant/child-id")?
    Check-->>Ctx: Ok(())
    Ctx->>DB: "SELECT state WHERE namespace='tenant/child-id'"
    DB-->>Handler: Ok(Some(bytes))

    Note over Handler,DB: Any actor handler can also call grant_cross_namespace
    Handler->>Ctx: grant_cross_namespace(namespace_from_payload)
    Ctx->>Ctx: grants.insert(namespace_from_payload)
    Handler->>Ctx: load_actor_state(namespace_from_payload, ...)
    Ctx->>Check: granted via self-grant
    Ctx->>DB: "SELECT state WHERE namespace=attacker_value"
    DB-->>Handler: Ok(Some(bytes))
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Handler as Actor::handle()
    participant Ctx as ActorContext
    participant Check as require_namespace_access()
    participant DB as PostgreSQL

    Note over Handler,DB: Same-namespace access (always allowed)
    Handler->>Ctx: load_actor_state("ns-a", "Process")
    Ctx->>Check: "namespace == self_handle.namespace?"
    Check-->>Ctx: Ok(())
    Ctx->>DB: "SELECT state WHERE namespace='ns-a'"
    DB-->>Handler: Ok(Some(bytes))

    Note over Handler,DB: Cross-namespace tool executor path
    Handler->>Ctx: grant_cross_namespace("tenant/child-id")
    Ctx->>Ctx: grants.insert("tenant/child-id")
    Handler->>Ctx: load_actor_state("tenant/child-id", "Process")
    Ctx->>Check: grants.contains("tenant/child-id")?
    Check-->>Ctx: Ok(())
    Ctx->>DB: "SELECT state WHERE namespace='tenant/child-id'"
    DB-->>Handler: Ok(Some(bytes))

    Note over Handler,DB: Any actor handler can also call grant_cross_namespace
    Handler->>Ctx: grant_cross_namespace(namespace_from_payload)
    Ctx->>Ctx: grants.insert(namespace_from_payload)
    Handler->>Ctx: load_actor_state(namespace_from_payload, ...)
    Ctx->>Check: granted via self-grant
    Ctx->>DB: "SELECT state WHERE namespace=attacker_value"
    DB-->>Handler: Ok(Some(bytes))
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Acrates%2Ftemper-actor-runtime%2Fsrc%2Factor.rs%3A143-147%0A**%60grant_cross_namespace%60%20is%20%60pub%60%20%E2%80%94%20any%20actor%20handler%20can%20self-grant**%0A%0AThe%20ADR%20states%20%22grants%20are%20set%20only%20by%20runtime%2Ftool%20code%2C%20not%20by%20guest%20data%2C%22%20but%20%60grant_cross_namespace%60%20is%20a%20fully%20public%20method%20on%20%60ActorContext%60%2C%20which%20is%20the%20same%20%60ctx%60%20reference%20passed%20to%20every%20%60Actor%3A%3Ahandle%28%29%60%20implementation.%20Any%20handler%20that%20receives%20message%20payload%20containing%20an%20attacker-chosen%20namespace%20string%20can%20call%20%60ctx.grant_cross_namespace%28namespace_from_payload%29%60%20followed%20by%20%60ctx.load_actor_state%28namespace_from_payload%2C%20%E2%80%A6%29%60%20to%20read%20or%20overwrite%20rows%20in%20that%20namespace%20%E2%80%94%20bypassing%20the%20security%20boundary%20described%20in%20the%20ADR.%0A%0AMaking%20this%20%60pub%28crate%29%60%20would%20enforce%20the%20boundary%20within%20%60temper-actor-runtime%60%20but%20would%20break%20the%20%60temper-agents%60%20callers%20that%20legitimately%20need%20to%20issue%20grants.%20The%20real%20fix%20is%20a%20split-context%20design%3A%20pass%20a%20privilege-bearing%20%60RuntimeContext%60%20%28or%20a%20%60CapabilityToken%60%29%20to%20trusted%20tool%20code%20while%20only%20handing%20actors%20the%20restricted%20%60ActorContext%60.%20As-is%2C%20the%20capability%20check%20is%20a%20documentation%20convention%2C%20not%20a%20language-enforced%20boundary.%0A%0A%23%23%23%20Issue%202%20of%204%0Acrates%2Ftemper-agents%2Fsrc%2Ftool_executor.rs%3A362-365%0A**Co-located%20grant%20%2B%20access%20makes%20the%20namespace%20check%20a%20no-op**%0A%0AIn%20both%20%60get_process_state%60%20and%20the%20%60wait_child%60%20branch%2C%20the%20pattern%20is%3A%20build%20%60target_ns%60%20from%20user-supplied%20%60process_id%60%20%2F%20%60child_id%60%2C%20immediately%20call%20%60ctx.grant_cross_namespace%28target_ns.clone%28%29%29%60%2C%20then%20call%20%60ctx.load_actor_state%28%26target_ns%2C%20%E2%80%A6%29%60.%20Because%20the%20grant%20is%20issued%20unconditionally%20for%20whatever%20namespace%20string%20the%20caller%20passes%2C%20the%20capability%20check%20in%20%60require_namespace_access%60%20is%20trivially%20satisfied%20for%20any%20user-provided%20value.%20An%20actor%20told%20to%20%60get_process_status%60%20with%20%60process_id%20%3D%20%22..%2F..%2Fother-tenant%2Fsecret%22%60%20%28or%20any%20peer%20tenant%20namespace%29%20would%20receive%20a%20grant%20and%20complete%20the%20read%20%E2%80%94%20identical%20behavior%20to%20the%20pre-ARN-215%20code.%0A%0AThe%20same%20pattern%20appears%20in%20%60common.rs%60%20%60append_message%60%20%28line%2074%29.%20If%20the%20intent%20is%20that%20all%20process-ID%20lookups%20within%20the%20same%20tenant%20are%20always%20permitted%2C%20that%20pre-condition%20should%20be%20validated%20%28e.g.%2C%20assert%20%60target_ns%60%20is%20a%20direct%20child%20of%20the%20current%20tenant%29%20before%20the%20grant%20is%20issued%2C%20rather%20than%20granting%20whatever%20string%20arrives.%0A%0A%23%23%23%20Issue%203%20of%204%0Acrates%2Ftemper-actor-runtime%2Fsrc%2Factor.rs%3A159-163%0A%60unwrap_or%28false%29%60%20silently%20fail-closes%20when%20the%20mutex%20is%20poisoned%2C%20which%20is%20the%20right%20behavior%2C%20but%20pairing%20it%20with%20the%20silent-drop%20in%20%60grant_cross_namespace%60%20means%20a%20poisoned%20mutex%20produces%20a%20confusing%20%60NamespaceDenied%60%20error%20with%20no%20diagnostic%20signal.%20Consider%20recovering%20the%20inner%20value%20from%20the%20poison%20error%20in%20both%20places%20to%20preserve%20the%20grant%20data%20and%20avoid%20spurious%20denials.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20granted%20%3D%20self%0A%20%20%20%20%20%20%20%20%20%20%20%20.cross_namespace_grants%0A%20%20%20%20%20%20%20%20%20%20%20%20.lock%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.unwrap_or_else%28%7Ce%7C%20e.into_inner%28%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.contains%28namespace%29%3B%0A%60%60%60%0A%0A%281%20more%20issue%20omitted%20due%20to%20length%20limits.%20Use%20individual%20%22Fix%20in%20Claude%20Code%22%20links%20for%20remaining%20issues.%29%0A&repo=nerdsane%2Ftemper&pr=363&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22grok%2Farn-215-actor-namespace-cap%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22grok%2Farn-215-actor-namespace-cap%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Acrates%2Ftemper-actor-runtime%2Fsrc%2Factor.rs%3A143-147%0A**%60grant_cross_namespace%60%20is%20%60pub%60%20%E2%80%94%20any%20actor%20handler%20can%20self-grant**%0A%0AThe%20ADR%20states%20%22grants%20are%20set%20only%20by%20runtime%2Ftool%20code%2C%20not%20by%20guest%20data%2C%22%20but%20%60grant_cross_namespace%60%20is%20a%20fully%20public%20method%20on%20%60ActorContext%60%2C%20which%20is%20the%20same%20%60ctx%60%20reference%20passed%20to%20every%20%60Actor%3A%3Ahandle%28%29%60%20implementation.%20Any%20handler%20that%20receives%20message%20payload%20containing%20an%20attacker-chosen%20namespace%20string%20can%20call%20%60ctx.grant_cross_namespace%28namespace_from_payload%29%60%20followed%20by%20%60ctx.load_actor_state%28namespace_from_payload%2C%20%E2%80%A6%29%60%20to%20read%20or%20overwrite%20rows%20in%20that%20namespace%20%E2%80%94%20bypassing%20the%20security%20boundary%20described%20in%20the%20ADR.%0A%0AMaking%20this%20%60pub%28crate%29%60%20would%20enforce%20the%20boundary%20within%20%60temper-actor-runtime%60%20but%20would%20break%20the%20%60temper-agents%60%20callers%20that%20legitimately%20need%20to%20issue%20grants.%20The%20real%20fix%20is%20a%20split-context%20design%3A%20pass%20a%20privilege-bearing%20%60RuntimeContext%60%20%28or%20a%20%60CapabilityToken%60%29%20to%20trusted%20tool%20code%20while%20only%20handing%20actors%20the%20restricted%20%60ActorContext%60.%20As-is%2C%20the%20capability%20check%20is%20a%20documentation%20convention%2C%20not%20a%20language-enforced%20boundary.%0A%0A%23%23%23%20Issue%202%20of%204%0Acrates%2Ftemper-agents%2Fsrc%2Ftool_executor.rs%3A362-365%0A**Co-located%20grant%20%2B%20access%20makes%20the%20namespace%20check%20a%20no-op**%0A%0AIn%20both%20%60get_process_state%60%20and%20the%20%60wait_child%60%20branch%2C%20the%20pattern%20is%3A%20build%20%60target_ns%60%20from%20user-supplied%20%60process_id%60%20%2F%20%60child_id%60%2C%20immediately%20call%20%60ctx.grant_cross_namespace%28target_ns.clone%28%29%29%60%2C%20then%20call%20%60ctx.load_actor_state%28%26target_ns%2C%20%E2%80%A6%29%60.%20Because%20the%20grant%20is%20issued%20unconditionally%20for%20whatever%20namespace%20string%20the%20caller%20passes%2C%20the%20capability%20check%20in%20%60require_namespace_access%60%20is%20trivially%20satisfied%20for%20any%20user-provided%20value.%20An%20actor%20told%20to%20%60get_process_status%60%20with%20%60process_id%20%3D%20%22..%2F..%2Fother-tenant%2Fsecret%22%60%20%28or%20any%20peer%20tenant%20namespace%29%20would%20receive%20a%20grant%20and%20complete%20the%20read%20%E2%80%94%20identical%20behavior%20to%20the%20pre-ARN-215%20code.%0A%0AThe%20same%20pattern%20appears%20in%20%60common.rs%60%20%60append_message%60%20%28line%2074%29.%20If%20the%20intent%20is%20that%20all%20process-ID%20lookups%20within%20the%20same%20tenant%20are%20always%20permitted%2C%20that%20pre-condition%20should%20be%20validated%20%28e.g.%2C%20assert%20%60target_ns%60%20is%20a%20direct%20child%20of%20the%20current%20tenant%29%20before%20the%20grant%20is%20issued%2C%20rather%20than%20granting%20whatever%20string%20arrives.%0A%0A%23%23%23%20Issue%203%20of%204%0Acrates%2Ftemper-actor-runtime%2Fsrc%2Factor.rs%3A159-163%0A%60unwrap_or%28false%29%60%20silently%20fail-closes%20when%20the%20mutex%20is%20poisoned%2C%20which%20is%20the%20right%20behavior%2C%20but%20pairing%20it%20with%20the%20silent-drop%20in%20%60grant_cross_namespace%60%20means%20a%20poisoned%20mutex%20produces%20a%20confusing%20%60NamespaceDenied%60%20error%20with%20no%20diagnostic%20signal.%20Consider%20recovering%20the%20inner%20value%20from%20the%20poison%20error%20in%20both%20places%20to%20preserve%20the%20grant%20data%20and%20avoid%20spurious%20denials.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20granted%20%3D%20self%0A%20%20%20%20%20%20%20%20%20%20%20%20.cross_namespace_grants%0A%20%20%20%20%20%20%20%20%20%20%20%20.lock%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.unwrap_or_else%28%7Ce%7C%20e.into_inner%28%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.contains%28namespace%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Acrates%2Ftemper-actor-runtime%2Fsrc%2Factor.rs%3A143-147%0AConsistent%20with%20the%20suggestion%20above%3A%20recover%20from%20mutex%20poison%20here%20too%20rather%20than%20silently%20dropping%20the%20grant%2C%20to%20avoid%20spurious%20%60NamespaceDenied%60%20errors%20that%20would%20otherwise%20be%20very%20hard%20to%20diagnose.%0A%0A%60%60%60suggestion%0A%20%20%20%20pub%20fn%20grant_cross_namespace%28%26self%2C%20namespace%3A%20impl%20Into%3CString%3E%29%20%7B%0A%20%20%20%20%20%20%20%20self.cross_namespace_grants%0A%20%20%20%20%20%20%20%20%20%20%20%20.lock%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.unwrap_or_else%28%7Ce%7C%20e.into_inner%28%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.insert%28namespace.into%28%29%29%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=nerdsane%2Ftemper&pr=363&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Acrates%2Ftemper-actor-runtime%2Fsrc%2Factor.rs%3A143-147%0A**%60grant_cross_namespace%60%20is%20%60pub%60%20%E2%80%94%20any%20actor%20handler%20can%20self-grant**%0A%0AThe%20ADR%20states%20%22grants%20are%20set%20only%20by%20runtime%2Ftool%20code%2C%20not%20by%20guest%20data%2C%22%20but%20%60grant_cross_namespace%60%20is%20a%20fully%20public%20method%20on%20%60ActorContext%60%2C%20which%20is%20the%20same%20%60ctx%60%20reference%20passed%20to%20every%20%60Actor%3A%3Ahandle%28%29%60%20implementation.%20Any%20handler%20that%20receives%20message%20payload%20containing%20an%20attacker-chosen%20namespace%20string%20can%20call%20%60ctx.grant_cross_namespace%28namespace_from_payload%29%60%20followed%20by%20%60ctx.load_actor_state%28namespace_from_payload%2C%20%E2%80%A6%29%60%20to%20read%20or%20overwrite%20rows%20in%20that%20namespace%20%E2%80%94%20bypassing%20the%20security%20boundary%20described%20in%20the%20ADR.%0A%0AMaking%20this%20%60pub%28crate%29%60%20would%20enforce%20the%20boundary%20within%20%60temper-actor-runtime%60%20but%20would%20break%20the%20%60temper-agents%60%20callers%20that%20legitimately%20need%20to%20issue%20grants.%20The%20real%20fix%20is%20a%20split-context%20design%3A%20pass%20a%20privilege-bearing%20%60RuntimeContext%60%20%28or%20a%20%60CapabilityToken%60%29%20to%20trusted%20tool%20code%20while%20only%20handing%20actors%20the%20restricted%20%60ActorContext%60.%20As-is%2C%20the%20capability%20check%20is%20a%20documentation%20convention%2C%20not%20a%20language-enforced%20boundary.%0A%0A%23%23%23%20Issue%202%20of%204%0Acrates%2Ftemper-agents%2Fsrc%2Ftool_executor.rs%3A362-365%0A**Co-located%20grant%20%2B%20access%20makes%20the%20namespace%20check%20a%20no-op**%0A%0AIn%20both%20%60get_process_state%60%20and%20the%20%60wait_child%60%20branch%2C%20the%20pattern%20is%3A%20build%20%60target_ns%60%20from%20user-supplied%20%60process_id%60%20%2F%20%60child_id%60%2C%20immediately%20call%20%60ctx.grant_cross_namespace%28target_ns.clone%28%29%29%60%2C%20then%20call%20%60ctx.load_actor_state%28%26target_ns%2C%20%E2%80%A6%29%60.%20Because%20the%20grant%20is%20issued%20unconditionally%20for%20whatever%20namespace%20string%20the%20caller%20passes%2C%20the%20capability%20check%20in%20%60require_namespace_access%60%20is%20trivially%20satisfied%20for%20any%20user-provided%20value.%20An%20actor%20told%20to%20%60get_process_status%60%20with%20%60process_id%20%3D%20%22..%2F..%2Fother-tenant%2Fsecret%22%60%20%28or%20any%20peer%20tenant%20namespace%29%20would%20receive%20a%20grant%20and%20complete%20the%20read%20%E2%80%94%20identical%20behavior%20to%20the%20pre-ARN-215%20code.%0A%0AThe%20same%20pattern%20appears%20in%20%60common.rs%60%20%60append_message%60%20%28line%2074%29.%20If%20the%20intent%20is%20that%20all%20process-ID%20lookups%20within%20the%20same%20tenant%20are%20always%20permitted%2C%20that%20pre-condition%20should%20be%20validated%20%28e.g.%2C%20assert%20%60target_ns%60%20is%20a%20direct%20child%20of%20the%20current%20tenant%29%20before%20the%20grant%20is%20issued%2C%20rather%20than%20granting%20whatever%20string%20arrives.%0A%0A%23%23%23%20Issue%203%20of%204%0Acrates%2Ftemper-actor-runtime%2Fsrc%2Factor.rs%3A159-163%0A%60unwrap_or%28false%29%60%20silently%20fail-closes%20when%20the%20mutex%20is%20poisoned%2C%20which%20is%20the%20right%20behavior%2C%20but%20pairing%20it%20with%20the%20silent-drop%20in%20%60grant_cross_namespace%60%20means%20a%20poisoned%20mutex%20produces%20a%20confusing%20%60NamespaceDenied%60%20error%20with%20no%20diagnostic%20signal.%20Consider%20recovering%20the%20inner%20value%20from%20the%20poison%20error%20in%20both%20places%20to%20preserve%20the%20grant%20data%20and%20avoid%20spurious%20denials.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20granted%20%3D%20self%0A%20%20%20%20%20%20%20%20%20%20%20%20.cross_namespace_grants%0A%20%20%20%20%20%20%20%20%20%20%20%20.lock%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.unwrap_or_else%28%7Ce%7C%20e.into_inner%28%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.contains%28namespace%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Acrates%2Ftemper-actor-runtime%2Fsrc%2Factor.rs%3A143-147%0AConsistent%20with%20the%20suggestion%20above%3A%20recover%20from%20mutex%20poison%20here%20too%20rather%20than%20silently%20dropping%20the%20grant%2C%20to%20avoid%20spurious%20%60NamespaceDenied%60%20errors%20that%20would%20otherwise%20be%20very%20hard%20to%20diagnose.%0A%0A%60%60%60suggestion%0A%20%20%20%20pub%20fn%20grant_cross_namespace%28%26self%2C%20namespace%3A%20impl%20Into%3CString%3E%29%20%7B%0A%20%20%20%20%20%20%20%20self.cross_namespace_grants%0A%20%20%20%20%20%20%20%20%20%20%20%20.lock%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.unwrap_or_else%28%7Ce%7C%20e.into_inner%28%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.insert%28namespace.into%28%29%29%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&pr=363&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
crates/temper-actor-runtime/src/actor.rs:143-147
**`grant_cross_namespace` is `pub` — any actor handler can self-grant**

The ADR states "grants are set only by runtime/tool code, not by guest data," but `grant_cross_namespace` is a fully public method on `ActorContext`, which is the same `ctx` reference passed to every `Actor::handle()` implementation. Any handler that receives message payload containing an attacker-chosen namespace string can call `ctx.grant_cross_namespace(namespace_from_payload)` followed by `ctx.load_actor_state(namespace_from_payload, …)` to read or overwrite rows in that namespace — bypassing the security boundary described in the ADR.

Making this `pub(crate)` would enforce the boundary within `temper-actor-runtime` but would break the `temper-agents` callers that legitimately need to issue grants. The real fix is a split-context design: pass a privilege-bearing `RuntimeContext` (or a `CapabilityToken`) to trusted tool code while only handing actors the restricted `ActorContext`. As-is, the capability check is a documentation convention, not a language-enforced boundary.

### Issue 2 of 4
crates/temper-agents/src/tool_executor.rs:362-365
**Co-located grant + access makes the namespace check a no-op**

In both `get_process_state` and the `wait_child` branch, the pattern is: build `target_ns` from user-supplied `process_id` / `child_id`, immediately call `ctx.grant_cross_namespace(target_ns.clone())`, then call `ctx.load_actor_state(&target_ns, …)`. Because the grant is issued unconditionally for whatever namespace string the caller passes, the capability check in `require_namespace_access` is trivially satisfied for any user-provided value. An actor told to `get_process_status` with `process_id = "../../other-tenant/secret"` (or any peer tenant namespace) would receive a grant and complete the read — identical behavior to the pre-ARN-215 code.

The same pattern appears in `common.rs` `append_message` (line 74). If the intent is that all process-ID lookups within the same tenant are always permitted, that pre-condition should be validated (e.g., assert `target_ns` is a direct child of the current tenant) before the grant is issued, rather than granting whatever string arrives.

### Issue 3 of 4
crates/temper-actor-runtime/src/actor.rs:159-163
`unwrap_or(false)` silently fail-closes when the mutex is poisoned, which is the right behavior, but pairing it with the silent-drop in `grant_cross_namespace` means a poisoned mutex produces a confusing `NamespaceDenied` error with no diagnostic signal. Consider recovering the inner value from the poison error in both places to preserve the grant data and avoid spurious denials.

```suggestion
        let granted = self
            .cross_namespace_grants
            .lock()
            .unwrap_or_else(|e| e.into_inner())
            .contains(namespace);
```

### Issue 4 of 4
crates/temper-actor-runtime/src/actor.rs:143-147
Consistent with the suggestion above: recover from mutex poison here too rather than silently dropping the grant, to avoid spurious `NamespaceDenied` errors that would otherwise be very hard to diagnose.

```suggestion
    pub fn grant_cross_namespace(&self, namespace: impl Into<String>) {
        self.cross_namespace_grants
            .lock()
            .unwrap_or_else(|e| e.into_inner())
            .insert(namespace.into());
    }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(actor-runtime): require namespace gr..."](https://github.com/nerdsane/temper/commit/7d00a5dec828f9a996ec13f5bf631f8dc8ce8fcf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43651359)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->