### PR TITLE
fix(mcp): bind trajectory to identity tenant and bound capture (ARN-222)

### DIFF
--- a/crates/temper-mcp/src/lib.rs
+++ b/crates/temper-mcp/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod protocol;
 mod runtime;
+mod trajectory_bounds;
 
 pub mod repl;
 pub use runtime::run_stdio_server;

--- a/crates/temper-mcp/src/runtime.rs
+++ b/crates/temper-mcp/src/runtime.rs
@@ -15,12 +15,12 @@ use tokio::io::{self, AsyncBufReadExt, AsyncWriteExt, BufReader};
 use super::McpConfig;
 use super::protocol::dispatch_json_line;
 use crate::trajectory_bounds::{
-    MAX_STDIO_LINE_BYTES, MAX_TRAJECTORY_CODE_CHARS, MAX_TRAJECTORY_RESULT_CHARS, char_safe_truncate,
+    MAX_STDIO_LINE_BYTES, MAX_TRAJECTORY_CODE_CHARS, MAX_TRAJECTORY_RESULT_CHARS,
+    char_safe_truncate,
 };
 
 const OTS_UPLOAD_MAX_ATTEMPTS: u32 = 3;
 const OTS_UPLOAD_RETRY_DELAY_MS: u64 = 100;
-
 
 /// Client identity received from the MCP `initialize` handshake.
 #[derive(Clone, Debug, Default)]
@@ -176,16 +176,13 @@ impl RuntimeContext {
     pub(crate) fn record_execute_turn(&mut self, code: &str, result: &Result<String>) {
         // ARN-222: bound capture size before retention (char-safe).
         let code = char_safe_truncate(code, MAX_TRAJECTORY_CODE_CHARS);
-        let call_metadata = extract_temper_call_metadata(&code);
+        let extracted_actions = extract_trajectory_actions_from_code(&code);
 
         // ARN-222: only track metadata for the session-bound identity tenant.
-        // Cross-tenant code must not retarget the upload under a different tenant,
-        // and must not retain foreign-tenant code/results under this identity.
-        let mut has_cross_tenant = false;
-        for meta in &call_metadata {
+        // Cross-tenant code must not retarget the upload under a different tenant.
+        for meta in extract_temper_call_metadata(&code) {
             if let Some(ref tenant) = meta.tenant {
                 if tenant != &self.identity_tenant {
-                    has_cross_tenant = true;
                     tracing::warn!(
                         identity_tenant = %self.identity_tenant,
                         other_tenant = %tenant,
@@ -198,7 +195,7 @@ impl RuntimeContext {
                     .and_modify(|count| *count += 1)
                     .or_insert(1);
             }
-            if let Some(ref entity_type) = meta.entity_type
+            if let Some(entity_type) = meta.entity_type
                 && meta
                     .tenant
                     .as_deref()
@@ -206,7 +203,7 @@ impl RuntimeContext {
                     == self.identity_tenant
             {
                 self.entity_types_seen
-                    .entry(entity_type.clone())
+                    .entry(entity_type)
                     .and_modify(|count| *count += 1)
                     .or_insert(1);
             }
@@ -219,69 +216,41 @@ impl RuntimeContext {
         let now = sim_now(); // determinism-ok: sim_now is DST-safe
         builder.start_turn(now);
 
-        // ARN-222: redact cross-tenant execute bodies so foreign content is not
-        // durably stored under the identity tenant's trajectory.
-        const CROSS_TENANT_REDACTED: &str =
-            "[redacted: cross-tenant execute omitted from trajectory]";
-        let code_for_record = if has_cross_tenant {
-            CROSS_TENANT_REDACTED.to_string()
-        } else {
-            code.clone()
-        };
-
+        // User message: the Python code submitted (bounded).
         builder.add_message(OTSMessage::new(
             MessageRole::User,
-            OTSMessageContent::text(&code_for_record),
+            OTSMessageContent::text(&code),
             now,
         ));
 
         // Decision: the execution outcome
-        let (outcome_str, consequence) = if has_cross_tenant {
-            builder.add_message(OTSMessage::new(
-                MessageRole::Assistant,
-                OTSMessageContent::text(CROSS_TENANT_REDACTED),
-                now,
-            ));
-            match result {
-                Ok(_) => ("success", OTSConsequence::success()),
-                Err(_) => (
-                    "failure",
-                    OTSConsequence::failure().with_error_type(CROSS_TENANT_REDACTED),
-                ),
+        let (outcome_str, consequence) = match result {
+            Ok(text) => {
+                let text = char_safe_truncate(text, MAX_TRAJECTORY_RESULT_CHARS);
+                builder.add_message(OTSMessage::new(
+                    MessageRole::Assistant,
+                    OTSMessageContent::text(&text),
+                    now,
+                ));
+                ("success", OTSConsequence::success())
             }
-        } else {
-            match result {
-                Ok(text) => {
-                    let text = char_safe_truncate(text, MAX_TRAJECTORY_RESULT_CHARS);
-                    builder.add_message(OTSMessage::new(
-                        MessageRole::Assistant,
-                        OTSMessageContent::text(&text),
-                        now,
-                    ));
-                    ("success", OTSConsequence::success())
-                }
-                Err(e) => {
-                    let err = char_safe_truncate(&e.to_string(), MAX_TRAJECTORY_RESULT_CHARS);
-                    builder.add_message(OTSMessage::new(
-                        MessageRole::Assistant,
-                        OTSMessageContent::text(&err),
-                        now,
-                    ));
-                    ("failure", OTSConsequence::failure().with_error_type(err))
-                }
+            Err(e) => {
+                let err = char_safe_truncate(&e.to_string(), MAX_TRAJECTORY_RESULT_CHARS);
+                builder.add_message(OTSMessage::new(
+                    MessageRole::Assistant,
+                    OTSMessageContent::text(&err),
+                    now,
+                ));
+                ("failure", OTSConsequence::failure().with_error_type(err))
             }
         };
 
-        let summary = char_safe_truncate(&code_for_record, 100);
+        let summary = char_safe_truncate(&code, 100);
         let mut choice = OTSChoice::new(format!("execute: {summary}"));
-        // Only attach action args for same-tenant executes (no foreign params).
-        if !has_cross_tenant {
-            let extracted_actions = extract_trajectory_actions_from_code(&code);
-            if !extracted_actions.is_empty() {
-                choice = choice.with_arguments(serde_json::json!({
-                    "trajectory_actions": extracted_actions,
-                }));
-            }
+        if !extracted_actions.is_empty() {
+            choice = choice.with_arguments(serde_json::json!({
+                "trajectory_actions": extracted_actions,
+            }));
         }
 
         let decision = OTSDecision::new(DecisionType::ToolSelection, choice, consequence);
@@ -289,11 +258,7 @@ impl RuntimeContext {
 
         builder.end_turn(now);
 
-        tracing::debug!(
-            outcome = outcome_str,
-            cross_tenant_redacted = has_cross_tenant,
-            "ots.trajectory.turn_recorded"
-        );
+        tracing::debug!(outcome = outcome_str, "ots.trajectory.turn_recorded");
     }
 
     /// Flush a snapshot of the trajectory mid-session without consuming it.
@@ -914,23 +879,6 @@ pub async fn run_stdio_server(config: McpConfig) -> Result<()> {
                 limit = MAX_STDIO_LINE_BYTES,
                 "mcp.stdio.line_too_large"
             );
-            // Always answer so clients do not hang waiting for a response.
-            let response = serde_json::json!({
-                "jsonrpc": "2.0",
-                "id": null,
-                "error": {
-                    "code": -32600,
-                    "message": format!(
-                        "request too large: {} bytes (limit {})",
-                        line.len(),
-                        MAX_STDIO_LINE_BYTES
-                    ),
-                },
-            });
-            let encoded = serde_json::to_string(&response)?;
-            stdout.write_all(encoded.as_bytes()).await?;
-            stdout.write_all(b"\n").await?;
-            stdout.flush().await?;
             continue;
         }
 

--- a/crates/temper-mcp/src/runtime.rs
+++ b/crates/temper-mcp/src/runtime.rs
@@ -15,12 +15,12 @@ use tokio::io::{self, AsyncBufReadExt, AsyncWriteExt, BufReader};
 use super::McpConfig;
 use super::protocol::dispatch_json_line;
 use crate::trajectory_bounds::{
-    MAX_STDIO_LINE_BYTES, MAX_TRAJECTORY_CODE_CHARS, MAX_TRAJECTORY_RESULT_CHARS, char_safe_truncate,
+    MAX_STDIO_LINE_BYTES, MAX_TRAJECTORY_CODE_CHARS, MAX_TRAJECTORY_RESULT_CHARS,
+    char_safe_truncate,
 };
 
 const OTS_UPLOAD_MAX_ATTEMPTS: u32 = 3;
 const OTS_UPLOAD_RETRY_DELAY_MS: u64 = 100;
-
 
 /// Client identity received from the MCP `initialize` handshake.
 #[derive(Clone, Debug, Default)]

--- a/crates/temper-mcp/src/runtime.rs
+++ b/crates/temper-mcp/src/runtime.rs
@@ -176,13 +176,16 @@ impl RuntimeContext {
     pub(crate) fn record_execute_turn(&mut self, code: &str, result: &Result<String>) {
         // ARN-222: bound capture size before retention (char-safe).
         let code = char_safe_truncate(code, MAX_TRAJECTORY_CODE_CHARS);
-        let extracted_actions = extract_trajectory_actions_from_code(&code);
+        let call_metadata = extract_temper_call_metadata(&code);
 
         // ARN-222: only track metadata for the session-bound identity tenant.
-        // Cross-tenant code must not retarget the upload under a different tenant.
-        for meta in extract_temper_call_metadata(&code) {
+        // Cross-tenant code must not retarget the upload under a different tenant,
+        // and must not retain foreign-tenant code/results under this identity.
+        let mut has_cross_tenant = false;
+        for meta in &call_metadata {
             if let Some(ref tenant) = meta.tenant {
                 if tenant != &self.identity_tenant {
+                    has_cross_tenant = true;
                     tracing::warn!(
                         identity_tenant = %self.identity_tenant,
                         other_tenant = %tenant,
@@ -195,7 +198,7 @@ impl RuntimeContext {
                     .and_modify(|count| *count += 1)
                     .or_insert(1);
             }
-            if let Some(entity_type) = meta.entity_type
+            if let Some(ref entity_type) = meta.entity_type
                 && meta
                     .tenant
                     .as_deref()
@@ -203,7 +206,7 @@ impl RuntimeContext {
                     == self.identity_tenant
             {
                 self.entity_types_seen
-                    .entry(entity_type)
+                    .entry(entity_type.clone())
                     .and_modify(|count| *count += 1)
                     .or_insert(1);
             }
@@ -216,41 +219,69 @@ impl RuntimeContext {
         let now = sim_now(); // determinism-ok: sim_now is DST-safe
         builder.start_turn(now);
 
-        // User message: the Python code submitted (bounded).
+        // ARN-222: redact cross-tenant execute bodies so foreign content is not
+        // durably stored under the identity tenant's trajectory.
+        const CROSS_TENANT_REDACTED: &str =
+            "[redacted: cross-tenant execute omitted from trajectory]";
+        let code_for_record = if has_cross_tenant {
+            CROSS_TENANT_REDACTED.to_string()
+        } else {
+            code.clone()
+        };
+
         builder.add_message(OTSMessage::new(
             MessageRole::User,
-            OTSMessageContent::text(&code),
+            OTSMessageContent::text(&code_for_record),
             now,
         ));
 
         // Decision: the execution outcome
-        let (outcome_str, consequence) = match result {
-            Ok(text) => {
-                let text = char_safe_truncate(text, MAX_TRAJECTORY_RESULT_CHARS);
-                builder.add_message(OTSMessage::new(
-                    MessageRole::Assistant,
-                    OTSMessageContent::text(&text),
-                    now,
-                ));
-                ("success", OTSConsequence::success())
+        let (outcome_str, consequence) = if has_cross_tenant {
+            builder.add_message(OTSMessage::new(
+                MessageRole::Assistant,
+                OTSMessageContent::text(CROSS_TENANT_REDACTED),
+                now,
+            ));
+            match result {
+                Ok(_) => ("success", OTSConsequence::success()),
+                Err(_) => (
+                    "failure",
+                    OTSConsequence::failure().with_error_type(CROSS_TENANT_REDACTED),
+                ),
             }
-            Err(e) => {
-                let err = char_safe_truncate(&e.to_string(), MAX_TRAJECTORY_RESULT_CHARS);
-                builder.add_message(OTSMessage::new(
-                    MessageRole::Assistant,
-                    OTSMessageContent::text(&err),
-                    now,
-                ));
-                ("failure", OTSConsequence::failure().with_error_type(err))
+        } else {
+            match result {
+                Ok(text) => {
+                    let text = char_safe_truncate(text, MAX_TRAJECTORY_RESULT_CHARS);
+                    builder.add_message(OTSMessage::new(
+                        MessageRole::Assistant,
+                        OTSMessageContent::text(&text),
+                        now,
+                    ));
+                    ("success", OTSConsequence::success())
+                }
+                Err(e) => {
+                    let err = char_safe_truncate(&e.to_string(), MAX_TRAJECTORY_RESULT_CHARS);
+                    builder.add_message(OTSMessage::new(
+                        MessageRole::Assistant,
+                        OTSMessageContent::text(&err),
+                        now,
+                    ));
+                    ("failure", OTSConsequence::failure().with_error_type(err))
+                }
             }
         };
 
-        let summary = char_safe_truncate(&code, 100);
+        let summary = char_safe_truncate(&code_for_record, 100);
         let mut choice = OTSChoice::new(format!("execute: {summary}"));
-        if !extracted_actions.is_empty() {
-            choice = choice.with_arguments(serde_json::json!({
-                "trajectory_actions": extracted_actions,
-            }));
+        // Only attach action args for same-tenant executes (no foreign params).
+        if !has_cross_tenant {
+            let extracted_actions = extract_trajectory_actions_from_code(&code);
+            if !extracted_actions.is_empty() {
+                choice = choice.with_arguments(serde_json::json!({
+                    "trajectory_actions": extracted_actions,
+                }));
+            }
         }
 
         let decision = OTSDecision::new(DecisionType::ToolSelection, choice, consequence);
@@ -258,7 +289,11 @@ impl RuntimeContext {
 
         builder.end_turn(now);
 
-        tracing::debug!(outcome = outcome_str, "ots.trajectory.turn_recorded");
+        tracing::debug!(
+            outcome = outcome_str,
+            cross_tenant_redacted = has_cross_tenant,
+            "ots.trajectory.turn_recorded"
+        );
     }
 
     /// Flush a snapshot of the trajectory mid-session without consuming it.
@@ -879,6 +914,23 @@ pub async fn run_stdio_server(config: McpConfig) -> Result<()> {
                 limit = MAX_STDIO_LINE_BYTES,
                 "mcp.stdio.line_too_large"
             );
+            // Always answer so clients do not hang waiting for a response.
+            let response = serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": null,
+                "error": {
+                    "code": -32600,
+                    "message": format!(
+                        "request too large: {} bytes (limit {})",
+                        line.len(),
+                        MAX_STDIO_LINE_BYTES
+                    ),
+                },
+            });
+            let encoded = serde_json::to_string(&response)?;
+            stdout.write_all(encoded.as_bytes()).await?;
+            stdout.write_all(b"\n").await?;
+            stdout.flush().await?;
             continue;
         }
 

--- a/crates/temper-mcp/src/runtime.rs
+++ b/crates/temper-mcp/src/runtime.rs
@@ -18,6 +18,23 @@ use super::protocol::dispatch_json_line;
 const OTS_UPLOAD_MAX_ATTEMPTS: u32 = 3;
 const OTS_UPLOAD_RETRY_DELAY_MS: u64 = 100;
 
+/// Max UTF-8 characters retained for trajectory code/results (ARN-222).
+const MAX_TRAJECTORY_CODE_CHARS: usize = 16_384;
+/// Max UTF-8 characters retained for execution results (ARN-222).
+const MAX_TRAJECTORY_RESULT_CHARS: usize = 16_384;
+/// Max stdio JSON-RPC line bytes accepted (ARN-222).
+const MAX_STDIO_LINE_BYTES: usize = 1_048_576;
+
+/// Character-safe truncation with an explicit marker (never panics on multibyte).
+fn char_safe_truncate(s: &str, max_chars: usize) -> String {
+    let count = s.chars().count();
+    if count <= max_chars {
+        return s.to_string();
+    }
+    let truncated: String = s.chars().take(max_chars).collect();
+    format!("{truncated}…[truncated]")
+}
+
 /// Client identity received from the MCP `initialize` handshake.
 #[derive(Clone, Debug, Default)]
 pub(crate) struct ClientInfo {
@@ -170,7 +187,41 @@ impl RuntimeContext {
 
     /// Record an execute tool call as an OTS turn with a decision.
     pub(crate) fn record_execute_turn(&mut self, code: &str, result: &Result<String>) {
-        let extracted_actions = extract_trajectory_actions_from_code(code);
+        // ARN-222: bound capture size before retention (char-safe).
+        let code = char_safe_truncate(code, MAX_TRAJECTORY_CODE_CHARS);
+        let extracted_actions = extract_trajectory_actions_from_code(&code);
+
+        // ARN-222: only track metadata for the session-bound identity tenant.
+        // Cross-tenant code must not retarget the upload under a different tenant.
+        for meta in extract_temper_call_metadata(&code) {
+            if let Some(ref tenant) = meta.tenant {
+                if tenant != &self.identity_tenant {
+                    tracing::warn!(
+                        identity_tenant = %self.identity_tenant,
+                        other_tenant = %tenant,
+                        "ots.trajectory.skip_cross_tenant_metadata"
+                    );
+                    continue;
+                }
+                self.tenants_seen
+                    .entry(tenant.clone())
+                    .and_modify(|count| *count += 1)
+                    .or_insert(1);
+            }
+            if let Some(entity_type) = meta.entity_type {
+                if meta
+                    .tenant
+                    .as_deref()
+                    .unwrap_or(self.identity_tenant.as_str())
+                    == self.identity_tenant
+                {
+                    self.entity_types_seen
+                        .entry(entity_type)
+                        .and_modify(|count| *count += 1)
+                        .or_insert(1);
+                }
+            }
+        }
 
         let Some(ref mut builder) = self.trajectory else {
             return;
@@ -179,38 +230,37 @@ impl RuntimeContext {
         let now = sim_now(); // determinism-ok: sim_now is DST-safe
         builder.start_turn(now);
 
-        // User message: the Python code submitted
+        // User message: the Python code submitted (bounded).
         builder.add_message(OTSMessage::new(
             MessageRole::User,
-            OTSMessageContent::text(code),
+            OTSMessageContent::text(&code),
             now,
         ));
 
         // Decision: the execution outcome
         let (outcome_str, consequence) = match result {
             Ok(text) => {
-                // Assistant message: the execution result
+                let text = char_safe_truncate(text, MAX_TRAJECTORY_RESULT_CHARS);
                 builder.add_message(OTSMessage::new(
                     MessageRole::Assistant,
-                    OTSMessageContent::text(text),
+                    OTSMessageContent::text(&text),
                     now,
                 ));
                 ("success", OTSConsequence::success())
             }
             Err(e) => {
+                let err = char_safe_truncate(&e.to_string(), MAX_TRAJECTORY_RESULT_CHARS);
                 builder.add_message(OTSMessage::new(
                     MessageRole::Assistant,
-                    OTSMessageContent::text(e.to_string()),
+                    OTSMessageContent::text(&err),
                     now,
                 ));
-                (
-                    "failure",
-                    OTSConsequence::failure().with_error_type(e.to_string()),
-                )
+                ("failure", OTSConsequence::failure().with_error_type(err))
             }
         };
 
-        let mut choice = OTSChoice::new(format!("execute: {}", &code[..code.len().min(100)]));
+        let summary = char_safe_truncate(&code, 100);
+        let mut choice = OTSChoice::new(format!("execute: {summary}"));
         if !extracted_actions.is_empty() {
             choice = choice.with_arguments(serde_json::json!({
                 "trajectory_actions": extracted_actions,
@@ -223,21 +273,6 @@ impl RuntimeContext {
         builder.end_turn(now);
 
         tracing::debug!(outcome = outcome_str, "ots.trajectory.turn_recorded");
-
-        for meta in extract_temper_call_metadata(code) {
-            if let Some(tenant) = meta.tenant {
-                self.tenants_seen
-                    .entry(tenant)
-                    .and_modify(|count| *count += 1)
-                    .or_insert(1);
-            }
-            if let Some(entity_type) = meta.entity_type {
-                self.entity_types_seen
-                    .entry(entity_type)
-                    .and_modify(|count| *count += 1)
-                    .or_insert(1);
-            }
-        }
     }
 
     /// Flush a snapshot of the trajectory mid-session without consuming it.
@@ -360,13 +395,9 @@ impl RuntimeContext {
         }
     }
 
-    /// Most-used tenant for this session, falling back to configured identity tenant.
+    /// Session-bound tenant (ARN-222): never retarget uploads by majority vote.
     fn primary_tenant(&self) -> &str {
-        self.tenants_seen
-            .iter()
-            .max_by_key(|(_, count)| *count)
-            .map(|(tenant, _)| tenant.as_str())
-            .unwrap_or(self.identity_tenant.as_str())
+        self.identity_tenant.as_str()
     }
 
     /// Most-used entity type for this session.
@@ -855,6 +886,15 @@ pub async fn run_stdio_server(config: McpConfig) -> Result<()> {
         if line.is_empty() {
             continue;
         }
+        // ARN-222: reject unbounded stdio frames before parse/dispatch.
+        if line.len() > MAX_STDIO_LINE_BYTES {
+            tracing::warn!(
+                bytes = line.len(),
+                limit = MAX_STDIO_LINE_BYTES,
+                "mcp.stdio.line_too_large"
+            );
+            continue;
+        }
 
         if let Some(response) = dispatch_json_line(&mut ctx, line).await {
             let encoded = serde_json::to_string(&response)?;
@@ -974,5 +1014,38 @@ await temper.create("tenant-b", "Task", {"Title": "x"})
         ctx.finalize_trajectory().await;
 
         assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn char_safe_truncate_handles_multibyte() {
+        let s = "日本語テスト";
+        let out = char_safe_truncate(s, 2);
+        assert!(out.starts_with("日本"), "{out}");
+        assert!(out.contains("[truncated]"), "{out}");
+        // Must not panic and must be valid UTF-8.
+        assert!(std::str::from_utf8(out.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn primary_tenant_is_identity_not_majority() {
+        let mut ctx = RuntimeContext {
+            base_url: "http://127.0.0.1".into(),
+            http: reqwest::Client::new(),
+            agent_id: None,
+            agent_type: None,
+            session_id: None,
+            api_key: None,
+            identity_tenant: "bound-tenant".into(),
+            sandbox: temper_sandbox::runner::PersistentSandbox::new(&[]),
+            trajectory: None,
+            tenants_seen: BTreeMap::from([
+                ("other".into(), 99usize),
+                ("bound-tenant".into(), 1usize),
+            ]),
+            entity_types_seen: BTreeMap::new(),
+        };
+        assert_eq!(ctx.primary_tenant(), "bound-tenant");
+        // silence mut warning if any
+        let _ = &mut ctx;
     }
 }

--- a/crates/temper-mcp/src/runtime.rs
+++ b/crates/temper-mcp/src/runtime.rs
@@ -176,16 +176,13 @@ impl RuntimeContext {
     pub(crate) fn record_execute_turn(&mut self, code: &str, result: &Result<String>) {
         // ARN-222: bound capture size before retention (char-safe).
         let code = char_safe_truncate(code, MAX_TRAJECTORY_CODE_CHARS);
-        let call_metadata = extract_temper_call_metadata(&code);
+        let extracted_actions = extract_trajectory_actions_from_code(&code);
 
         // ARN-222: only track metadata for the session-bound identity tenant.
-        // Cross-tenant code must not retarget the upload under a different tenant,
-        // and must not retain foreign-tenant code/results under this identity.
-        let mut has_cross_tenant = false;
-        for meta in &call_metadata {
+        // Cross-tenant code must not retarget the upload under a different tenant.
+        for meta in extract_temper_call_metadata(&code) {
             if let Some(ref tenant) = meta.tenant {
                 if tenant != &self.identity_tenant {
-                    has_cross_tenant = true;
                     tracing::warn!(
                         identity_tenant = %self.identity_tenant,
                         other_tenant = %tenant,
@@ -198,7 +195,7 @@ impl RuntimeContext {
                     .and_modify(|count| *count += 1)
                     .or_insert(1);
             }
-            if let Some(ref entity_type) = meta.entity_type
+            if let Some(entity_type) = meta.entity_type
                 && meta
                     .tenant
                     .as_deref()
@@ -206,7 +203,7 @@ impl RuntimeContext {
                     == self.identity_tenant
             {
                 self.entity_types_seen
-                    .entry(entity_type.clone())
+                    .entry(entity_type)
                     .and_modify(|count| *count += 1)
                     .or_insert(1);
             }
@@ -219,69 +216,41 @@ impl RuntimeContext {
         let now = sim_now(); // determinism-ok: sim_now is DST-safe
         builder.start_turn(now);
 
-        // ARN-222: redact cross-tenant execute bodies so foreign content is not
-        // durably stored under the identity tenant's trajectory.
-        const CROSS_TENANT_REDACTED: &str =
-            "[redacted: cross-tenant execute omitted from trajectory]";
-        let code_for_record = if has_cross_tenant {
-            CROSS_TENANT_REDACTED.to_string()
-        } else {
-            code.clone()
-        };
-
+        // User message: the Python code submitted (bounded).
         builder.add_message(OTSMessage::new(
             MessageRole::User,
-            OTSMessageContent::text(&code_for_record),
+            OTSMessageContent::text(&code),
             now,
         ));
 
         // Decision: the execution outcome
-        let (outcome_str, consequence) = if has_cross_tenant {
-            builder.add_message(OTSMessage::new(
-                MessageRole::Assistant,
-                OTSMessageContent::text(CROSS_TENANT_REDACTED),
-                now,
-            ));
-            match result {
-                Ok(_) => ("success", OTSConsequence::success()),
-                Err(_) => (
-                    "failure",
-                    OTSConsequence::failure().with_error_type(CROSS_TENANT_REDACTED),
-                ),
+        let (outcome_str, consequence) = match result {
+            Ok(text) => {
+                let text = char_safe_truncate(text, MAX_TRAJECTORY_RESULT_CHARS);
+                builder.add_message(OTSMessage::new(
+                    MessageRole::Assistant,
+                    OTSMessageContent::text(&text),
+                    now,
+                ));
+                ("success", OTSConsequence::success())
             }
-        } else {
-            match result {
-                Ok(text) => {
-                    let text = char_safe_truncate(text, MAX_TRAJECTORY_RESULT_CHARS);
-                    builder.add_message(OTSMessage::new(
-                        MessageRole::Assistant,
-                        OTSMessageContent::text(&text),
-                        now,
-                    ));
-                    ("success", OTSConsequence::success())
-                }
-                Err(e) => {
-                    let err = char_safe_truncate(&e.to_string(), MAX_TRAJECTORY_RESULT_CHARS);
-                    builder.add_message(OTSMessage::new(
-                        MessageRole::Assistant,
-                        OTSMessageContent::text(&err),
-                        now,
-                    ));
-                    ("failure", OTSConsequence::failure().with_error_type(err))
-                }
+            Err(e) => {
+                let err = char_safe_truncate(&e.to_string(), MAX_TRAJECTORY_RESULT_CHARS);
+                builder.add_message(OTSMessage::new(
+                    MessageRole::Assistant,
+                    OTSMessageContent::text(&err),
+                    now,
+                ));
+                ("failure", OTSConsequence::failure().with_error_type(err))
             }
         };
 
-        let summary = char_safe_truncate(&code_for_record, 100);
+        let summary = char_safe_truncate(&code, 100);
         let mut choice = OTSChoice::new(format!("execute: {summary}"));
-        // Only attach action args for same-tenant executes (no foreign params).
-        if !has_cross_tenant {
-            let extracted_actions = extract_trajectory_actions_from_code(&code);
-            if !extracted_actions.is_empty() {
-                choice = choice.with_arguments(serde_json::json!({
-                    "trajectory_actions": extracted_actions,
-                }));
-            }
+        if !extracted_actions.is_empty() {
+            choice = choice.with_arguments(serde_json::json!({
+                "trajectory_actions": extracted_actions,
+            }));
         }
 
         let decision = OTSDecision::new(DecisionType::ToolSelection, choice, consequence);
@@ -289,11 +258,7 @@ impl RuntimeContext {
 
         builder.end_turn(now);
 
-        tracing::debug!(
-            outcome = outcome_str,
-            cross_tenant_redacted = has_cross_tenant,
-            "ots.trajectory.turn_recorded"
-        );
+        tracing::debug!(outcome = outcome_str, "ots.trajectory.turn_recorded");
     }
 
     /// Flush a snapshot of the trajectory mid-session without consuming it.
@@ -914,23 +879,6 @@ pub async fn run_stdio_server(config: McpConfig) -> Result<()> {
                 limit = MAX_STDIO_LINE_BYTES,
                 "mcp.stdio.line_too_large"
             );
-            // Always answer so clients do not hang waiting for a response.
-            let response = serde_json::json!({
-                "jsonrpc": "2.0",
-                "id": null,
-                "error": {
-                    "code": -32600,
-                    "message": format!(
-                        "request too large: {} bytes (limit {})",
-                        line.len(),
-                        MAX_STDIO_LINE_BYTES
-                    ),
-                },
-            });
-            let encoded = serde_json::to_string(&response)?;
-            stdout.write_all(encoded.as_bytes()).await?;
-            stdout.write_all(b"\n").await?;
-            stdout.flush().await?;
             continue;
         }
 

--- a/crates/temper-mcp/src/runtime.rs
+++ b/crates/temper-mcp/src/runtime.rs
@@ -15,12 +15,12 @@ use tokio::io::{self, AsyncBufReadExt, AsyncWriteExt, BufReader};
 use super::McpConfig;
 use super::protocol::dispatch_json_line;
 use crate::trajectory_bounds::{
-    MAX_STDIO_LINE_BYTES, MAX_TRAJECTORY_CODE_CHARS, MAX_TRAJECTORY_RESULT_CHARS,
-    char_safe_truncate,
+    MAX_STDIO_LINE_BYTES, MAX_TRAJECTORY_CODE_CHARS, MAX_TRAJECTORY_RESULT_CHARS, char_safe_truncate,
 };
 
 const OTS_UPLOAD_MAX_ATTEMPTS: u32 = 3;
 const OTS_UPLOAD_RETRY_DELAY_MS: u64 = 100;
+
 
 /// Client identity received from the MCP `initialize` handshake.
 #[derive(Clone, Debug, Default)]
@@ -176,13 +176,16 @@ impl RuntimeContext {
     pub(crate) fn record_execute_turn(&mut self, code: &str, result: &Result<String>) {
         // ARN-222: bound capture size before retention (char-safe).
         let code = char_safe_truncate(code, MAX_TRAJECTORY_CODE_CHARS);
-        let extracted_actions = extract_trajectory_actions_from_code(&code);
+        let call_metadata = extract_temper_call_metadata(&code);
 
         // ARN-222: only track metadata for the session-bound identity tenant.
-        // Cross-tenant code must not retarget the upload under a different tenant.
-        for meta in extract_temper_call_metadata(&code) {
+        // Cross-tenant code must not retarget the upload under a different tenant,
+        // and must not retain foreign-tenant code/results under this identity.
+        let mut has_cross_tenant = false;
+        for meta in &call_metadata {
             if let Some(ref tenant) = meta.tenant {
                 if tenant != &self.identity_tenant {
+                    has_cross_tenant = true;
                     tracing::warn!(
                         identity_tenant = %self.identity_tenant,
                         other_tenant = %tenant,
@@ -195,7 +198,7 @@ impl RuntimeContext {
                     .and_modify(|count| *count += 1)
                     .or_insert(1);
             }
-            if let Some(entity_type) = meta.entity_type
+            if let Some(ref entity_type) = meta.entity_type
                 && meta
                     .tenant
                     .as_deref()
@@ -203,7 +206,7 @@ impl RuntimeContext {
                     == self.identity_tenant
             {
                 self.entity_types_seen
-                    .entry(entity_type)
+                    .entry(entity_type.clone())
                     .and_modify(|count| *count += 1)
                     .or_insert(1);
             }
@@ -216,41 +219,69 @@ impl RuntimeContext {
         let now = sim_now(); // determinism-ok: sim_now is DST-safe
         builder.start_turn(now);
 
-        // User message: the Python code submitted (bounded).
+        // ARN-222: redact cross-tenant execute bodies so foreign content is not
+        // durably stored under the identity tenant's trajectory.
+        const CROSS_TENANT_REDACTED: &str =
+            "[redacted: cross-tenant execute omitted from trajectory]";
+        let code_for_record = if has_cross_tenant {
+            CROSS_TENANT_REDACTED.to_string()
+        } else {
+            code.clone()
+        };
+
         builder.add_message(OTSMessage::new(
             MessageRole::User,
-            OTSMessageContent::text(&code),
+            OTSMessageContent::text(&code_for_record),
             now,
         ));
 
         // Decision: the execution outcome
-        let (outcome_str, consequence) = match result {
-            Ok(text) => {
-                let text = char_safe_truncate(text, MAX_TRAJECTORY_RESULT_CHARS);
-                builder.add_message(OTSMessage::new(
-                    MessageRole::Assistant,
-                    OTSMessageContent::text(&text),
-                    now,
-                ));
-                ("success", OTSConsequence::success())
+        let (outcome_str, consequence) = if has_cross_tenant {
+            builder.add_message(OTSMessage::new(
+                MessageRole::Assistant,
+                OTSMessageContent::text(CROSS_TENANT_REDACTED),
+                now,
+            ));
+            match result {
+                Ok(_) => ("success", OTSConsequence::success()),
+                Err(_) => (
+                    "failure",
+                    OTSConsequence::failure().with_error_type(CROSS_TENANT_REDACTED),
+                ),
             }
-            Err(e) => {
-                let err = char_safe_truncate(&e.to_string(), MAX_TRAJECTORY_RESULT_CHARS);
-                builder.add_message(OTSMessage::new(
-                    MessageRole::Assistant,
-                    OTSMessageContent::text(&err),
-                    now,
-                ));
-                ("failure", OTSConsequence::failure().with_error_type(err))
+        } else {
+            match result {
+                Ok(text) => {
+                    let text = char_safe_truncate(text, MAX_TRAJECTORY_RESULT_CHARS);
+                    builder.add_message(OTSMessage::new(
+                        MessageRole::Assistant,
+                        OTSMessageContent::text(&text),
+                        now,
+                    ));
+                    ("success", OTSConsequence::success())
+                }
+                Err(e) => {
+                    let err = char_safe_truncate(&e.to_string(), MAX_TRAJECTORY_RESULT_CHARS);
+                    builder.add_message(OTSMessage::new(
+                        MessageRole::Assistant,
+                        OTSMessageContent::text(&err),
+                        now,
+                    ));
+                    ("failure", OTSConsequence::failure().with_error_type(err))
+                }
             }
         };
 
-        let summary = char_safe_truncate(&code, 100);
+        let summary = char_safe_truncate(&code_for_record, 100);
         let mut choice = OTSChoice::new(format!("execute: {summary}"));
-        if !extracted_actions.is_empty() {
-            choice = choice.with_arguments(serde_json::json!({
-                "trajectory_actions": extracted_actions,
-            }));
+        // Only attach action args for same-tenant executes (no foreign params).
+        if !has_cross_tenant {
+            let extracted_actions = extract_trajectory_actions_from_code(&code);
+            if !extracted_actions.is_empty() {
+                choice = choice.with_arguments(serde_json::json!({
+                    "trajectory_actions": extracted_actions,
+                }));
+            }
         }
 
         let decision = OTSDecision::new(DecisionType::ToolSelection, choice, consequence);
@@ -258,7 +289,11 @@ impl RuntimeContext {
 
         builder.end_turn(now);
 
-        tracing::debug!(outcome = outcome_str, "ots.trajectory.turn_recorded");
+        tracing::debug!(
+            outcome = outcome_str,
+            cross_tenant_redacted = has_cross_tenant,
+            "ots.trajectory.turn_recorded"
+        );
     }
 
     /// Flush a snapshot of the trajectory mid-session without consuming it.
@@ -879,6 +914,23 @@ pub async fn run_stdio_server(config: McpConfig) -> Result<()> {
                 limit = MAX_STDIO_LINE_BYTES,
                 "mcp.stdio.line_too_large"
             );
+            // Always answer so clients do not hang waiting for a response.
+            let response = serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": null,
+                "error": {
+                    "code": -32600,
+                    "message": format!(
+                        "request too large: {} bytes (limit {})",
+                        line.len(),
+                        MAX_STDIO_LINE_BYTES
+                    ),
+                },
+            });
+            let encoded = serde_json::to_string(&response)?;
+            stdout.write_all(encoded.as_bytes()).await?;
+            stdout.write_all(b"\n").await?;
+            stdout.flush().await?;
             continue;
         }
 

--- a/crates/temper-mcp/src/runtime.rs
+++ b/crates/temper-mcp/src/runtime.rs
@@ -14,26 +14,13 @@ use tokio::io::{self, AsyncBufReadExt, AsyncWriteExt, BufReader};
 
 use super::McpConfig;
 use super::protocol::dispatch_json_line;
+use crate::trajectory_bounds::{
+    MAX_STDIO_LINE_BYTES, MAX_TRAJECTORY_CODE_CHARS, MAX_TRAJECTORY_RESULT_CHARS, char_safe_truncate,
+};
 
 const OTS_UPLOAD_MAX_ATTEMPTS: u32 = 3;
 const OTS_UPLOAD_RETRY_DELAY_MS: u64 = 100;
 
-/// Max UTF-8 characters retained for trajectory code/results (ARN-222).
-const MAX_TRAJECTORY_CODE_CHARS: usize = 16_384;
-/// Max UTF-8 characters retained for execution results (ARN-222).
-const MAX_TRAJECTORY_RESULT_CHARS: usize = 16_384;
-/// Max stdio JSON-RPC line bytes accepted (ARN-222).
-const MAX_STDIO_LINE_BYTES: usize = 1_048_576;
-
-/// Character-safe truncation with an explicit marker (never panics on multibyte).
-fn char_safe_truncate(s: &str, max_chars: usize) -> String {
-    let count = s.chars().count();
-    if count <= max_chars {
-        return s.to_string();
-    }
-    let truncated: String = s.chars().take(max_chars).collect();
-    format!("{truncated}…[truncated]")
-}
 
 /// Client identity received from the MCP `initialize` handshake.
 #[derive(Clone, Debug, Default)]
@@ -208,18 +195,17 @@ impl RuntimeContext {
                     .and_modify(|count| *count += 1)
                     .or_insert(1);
             }
-            if let Some(entity_type) = meta.entity_type {
-                if meta
+            if let Some(entity_type) = meta.entity_type
+                && meta
                     .tenant
                     .as_deref()
                     .unwrap_or(self.identity_tenant.as_str())
                     == self.identity_tenant
-                {
-                    self.entity_types_seen
-                        .entry(entity_type)
-                        .and_modify(|count| *count += 1)
-                        .or_insert(1);
-                }
+            {
+                self.entity_types_seen
+                    .entry(entity_type)
+                    .and_modify(|count| *count += 1)
+                    .or_insert(1);
             }
         }
 
@@ -911,141 +897,5 @@ pub async fn run_stdio_server(config: McpConfig) -> Result<()> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use axum::{Router, extract::State, http::StatusCode, routing::post};
-    use std::sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
-    };
-
-    #[test]
-    fn extract_trajectory_actions_from_temper_action_calls() {
-        let code = r#"
-result = temper.action("Issue", "issue-1", "PromoteToCritical", {"Reason": "prod incident"})
-other = temper.action('Issue', 'issue-1', 'Assign', {'AgentId': 'agent-2'})
-tenant = temper.action("gepa-tenant", "Issues", "11111111-1111-1111-1111-111111111111", "Reassign", {"NewAssigneeId": "agent-3"})
-"#;
-
-        let actions = extract_trajectory_actions_from_code(code);
-        assert_eq!(actions.len(), 3);
-        assert_eq!(
-            actions[0].get("action").and_then(Value::as_str),
-            Some("PromoteToCritical")
-        );
-        assert_eq!(
-            actions[2]
-                .get("params")
-                .and_then(Value::as_object)
-                .and_then(|m| m.get("NewAssigneeId"))
-                .and_then(Value::as_str),
-            Some("agent-3")
-        );
-    }
-
-    #[test]
-    fn normalize_python_literals_to_json() {
-        let value = parse_python_json_value("{'enabled': True, 'reason': None, 'count': 2}")
-            .expect("python dict should parse");
-        assert_eq!(value["enabled"], serde_json::json!(true));
-        assert_eq!(value["reason"], serde_json::Value::Null);
-        assert_eq!(value["count"], serde_json::json!(2));
-    }
-
-    #[test]
-    fn extract_temper_call_metadata_tracks_tenant_and_entity() {
-        let code = r#"
-await temper.action("tenant-a", "Issue", "i-1", "Assign", {"AgentId": "agent-1"})
-await temper.create("tenant-b", "Task", {"Title": "x"})
-"#;
-        let metadata = extract_temper_call_metadata(code);
-        assert!(
-            metadata.iter().any(|m| {
-                m.tenant.as_deref() == Some("tenant-a") && m.entity_type.as_deref() == Some("Issue")
-            }),
-            "expected tenant-a/Issue metadata"
-        );
-        assert!(
-            metadata.iter().any(|m| {
-                m.tenant.as_deref() == Some("tenant-b") && m.entity_type.as_deref() == Some("Task")
-            }),
-            "expected tenant-b/Task metadata"
-        );
-    }
-
-    #[tokio::test]
-    async fn finalize_trajectory_retries_retryable_ots_upload_failure() {
-        async fn handler(State(attempts): State<Arc<AtomicUsize>>) -> StatusCode {
-            let attempt = attempts.fetch_add(1, Ordering::SeqCst);
-            if attempt == 0 {
-                StatusCode::SERVICE_UNAVAILABLE
-            } else {
-                StatusCode::ACCEPTED
-            }
-        }
-
-        let attempts = Arc::new(AtomicUsize::new(0));
-        let app = Router::new()
-            .route("/api/ots/trajectories", post(handler))
-            .with_state(attempts.clone());
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("bind test server");
-        let addr = listener.local_addr().expect("test server addr");
-        tokio::spawn(async move {
-            axum::serve(listener, app).await.expect("serve test server");
-        });
-
-        let mut ctx = RuntimeContext {
-            base_url: format!("http://{addr}"),
-            http: reqwest::Client::new(),
-            agent_id: Some("agent".to_string()),
-            agent_type: Some("test-agent".to_string()),
-            session_id: Some("session".to_string()),
-            api_key: None,
-            identity_tenant: "tenant".to_string(),
-            sandbox: temper_sandbox::runner::PersistentSandbox::new(&[("temper", "Temper", 1)]),
-            trajectory: None,
-            tenants_seen: BTreeMap::new(),
-            entity_types_seen: BTreeMap::new(),
-        };
-        ctx.init_trajectory();
-
-        ctx.finalize_trajectory().await;
-
-        assert_eq!(attempts.load(Ordering::SeqCst), 2);
-    }
-
-    #[test]
-    fn char_safe_truncate_handles_multibyte() {
-        let s = "日本語テスト";
-        let out = char_safe_truncate(s, 2);
-        assert!(out.starts_with("日本"), "{out}");
-        assert!(out.contains("[truncated]"), "{out}");
-        // Must not panic and must be valid UTF-8.
-        assert!(std::str::from_utf8(out.as_bytes()).is_ok());
-    }
-
-    #[test]
-    fn primary_tenant_is_identity_not_majority() {
-        let mut ctx = RuntimeContext {
-            base_url: "http://127.0.0.1".into(),
-            http: reqwest::Client::new(),
-            agent_id: None,
-            agent_type: None,
-            session_id: None,
-            api_key: None,
-            identity_tenant: "bound-tenant".into(),
-            sandbox: temper_sandbox::runner::PersistentSandbox::new(&[]),
-            trajectory: None,
-            tenants_seen: BTreeMap::from([
-                ("other".into(), 99usize),
-                ("bound-tenant".into(), 1usize),
-            ]),
-            entity_types_seen: BTreeMap::new(),
-        };
-        assert_eq!(ctx.primary_tenant(), "bound-tenant");
-        // silence mut warning if any
-        let _ = &mut ctx;
-    }
-}
+#[path = "runtime_tests.rs"]
+mod tests;

--- a/crates/temper-mcp/src/runtime_tests.rs
+++ b/crates/temper-mcp/src/runtime_tests.rs
@@ -1,0 +1,140 @@
+//! Unit tests for MCP runtime (ARN-222).
+
+use super::*;
+
+    use super::*;
+    use axum::{Router, extract::State, http::StatusCode, routing::post};
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    #[test]
+    fn extract_trajectory_actions_from_temper_action_calls() {
+        let code = r#"
+result = temper.action("Issue", "issue-1", "PromoteToCritical", {"Reason": "prod incident"})
+other = temper.action('Issue', 'issue-1', 'Assign', {'AgentId': 'agent-2'})
+tenant = temper.action("gepa-tenant", "Issues", "11111111-1111-1111-1111-111111111111", "Reassign", {"NewAssigneeId": "agent-3"})
+"#;
+
+        let actions = extract_trajectory_actions_from_code(code);
+        assert_eq!(actions.len(), 3);
+        assert_eq!(
+            actions[0].get("action").and_then(Value::as_str),
+            Some("PromoteToCritical")
+        );
+        assert_eq!(
+            actions[2]
+                .get("params")
+                .and_then(Value::as_object)
+                .and_then(|m| m.get("NewAssigneeId"))
+                .and_then(Value::as_str),
+            Some("agent-3")
+        );
+    }
+
+    #[test]
+    fn normalize_python_literals_to_json() {
+        let value = parse_python_json_value("{'enabled': True, 'reason': None, 'count': 2}")
+            .expect("python dict should parse");
+        assert_eq!(value["enabled"], serde_json::json!(true));
+        assert_eq!(value["reason"], serde_json::Value::Null);
+        assert_eq!(value["count"], serde_json::json!(2));
+    }
+
+    #[test]
+    fn extract_temper_call_metadata_tracks_tenant_and_entity() {
+        let code = r#"
+await temper.action("tenant-a", "Issue", "i-1", "Assign", {"AgentId": "agent-1"})
+await temper.create("tenant-b", "Task", {"Title": "x"})
+"#;
+        let metadata = extract_temper_call_metadata(code);
+        assert!(
+            metadata.iter().any(|m| {
+                m.tenant.as_deref() == Some("tenant-a") && m.entity_type.as_deref() == Some("Issue")
+            }),
+            "expected tenant-a/Issue metadata"
+        );
+        assert!(
+            metadata.iter().any(|m| {
+                m.tenant.as_deref() == Some("tenant-b") && m.entity_type.as_deref() == Some("Task")
+            }),
+            "expected tenant-b/Task metadata"
+        );
+    }
+
+    #[tokio::test]
+    async fn finalize_trajectory_retries_retryable_ots_upload_failure() {
+        async fn handler(State(attempts): State<Arc<AtomicUsize>>) -> StatusCode {
+            let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+            if attempt == 0 {
+                StatusCode::SERVICE_UNAVAILABLE
+            } else {
+                StatusCode::ACCEPTED
+            }
+        }
+
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let app = Router::new()
+            .route("/api/ots/trajectories", post(handler))
+            .with_state(attempts.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let addr = listener.local_addr().expect("test server addr");
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve test server");
+        });
+
+        let mut ctx = RuntimeContext {
+            base_url: format!("http://{addr}"),
+            http: reqwest::Client::new(),
+            agent_id: Some("agent".to_string()),
+            agent_type: Some("test-agent".to_string()),
+            session_id: Some("session".to_string()),
+            api_key: None,
+            identity_tenant: "tenant".to_string(),
+            sandbox: temper_sandbox::runner::PersistentSandbox::new(&[("temper", "Temper", 1)]),
+            trajectory: None,
+            tenants_seen: BTreeMap::new(),
+            entity_types_seen: BTreeMap::new(),
+        };
+        ctx.init_trajectory();
+
+        ctx.finalize_trajectory().await;
+
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn char_safe_truncate_handles_multibyte() {
+        let s = "日本語テスト";
+        let out = char_safe_truncate(s, 2);
+        assert!(out.starts_with("日本"), "{out}");
+        assert!(out.contains("[truncated]"), "{out}");
+        // Must not panic and must be valid UTF-8.
+        assert!(std::str::from_utf8(out.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn primary_tenant_is_identity_not_majority() {
+        let mut ctx = RuntimeContext {
+            base_url: "http://127.0.0.1".into(),
+            http: reqwest::Client::new(),
+            agent_id: None,
+            agent_type: None,
+            session_id: None,
+            api_key: None,
+            identity_tenant: "bound-tenant".into(),
+            sandbox: temper_sandbox::runner::PersistentSandbox::new(&[]),
+            trajectory: None,
+            tenants_seen: BTreeMap::from([
+                ("other".into(), 99usize),
+                ("bound-tenant".into(), 1usize),
+            ]),
+            entity_types_seen: BTreeMap::new(),
+        };
+        assert_eq!(ctx.primary_tenant(), "bound-tenant");
+        // silence mut warning if any
+        let _ = &mut ctx;
+    }

--- a/crates/temper-mcp/src/runtime_tests.rs
+++ b/crates/temper-mcp/src/runtime_tests.rs
@@ -1,140 +1,218 @@
 //! Unit tests for MCP runtime (ARN-222).
 
 use super::*;
+use axum::{Router, extract::State, http::StatusCode, routing::post};
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
 
-    use super::*;
-    use axum::{Router, extract::State, http::StatusCode, routing::post};
-    use std::sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
-    };
-
-    #[test]
-    fn extract_trajectory_actions_from_temper_action_calls() {
-        let code = r#"
+#[test]
+fn extract_trajectory_actions_from_temper_action_calls() {
+    let code = r#"
 result = temper.action("Issue", "issue-1", "PromoteToCritical", {"Reason": "prod incident"})
 other = temper.action('Issue', 'issue-1', 'Assign', {'AgentId': 'agent-2'})
 tenant = temper.action("gepa-tenant", "Issues", "11111111-1111-1111-1111-111111111111", "Reassign", {"NewAssigneeId": "agent-3"})
 "#;
 
-        let actions = extract_trajectory_actions_from_code(code);
-        assert_eq!(actions.len(), 3);
-        assert_eq!(
-            actions[0].get("action").and_then(Value::as_str),
-            Some("PromoteToCritical")
-        );
-        assert_eq!(
-            actions[2]
-                .get("params")
-                .and_then(Value::as_object)
-                .and_then(|m| m.get("NewAssigneeId"))
-                .and_then(Value::as_str),
-            Some("agent-3")
-        );
-    }
+    let actions = extract_trajectory_actions_from_code(code);
+    assert_eq!(actions.len(), 3);
+    assert_eq!(
+        actions[0].get("action").and_then(Value::as_str),
+        Some("PromoteToCritical")
+    );
+    assert_eq!(
+        actions[2]
+            .get("params")
+            .and_then(Value::as_object)
+            .and_then(|m| m.get("NewAssigneeId"))
+            .and_then(Value::as_str),
+        Some("agent-3")
+    );
+}
 
-    #[test]
-    fn normalize_python_literals_to_json() {
-        let value = parse_python_json_value("{'enabled': True, 'reason': None, 'count': 2}")
-            .expect("python dict should parse");
-        assert_eq!(value["enabled"], serde_json::json!(true));
-        assert_eq!(value["reason"], serde_json::Value::Null);
-        assert_eq!(value["count"], serde_json::json!(2));
-    }
+#[test]
+fn normalize_python_literals_to_json() {
+    let value = parse_python_json_value("{'enabled': True, 'reason': None, 'count': 2}")
+        .expect("python dict should parse");
+    assert_eq!(value["enabled"], serde_json::json!(true));
+    assert_eq!(value["reason"], serde_json::Value::Null);
+    assert_eq!(value["count"], serde_json::json!(2));
+}
 
-    #[test]
-    fn extract_temper_call_metadata_tracks_tenant_and_entity() {
-        let code = r#"
+#[test]
+fn extract_temper_call_metadata_tracks_tenant_and_entity() {
+    let code = r#"
 await temper.action("tenant-a", "Issue", "i-1", "Assign", {"AgentId": "agent-1"})
 await temper.create("tenant-b", "Task", {"Title": "x"})
 "#;
-        let metadata = extract_temper_call_metadata(code);
-        assert!(
-            metadata.iter().any(|m| {
-                m.tenant.as_deref() == Some("tenant-a") && m.entity_type.as_deref() == Some("Issue")
-            }),
-            "expected tenant-a/Issue metadata"
-        );
-        assert!(
-            metadata.iter().any(|m| {
-                m.tenant.as_deref() == Some("tenant-b") && m.entity_type.as_deref() == Some("Task")
-            }),
-            "expected tenant-b/Task metadata"
-        );
-    }
+    let metadata = extract_temper_call_metadata(code);
+    assert!(
+        metadata.iter().any(|m| {
+            m.tenant.as_deref() == Some("tenant-a") && m.entity_type.as_deref() == Some("Issue")
+        }),
+        "expected tenant-a/Issue metadata"
+    );
+    assert!(
+        metadata.iter().any(|m| {
+            m.tenant.as_deref() == Some("tenant-b") && m.entity_type.as_deref() == Some("Task")
+        }),
+        "expected tenant-b/Task metadata"
+    );
+}
 
-    #[tokio::test]
-    async fn finalize_trajectory_retries_retryable_ots_upload_failure() {
-        async fn handler(State(attempts): State<Arc<AtomicUsize>>) -> StatusCode {
-            let attempt = attempts.fetch_add(1, Ordering::SeqCst);
-            if attempt == 0 {
-                StatusCode::SERVICE_UNAVAILABLE
-            } else {
-                StatusCode::ACCEPTED
-            }
+#[tokio::test]
+async fn finalize_trajectory_retries_retryable_ots_upload_failure() {
+    async fn handler(State(attempts): State<Arc<AtomicUsize>>) -> StatusCode {
+        let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+        if attempt == 0 {
+            StatusCode::SERVICE_UNAVAILABLE
+        } else {
+            StatusCode::ACCEPTED
         }
-
-        let attempts = Arc::new(AtomicUsize::new(0));
-        let app = Router::new()
-            .route("/api/ots/trajectories", post(handler))
-            .with_state(attempts.clone());
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("bind test server");
-        let addr = listener.local_addr().expect("test server addr");
-        tokio::spawn(async move {
-            axum::serve(listener, app).await.expect("serve test server");
-        });
-
-        let mut ctx = RuntimeContext {
-            base_url: format!("http://{addr}"),
-            http: reqwest::Client::new(),
-            agent_id: Some("agent".to_string()),
-            agent_type: Some("test-agent".to_string()),
-            session_id: Some("session".to_string()),
-            api_key: None,
-            identity_tenant: "tenant".to_string(),
-            sandbox: temper_sandbox::runner::PersistentSandbox::new(&[("temper", "Temper", 1)]),
-            trajectory: None,
-            tenants_seen: BTreeMap::new(),
-            entity_types_seen: BTreeMap::new(),
-        };
-        ctx.init_trajectory();
-
-        ctx.finalize_trajectory().await;
-
-        assert_eq!(attempts.load(Ordering::SeqCst), 2);
     }
 
-    #[test]
-    fn char_safe_truncate_handles_multibyte() {
-        let s = "日本語テスト";
-        let out = char_safe_truncate(s, 2);
-        assert!(out.starts_with("日本"), "{out}");
-        assert!(out.contains("[truncated]"), "{out}");
-        // Must not panic and must be valid UTF-8.
-        assert!(std::str::from_utf8(out.as_bytes()).is_ok());
-    }
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let app = Router::new()
+        .route("/api/ots/trajectories", post(handler))
+        .with_state(attempts.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test server");
+    let addr = listener.local_addr().expect("test server addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve test server");
+    });
 
-    #[test]
-    fn primary_tenant_is_identity_not_majority() {
-        let mut ctx = RuntimeContext {
-            base_url: "http://127.0.0.1".into(),
-            http: reqwest::Client::new(),
-            agent_id: None,
-            agent_type: None,
-            session_id: None,
-            api_key: None,
-            identity_tenant: "bound-tenant".into(),
-            sandbox: temper_sandbox::runner::PersistentSandbox::new(&[]),
-            trajectory: None,
-            tenants_seen: BTreeMap::from([
-                ("other".into(), 99usize),
-                ("bound-tenant".into(), 1usize),
-            ]),
-            entity_types_seen: BTreeMap::new(),
-        };
-        assert_eq!(ctx.primary_tenant(), "bound-tenant");
-        // silence mut warning if any
-        let _ = &mut ctx;
-    }
+    let mut ctx = RuntimeContext {
+        base_url: format!("http://{addr}"),
+        http: reqwest::Client::new(),
+        agent_id: Some("agent".to_string()),
+        agent_type: Some("test-agent".to_string()),
+        session_id: Some("session".to_string()),
+        api_key: None,
+        identity_tenant: "tenant".to_string(),
+        sandbox: temper_sandbox::runner::PersistentSandbox::new(&[("temper", "Temper", 1)]),
+        trajectory: None,
+        tenants_seen: BTreeMap::new(),
+        entity_types_seen: BTreeMap::new(),
+    };
+    ctx.init_trajectory();
+
+    ctx.finalize_trajectory().await;
+
+    assert_eq!(attempts.load(Ordering::SeqCst), 2);
+}
+
+#[test]
+fn char_safe_truncate_handles_multibyte() {
+    let s = "日本語テスト";
+    let out = char_safe_truncate(s, 2);
+    assert!(out.starts_with("日本"), "{out}");
+    assert!(out.contains("[truncated]"), "{out}");
+    // Must not panic and must be valid UTF-8.
+    assert!(std::str::from_utf8(out.as_bytes()).is_ok());
+}
+
+#[test]
+fn primary_tenant_is_identity_not_majority() {
+    let ctx = RuntimeContext {
+        base_url: "http://127.0.0.1".into(),
+        http: reqwest::Client::new(),
+        agent_id: None,
+        agent_type: None,
+        session_id: None,
+        api_key: None,
+        identity_tenant: "bound-tenant".into(),
+        sandbox: temper_sandbox::runner::PersistentSandbox::new(&[]),
+        trajectory: None,
+        tenants_seen: BTreeMap::from([
+            ("other".into(), 99usize),
+            ("bound-tenant".into(), 1usize),
+        ]),
+        entity_types_seen: BTreeMap::new(),
+    };
+    assert_eq!(ctx.primary_tenant(), "bound-tenant");
+}
+
+#[test]
+fn cross_tenant_execute_content_redacted_from_trajectory() {
+    let mut ctx = RuntimeContext {
+        base_url: "http://127.0.0.1".into(),
+        http: reqwest::Client::new(),
+        agent_id: Some("agent".into()),
+        agent_type: Some("test".into()),
+        session_id: Some("sess".into()),
+        api_key: None,
+        identity_tenant: "tenant-a".into(),
+        sandbox: temper_sandbox::runner::PersistentSandbox::new(&[]),
+        trajectory: None,
+        tenants_seen: BTreeMap::new(),
+        entity_types_seen: BTreeMap::new(),
+    };
+    ctx.init_trajectory();
+
+    let foreign_secret = "FOREIGN_TENANT_SECRET_PAYLOAD";
+    let code = format!(
+        r#"await temper.action("tenant-b", "Issue", "i-1", "Assign", {{"Secret": "{foreign_secret}"}})"#
+    );
+    let result = Ok(format!("leaked result with {foreign_secret}"));
+    ctx.record_execute_turn(&code, &result);
+
+    let snapshot = ctx
+        .trajectory
+        .as_ref()
+        .expect("trajectory")
+        .snapshot();
+    let dump = serde_json::to_string(&snapshot).expect("serialize");
+    assert!(
+        !dump.contains(foreign_secret),
+        "foreign-tenant content must not be retained under identity trajectory: {dump}"
+    );
+    assert!(
+        !dump.contains("tenant-b"),
+        "cross-tenant identifiers must not remain in retained execute body: {dump}"
+    );
+    assert!(
+        dump.contains("cross-tenant execute omitted"),
+        "expected redaction marker in trajectory: {dump}"
+    );
+    // Metadata counters must not adopt the foreign tenant.
+    assert!(!ctx.tenants_seen.contains_key("tenant-b"));
+    assert_eq!(ctx.primary_tenant(), "tenant-a");
+}
+
+#[test]
+fn same_tenant_execute_content_retained() {
+    let mut ctx = RuntimeContext {
+        base_url: "http://127.0.0.1".into(),
+        http: reqwest::Client::new(),
+        agent_id: Some("agent".into()),
+        agent_type: Some("test".into()),
+        session_id: Some("sess".into()),
+        api_key: None,
+        identity_tenant: "tenant-a".into(),
+        sandbox: temper_sandbox::runner::PersistentSandbox::new(&[]),
+        trajectory: None,
+        tenants_seen: BTreeMap::new(),
+        entity_types_seen: BTreeMap::new(),
+    };
+    ctx.init_trajectory();
+
+    let code =
+        r#"await temper.action("tenant-a", "Issue", "i-1", "Assign", {"AgentId": "agent-1"})"#;
+    let result = Ok("ok-result".to_string());
+    ctx.record_execute_turn(code, &result);
+
+    let snapshot = ctx
+        .trajectory
+        .as_ref()
+        .expect("trajectory")
+        .snapshot();
+    let dump = serde_json::to_string(&snapshot).expect("serialize");
+    assert!(
+        dump.contains("tenant-a") && dump.contains("ok-result"),
+        "same-tenant execute should retain code/result: {dump}"
+    );
+    assert!(!dump.contains("cross-tenant execute omitted"), "{dump}");
+}

--- a/crates/temper-mcp/src/runtime_tests.rs
+++ b/crates/temper-mcp/src/runtime_tests.rs
@@ -1,7 +1,6 @@
 //! Unit tests for MCP runtime (ARN-222).
 
 use super::*;
-
 use axum::{Router, extract::State, http::StatusCode, routing::post};
 use std::sync::{
     Arc,
@@ -107,17 +106,18 @@ async fn finalize_trajectory_retries_retryable_ots_upload_failure() {
 
 #[test]
 fn char_safe_truncate_handles_multibyte() {
-    let s = "日本語テスト";
-    let out = char_safe_truncate(s, 2);
-    assert!(out.starts_with("日本"), "{out}");
+    let s = "日本語テスト".repeat(10);
+    let out = char_safe_truncate(&s, 20); // marker counts toward max_chars
+    assert!(out.starts_with('日'), "{out}");
     assert!(out.contains("[truncated]"), "{out}");
+    assert_eq!(out.chars().count(), 20, "{out}");
     // Must not panic and must be valid UTF-8.
     assert!(std::str::from_utf8(out.as_bytes()).is_ok());
 }
 
 #[test]
 fn primary_tenant_is_identity_not_majority() {
-    let mut ctx = RuntimeContext {
+    let ctx = RuntimeContext {
         base_url: "http://127.0.0.1".into(),
         http: reqwest::Client::new(),
         agent_id: None,
@@ -127,10 +127,93 @@ fn primary_tenant_is_identity_not_majority() {
         identity_tenant: "bound-tenant".into(),
         sandbox: temper_sandbox::runner::PersistentSandbox::new(&[]),
         trajectory: None,
-        tenants_seen: BTreeMap::from([("other".into(), 99usize), ("bound-tenant".into(), 1usize)]),
+        tenants_seen: BTreeMap::from([
+            ("other".into(), 99usize),
+            ("bound-tenant".into(), 1usize),
+        ]),
         entity_types_seen: BTreeMap::new(),
     };
     assert_eq!(ctx.primary_tenant(), "bound-tenant");
-    // silence mut warning if any
-    let _ = &mut ctx;
+}
+
+#[test]
+fn cross_tenant_execute_content_redacted_from_trajectory() {
+    let mut ctx = RuntimeContext {
+        base_url: "http://127.0.0.1".into(),
+        http: reqwest::Client::new(),
+        agent_id: Some("agent".into()),
+        agent_type: Some("test".into()),
+        session_id: Some("sess".into()),
+        api_key: None,
+        identity_tenant: "tenant-a".into(),
+        sandbox: temper_sandbox::runner::PersistentSandbox::new(&[]),
+        trajectory: None,
+        tenants_seen: BTreeMap::new(),
+        entity_types_seen: BTreeMap::new(),
+    };
+    ctx.init_trajectory();
+
+    let foreign_secret = "FOREIGN_TENANT_SECRET_PAYLOAD";
+    let code = format!(
+        r#"await temper.action("tenant-b", "Issue", "i-1", "Assign", {{"Secret": "{foreign_secret}"}})"#
+    );
+    let result = Ok(format!("leaked result with {foreign_secret}"));
+    ctx.record_execute_turn(&code, &result);
+
+    let snapshot = ctx
+        .trajectory
+        .as_ref()
+        .expect("trajectory")
+        .snapshot();
+    let dump = serde_json::to_string(&snapshot).expect("serialize");
+    assert!(
+        !dump.contains(foreign_secret),
+        "foreign-tenant content must not be retained under identity trajectory: {dump}"
+    );
+    assert!(
+        !dump.contains("tenant-b"),
+        "cross-tenant identifiers must not remain in retained execute body: {dump}"
+    );
+    assert!(
+        dump.contains("cross-tenant execute omitted"),
+        "expected redaction marker in trajectory: {dump}"
+    );
+    // Metadata counters must not adopt the foreign tenant.
+    assert!(!ctx.tenants_seen.contains_key("tenant-b"));
+    assert_eq!(ctx.primary_tenant(), "tenant-a");
+}
+
+#[test]
+fn same_tenant_execute_content_retained() {
+    let mut ctx = RuntimeContext {
+        base_url: "http://127.0.0.1".into(),
+        http: reqwest::Client::new(),
+        agent_id: Some("agent".into()),
+        agent_type: Some("test".into()),
+        session_id: Some("sess".into()),
+        api_key: None,
+        identity_tenant: "tenant-a".into(),
+        sandbox: temper_sandbox::runner::PersistentSandbox::new(&[]),
+        trajectory: None,
+        tenants_seen: BTreeMap::new(),
+        entity_types_seen: BTreeMap::new(),
+    };
+    ctx.init_trajectory();
+
+    let code =
+        r#"await temper.action("tenant-a", "Issue", "i-1", "Assign", {"AgentId": "agent-1"})"#;
+    let result = Ok("ok-result".to_string());
+    ctx.record_execute_turn(code, &result);
+
+    let snapshot = ctx
+        .trajectory
+        .as_ref()
+        .expect("trajectory")
+        .snapshot();
+    let dump = serde_json::to_string(&snapshot).expect("serialize");
+    assert!(
+        dump.contains("tenant-a") && dump.contains("ok-result"),
+        "same-tenant execute should retain code/result: {dump}"
+    );
+    assert!(!dump.contains("cross-tenant execute omitted"), "{dump}");
 }

--- a/crates/temper-mcp/src/runtime_tests.rs
+++ b/crates/temper-mcp/src/runtime_tests.rs
@@ -1,7 +1,6 @@
 //! Unit tests for MCP runtime (ARN-222).
 
 use super::*;
-
 use axum::{Router, extract::State, http::StatusCode, routing::post};
 use std::sync::{
     Arc,
@@ -107,17 +106,18 @@ async fn finalize_trajectory_retries_retryable_ots_upload_failure() {
 
 #[test]
 fn char_safe_truncate_handles_multibyte() {
-    let s = "日本語テスト";
-    let out = char_safe_truncate(s, 2);
-    assert!(out.starts_with("日本"), "{out}");
+    let s = "日本語テスト".repeat(10);
+    let out = char_safe_truncate(&s, 20); // marker counts toward max_chars
+    assert!(out.starts_with('日'), "{out}");
     assert!(out.contains("[truncated]"), "{out}");
+    assert_eq!(out.chars().count(), 20, "{out}");
     // Must not panic and must be valid UTF-8.
     assert!(std::str::from_utf8(out.as_bytes()).is_ok());
 }
 
 #[test]
 fn primary_tenant_is_identity_not_majority() {
-    let mut ctx = RuntimeContext {
+    let ctx = RuntimeContext {
         base_url: "http://127.0.0.1".into(),
         http: reqwest::Client::new(),
         agent_id: None,
@@ -131,6 +131,78 @@ fn primary_tenant_is_identity_not_majority() {
         entity_types_seen: BTreeMap::new(),
     };
     assert_eq!(ctx.primary_tenant(), "bound-tenant");
-    // silence mut warning if any
-    let _ = &mut ctx;
+}
+
+#[test]
+fn cross_tenant_execute_content_redacted_from_trajectory() {
+    let mut ctx = RuntimeContext {
+        base_url: "http://127.0.0.1".into(),
+        http: reqwest::Client::new(),
+        agent_id: Some("agent".into()),
+        agent_type: Some("test".into()),
+        session_id: Some("sess".into()),
+        api_key: None,
+        identity_tenant: "tenant-a".into(),
+        sandbox: temper_sandbox::runner::PersistentSandbox::new(&[]),
+        trajectory: None,
+        tenants_seen: BTreeMap::new(),
+        entity_types_seen: BTreeMap::new(),
+    };
+    ctx.init_trajectory();
+
+    let foreign_secret = "FOREIGN_TENANT_SECRET_PAYLOAD";
+    let code = format!(
+        r#"await temper.action("tenant-b", "Issue", "i-1", "Assign", {{"Secret": "{foreign_secret}"}})"#
+    );
+    let result = Ok(format!("leaked result with {foreign_secret}"));
+    ctx.record_execute_turn(&code, &result);
+
+    let snapshot = ctx.trajectory.as_ref().expect("trajectory").snapshot();
+    let dump = serde_json::to_string(&snapshot).expect("serialize");
+    assert!(
+        !dump.contains(foreign_secret),
+        "foreign-tenant content must not be retained under identity trajectory: {dump}"
+    );
+    assert!(
+        !dump.contains("tenant-b"),
+        "cross-tenant identifiers must not remain in retained execute body: {dump}"
+    );
+    assert!(
+        dump.contains("cross-tenant execute omitted"),
+        "expected redaction marker in trajectory: {dump}"
+    );
+    // Metadata counters must not adopt the foreign tenant.
+    assert!(!ctx.tenants_seen.contains_key("tenant-b"));
+    assert_eq!(ctx.primary_tenant(), "tenant-a");
+}
+
+#[test]
+fn same_tenant_execute_content_retained() {
+    let mut ctx = RuntimeContext {
+        base_url: "http://127.0.0.1".into(),
+        http: reqwest::Client::new(),
+        agent_id: Some("agent".into()),
+        agent_type: Some("test".into()),
+        session_id: Some("sess".into()),
+        api_key: None,
+        identity_tenant: "tenant-a".into(),
+        sandbox: temper_sandbox::runner::PersistentSandbox::new(&[]),
+        trajectory: None,
+        tenants_seen: BTreeMap::new(),
+        entity_types_seen: BTreeMap::new(),
+    };
+    ctx.init_trajectory();
+
+    let code =
+        r#"await temper.action("tenant-a", "Issue", "i-1", "Assign", {"AgentId": "agent-1"})"#;
+    let result = Ok("ok-result".to_string());
+    ctx.record_execute_turn(code, &result);
+
+    let snapshot = ctx.trajectory.as_ref().expect("trajectory").snapshot();
+    let dump = serde_json::to_string(&snapshot).expect("serialize");
+    assert!(
+        dump.contains("tenant-a") && dump.contains("ok-result"),
+        "same-tenant execute should retain code/result: {dump}"
+    );
+    assert!(!dump.contains("cross-tenant execute omitted"), "{dump}");
 }

--- a/crates/temper-mcp/src/runtime_tests.rs
+++ b/crates/temper-mcp/src/runtime_tests.rs
@@ -2,138 +2,135 @@
 
 use super::*;
 
-    use axum::{Router, extract::State, http::StatusCode, routing::post};
-    use std::sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
-    };
+use axum::{Router, extract::State, http::StatusCode, routing::post};
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
 
-    #[test]
-    fn extract_trajectory_actions_from_temper_action_calls() {
-        let code = r#"
+#[test]
+fn extract_trajectory_actions_from_temper_action_calls() {
+    let code = r#"
 result = temper.action("Issue", "issue-1", "PromoteToCritical", {"Reason": "prod incident"})
 other = temper.action('Issue', 'issue-1', 'Assign', {'AgentId': 'agent-2'})
 tenant = temper.action("gepa-tenant", "Issues", "11111111-1111-1111-1111-111111111111", "Reassign", {"NewAssigneeId": "agent-3"})
 "#;
 
-        let actions = extract_trajectory_actions_from_code(code);
-        assert_eq!(actions.len(), 3);
-        assert_eq!(
-            actions[0].get("action").and_then(Value::as_str),
-            Some("PromoteToCritical")
-        );
-        assert_eq!(
-            actions[2]
-                .get("params")
-                .and_then(Value::as_object)
-                .and_then(|m| m.get("NewAssigneeId"))
-                .and_then(Value::as_str),
-            Some("agent-3")
-        );
-    }
+    let actions = extract_trajectory_actions_from_code(code);
+    assert_eq!(actions.len(), 3);
+    assert_eq!(
+        actions[0].get("action").and_then(Value::as_str),
+        Some("PromoteToCritical")
+    );
+    assert_eq!(
+        actions[2]
+            .get("params")
+            .and_then(Value::as_object)
+            .and_then(|m| m.get("NewAssigneeId"))
+            .and_then(Value::as_str),
+        Some("agent-3")
+    );
+}
 
-    #[test]
-    fn normalize_python_literals_to_json() {
-        let value = parse_python_json_value("{'enabled': True, 'reason': None, 'count': 2}")
-            .expect("python dict should parse");
-        assert_eq!(value["enabled"], serde_json::json!(true));
-        assert_eq!(value["reason"], serde_json::Value::Null);
-        assert_eq!(value["count"], serde_json::json!(2));
-    }
+#[test]
+fn normalize_python_literals_to_json() {
+    let value = parse_python_json_value("{'enabled': True, 'reason': None, 'count': 2}")
+        .expect("python dict should parse");
+    assert_eq!(value["enabled"], serde_json::json!(true));
+    assert_eq!(value["reason"], serde_json::Value::Null);
+    assert_eq!(value["count"], serde_json::json!(2));
+}
 
-    #[test]
-    fn extract_temper_call_metadata_tracks_tenant_and_entity() {
-        let code = r#"
+#[test]
+fn extract_temper_call_metadata_tracks_tenant_and_entity() {
+    let code = r#"
 await temper.action("tenant-a", "Issue", "i-1", "Assign", {"AgentId": "agent-1"})
 await temper.create("tenant-b", "Task", {"Title": "x"})
 "#;
-        let metadata = extract_temper_call_metadata(code);
-        assert!(
-            metadata.iter().any(|m| {
-                m.tenant.as_deref() == Some("tenant-a") && m.entity_type.as_deref() == Some("Issue")
-            }),
-            "expected tenant-a/Issue metadata"
-        );
-        assert!(
-            metadata.iter().any(|m| {
-                m.tenant.as_deref() == Some("tenant-b") && m.entity_type.as_deref() == Some("Task")
-            }),
-            "expected tenant-b/Task metadata"
-        );
-    }
+    let metadata = extract_temper_call_metadata(code);
+    assert!(
+        metadata.iter().any(|m| {
+            m.tenant.as_deref() == Some("tenant-a") && m.entity_type.as_deref() == Some("Issue")
+        }),
+        "expected tenant-a/Issue metadata"
+    );
+    assert!(
+        metadata.iter().any(|m| {
+            m.tenant.as_deref() == Some("tenant-b") && m.entity_type.as_deref() == Some("Task")
+        }),
+        "expected tenant-b/Task metadata"
+    );
+}
 
-    #[tokio::test]
-    async fn finalize_trajectory_retries_retryable_ots_upload_failure() {
-        async fn handler(State(attempts): State<Arc<AtomicUsize>>) -> StatusCode {
-            let attempt = attempts.fetch_add(1, Ordering::SeqCst);
-            if attempt == 0 {
-                StatusCode::SERVICE_UNAVAILABLE
-            } else {
-                StatusCode::ACCEPTED
-            }
+#[tokio::test]
+async fn finalize_trajectory_retries_retryable_ots_upload_failure() {
+    async fn handler(State(attempts): State<Arc<AtomicUsize>>) -> StatusCode {
+        let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+        if attempt == 0 {
+            StatusCode::SERVICE_UNAVAILABLE
+        } else {
+            StatusCode::ACCEPTED
         }
-
-        let attempts = Arc::new(AtomicUsize::new(0));
-        let app = Router::new()
-            .route("/api/ots/trajectories", post(handler))
-            .with_state(attempts.clone());
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("bind test server");
-        let addr = listener.local_addr().expect("test server addr");
-        tokio::spawn(async move {
-            axum::serve(listener, app).await.expect("serve test server");
-        });
-
-        let mut ctx = RuntimeContext {
-            base_url: format!("http://{addr}"),
-            http: reqwest::Client::new(),
-            agent_id: Some("agent".to_string()),
-            agent_type: Some("test-agent".to_string()),
-            session_id: Some("session".to_string()),
-            api_key: None,
-            identity_tenant: "tenant".to_string(),
-            sandbox: temper_sandbox::runner::PersistentSandbox::new(&[("temper", "Temper", 1)]),
-            trajectory: None,
-            tenants_seen: BTreeMap::new(),
-            entity_types_seen: BTreeMap::new(),
-        };
-        ctx.init_trajectory();
-
-        ctx.finalize_trajectory().await;
-
-        assert_eq!(attempts.load(Ordering::SeqCst), 2);
     }
 
-    #[test]
-    fn char_safe_truncate_handles_multibyte() {
-        let s = "日本語テスト";
-        let out = char_safe_truncate(s, 2);
-        assert!(out.starts_with("日本"), "{out}");
-        assert!(out.contains("[truncated]"), "{out}");
-        // Must not panic and must be valid UTF-8.
-        assert!(std::str::from_utf8(out.as_bytes()).is_ok());
-    }
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let app = Router::new()
+        .route("/api/ots/trajectories", post(handler))
+        .with_state(attempts.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test server");
+    let addr = listener.local_addr().expect("test server addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve test server");
+    });
 
-    #[test]
-    fn primary_tenant_is_identity_not_majority() {
-        let mut ctx = RuntimeContext {
-            base_url: "http://127.0.0.1".into(),
-            http: reqwest::Client::new(),
-            agent_id: None,
-            agent_type: None,
-            session_id: None,
-            api_key: None,
-            identity_tenant: "bound-tenant".into(),
-            sandbox: temper_sandbox::runner::PersistentSandbox::new(&[]),
-            trajectory: None,
-            tenants_seen: BTreeMap::from([
-                ("other".into(), 99usize),
-                ("bound-tenant".into(), 1usize),
-            ]),
-            entity_types_seen: BTreeMap::new(),
-        };
-        assert_eq!(ctx.primary_tenant(), "bound-tenant");
-        // silence mut warning if any
-        let _ = &mut ctx;
-    }
+    let mut ctx = RuntimeContext {
+        base_url: format!("http://{addr}"),
+        http: reqwest::Client::new(),
+        agent_id: Some("agent".to_string()),
+        agent_type: Some("test-agent".to_string()),
+        session_id: Some("session".to_string()),
+        api_key: None,
+        identity_tenant: "tenant".to_string(),
+        sandbox: temper_sandbox::runner::PersistentSandbox::new(&[("temper", "Temper", 1)]),
+        trajectory: None,
+        tenants_seen: BTreeMap::new(),
+        entity_types_seen: BTreeMap::new(),
+    };
+    ctx.init_trajectory();
+
+    ctx.finalize_trajectory().await;
+
+    assert_eq!(attempts.load(Ordering::SeqCst), 2);
+}
+
+#[test]
+fn char_safe_truncate_handles_multibyte() {
+    let s = "日本語テスト";
+    let out = char_safe_truncate(s, 2);
+    assert!(out.starts_with("日本"), "{out}");
+    assert!(out.contains("[truncated]"), "{out}");
+    // Must not panic and must be valid UTF-8.
+    assert!(std::str::from_utf8(out.as_bytes()).is_ok());
+}
+
+#[test]
+fn primary_tenant_is_identity_not_majority() {
+    let mut ctx = RuntimeContext {
+        base_url: "http://127.0.0.1".into(),
+        http: reqwest::Client::new(),
+        agent_id: None,
+        agent_type: None,
+        session_id: None,
+        api_key: None,
+        identity_tenant: "bound-tenant".into(),
+        sandbox: temper_sandbox::runner::PersistentSandbox::new(&[]),
+        trajectory: None,
+        tenants_seen: BTreeMap::from([("other".into(), 99usize), ("bound-tenant".into(), 1usize)]),
+        entity_types_seen: BTreeMap::new(),
+    };
+    assert_eq!(ctx.primary_tenant(), "bound-tenant");
+    // silence mut warning if any
+    let _ = &mut ctx;
+}

--- a/crates/temper-mcp/src/runtime_tests.rs
+++ b/crates/temper-mcp/src/runtime_tests.rs
@@ -1,6 +1,7 @@
 //! Unit tests for MCP runtime (ARN-222).
 
 use super::*;
+
 use axum::{Router, extract::State, http::StatusCode, routing::post};
 use std::sync::{
     Arc,
@@ -106,18 +107,17 @@ async fn finalize_trajectory_retries_retryable_ots_upload_failure() {
 
 #[test]
 fn char_safe_truncate_handles_multibyte() {
-    let s = "日本語テスト".repeat(10);
-    let out = char_safe_truncate(&s, 20); // marker counts toward max_chars
-    assert!(out.starts_with('日'), "{out}");
+    let s = "日本語テスト";
+    let out = char_safe_truncate(s, 2);
+    assert!(out.starts_with("日本"), "{out}");
     assert!(out.contains("[truncated]"), "{out}");
-    assert_eq!(out.chars().count(), 20, "{out}");
     // Must not panic and must be valid UTF-8.
     assert!(std::str::from_utf8(out.as_bytes()).is_ok());
 }
 
 #[test]
 fn primary_tenant_is_identity_not_majority() {
-    let ctx = RuntimeContext {
+    let mut ctx = RuntimeContext {
         base_url: "http://127.0.0.1".into(),
         http: reqwest::Client::new(),
         agent_id: None,
@@ -127,93 +127,10 @@ fn primary_tenant_is_identity_not_majority() {
         identity_tenant: "bound-tenant".into(),
         sandbox: temper_sandbox::runner::PersistentSandbox::new(&[]),
         trajectory: None,
-        tenants_seen: BTreeMap::from([
-            ("other".into(), 99usize),
-            ("bound-tenant".into(), 1usize),
-        ]),
+        tenants_seen: BTreeMap::from([("other".into(), 99usize), ("bound-tenant".into(), 1usize)]),
         entity_types_seen: BTreeMap::new(),
     };
     assert_eq!(ctx.primary_tenant(), "bound-tenant");
-}
-
-#[test]
-fn cross_tenant_execute_content_redacted_from_trajectory() {
-    let mut ctx = RuntimeContext {
-        base_url: "http://127.0.0.1".into(),
-        http: reqwest::Client::new(),
-        agent_id: Some("agent".into()),
-        agent_type: Some("test".into()),
-        session_id: Some("sess".into()),
-        api_key: None,
-        identity_tenant: "tenant-a".into(),
-        sandbox: temper_sandbox::runner::PersistentSandbox::new(&[]),
-        trajectory: None,
-        tenants_seen: BTreeMap::new(),
-        entity_types_seen: BTreeMap::new(),
-    };
-    ctx.init_trajectory();
-
-    let foreign_secret = "FOREIGN_TENANT_SECRET_PAYLOAD";
-    let code = format!(
-        r#"await temper.action("tenant-b", "Issue", "i-1", "Assign", {{"Secret": "{foreign_secret}"}})"#
-    );
-    let result = Ok(format!("leaked result with {foreign_secret}"));
-    ctx.record_execute_turn(&code, &result);
-
-    let snapshot = ctx
-        .trajectory
-        .as_ref()
-        .expect("trajectory")
-        .snapshot();
-    let dump = serde_json::to_string(&snapshot).expect("serialize");
-    assert!(
-        !dump.contains(foreign_secret),
-        "foreign-tenant content must not be retained under identity trajectory: {dump}"
-    );
-    assert!(
-        !dump.contains("tenant-b"),
-        "cross-tenant identifiers must not remain in retained execute body: {dump}"
-    );
-    assert!(
-        dump.contains("cross-tenant execute omitted"),
-        "expected redaction marker in trajectory: {dump}"
-    );
-    // Metadata counters must not adopt the foreign tenant.
-    assert!(!ctx.tenants_seen.contains_key("tenant-b"));
-    assert_eq!(ctx.primary_tenant(), "tenant-a");
-}
-
-#[test]
-fn same_tenant_execute_content_retained() {
-    let mut ctx = RuntimeContext {
-        base_url: "http://127.0.0.1".into(),
-        http: reqwest::Client::new(),
-        agent_id: Some("agent".into()),
-        agent_type: Some("test".into()),
-        session_id: Some("sess".into()),
-        api_key: None,
-        identity_tenant: "tenant-a".into(),
-        sandbox: temper_sandbox::runner::PersistentSandbox::new(&[]),
-        trajectory: None,
-        tenants_seen: BTreeMap::new(),
-        entity_types_seen: BTreeMap::new(),
-    };
-    ctx.init_trajectory();
-
-    let code =
-        r#"await temper.action("tenant-a", "Issue", "i-1", "Assign", {"AgentId": "agent-1"})"#;
-    let result = Ok("ok-result".to_string());
-    ctx.record_execute_turn(code, &result);
-
-    let snapshot = ctx
-        .trajectory
-        .as_ref()
-        .expect("trajectory")
-        .snapshot();
-    let dump = serde_json::to_string(&snapshot).expect("serialize");
-    assert!(
-        dump.contains("tenant-a") && dump.contains("ok-result"),
-        "same-tenant execute should retain code/result: {dump}"
-    );
-    assert!(!dump.contains("cross-tenant execute omitted"), "{dump}");
+    // silence mut warning if any
+    let _ = &mut ctx;
 }

--- a/crates/temper-mcp/src/runtime_tests.rs
+++ b/crates/temper-mcp/src/runtime_tests.rs
@@ -1,218 +1,139 @@
 //! Unit tests for MCP runtime (ARN-222).
 
 use super::*;
-use axum::{Router, extract::State, http::StatusCode, routing::post};
-use std::sync::{
-    Arc,
-    atomic::{AtomicUsize, Ordering},
-};
 
-#[test]
-fn extract_trajectory_actions_from_temper_action_calls() {
-    let code = r#"
+    use axum::{Router, extract::State, http::StatusCode, routing::post};
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    #[test]
+    fn extract_trajectory_actions_from_temper_action_calls() {
+        let code = r#"
 result = temper.action("Issue", "issue-1", "PromoteToCritical", {"Reason": "prod incident"})
 other = temper.action('Issue', 'issue-1', 'Assign', {'AgentId': 'agent-2'})
 tenant = temper.action("gepa-tenant", "Issues", "11111111-1111-1111-1111-111111111111", "Reassign", {"NewAssigneeId": "agent-3"})
 "#;
 
-    let actions = extract_trajectory_actions_from_code(code);
-    assert_eq!(actions.len(), 3);
-    assert_eq!(
-        actions[0].get("action").and_then(Value::as_str),
-        Some("PromoteToCritical")
-    );
-    assert_eq!(
-        actions[2]
-            .get("params")
-            .and_then(Value::as_object)
-            .and_then(|m| m.get("NewAssigneeId"))
-            .and_then(Value::as_str),
-        Some("agent-3")
-    );
-}
+        let actions = extract_trajectory_actions_from_code(code);
+        assert_eq!(actions.len(), 3);
+        assert_eq!(
+            actions[0].get("action").and_then(Value::as_str),
+            Some("PromoteToCritical")
+        );
+        assert_eq!(
+            actions[2]
+                .get("params")
+                .and_then(Value::as_object)
+                .and_then(|m| m.get("NewAssigneeId"))
+                .and_then(Value::as_str),
+            Some("agent-3")
+        );
+    }
 
-#[test]
-fn normalize_python_literals_to_json() {
-    let value = parse_python_json_value("{'enabled': True, 'reason': None, 'count': 2}")
-        .expect("python dict should parse");
-    assert_eq!(value["enabled"], serde_json::json!(true));
-    assert_eq!(value["reason"], serde_json::Value::Null);
-    assert_eq!(value["count"], serde_json::json!(2));
-}
+    #[test]
+    fn normalize_python_literals_to_json() {
+        let value = parse_python_json_value("{'enabled': True, 'reason': None, 'count': 2}")
+            .expect("python dict should parse");
+        assert_eq!(value["enabled"], serde_json::json!(true));
+        assert_eq!(value["reason"], serde_json::Value::Null);
+        assert_eq!(value["count"], serde_json::json!(2));
+    }
 
-#[test]
-fn extract_temper_call_metadata_tracks_tenant_and_entity() {
-    let code = r#"
+    #[test]
+    fn extract_temper_call_metadata_tracks_tenant_and_entity() {
+        let code = r#"
 await temper.action("tenant-a", "Issue", "i-1", "Assign", {"AgentId": "agent-1"})
 await temper.create("tenant-b", "Task", {"Title": "x"})
 "#;
-    let metadata = extract_temper_call_metadata(code);
-    assert!(
-        metadata.iter().any(|m| {
-            m.tenant.as_deref() == Some("tenant-a") && m.entity_type.as_deref() == Some("Issue")
-        }),
-        "expected tenant-a/Issue metadata"
-    );
-    assert!(
-        metadata.iter().any(|m| {
-            m.tenant.as_deref() == Some("tenant-b") && m.entity_type.as_deref() == Some("Task")
-        }),
-        "expected tenant-b/Task metadata"
-    );
-}
-
-#[tokio::test]
-async fn finalize_trajectory_retries_retryable_ots_upload_failure() {
-    async fn handler(State(attempts): State<Arc<AtomicUsize>>) -> StatusCode {
-        let attempt = attempts.fetch_add(1, Ordering::SeqCst);
-        if attempt == 0 {
-            StatusCode::SERVICE_UNAVAILABLE
-        } else {
-            StatusCode::ACCEPTED
-        }
+        let metadata = extract_temper_call_metadata(code);
+        assert!(
+            metadata.iter().any(|m| {
+                m.tenant.as_deref() == Some("tenant-a") && m.entity_type.as_deref() == Some("Issue")
+            }),
+            "expected tenant-a/Issue metadata"
+        );
+        assert!(
+            metadata.iter().any(|m| {
+                m.tenant.as_deref() == Some("tenant-b") && m.entity_type.as_deref() == Some("Task")
+            }),
+            "expected tenant-b/Task metadata"
+        );
     }
 
-    let attempts = Arc::new(AtomicUsize::new(0));
-    let app = Router::new()
-        .route("/api/ots/trajectories", post(handler))
-        .with_state(attempts.clone());
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("bind test server");
-    let addr = listener.local_addr().expect("test server addr");
-    tokio::spawn(async move {
-        axum::serve(listener, app).await.expect("serve test server");
-    });
+    #[tokio::test]
+    async fn finalize_trajectory_retries_retryable_ots_upload_failure() {
+        async fn handler(State(attempts): State<Arc<AtomicUsize>>) -> StatusCode {
+            let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+            if attempt == 0 {
+                StatusCode::SERVICE_UNAVAILABLE
+            } else {
+                StatusCode::ACCEPTED
+            }
+        }
 
-    let mut ctx = RuntimeContext {
-        base_url: format!("http://{addr}"),
-        http: reqwest::Client::new(),
-        agent_id: Some("agent".to_string()),
-        agent_type: Some("test-agent".to_string()),
-        session_id: Some("session".to_string()),
-        api_key: None,
-        identity_tenant: "tenant".to_string(),
-        sandbox: temper_sandbox::runner::PersistentSandbox::new(&[("temper", "Temper", 1)]),
-        trajectory: None,
-        tenants_seen: BTreeMap::new(),
-        entity_types_seen: BTreeMap::new(),
-    };
-    ctx.init_trajectory();
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let app = Router::new()
+            .route("/api/ots/trajectories", post(handler))
+            .with_state(attempts.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let addr = listener.local_addr().expect("test server addr");
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve test server");
+        });
 
-    ctx.finalize_trajectory().await;
+        let mut ctx = RuntimeContext {
+            base_url: format!("http://{addr}"),
+            http: reqwest::Client::new(),
+            agent_id: Some("agent".to_string()),
+            agent_type: Some("test-agent".to_string()),
+            session_id: Some("session".to_string()),
+            api_key: None,
+            identity_tenant: "tenant".to_string(),
+            sandbox: temper_sandbox::runner::PersistentSandbox::new(&[("temper", "Temper", 1)]),
+            trajectory: None,
+            tenants_seen: BTreeMap::new(),
+            entity_types_seen: BTreeMap::new(),
+        };
+        ctx.init_trajectory();
 
-    assert_eq!(attempts.load(Ordering::SeqCst), 2);
-}
+        ctx.finalize_trajectory().await;
 
-#[test]
-fn char_safe_truncate_handles_multibyte() {
-    let s = "日本語テスト";
-    let out = char_safe_truncate(s, 2);
-    assert!(out.starts_with("日本"), "{out}");
-    assert!(out.contains("[truncated]"), "{out}");
-    // Must not panic and must be valid UTF-8.
-    assert!(std::str::from_utf8(out.as_bytes()).is_ok());
-}
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
 
-#[test]
-fn primary_tenant_is_identity_not_majority() {
-    let ctx = RuntimeContext {
-        base_url: "http://127.0.0.1".into(),
-        http: reqwest::Client::new(),
-        agent_id: None,
-        agent_type: None,
-        session_id: None,
-        api_key: None,
-        identity_tenant: "bound-tenant".into(),
-        sandbox: temper_sandbox::runner::PersistentSandbox::new(&[]),
-        trajectory: None,
-        tenants_seen: BTreeMap::from([
-            ("other".into(), 99usize),
-            ("bound-tenant".into(), 1usize),
-        ]),
-        entity_types_seen: BTreeMap::new(),
-    };
-    assert_eq!(ctx.primary_tenant(), "bound-tenant");
-}
+    #[test]
+    fn char_safe_truncate_handles_multibyte() {
+        let s = "日本語テスト";
+        let out = char_safe_truncate(s, 2);
+        assert!(out.starts_with("日本"), "{out}");
+        assert!(out.contains("[truncated]"), "{out}");
+        // Must not panic and must be valid UTF-8.
+        assert!(std::str::from_utf8(out.as_bytes()).is_ok());
+    }
 
-#[test]
-fn cross_tenant_execute_content_redacted_from_trajectory() {
-    let mut ctx = RuntimeContext {
-        base_url: "http://127.0.0.1".into(),
-        http: reqwest::Client::new(),
-        agent_id: Some("agent".into()),
-        agent_type: Some("test".into()),
-        session_id: Some("sess".into()),
-        api_key: None,
-        identity_tenant: "tenant-a".into(),
-        sandbox: temper_sandbox::runner::PersistentSandbox::new(&[]),
-        trajectory: None,
-        tenants_seen: BTreeMap::new(),
-        entity_types_seen: BTreeMap::new(),
-    };
-    ctx.init_trajectory();
-
-    let foreign_secret = "FOREIGN_TENANT_SECRET_PAYLOAD";
-    let code = format!(
-        r#"await temper.action("tenant-b", "Issue", "i-1", "Assign", {{"Secret": "{foreign_secret}"}})"#
-    );
-    let result = Ok(format!("leaked result with {foreign_secret}"));
-    ctx.record_execute_turn(&code, &result);
-
-    let snapshot = ctx
-        .trajectory
-        .as_ref()
-        .expect("trajectory")
-        .snapshot();
-    let dump = serde_json::to_string(&snapshot).expect("serialize");
-    assert!(
-        !dump.contains(foreign_secret),
-        "foreign-tenant content must not be retained under identity trajectory: {dump}"
-    );
-    assert!(
-        !dump.contains("tenant-b"),
-        "cross-tenant identifiers must not remain in retained execute body: {dump}"
-    );
-    assert!(
-        dump.contains("cross-tenant execute omitted"),
-        "expected redaction marker in trajectory: {dump}"
-    );
-    // Metadata counters must not adopt the foreign tenant.
-    assert!(!ctx.tenants_seen.contains_key("tenant-b"));
-    assert_eq!(ctx.primary_tenant(), "tenant-a");
-}
-
-#[test]
-fn same_tenant_execute_content_retained() {
-    let mut ctx = RuntimeContext {
-        base_url: "http://127.0.0.1".into(),
-        http: reqwest::Client::new(),
-        agent_id: Some("agent".into()),
-        agent_type: Some("test".into()),
-        session_id: Some("sess".into()),
-        api_key: None,
-        identity_tenant: "tenant-a".into(),
-        sandbox: temper_sandbox::runner::PersistentSandbox::new(&[]),
-        trajectory: None,
-        tenants_seen: BTreeMap::new(),
-        entity_types_seen: BTreeMap::new(),
-    };
-    ctx.init_trajectory();
-
-    let code =
-        r#"await temper.action("tenant-a", "Issue", "i-1", "Assign", {"AgentId": "agent-1"})"#;
-    let result = Ok("ok-result".to_string());
-    ctx.record_execute_turn(code, &result);
-
-    let snapshot = ctx
-        .trajectory
-        .as_ref()
-        .expect("trajectory")
-        .snapshot();
-    let dump = serde_json::to_string(&snapshot).expect("serialize");
-    assert!(
-        dump.contains("tenant-a") && dump.contains("ok-result"),
-        "same-tenant execute should retain code/result: {dump}"
-    );
-    assert!(!dump.contains("cross-tenant execute omitted"), "{dump}");
-}
+    #[test]
+    fn primary_tenant_is_identity_not_majority() {
+        let mut ctx = RuntimeContext {
+            base_url: "http://127.0.0.1".into(),
+            http: reqwest::Client::new(),
+            agent_id: None,
+            agent_type: None,
+            session_id: None,
+            api_key: None,
+            identity_tenant: "bound-tenant".into(),
+            sandbox: temper_sandbox::runner::PersistentSandbox::new(&[]),
+            trajectory: None,
+            tenants_seen: BTreeMap::from([
+                ("other".into(), 99usize),
+                ("bound-tenant".into(), 1usize),
+            ]),
+            entity_types_seen: BTreeMap::new(),
+        };
+        assert_eq!(ctx.primary_tenant(), "bound-tenant");
+        // silence mut warning if any
+        let _ = &mut ctx;
+    }

--- a/crates/temper-mcp/src/trajectory_bounds.rs
+++ b/crates/temper-mcp/src/trajectory_bounds.rs
@@ -1,32 +1,20 @@
 //! Trajectory capture budgets (ARN-222 / ADR-0163).
 
-/// Max UTF-8 characters retained for trajectory code/results (includes truncation marker).
+/// Max UTF-8 characters retained for trajectory code/results.
 pub(crate) const MAX_TRAJECTORY_CODE_CHARS: usize = 16_384;
-/// Max UTF-8 characters retained for execution results (includes truncation marker).
+/// Max UTF-8 characters retained for execution results.
 pub(crate) const MAX_TRAJECTORY_RESULT_CHARS: usize = 16_384;
 /// Max stdio JSON-RPC line bytes accepted.
 pub(crate) const MAX_STDIO_LINE_BYTES: usize = 1_048_576;
 
-/// Marker appended when truncating; counted against `max_chars`.
-const TRUNCATION_MARKER: &str = "…[truncated]";
-
 /// Character-safe truncation with an explicit marker (never panics on multibyte).
-///
-/// When truncation occurs the returned string's char count is at most `max_chars`
-/// (prefix + `TRUNCATION_MARKER`). If `max_chars` is smaller than the marker, the
-/// marker alone is returned truncated to `max_chars`.
 pub(crate) fn char_safe_truncate(s: &str, max_chars: usize) -> String {
     let count = s.chars().count();
     if count <= max_chars {
         return s.to_string();
     }
-    let marker_chars = TRUNCATION_MARKER.chars().count();
-    if max_chars <= marker_chars {
-        return TRUNCATION_MARKER.chars().take(max_chars).collect();
-    }
-    let keep = max_chars - marker_chars;
-    let truncated: String = s.chars().take(keep).collect();
-    format!("{truncated}{TRUNCATION_MARKER}")
+    let truncated: String = s.chars().take(max_chars).collect();
+    format!("{truncated}…[truncated]")
 }
 
 #[cfg(test)]
@@ -35,19 +23,10 @@ mod tests {
 
     #[test]
     fn char_safe_truncate_handles_multibyte() {
-        let s = "日本語テスト".repeat(10); // long multibyte input
-        let out = char_safe_truncate(&s, 20); // force truncation; marker counts toward budget
-        assert!(out.starts_with('日'), "{out}");
+        let s = "日本語テスト";
+        let out = char_safe_truncate(s, 2);
+        assert!(out.starts_with("日本"), "{out}");
         assert!(out.contains("[truncated]"), "{out}");
-        assert_eq!(out.chars().count(), 20, "{out}");
         assert!(std::str::from_utf8(out.as_bytes()).is_ok());
-    }
-
-    #[test]
-    fn char_safe_truncate_respects_budget_including_marker() {
-        let s = "abcdefghijklmnopqrstuvwxyz";
-        let out = char_safe_truncate(s, 15);
-        assert!(out.chars().count() <= 15, "len={} out={out}", out.chars().count());
-        assert!(out.contains("[truncated]"), "{out}");
     }
 }

--- a/crates/temper-mcp/src/trajectory_bounds.rs
+++ b/crates/temper-mcp/src/trajectory_bounds.rs
@@ -1,4 +1,4 @@
-//! Trajectory capture budgets (ARN-222 / ADR-0163).
+//! Trajectory capture budgets (ARN-222 / ADR-0166).
 
 /// Max UTF-8 characters retained for trajectory code/results (includes truncation marker).
 pub(crate) const MAX_TRAJECTORY_CODE_CHARS: usize = 16_384;

--- a/crates/temper-mcp/src/trajectory_bounds.rs
+++ b/crates/temper-mcp/src/trajectory_bounds.rs
@@ -1,20 +1,32 @@
 //! Trajectory capture budgets (ARN-222 / ADR-0163).
 
-/// Max UTF-8 characters retained for trajectory code/results.
+/// Max UTF-8 characters retained for trajectory code/results (includes truncation marker).
 pub(crate) const MAX_TRAJECTORY_CODE_CHARS: usize = 16_384;
-/// Max UTF-8 characters retained for execution results.
+/// Max UTF-8 characters retained for execution results (includes truncation marker).
 pub(crate) const MAX_TRAJECTORY_RESULT_CHARS: usize = 16_384;
 /// Max stdio JSON-RPC line bytes accepted.
 pub(crate) const MAX_STDIO_LINE_BYTES: usize = 1_048_576;
 
+/// Marker appended when truncating; counted against `max_chars`.
+const TRUNCATION_MARKER: &str = "…[truncated]";
+
 /// Character-safe truncation with an explicit marker (never panics on multibyte).
+///
+/// When truncation occurs the returned string's char count is at most `max_chars`
+/// (prefix + `TRUNCATION_MARKER`). If `max_chars` is smaller than the marker, the
+/// marker alone is returned truncated to `max_chars`.
 pub(crate) fn char_safe_truncate(s: &str, max_chars: usize) -> String {
     let count = s.chars().count();
     if count <= max_chars {
         return s.to_string();
     }
-    let truncated: String = s.chars().take(max_chars).collect();
-    format!("{truncated}…[truncated]")
+    let marker_chars = TRUNCATION_MARKER.chars().count();
+    if max_chars <= marker_chars {
+        return TRUNCATION_MARKER.chars().take(max_chars).collect();
+    }
+    let keep = max_chars - marker_chars;
+    let truncated: String = s.chars().take(keep).collect();
+    format!("{truncated}{TRUNCATION_MARKER}")
 }
 
 #[cfg(test)]
@@ -23,10 +35,19 @@ mod tests {
 
     #[test]
     fn char_safe_truncate_handles_multibyte() {
-        let s = "日本語テスト";
-        let out = char_safe_truncate(s, 2);
-        assert!(out.starts_with("日本"), "{out}");
+        let s = "日本語テスト".repeat(10); // long multibyte input
+        let out = char_safe_truncate(&s, 20); // force truncation; marker counts toward budget
+        assert!(out.starts_with('日'), "{out}");
         assert!(out.contains("[truncated]"), "{out}");
+        assert_eq!(out.chars().count(), 20, "{out}");
         assert!(std::str::from_utf8(out.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn char_safe_truncate_respects_budget_including_marker() {
+        let s = "abcdefghijklmnopqrstuvwxyz";
+        let out = char_safe_truncate(s, 15);
+        assert!(out.chars().count() <= 15, "len={} out={out}", out.chars().count());
+        assert!(out.contains("[truncated]"), "{out}");
     }
 }

--- a/crates/temper-mcp/src/trajectory_bounds.rs
+++ b/crates/temper-mcp/src/trajectory_bounds.rs
@@ -1,20 +1,32 @@
 //! Trajectory capture budgets (ARN-222 / ADR-0163).
 
-/// Max UTF-8 characters retained for trajectory code/results.
+/// Max UTF-8 characters retained for trajectory code/results (includes truncation marker).
 pub(crate) const MAX_TRAJECTORY_CODE_CHARS: usize = 16_384;
-/// Max UTF-8 characters retained for execution results.
+/// Max UTF-8 characters retained for execution results (includes truncation marker).
 pub(crate) const MAX_TRAJECTORY_RESULT_CHARS: usize = 16_384;
 /// Max stdio JSON-RPC line bytes accepted.
 pub(crate) const MAX_STDIO_LINE_BYTES: usize = 1_048_576;
 
+/// Marker appended when truncating; counted against `max_chars`.
+const TRUNCATION_MARKER: &str = "…[truncated]";
+
 /// Character-safe truncation with an explicit marker (never panics on multibyte).
+///
+/// When truncation occurs the returned string's char count is at most `max_chars`
+/// (prefix + `TRUNCATION_MARKER`). If `max_chars` is smaller than the marker, the
+/// marker alone is returned truncated to `max_chars`.
 pub(crate) fn char_safe_truncate(s: &str, max_chars: usize) -> String {
     let count = s.chars().count();
     if count <= max_chars {
         return s.to_string();
     }
-    let truncated: String = s.chars().take(max_chars).collect();
-    format!("{truncated}…[truncated]")
+    let marker_chars = TRUNCATION_MARKER.chars().count();
+    if max_chars <= marker_chars {
+        return TRUNCATION_MARKER.chars().take(max_chars).collect();
+    }
+    let keep = max_chars - marker_chars;
+    let truncated: String = s.chars().take(keep).collect();
+    format!("{truncated}{TRUNCATION_MARKER}")
 }
 
 #[cfg(test)]
@@ -23,10 +35,23 @@ mod tests {
 
     #[test]
     fn char_safe_truncate_handles_multibyte() {
-        let s = "日本語テスト";
-        let out = char_safe_truncate(s, 2);
-        assert!(out.starts_with("日本"), "{out}");
+        let s = "日本語テスト".repeat(10); // long multibyte input
+        let out = char_safe_truncate(&s, 20); // force truncation; marker counts toward budget
+        assert!(out.starts_with('日'), "{out}");
         assert!(out.contains("[truncated]"), "{out}");
+        assert_eq!(out.chars().count(), 20, "{out}");
         assert!(std::str::from_utf8(out.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn char_safe_truncate_respects_budget_including_marker() {
+        let s = "abcdefghijklmnopqrstuvwxyz";
+        let out = char_safe_truncate(s, 15);
+        assert!(
+            out.chars().count() <= 15,
+            "len={} out={out}",
+            out.chars().count()
+        );
+        assert!(out.contains("[truncated]"), "{out}");
     }
 }

--- a/crates/temper-mcp/src/trajectory_bounds.rs
+++ b/crates/temper-mcp/src/trajectory_bounds.rs
@@ -1,0 +1,32 @@
+//! Trajectory capture budgets (ARN-222 / ADR-0163).
+
+/// Max UTF-8 characters retained for trajectory code/results.
+pub(crate) const MAX_TRAJECTORY_CODE_CHARS: usize = 16_384;
+/// Max UTF-8 characters retained for execution results.
+pub(crate) const MAX_TRAJECTORY_RESULT_CHARS: usize = 16_384;
+/// Max stdio JSON-RPC line bytes accepted.
+pub(crate) const MAX_STDIO_LINE_BYTES: usize = 1_048_576;
+
+/// Character-safe truncation with an explicit marker (never panics on multibyte).
+pub(crate) fn char_safe_truncate(s: &str, max_chars: usize) -> String {
+    let count = s.chars().count();
+    if count <= max_chars {
+        return s.to_string();
+    }
+    let truncated: String = s.chars().take(max_chars).collect();
+    format!("{truncated}…[truncated]")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn char_safe_truncate_handles_multibyte() {
+        let s = "日本語テスト";
+        let out = char_safe_truncate(s, 2);
+        assert!(out.starts_with("日本"), "{out}");
+        assert!(out.contains("[truncated]"), "{out}");
+        assert!(std::str::from_utf8(out.as_bytes()).is_ok());
+    }
+}

--- a/docs/adrs/0163-mcp-trajectory-tenant-isolation.md
+++ b/docs/adrs/0163-mcp-trajectory-tenant-isolation.md
@@ -8,8 +8,4 @@
 
 1. Trajectory uploads always use `identity_tenant` (never majority-vote of seen tenants).
 2. Cross-tenant call metadata is not accumulated into session tenant counters.
-3. When execute code references any tenant other than `identity_tenant`, retain a
-   redaction marker instead of raw code/results/action args under the identity
-   trajectory (no durable foreign-tenant content disclosure).
-4. Code/results are char-safe truncated before retention; stdio lines are
-   byte-budgeted and oversized frames receive a JSON-RPC error response.
+3. Code/results are char-safe truncated before retention; stdio lines are byte-budgeted.

--- a/docs/adrs/0163-mcp-trajectory-tenant-isolation.md
+++ b/docs/adrs/0163-mcp-trajectory-tenant-isolation.md
@@ -1,0 +1,11 @@
+# ADR-0163: MCP trajectory tenant isolation and bounded capture (ARN-222)
+
+- Status: Accepted
+- Date: 2026-07-12
+- Related: ARN-222, `crates/temper-mcp/src/runtime.rs`
+
+## Decision
+
+1. Trajectory uploads always use `identity_tenant` (never majority-vote of seen tenants).
+2. Cross-tenant call metadata is not accumulated into session tenant counters.
+3. Code/results are char-safe truncated before retention; stdio lines are byte-budgeted.

--- a/docs/adrs/0163-mcp-trajectory-tenant-isolation.md
+++ b/docs/adrs/0163-mcp-trajectory-tenant-isolation.md
@@ -8,4 +8,8 @@
 
 1. Trajectory uploads always use `identity_tenant` (never majority-vote of seen tenants).
 2. Cross-tenant call metadata is not accumulated into session tenant counters.
-3. Code/results are char-safe truncated before retention; stdio lines are byte-budgeted.
+3. When execute code references any tenant other than `identity_tenant`, retain a
+   redaction marker instead of raw code/results/action args under the identity
+   trajectory (no durable foreign-tenant content disclosure).
+4. Code/results are char-safe truncated before retention; stdio lines are
+   byte-budgeted and oversized frames receive a JSON-RPC error response.

--- a/docs/adrs/0166-mcp-trajectory-tenant-isolation.md
+++ b/docs/adrs/0166-mcp-trajectory-tenant-isolation.md
@@ -1,4 +1,4 @@
-# ADR-0163: MCP trajectory tenant isolation and bounded capture (ARN-222)
+# ADR-0166: MCP trajectory tenant isolation and bounded capture (ARN-222)
 
 - Status: Accepted
 - Date: 2026-07-12


### PR DESCRIPTION
## Summary
ARN-222: MCP trajectory capture isolation + admission.

- Upload tenant = session identity only
- No cross-tenant metadata majority retargeting
- Char-safe truncation for code/results
- Stdio line byte budget
- ADR-0163

Linear: ARN-222

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens MCP trajectory capture against cross-tenant data pollution (ARN-222): `primary_tenant()` is changed from a majority-vote of observed call tenants to always returning `identity_tenant`, cross-tenant metadata is filtered out with a warning log, and a new `trajectory_bounds` module introduces char-safe truncation for code/results (16 384 chars each) and a 1 MiB stdio line cap.

- **Tenant isolation** (`runtime.rs`): `primary_tenant()` now unconditionally returns `identity_tenant`; metadata from calls targeting a different tenant is skipped before it can influence `tenants_seen` or `entity_types_seen`, closing the retargeting vector.
- **Bounded capture** (`trajectory_bounds.rs`): `char_safe_truncate` is applied to code, results, and error strings before they are stored in the OTS trajectory; the 1 MiB stdio guard rejects oversized frames before JSON parse/dispatch.
- **Test extraction** (`runtime_tests.rs`): existing tests are moved to a separate file and two new tests are added — one for multibyte truncation correctness and one asserting the primary-tenant invariant.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The core tenant-isolation logic and truncation are correct and well-tested, but the test file has a duplicate import that will break the build under the project's clippy/pre-push gates, and the stdio line guard does not prevent memory buffering before the check.

The duplicate `use super::*;` in `runtime_tests.rs` is a build-breaking issue under Rust 2024 edition and the project's deny(warnings)/clippy pipeline, introduced by an incomplete extraction of the test module. The stdio byte-budget check protects against dispatch of oversized frames but cannot prevent the `AsyncBufReadExt::lines` reader from buffering them first, leaving the claimed protection incomplete. These two issues — one a definite build regression, one a gap in the stated security guarantee — together pull the score below what the otherwise solid tenant-isolation logic would warrant.

`crates/temper-mcp/src/runtime_tests.rs` needs the duplicate `use super::*;` removed and the file dedented. `crates/temper-mcp/src/runtime.rs` (`run_stdio_server`) needs either a bounded line reader or a JSON-RPC error response for oversized frames.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/temper-mcp/src/runtime.rs | Core security fix: primary_tenant() now always returns identity_tenant (no majority-vote retargeting), cross-tenant metadata is skipped with a warn log, and char_safe_truncate bounds code/result capture. Silent discard of oversized stdio lines without a JSON-RPC error response will cause client hangs on requests exceeding 1 MB. |
| crates/temper-mcp/src/runtime_tests.rs | Extracted from inline mod tests; adds two new tests (char_safe_truncate multibyte, primary_tenant identity invariant). Has a duplicate `use super::*;` at module scope (leftover from extraction) and is missing a trailing newline — both will produce warnings/errors under Rust 2024 + clippy. |
| crates/temper-mcp/src/trajectory_bounds.rs | New module defining MAX_TRAJECTORY_CODE_CHARS (16 384), MAX_TRAJECTORY_RESULT_CHARS (16 384), MAX_STDIO_LINE_BYTES (1 MiB), and char_safe_truncate. Implementation is correct and well-tested; the only gap is that the returned string can exceed max_chars by 11 chars when truncated (undocumented). |
| crates/temper-mcp/src/lib.rs | One-line addition registering trajectory_bounds as a private module. No issues. |
| docs/adrs/0163-mcp-trajectory-tenant-isolation.md | Minimal ADR capturing the three key decisions (identity_tenant-only upload, no cross-tenant counter accumulation, char-safe truncation + stdio byte budget). Content is accurate but abbreviated relative to the project's ADR template; missing Motivation, Consequences, and Alternatives Considered sections. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client as MCP Client
    participant Stdio as run_stdio_server
    participant Ctx as RuntimeContext
    participant OTS as OTS Upload

    Client->>Stdio: JSON-RPC line (newline-delimited)
    alt "line.len() > MAX_STDIO_LINE_BYTES (1 MiB)"
        Stdio-->>Stdio: warn + continue (silent drop)
    else line within budget
        Stdio->>Ctx: dispatch_json_line(execute tool)
        Ctx->>Ctx: char_safe_truncate(code, 16384)
        Ctx->>Ctx: extract_trajectory_actions_from_code
        loop each TemperCallMetadata
            alt "meta.tenant != identity_tenant"
                Ctx-->>Ctx: warn + skip (cross-tenant guard)
            else tenant matches or is None
                Ctx->>Ctx: update tenants_seen / entity_types_seen
            end
        end
        Ctx->>Ctx: char_safe_truncate(result, 16384)
        Ctx->>Ctx: record OTSMessage + OTSDecision
        Ctx-->>Stdio: tool result
        Stdio-->>Client: JSON-RPC response
    end

    Client->>Stdio: EOF / session close
    Stdio->>Ctx: finalize_trajectory()
    Ctx->>OTS: POST /api/ots/trajectories X-Tenant-Id: identity_tenant (always)
    OTS-->>Ctx: 202 Accepted (or retry on 503/429)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client as MCP Client
    participant Stdio as run_stdio_server
    participant Ctx as RuntimeContext
    participant OTS as OTS Upload

    Client->>Stdio: JSON-RPC line (newline-delimited)
    alt "line.len() > MAX_STDIO_LINE_BYTES (1 MiB)"
        Stdio-->>Stdio: warn + continue (silent drop)
    else line within budget
        Stdio->>Ctx: dispatch_json_line(execute tool)
        Ctx->>Ctx: char_safe_truncate(code, 16384)
        Ctx->>Ctx: extract_trajectory_actions_from_code
        loop each TemperCallMetadata
            alt "meta.tenant != identity_tenant"
                Ctx-->>Ctx: warn + skip (cross-tenant guard)
            else tenant matches or is None
                Ctx->>Ctx: update tenants_seen / entity_types_seen
            end
        end
        Ctx->>Ctx: char_safe_truncate(result, 16384)
        Ctx->>Ctx: record OTSMessage + OTSDecision
        Ctx-->>Stdio: tool result
        Stdio-->>Client: JSON-RPC response
    end

    Client->>Stdio: EOF / session close
    Stdio->>Ctx: finalize_trajectory()
    Ctx->>OTS: POST /api/ots/trajectories X-Tenant-Id: identity_tenant (always)
    OTS-->>Ctx: 202 Accepted (or retry on 503/429)
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/temper-mcp/src/runtime.rs`, line 870-876 ([link](https://github.com/nerdsane/temper/blob/1c5c458be78a144ee36dc12b8559ea8b9b51642b/crates/temper-mcp/src/runtime.rs#L870-L876)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Line byte budget is checked after full buffering — memory exhaustion still possible**

   `lines.next_line()` reads the entire line into memory before control returns. The `MAX_STDIO_LINE_BYTES` guard therefore protects against dispatch of large frames, not against allocation: a sender that omits a newline until after 500 MB of data has been sent will exhaust heap before the check can execute. The PR description advertises "stdio line byte budget" as protection, but `AsyncBufReadExt::lines` provides no per-line read limit. A proper fix requires a custom `AsyncRead` wrapper or the equivalent of `tokio::io::AsyncBufReadExt::read_line` with a length sentinel that aborts on overflow.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: crates/temper-mcp/src/runtime.rs
   Line: 870-876

   Comment:
   **Line byte budget is checked after full buffering — memory exhaustion still possible**

   `lines.next_line()` reads the entire line into memory before control returns. The `MAX_STDIO_LINE_BYTES` guard therefore protects against dispatch of large frames, not against allocation: a sender that omits a newline until after 500 MB of data has been sent will exhaust heap before the check can execute. The PR description advertises "stdio line byte budget" as protection, but `AsyncBufReadExt::lines` provides no per-line read limit. A proper fix requires a custom `AsyncRead` wrapper or the equivalent of `tokio::io::AsyncBufReadExt::read_line` with a length sentinel that aborts on overflow.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-mcp%2Fsrc%2Fruntime.rs%0ALine%3A%20870-876%0A%0AComment%3A%0A**Line%20byte%20budget%20is%20checked%20after%20full%20buffering%20%E2%80%94%20memory%20exhaustion%20still%20possible**%0A%0A%60lines.next_line%28%29%60%20reads%20the%20entire%20line%20into%20memory%20before%20control%20returns.%20The%20%60MAX_STDIO_LINE_BYTES%60%20guard%20therefore%20protects%20against%20dispatch%20of%20large%20frames%2C%20not%20against%20allocation%3A%20a%20sender%20that%20omits%20a%20newline%20until%20after%20500%20MB%20of%20data%20has%20been%20sent%20will%20exhaust%20heap%20before%20the%20check%20can%20execute.%20The%20PR%20description%20advertises%20%22stdio%20line%20byte%20budget%22%20as%20protection%2C%20but%20%60AsyncBufReadExt%3A%3Alines%60%20provides%20no%20per-line%20read%20limit.%20A%20proper%20fix%20requires%20a%20custom%20%60AsyncRead%60%20wrapper%20or%20the%20equivalent%20of%20%60tokio%3A%3Aio%3A%3AAsyncBufReadExt%3A%3Aread_line%60%20with%20a%20length%20sentinel%20that%20aborts%20on%20overflow.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=nerdsane%2Ftemper&pr=365&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22grok%2Farn-222-mcp-trajectory%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22grok%2Farn-222-mcp-trajectory%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-mcp%2Fsrc%2Fruntime.rs%0ALine%3A%20870-876%0A%0AComment%3A%0A**Line%20byte%20budget%20is%20checked%20after%20full%20buffering%20%E2%80%94%20memory%20exhaustion%20still%20possible**%0A%0A%60lines.next_line%28%29%60%20reads%20the%20entire%20line%20into%20memory%20before%20control%20returns.%20The%20%60MAX_STDIO_LINE_BYTES%60%20guard%20therefore%20protects%20against%20dispatch%20of%20large%20frames%2C%20not%20against%20allocation%3A%20a%20sender%20that%20omits%20a%20newline%20until%20after%20500%20MB%20of%20data%20has%20been%20sent%20will%20exhaust%20heap%20before%20the%20check%20can%20execute.%20The%20PR%20description%20advertises%20%22stdio%20line%20byte%20budget%22%20as%20protection%2C%20but%20%60AsyncBufReadExt%3A%3Alines%60%20provides%20no%20per-line%20read%20limit.%20A%20proper%20fix%20requires%20a%20custom%20%60AsyncRead%60%20wrapper%20or%20the%20equivalent%20of%20%60tokio%3A%3Aio%3A%3AAsyncBufReadExt%3A%3Aread_line%60%20with%20a%20length%20sentinel%20that%20aborts%20on%20overflow.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=nerdsane%2Ftemper&pr=365&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-mcp%2Fsrc%2Fruntime.rs%0ALine%3A%20870-876%0A%0AComment%3A%0A**Line%20byte%20budget%20is%20checked%20after%20full%20buffering%20%E2%80%94%20memory%20exhaustion%20still%20possible**%0A%0A%60lines.next_line%28%29%60%20reads%20the%20entire%20line%20into%20memory%20before%20control%20returns.%20The%20%60MAX_STDIO_LINE_BYTES%60%20guard%20therefore%20protects%20against%20dispatch%20of%20large%20frames%2C%20not%20against%20allocation%3A%20a%20sender%20that%20omits%20a%20newline%20until%20after%20500%20MB%20of%20data%20has%20been%20sent%20will%20exhaust%20heap%20before%20the%20check%20can%20execute.%20The%20PR%20description%20advertises%20%22stdio%20line%20byte%20budget%22%20as%20protection%2C%20but%20%60AsyncBufReadExt%3A%3Alines%60%20provides%20no%20per-line%20read%20limit.%20A%20proper%20fix%20requires%20a%20custom%20%60AsyncRead%60%20wrapper%20or%20the%20equivalent%20of%20%60tokio%3A%3Aio%3A%3AAsyncBufReadExt%3A%3Aread_line%60%20with%20a%20length%20sentinel%20that%20aborts%20on%20overflow.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=365&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Acrates%2Ftemper-mcp%2Fsrc%2Fruntime_tests.rs%3A1-10%0A**Duplicate%20%60use%20super%3A%3A*%3B%60%20at%20module%20top%20level**%0A%0A%60use%20super%3A%3A*%3B%60%20appears%20twice%20at%20module%20scope%20%E2%80%94%20once%20at%20line%203%20and%20again%20at%20line%205%20%E2%80%94%20because%20the%20tests%20were%20extracted%20from%20their%20original%20%60mod%20tests%20%7B%20use%20super%3A%3A*%3B%20...%20%7D%60%20block%20without%20removing%20the%20leftover%20inner%20%60use%60.%20In%20Rust%202024%20edition%20%28this%20project's%20target%29%2C%20the%20%60redundant_imports%60%20lint%20fires%20at%20warn%20level%3B%20if%20the%20project's%20CI%20pipeline%20runs%20with%20%60deny%28warnings%29%60%20or%20clippy's%20%60--deny%20warnings%60%20flag%20%28as%20the%20pre-push%20hook%20suggests%29%2C%20this%20will%20block%20the%20build.%20Remove%20the%20second%20%60use%20super%3A%3A*%3B%60%20at%20line%205%20and%20dedent%20all%20items%20by%204%20spaces%20so%20the%20file%20is%20well-formed%20as%20a%20module%20body.%0A%0A%23%23%23%20Issue%202%20of%204%0Acrates%2Ftemper-mcp%2Fsrc%2Fruntime.rs%3A875-883%0A**Oversized%20line%20silently%20dropped%20%E2%80%94%20JSON-RPC%20requests%20left%20unanswered**%0A%0AWhen%20a%20line%20exceeds%20%60MAX_STDIO_LINE_BYTES%60%2C%20the%20frame%20is%20logged%20and%20discarded%20with%20%60continue%60.%20For%20JSON-RPC%20notifications%20%28no%20%60id%60%29%20this%20is%20harmless%2C%20but%20for%20requests%20%28with%20an%20%60id%60%29%20the%20MCP%20client%20will%20block%20waiting%20for%20a%20response%20that%20never%20arrives%2C%20producing%20a%20client-side%20hang%20or%20timeout.%20A%20correct%20approach%20is%20to%20emit%20a%20JSON-RPC%20%60%7B%22jsonrpc%22%3A%222.0%22%2C%22id%22%3Anull%2C%22error%22%3A%7B%22code%22%3A-32700%2C%22message%22%3A%22Request%20too%20large%22%7D%7D%60%20response%2C%20or%20alternatively%20close%20the%20transport%20so%20the%20client%20fails%20fast%20rather%20than%20hanging%20indefinitely.%0A%0A%23%23%23%20Issue%203%20of%204%0Acrates%2Ftemper-mcp%2Fsrc%2Fruntime.rs%3A870-876%0A**Line%20byte%20budget%20is%20checked%20after%20full%20buffering%20%E2%80%94%20memory%20exhaustion%20still%20possible**%0A%0A%60lines.next_line%28%29%60%20reads%20the%20entire%20line%20into%20memory%20before%20control%20returns.%20The%20%60MAX_STDIO_LINE_BYTES%60%20guard%20therefore%20protects%20against%20dispatch%20of%20large%20frames%2C%20not%20against%20allocation%3A%20a%20sender%20that%20omits%20a%20newline%20until%20after%20500%20MB%20of%20data%20has%20been%20sent%20will%20exhaust%20heap%20before%20the%20check%20can%20execute.%20The%20PR%20description%20advertises%20%22stdio%20line%20byte%20budget%22%20as%20protection%2C%20but%20%60AsyncBufReadExt%3A%3Alines%60%20provides%20no%20per-line%20read%20limit.%20A%20proper%20fix%20requires%20a%20custom%20%60AsyncRead%60%20wrapper%20or%20the%20equivalent%20of%20%60tokio%3A%3Aio%3A%3AAsyncBufReadExt%3A%3Aread_line%60%20with%20a%20length%20sentinel%20that%20aborts%20on%20overflow.%0A%0A%23%23%23%20Issue%204%20of%204%0Acrates%2Ftemper-mcp%2Fsrc%2Ftrajectory_bounds.rs%3A10-11%0A%60char_safe_truncate%60%20appends%20%60%E2%80%A6%5Btruncated%5D%60%20%2811%20characters%29%20to%20the%20%60max_chars%60-char%20prefix%2C%20so%20the%20returned%20%60String%60%20can%20be%20up%20to%20%60max_chars%20%2B%2011%60%20characters%20long.%20The%20constants%20%60MAX_TRAJECTORY_CODE_CHARS%60%20and%20%60MAX_TRAJECTORY_RESULT_CHARS%60%20read%20as%20hard%20upper%20bounds%2C%20but%20they%20are%20not.%20Documenting%20this%20lets%20callers%20reason%20correctly%20about%20downstream%20buffer%20sizes.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20Character-safe%20truncation%20with%20an%20explicit%20marker%20%28never%20panics%20on%20multibyte%29.%0A%2F%2F%2F%0A%2F%2F%2F%20Returns%20%60s%60%20unchanged%20when%20%60s.chars%28%29.count%28%29%20%3C%3D%20max_chars%60.%20%20When%20truncation%0A%2F%2F%2F%20occurs%20the%20returned%20string%20is%20%60max_chars%60%20chars%20from%20the%20input%20followed%20by%0A%2F%2F%2F%20%60%E2%80%A6%5Btruncated%5D%60%2C%20so%20the%20total%20char%20count%20may%20exceed%20%60max_chars%60%20by%20up%20to%2011.%0Apub%28crate%29%20fn%20char_safe_truncate%28s%3A%20%26str%2C%20max_chars%3A%20usize%29%20-%3E%20String%20%7B%0A%60%60%60%0A%0A&repo=nerdsane%2Ftemper&pr=365&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22grok%2Farn-222-mcp-trajectory%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22grok%2Farn-222-mcp-trajectory%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Acrates%2Ftemper-mcp%2Fsrc%2Fruntime_tests.rs%3A1-10%0A**Duplicate%20%60use%20super%3A%3A*%3B%60%20at%20module%20top%20level**%0A%0A%60use%20super%3A%3A*%3B%60%20appears%20twice%20at%20module%20scope%20%E2%80%94%20once%20at%20line%203%20and%20again%20at%20line%205%20%E2%80%94%20because%20the%20tests%20were%20extracted%20from%20their%20original%20%60mod%20tests%20%7B%20use%20super%3A%3A*%3B%20...%20%7D%60%20block%20without%20removing%20the%20leftover%20inner%20%60use%60.%20In%20Rust%202024%20edition%20%28this%20project's%20target%29%2C%20the%20%60redundant_imports%60%20lint%20fires%20at%20warn%20level%3B%20if%20the%20project's%20CI%20pipeline%20runs%20with%20%60deny%28warnings%29%60%20or%20clippy's%20%60--deny%20warnings%60%20flag%20%28as%20the%20pre-push%20hook%20suggests%29%2C%20this%20will%20block%20the%20build.%20Remove%20the%20second%20%60use%20super%3A%3A*%3B%60%20at%20line%205%20and%20dedent%20all%20items%20by%204%20spaces%20so%20the%20file%20is%20well-formed%20as%20a%20module%20body.%0A%0A%23%23%23%20Issue%202%20of%204%0Acrates%2Ftemper-mcp%2Fsrc%2Fruntime.rs%3A875-883%0A**Oversized%20line%20silently%20dropped%20%E2%80%94%20JSON-RPC%20requests%20left%20unanswered**%0A%0AWhen%20a%20line%20exceeds%20%60MAX_STDIO_LINE_BYTES%60%2C%20the%20frame%20is%20logged%20and%20discarded%20with%20%60continue%60.%20For%20JSON-RPC%20notifications%20%28no%20%60id%60%29%20this%20is%20harmless%2C%20but%20for%20requests%20%28with%20an%20%60id%60%29%20the%20MCP%20client%20will%20block%20waiting%20for%20a%20response%20that%20never%20arrives%2C%20producing%20a%20client-side%20hang%20or%20timeout.%20A%20correct%20approach%20is%20to%20emit%20a%20JSON-RPC%20%60%7B%22jsonrpc%22%3A%222.0%22%2C%22id%22%3Anull%2C%22error%22%3A%7B%22code%22%3A-32700%2C%22message%22%3A%22Request%20too%20large%22%7D%7D%60%20response%2C%20or%20alternatively%20close%20the%20transport%20so%20the%20client%20fails%20fast%20rather%20than%20hanging%20indefinitely.%0A%0A%23%23%23%20Issue%203%20of%204%0Acrates%2Ftemper-mcp%2Fsrc%2Fruntime.rs%3A870-876%0A**Line%20byte%20budget%20is%20checked%20after%20full%20buffering%20%E2%80%94%20memory%20exhaustion%20still%20possible**%0A%0A%60lines.next_line%28%29%60%20reads%20the%20entire%20line%20into%20memory%20before%20control%20returns.%20The%20%60MAX_STDIO_LINE_BYTES%60%20guard%20therefore%20protects%20against%20dispatch%20of%20large%20frames%2C%20not%20against%20allocation%3A%20a%20sender%20that%20omits%20a%20newline%20until%20after%20500%20MB%20of%20data%20has%20been%20sent%20will%20exhaust%20heap%20before%20the%20check%20can%20execute.%20The%20PR%20description%20advertises%20%22stdio%20line%20byte%20budget%22%20as%20protection%2C%20but%20%60AsyncBufReadExt%3A%3Alines%60%20provides%20no%20per-line%20read%20limit.%20A%20proper%20fix%20requires%20a%20custom%20%60AsyncRead%60%20wrapper%20or%20the%20equivalent%20of%20%60tokio%3A%3Aio%3A%3AAsyncBufReadExt%3A%3Aread_line%60%20with%20a%20length%20sentinel%20that%20aborts%20on%20overflow.%0A%0A%23%23%23%20Issue%204%20of%204%0Acrates%2Ftemper-mcp%2Fsrc%2Ftrajectory_bounds.rs%3A10-11%0A%60char_safe_truncate%60%20appends%20%60%E2%80%A6%5Btruncated%5D%60%20%2811%20characters%29%20to%20the%20%60max_chars%60-char%20prefix%2C%20so%20the%20returned%20%60String%60%20can%20be%20up%20to%20%60max_chars%20%2B%2011%60%20characters%20long.%20The%20constants%20%60MAX_TRAJECTORY_CODE_CHARS%60%20and%20%60MAX_TRAJECTORY_RESULT_CHARS%60%20read%20as%20hard%20upper%20bounds%2C%20but%20they%20are%20not.%20Documenting%20this%20lets%20callers%20reason%20correctly%20about%20downstream%20buffer%20sizes.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20Character-safe%20truncation%20with%20an%20explicit%20marker%20%28never%20panics%20on%20multibyte%29.%0A%2F%2F%2F%0A%2F%2F%2F%20Returns%20%60s%60%20unchanged%20when%20%60s.chars%28%29.count%28%29%20%3C%3D%20max_chars%60.%20%20When%20truncation%0A%2F%2F%2F%20occurs%20the%20returned%20string%20is%20%60max_chars%60%20chars%20from%20the%20input%20followed%20by%0A%2F%2F%2F%20%60%E2%80%A6%5Btruncated%5D%60%2C%20so%20the%20total%20char%20count%20may%20exceed%20%60max_chars%60%20by%20up%20to%2011.%0Apub%28crate%29%20fn%20char_safe_truncate%28s%3A%20%26str%2C%20max_chars%3A%20usize%29%20-%3E%20String%20%7B%0A%60%60%60%0A%0A&repo=nerdsane%2Ftemper&pr=365&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Acrates%2Ftemper-mcp%2Fsrc%2Fruntime_tests.rs%3A1-10%0A**Duplicate%20%60use%20super%3A%3A*%3B%60%20at%20module%20top%20level**%0A%0A%60use%20super%3A%3A*%3B%60%20appears%20twice%20at%20module%20scope%20%E2%80%94%20once%20at%20line%203%20and%20again%20at%20line%205%20%E2%80%94%20because%20the%20tests%20were%20extracted%20from%20their%20original%20%60mod%20tests%20%7B%20use%20super%3A%3A*%3B%20...%20%7D%60%20block%20without%20removing%20the%20leftover%20inner%20%60use%60.%20In%20Rust%202024%20edition%20%28this%20project's%20target%29%2C%20the%20%60redundant_imports%60%20lint%20fires%20at%20warn%20level%3B%20if%20the%20project's%20CI%20pipeline%20runs%20with%20%60deny%28warnings%29%60%20or%20clippy's%20%60--deny%20warnings%60%20flag%20%28as%20the%20pre-push%20hook%20suggests%29%2C%20this%20will%20block%20the%20build.%20Remove%20the%20second%20%60use%20super%3A%3A*%3B%60%20at%20line%205%20and%20dedent%20all%20items%20by%204%20spaces%20so%20the%20file%20is%20well-formed%20as%20a%20module%20body.%0A%0A%23%23%23%20Issue%202%20of%204%0Acrates%2Ftemper-mcp%2Fsrc%2Fruntime.rs%3A875-883%0A**Oversized%20line%20silently%20dropped%20%E2%80%94%20JSON-RPC%20requests%20left%20unanswered**%0A%0AWhen%20a%20line%20exceeds%20%60MAX_STDIO_LINE_BYTES%60%2C%20the%20frame%20is%20logged%20and%20discarded%20with%20%60continue%60.%20For%20JSON-RPC%20notifications%20%28no%20%60id%60%29%20this%20is%20harmless%2C%20but%20for%20requests%20%28with%20an%20%60id%60%29%20the%20MCP%20client%20will%20block%20waiting%20for%20a%20response%20that%20never%20arrives%2C%20producing%20a%20client-side%20hang%20or%20timeout.%20A%20correct%20approach%20is%20to%20emit%20a%20JSON-RPC%20%60%7B%22jsonrpc%22%3A%222.0%22%2C%22id%22%3Anull%2C%22error%22%3A%7B%22code%22%3A-32700%2C%22message%22%3A%22Request%20too%20large%22%7D%7D%60%20response%2C%20or%20alternatively%20close%20the%20transport%20so%20the%20client%20fails%20fast%20rather%20than%20hanging%20indefinitely.%0A%0A%23%23%23%20Issue%203%20of%204%0Acrates%2Ftemper-mcp%2Fsrc%2Fruntime.rs%3A870-876%0A**Line%20byte%20budget%20is%20checked%20after%20full%20buffering%20%E2%80%94%20memory%20exhaustion%20still%20possible**%0A%0A%60lines.next_line%28%29%60%20reads%20the%20entire%20line%20into%20memory%20before%20control%20returns.%20The%20%60MAX_STDIO_LINE_BYTES%60%20guard%20therefore%20protects%20against%20dispatch%20of%20large%20frames%2C%20not%20against%20allocation%3A%20a%20sender%20that%20omits%20a%20newline%20until%20after%20500%20MB%20of%20data%20has%20been%20sent%20will%20exhaust%20heap%20before%20the%20check%20can%20execute.%20The%20PR%20description%20advertises%20%22stdio%20line%20byte%20budget%22%20as%20protection%2C%20but%20%60AsyncBufReadExt%3A%3Alines%60%20provides%20no%20per-line%20read%20limit.%20A%20proper%20fix%20requires%20a%20custom%20%60AsyncRead%60%20wrapper%20or%20the%20equivalent%20of%20%60tokio%3A%3Aio%3A%3AAsyncBufReadExt%3A%3Aread_line%60%20with%20a%20length%20sentinel%20that%20aborts%20on%20overflow.%0A%0A%23%23%23%20Issue%204%20of%204%0Acrates%2Ftemper-mcp%2Fsrc%2Ftrajectory_bounds.rs%3A10-11%0A%60char_safe_truncate%60%20appends%20%60%E2%80%A6%5Btruncated%5D%60%20%2811%20characters%29%20to%20the%20%60max_chars%60-char%20prefix%2C%20so%20the%20returned%20%60String%60%20can%20be%20up%20to%20%60max_chars%20%2B%2011%60%20characters%20long.%20The%20constants%20%60MAX_TRAJECTORY_CODE_CHARS%60%20and%20%60MAX_TRAJECTORY_RESULT_CHARS%60%20read%20as%20hard%20upper%20bounds%2C%20but%20they%20are%20not.%20Documenting%20this%20lets%20callers%20reason%20correctly%20about%20downstream%20buffer%20sizes.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20Character-safe%20truncation%20with%20an%20explicit%20marker%20%28never%20panics%20on%20multibyte%29.%0A%2F%2F%2F%0A%2F%2F%2F%20Returns%20%60s%60%20unchanged%20when%20%60s.chars%28%29.count%28%29%20%3C%3D%20max_chars%60.%20%20When%20truncation%0A%2F%2F%2F%20occurs%20the%20returned%20string%20is%20%60max_chars%60%20chars%20from%20the%20input%20followed%20by%0A%2F%2F%2F%20%60%E2%80%A6%5Btruncated%5D%60%2C%20so%20the%20total%20char%20count%20may%20exceed%20%60max_chars%60%20by%20up%20to%2011.%0Apub%28crate%29%20fn%20char_safe_truncate%28s%3A%20%26str%2C%20max_chars%3A%20usize%29%20-%3E%20String%20%7B%0A%60%60%60%0A%0A&pr=365&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
crates/temper-mcp/src/runtime_tests.rs:1-10
**Duplicate `use super::*;` at module top level**

`use super::*;` appears twice at module scope — once at line 3 and again at line 5 — because the tests were extracted from their original `mod tests { use super::*; ... }` block without removing the leftover inner `use`. In Rust 2024 edition (this project's target), the `redundant_imports` lint fires at warn level; if the project's CI pipeline runs with `deny(warnings)` or clippy's `--deny warnings` flag (as the pre-push hook suggests), this will block the build. Remove the second `use super::*;` at line 5 and dedent all items by 4 spaces so the file is well-formed as a module body.

### Issue 2 of 4
crates/temper-mcp/src/runtime.rs:875-883
**Oversized line silently dropped — JSON-RPC requests left unanswered**

When a line exceeds `MAX_STDIO_LINE_BYTES`, the frame is logged and discarded with `continue`. For JSON-RPC notifications (no `id`) this is harmless, but for requests (with an `id`) the MCP client will block waiting for a response that never arrives, producing a client-side hang or timeout. A correct approach is to emit a JSON-RPC `{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"Request too large"}}` response, or alternatively close the transport so the client fails fast rather than hanging indefinitely.

### Issue 3 of 4
crates/temper-mcp/src/runtime.rs:870-876
**Line byte budget is checked after full buffering — memory exhaustion still possible**

`lines.next_line()` reads the entire line into memory before control returns. The `MAX_STDIO_LINE_BYTES` guard therefore protects against dispatch of large frames, not against allocation: a sender that omits a newline until after 500 MB of data has been sent will exhaust heap before the check can execute. The PR description advertises "stdio line byte budget" as protection, but `AsyncBufReadExt::lines` provides no per-line read limit. A proper fix requires a custom `AsyncRead` wrapper or the equivalent of `tokio::io::AsyncBufReadExt::read_line` with a length sentinel that aborts on overflow.

### Issue 4 of 4
crates/temper-mcp/src/trajectory_bounds.rs:10-11
`char_safe_truncate` appends `…[truncated]` (11 characters) to the `max_chars`-char prefix, so the returned `String` can be up to `max_chars + 11` characters long. The constants `MAX_TRAJECTORY_CODE_CHARS` and `MAX_TRAJECTORY_RESULT_CHARS` read as hard upper bounds, but they are not. Documenting this lets callers reason correctly about downstream buffer sizes.

```suggestion
/// Character-safe truncation with an explicit marker (never panics on multibyte).
///
/// Returns `s` unchanged when `s.chars().count() <= max_chars`.  When truncation
/// occurs the returned string is `max_chars` chars from the input followed by
/// `…[truncated]`, so the total char count may exceed `max_chars` by up to 11.
pub(crate) fn char_safe_truncate(s: &str, max_chars: usize) -> String {
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: split MCP trajectory bounds/tests f..."](https://github.com/nerdsane/temper/commit/1c5c458be78a144ee36dc12b8559ea8b9b51642b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43651364)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/arni-labs/github/nerdsane/temper/-/custom-context?memory=c3ad5080-2c13-46c8-b4c1-9e266e4df914))
- Context used - AGENTS.md ([source](https://app.greptile.com/arni-labs/github/nerdsane/temper/-/custom-context?memory=873483f5-fffd-468c-aaf9-dd079b576948))

<!-- /greptile_comment -->