### PR TITLE
fix(store): enforce monotonic snapshot compare-and-set (ARN-239)

### DIFF
--- a/crates/temper-store-postgres/src/store.rs
+++ b/crates/temper-store-postgres/src/store.rs
@@ -849,11 +849,49 @@ impl EventStore for PostgresEventStore {
             .await
             .map_err(|e| PersistenceError::Storage(e.to_string()))?;
 
+        // ARN-239: read current latest for monotonic CAS.
+        let current: Option<(i64, Vec<u8>)> = crate::dbm::postgres_query_as!(
+            "SELECT sequence_nr, state FROM snapshots \
+             WHERE tenant = $1 AND entity_type = $2 AND entity_id = $3 \
+             FOR UPDATE",
+        )
+        .bind(tenant)
+        .bind(entity_type)
+        .bind(entity_id)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(|e| PersistenceError::Storage(e.to_string()))?;
+
+        if let Some((existing_seq, existing_state)) = current {
+            let existing_seq = existing_seq as u64;
+            if sequence_nr < existing_seq {
+                return Err(PersistenceError::ConcurrencyViolation {
+                    expected: existing_seq,
+                    actual: sequence_nr,
+                });
+            }
+            if sequence_nr == existing_seq {
+                if existing_state.as_slice() == snapshot {
+                    // Idempotent same-content retry.
+                    tx.commit()
+                        .await
+                        .map_err(|e| PersistenceError::Storage(e.to_string()))?;
+                    return Ok(());
+                }
+                return Err(PersistenceError::ConcurrencyViolation {
+                    expected: existing_seq,
+                    actual: sequence_nr,
+                });
+            }
+        }
+
+        // Only advance latest pointer forward (never backward).
         crate::dbm::postgres_query!(
             "INSERT INTO snapshots (tenant, entity_type, entity_id, sequence_nr, state) \
              VALUES ($1, $2, $3, $4, $5) \
              ON CONFLICT (tenant, entity_type, entity_id) \
-             DO UPDATE SET sequence_nr = $4, state = $5, created_at = now()",
+             DO UPDATE SET sequence_nr = EXCLUDED.sequence_nr, state = EXCLUDED.state, created_at = now() \
+             WHERE snapshots.sequence_nr < EXCLUDED.sequence_nr",
         )
         .bind(tenant)
         .bind(entity_type)
@@ -864,11 +902,11 @@ impl EventStore for PostgresEventStore {
         .await
         .map_err(|e| PersistenceError::Storage(e.to_string()))?;
 
+        // History is insert-only for a sequence (no content overwrite on conflict).
         crate::dbm::postgres_query!(
             "INSERT INTO snapshot_history (tenant, entity_type, entity_id, sequence_nr, state) \
              VALUES ($1, $2, $3, $4, $5) \
-             ON CONFLICT (tenant, entity_type, entity_id, sequence_nr) \
-             DO UPDATE SET state = $5, created_at = now()",
+             ON CONFLICT (tenant, entity_type, entity_id, sequence_nr) DO NOTHING",
         )
         .bind(tenant)
         .bind(entity_type)

--- a/crates/temper-store-redis/src/event_store.rs
+++ b/crates/temper-store-redis/src/event_store.rs
@@ -369,6 +369,27 @@ impl EventStore for RedisEventStore {
         let (tenant, entity_type, entity_id) =
             parse_persistence_id_parts(persistence_id).map_err(PersistenceError::Storage)?;
         let key = Self::snapshot_key(tenant, entity_type, entity_id);
+        // ARN-239: monotonic CAS against current latest.
+        let existing_raw: Option<String> = self.client.get(&key).await.map_err(storage_error)?;
+        if let Some(raw) = existing_raw
+            && let Ok(existing) = serde_json::from_str::<SnapshotRecord>(&raw)
+        {
+            if sequence_nr < existing.sequence_nr {
+                return Err(PersistenceError::ConcurrencyViolation {
+                    expected: existing.sequence_nr,
+                    actual: sequence_nr,
+                });
+            }
+            if sequence_nr == existing.sequence_nr {
+                if existing.snapshot.as_slice() == snapshot {
+                    return Ok(());
+                }
+                return Err(PersistenceError::ConcurrencyViolation {
+                    expected: existing.sequence_nr,
+                    actual: sequence_nr,
+                });
+            }
+        }
         let record = SnapshotRecord {
             sequence_nr,
             snapshot: snapshot.to_vec(),
@@ -382,18 +403,33 @@ impl EventStore for RedisEventStore {
             .map_err(storage_error)?;
 
         let history_key = Self::snapshot_history_key(tenant, entity_type, entity_id, sequence_nr);
-        let history = SnapshotHistoryRecord {
-            sequence_nr,
-            snapshot: snapshot.to_vec(),
-            created_at: chrono::Utc::now(),
-        };
-        let encoded_history = serde_json::to_string(&history)
-            .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
-        let _: () = self
-            .client
-            .set(&history_key, encoded_history, None, None, false)
-            .await
-            .map_err(storage_error)?;
+        // History: never overwrite different content at the same sequence.
+        let history_raw: Option<String> =
+            self.client.get(&history_key).await.map_err(storage_error)?;
+        if let Some(raw) = history_raw {
+            if let Ok(existing) = serde_json::from_str::<SnapshotHistoryRecord>(&raw)
+                && existing.snapshot.as_slice() != snapshot
+            {
+                return Err(PersistenceError::ConcurrencyViolation {
+                    expected: sequence_nr,
+                    actual: sequence_nr,
+                });
+            }
+            // same content — leave history entry
+        } else {
+            let history = SnapshotHistoryRecord {
+                sequence_nr,
+                snapshot: snapshot.to_vec(),
+                created_at: chrono::Utc::now(),
+            };
+            let encoded_history = serde_json::to_string(&history)
+                .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
+            let _: () = self
+                .client
+                .set(&history_key, encoded_history, None, None, false)
+                .await
+                .map_err(storage_error)?;
+        }
 
         let current_segment_key = Self::current_segment_key(tenant, entity_type, entity_id);
         let current_segment_raw: Option<String> = self

--- a/crates/temper-store-redis/src/event_store.rs
+++ b/crates/temper-store-redis/src/event_store.rs
@@ -6,9 +6,9 @@
 //! - `STRING` per entity for snapshots
 //! - `SET` per tenant to track distinct `(entity_type, entity_id)` pairs
 //!
-//! The `append()` operation uses a Lua script (`EVALSHA`) to atomically
-//! check-and-set the sequence number, preventing lost-update races between
-//! concurrent writers on the same entity.
+//! The `append()` and `save_snapshot()` operations use Lua scripts (`EVALSHA`)
+//! to atomically check-and-set sequence numbers, preventing lost-update races
+//! between concurrent writers on the same entity.
 
 use std::sync::Arc;
 
@@ -52,11 +52,83 @@ redis.call('SADD', entities_key, entity_ref)
 return {1, new_seq}
 "#;
 
+/// Lua script for atomic monotonic snapshot CAS (ARN-239).
+///
+/// KEYS[1] = latest snapshot key, KEYS[2] = history key for this sequence
+/// ARGV[1] = sequence_nr
+/// ARGV[2] = encoded SnapshotRecord JSON
+/// ARGV[3] = encoded SnapshotHistoryRecord JSON
+///
+/// Returns:
+///   `{1, seq}` written (advanced latest + history inserted if vacant)
+///   `{2, seq}` idempotent same-content success
+///   `{0, existing_seq}` concurrency violation (stale or conflicting content)
+const SNAPSHOT_CAS_LUA: &str = r#"
+local latest_key = KEYS[1]
+local history_key = KEYS[2]
+local seq = tonumber(ARGV[1])
+local new_latest = ARGV[2]
+local new_history = ARGV[3]
+
+local function snapshot_bytes_equal(a, b)
+    if type(a) ~= 'table' or type(b) ~= 'table' then
+        return false
+    end
+    if #a ~= #b then
+        return false
+    end
+    for i = 1, #a do
+        if a[i] ~= b[i] then
+            return false
+        end
+    end
+    return true
+end
+
+local existing_raw = redis.call('GET', latest_key)
+if existing_raw then
+    local ok, existing = pcall(cjson.decode, existing_raw)
+    if ok and type(existing) == 'table' and existing['sequence_nr'] ~= nil then
+        local existing_seq = tonumber(existing['sequence_nr'])
+        if seq < existing_seq then
+            return {0, existing_seq}
+        end
+        if seq == existing_seq then
+            local ok_new, new_obj = pcall(cjson.decode, new_latest)
+            if ok_new and type(new_obj) == 'table'
+                and snapshot_bytes_equal(existing['snapshot'], new_obj['snapshot']) then
+                return {2, existing_seq}
+            end
+            return {0, existing_seq}
+        end
+    end
+end
+
+-- History must not gain a different body at the same sequence.
+local history_raw = redis.call('GET', history_key)
+if history_raw then
+    local ok_h, existing_h = pcall(cjson.decode, history_raw)
+    local ok_n, new_h = pcall(cjson.decode, new_history)
+    if ok_h and ok_n and type(existing_h) == 'table' and type(new_h) == 'table' then
+        if not snapshot_bytes_equal(existing_h['snapshot'], new_h['snapshot']) then
+            return {0, seq}
+        end
+        -- same content: leave history, still advance/refresh latest below
+    end
+else
+    redis.call('SET', history_key, new_history)
+end
+
+redis.call('SET', latest_key, new_latest)
+return {1, seq}
+"#;
+
 /// Redis-backed event store.
 #[derive(Clone)]
 pub struct RedisEventStore {
     client: Arc<fred::clients::Client>,
     append_script: Script,
+    snapshot_script: Script,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -100,6 +172,7 @@ impl RedisEventStore {
         Ok(Self {
             client: Arc::new(client),
             append_script: Script::from_lua(APPEND_LUA),
+            snapshot_script: Script::from_lua(SNAPSHOT_CAS_LUA),
         })
     }
 
@@ -369,66 +442,52 @@ impl EventStore for RedisEventStore {
         let (tenant, entity_type, entity_id) =
             parse_persistence_id_parts(persistence_id).map_err(PersistenceError::Storage)?;
         let key = Self::snapshot_key(tenant, entity_type, entity_id);
-        // ARN-239: monotonic CAS against current latest.
-        let existing_raw: Option<String> = self.client.get(&key).await.map_err(storage_error)?;
-        if let Some(raw) = existing_raw
-            && let Ok(existing) = serde_json::from_str::<SnapshotRecord>(&raw)
-        {
-            if sequence_nr < existing.sequence_nr {
-                return Err(PersistenceError::ConcurrencyViolation {
-                    expected: existing.sequence_nr,
-                    actual: sequence_nr,
-                });
-            }
-            if sequence_nr == existing.sequence_nr {
-                if existing.snapshot.as_slice() == snapshot {
-                    return Ok(());
-                }
-                return Err(PersistenceError::ConcurrencyViolation {
-                    expected: existing.sequence_nr,
-                    actual: sequence_nr,
-                });
-            }
-        }
+        let history_key = Self::snapshot_history_key(tenant, entity_type, entity_id, sequence_nr);
+
+        // ARN-239: atomic monotonic CAS for latest + history (Lua, like append).
         let record = SnapshotRecord {
             sequence_nr,
             snapshot: snapshot.to_vec(),
         };
         let encoded = serde_json::to_string(&record)
             .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
-        let _: () = self
-            .client
-            .set(&key, encoded, None, None, false)
+        let history = SnapshotHistoryRecord {
+            sequence_nr,
+            snapshot: snapshot.to_vec(),
+            created_at: chrono::Utc::now(),
+        };
+        let encoded_history = serde_json::to_string(&history)
+            .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
+
+        let result: Vec<i64> = self
+            .snapshot_script
+            .evalsha_with_reload(
+                &self.client,
+                vec![key, history_key],
+                vec![sequence_nr.to_string(), encoded, encoded_history],
+            )
             .await
             .map_err(storage_error)?;
 
-        let history_key = Self::snapshot_history_key(tenant, entity_type, entity_id, sequence_nr);
-        // History: never overwrite different content at the same sequence.
-        let history_raw: Option<String> =
-            self.client.get(&history_key).await.map_err(storage_error)?;
-        if let Some(raw) = history_raw {
-            if let Ok(existing) = serde_json::from_str::<SnapshotHistoryRecord>(&raw)
-                && existing.snapshot.as_slice() != snapshot
-            {
+        match result.as_slice() {
+            [2, _] => {
+                // Idempotent same-content retry — no segment rotation needed.
+                return Ok(());
+            }
+            [0, existing_seq] => {
                 return Err(PersistenceError::ConcurrencyViolation {
-                    expected: sequence_nr,
+                    expected: *existing_seq as u64,
                     actual: sequence_nr,
                 });
             }
-            // same content — leave history entry
-        } else {
-            let history = SnapshotHistoryRecord {
-                sequence_nr,
-                snapshot: snapshot.to_vec(),
-                created_at: chrono::Utc::now(),
-            };
-            let encoded_history = serde_json::to_string(&history)
-                .map_err(|e| PersistenceError::Serialization(e.to_string()))?;
-            let _: () = self
-                .client
-                .set(&history_key, encoded_history, None, None, false)
-                .await
-                .map_err(storage_error)?;
+            [1, _] => {
+                // Advanced — continue to best-effort segment metadata update.
+            }
+            other => {
+                return Err(PersistenceError::Storage(format!(
+                    "unexpected snapshot Lua result: {other:?}"
+                )));
+            }
         }
 
         let current_segment_key = Self::current_segment_key(tenant, entity_type, entity_id);

--- a/crates/temper-store-sim/src/lib.rs
+++ b/crates/temper-store-sim/src/lib.rs
@@ -957,22 +957,24 @@ impl EventStore for SimEventStore {
             .snapshots
             .insert(persistence_id.to_string(), (sequence_nr, snapshot.to_vec()));
         // History is append-only for new sequence numbers (never overwrite).
-        let history = inner
+        use std::collections::btree_map::Entry;
+        match inner
             .snapshot_history
             .entry(persistence_id.to_string())
-            .or_default();
-        if history.contains_key(&sequence_nr) {
-            // Same sequence already recorded under a different path — conflict.
-            if history.get(&sequence_nr).map(|b| b.as_slice()) == Some(snapshot) {
-                // already consistent
-            } else {
-                return Err(PersistenceError::ConcurrencyViolation {
-                    expected: sequence_nr,
-                    actual: sequence_nr,
-                });
+            .or_default()
+            .entry(sequence_nr)
+        {
+            Entry::Occupied(occ) => {
+                if occ.get().as_slice() != snapshot {
+                    return Err(PersistenceError::ConcurrencyViolation {
+                        expected: sequence_nr,
+                        actual: sequence_nr,
+                    });
+                }
             }
-        } else {
-            history.insert(sequence_nr, snapshot.to_vec());
+            Entry::Vacant(vac) => {
+                vac.insert(snapshot.to_vec());
+            }
         }
         let segments = inner
             .event_segments

--- a/crates/temper-store-sim/src/lib.rs
+++ b/crates/temper-store-sim/src/lib.rs
@@ -953,10 +953,8 @@ impl EventStore for SimEventStore {
             // Higher sequence: keep history immutable; do not rewrite prior seq keys.
         }
 
-        inner
-            .snapshots
-            .insert(persistence_id.to_string(), (sequence_nr, snapshot.to_vec()));
-        // History is append-only for new sequence numbers (never overwrite).
+        // History check BEFORE latest pointer update so a conflict never leaves
+        // snapshots advanced to uncommitted content (ARN-239 / TigerStyle).
         use std::collections::btree_map::Entry;
         match inner
             .snapshot_history
@@ -976,6 +974,9 @@ impl EventStore for SimEventStore {
                 vac.insert(snapshot.to_vec());
             }
         }
+        inner
+            .snapshots
+            .insert(persistence_id.to_string(), (sequence_nr, snapshot.to_vec()));
         let segments = inner
             .event_segments
             .entry(persistence_id.to_string())

--- a/crates/temper-store-sim/src/lib.rs
+++ b/crates/temper-store-sim/src/lib.rs
@@ -933,14 +933,47 @@ impl EventStore for SimEventStore {
             ));
         }
 
+        // ARN-239: monotonic snapshot contract — reject stale, idempotent same content.
+        if let Some((existing_seq, existing_bytes)) = inner.snapshots.get(persistence_id) {
+            if sequence_nr < *existing_seq {
+                return Err(PersistenceError::ConcurrencyViolation {
+                    expected: *existing_seq,
+                    actual: sequence_nr,
+                });
+            }
+            if sequence_nr == *existing_seq {
+                if existing_bytes.as_slice() == snapshot {
+                    return Ok(());
+                }
+                return Err(PersistenceError::ConcurrencyViolation {
+                    expected: *existing_seq,
+                    actual: sequence_nr,
+                });
+            }
+            // Higher sequence: keep history immutable; do not rewrite prior seq keys.
+        }
+
         inner
             .snapshots
             .insert(persistence_id.to_string(), (sequence_nr, snapshot.to_vec()));
-        inner
+        // History is append-only for new sequence numbers (never overwrite).
+        let history = inner
             .snapshot_history
             .entry(persistence_id.to_string())
-            .or_default()
-            .insert(sequence_nr, snapshot.to_vec());
+            .or_default();
+        if history.contains_key(&sequence_nr) {
+            // Same sequence already recorded under a different path — conflict.
+            if history.get(&sequence_nr).map(|b| b.as_slice()) == Some(snapshot) {
+                // already consistent
+            } else {
+                return Err(PersistenceError::ConcurrencyViolation {
+                    expected: sequence_nr,
+                    actual: sequence_nr,
+                });
+            }
+        } else {
+            history.insert(sequence_nr, snapshot.to_vec());
+        }
         let segments = inner
             .event_segments
             .entry(persistence_id.to_string())

--- a/crates/temper-store-sim/src/tests.rs
+++ b/crates/temper-store-sim/src/tests.rs
@@ -292,3 +292,25 @@ async fn fault_injection_produces_errors() {
     let err = store.append(pid, 0, &[test_envelope(0, "Created")]).await;
     assert!(err.is_err());
 }
+
+#[tokio::test]
+async fn stale_snapshot_rejected_and_same_content_idempotent() {
+    let store = SimEventStore::no_faults(7);
+    let id = "default:Issue:i1";
+    store.save_snapshot(id, 5, b"v5").await.expect("save 5");
+    let err = store
+        .save_snapshot(id, 3, b"stale")
+        .await
+        .expect_err("stale");
+    assert!(matches!(
+        err,
+        temper_runtime::persistence::PersistenceError::ConcurrencyViolation { .. }
+    ));
+    store
+        .save_snapshot(id, 5, b"v5")
+        .await
+        .expect("idempotent same content");
+    let loaded = store.load_snapshot(id).await.expect("load").expect("some");
+    assert_eq!(loaded.0, 5);
+    assert_eq!(loaded.1, b"v5");
+}

--- a/crates/temper-store-sim/src/tests.rs
+++ b/crates/temper-store-sim/src/tests.rs
@@ -314,3 +314,24 @@ async fn stale_snapshot_rejected_and_same_content_idempotent() {
     assert_eq!(loaded.0, 5);
     assert_eq!(loaded.1, b"v5");
 }
+
+#[tokio::test]
+async fn same_sequence_conflicting_content_rejected() {
+    let store = SimEventStore::no_faults(11);
+    let id = "default:Issue:i2";
+    store
+        .save_snapshot(id, 4, b"original")
+        .await
+        .expect("save original");
+    let err = store
+        .save_snapshot(id, 4, b"different")
+        .await
+        .expect_err("conflict");
+    assert!(matches!(
+        err,
+        temper_runtime::persistence::PersistenceError::ConcurrencyViolation { .. }
+    ));
+    let loaded = store.load_snapshot(id).await.expect("load").expect("some");
+    assert_eq!(loaded.0, 4);
+    assert_eq!(loaded.1, b"original");
+}

--- a/crates/temper-store-turso/src/store/event_store.rs
+++ b/crates/temper-store-turso/src/store/event_store.rs
@@ -489,6 +489,36 @@ impl EventStore for TursoEventStore {
             .await
             .map_err(storage_error)?;
 
+        // ARN-239: monotonic latest + immutable history.
+        let mut current_rows = tx
+            .query(
+                "SELECT sequence_nr, snapshot FROM snapshots \
+                 WHERE tenant = ?1 AND entity_type = ?2 AND entity_id = ?3",
+                params![tenant, entity_type, entity_id],
+            )
+            .await
+            .map_err(storage_error)?;
+        if let Some(row) = current_rows.next().await.map_err(storage_error)? {
+            let existing_seq = row.get::<i64>(0).map_err(storage_error)? as u64;
+            let existing_bytes: Vec<u8> = row.get(1).map_err(storage_error)?;
+            if sequence_nr < existing_seq {
+                return Err(PersistenceError::ConcurrencyViolation {
+                    expected: existing_seq,
+                    actual: sequence_nr,
+                });
+            }
+            if sequence_nr == existing_seq {
+                if existing_bytes.as_slice() == snapshot {
+                    tx.commit().await.map_err(storage_error)?;
+                    return Ok(());
+                }
+                return Err(PersistenceError::ConcurrencyViolation {
+                    expected: existing_seq,
+                    actual: sequence_nr,
+                });
+            }
+        }
+
         tx.execute(
             "INSERT INTO snapshots (tenant, entity_type, entity_id, sequence_nr, snapshot)
              VALUES (?1, ?2, ?3, ?4, ?5)
@@ -496,7 +526,8 @@ impl EventStore for TursoEventStore {
              DO UPDATE SET
                 sequence_nr = excluded.sequence_nr,
                 snapshot = excluded.snapshot,
-                created_at = datetime('now')",
+                created_at = datetime('now')
+             WHERE snapshots.sequence_nr < excluded.sequence_nr",
             params![
                 tenant,
                 entity_type,
@@ -512,7 +543,7 @@ impl EventStore for TursoEventStore {
             "INSERT INTO snapshot_history (tenant, entity_type, entity_id, sequence_nr, snapshot)
              VALUES (?1, ?2, ?3, ?4, ?5)
              ON CONFLICT (tenant, entity_type, entity_id, sequence_nr)
-             DO UPDATE SET snapshot = excluded.snapshot, created_at = datetime('now')",
+             DO NOTHING",
             params![
                 tenant,
                 entity_type,

--- a/docs/adrs/0164-snapshot-monotonic-cas.md
+++ b/docs/adrs/0164-snapshot-monotonic-cas.md
@@ -1,0 +1,16 @@
+# ADR-0164: Monotonic snapshot compare-and-set (ARN-239)
+
+- Status: Accepted
+- Date: 2026-07-12
+- Related: ARN-239; all EventStore backends
+
+## Decision
+
+`save_snapshot` must:
+
+1. Reject `sequence_nr < current_latest` with `ConcurrencyViolation`
+2. Treat `sequence_nr == current` + identical bytes as idempotent success
+3. Reject same-sequence conflicting content
+4. Append history only (no overwrite of prior sequence content)
+
+Applied to Sim, Postgres, Turso, and Redis backends.

--- a/docs/adrs/0164-snapshot-monotonic-cas.md
+++ b/docs/adrs/0164-snapshot-monotonic-cas.md
@@ -14,3 +14,16 @@
 4. Append history only (no overwrite of prior sequence content)
 
 Applied to Sim, Postgres, Turso, and Redis backends.
+
+## Atomicity notes
+
+- **Postgres / Turso:** CAS is evaluated inside a transaction (Postgres uses
+  `SELECT … FOR UPDATE`). History uses insert-only / `DO NOTHING` on conflict.
+- **Redis:** Latest + history CAS runs in a single Lua script (same pattern as
+  `append`). Segment rotation remains best-effort after a successful advance.
+- **Sim:** In-memory map under the store mutex.
+
+## Non-goals (follow-up)
+
+- Journal-head guard (snapshot sequence vs event journal head).
+- Shared multi-backend conformance suite beyond Sim unit tests.

--- a/docs/adrs/0167-snapshot-monotonic-cas.md
+++ b/docs/adrs/0167-snapshot-monotonic-cas.md
@@ -1,4 +1,4 @@
-# ADR-0164: Monotonic snapshot compare-and-set (ARN-239)
+# ADR-0167: Monotonic snapshot compare-and-set (ARN-239)
 
 - Status: Accepted
 - Date: 2026-07-12


### PR DESCRIPTION
## Summary
ARN-239: EventStore snapshots are monotonic.

- Stale lower sequence → ConcurrencyViolation
- Same sequence + same content → idempotent Ok
- Same sequence + different content → ConcurrencyViolation
- History insert-only / no overwrite
- Backends: sim, postgres, turso, redis
- ADR-0164

## Tests
- [x] sim `stale_snapshot_rejected_and_same_content_idempotent`
- [x] all 4 store crates compile
- [ ] CI green

Linear: ARN-239

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enforces a monotonic compare-and-set contract on `save_snapshot` across all four backends (Sim, Postgres, Turso, Redis): stale sequences are rejected with `ConcurrencyViolation`, same-sequence same-content writes are idempotent, same-sequence different-content writes are rejected, and snapshot history is now insert-only.

- **Postgres and Turso** implement the check atomically \u2014 Postgres with `SELECT \u2026 FOR UPDATE` inside a transaction, Turso with `TransactionBehavior::Immediate` \u2014 and are correct.
- **Redis** reads the current key, checks it in application code, then unconditionally `SET`s the new value without any atomic guarantee; two concurrent writers can both pass the guard and the later-arriving write wins regardless of sequence order, potentially regressing the stored snapshot to a lower sequence.
- **Sim** performs `snapshots.insert` before the history conflict check, leaving the snapshot map advanced even when the history check later returns an error; the ordering violates the \"fail before mutating state\" principle from TigerStyle.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The Postgres and Turso implementations are correct and safe to merge as-is. The Redis backend has a real concurrency hole that needs to be fixed before this reaches production Redis usage.

The Redis backend read-check-write is not atomic: two concurrent callers can both pass the monotonicity guard and the later SET wins regardless of sequence order, meaning a stale snapshot can permanently overwrite a newer one. The Sim store also mutates the snapshot map before completing all its checks, leaving state inconsistent if the history guard ever fires.

crates/temper-store-redis/src/event_store.rs needs an atomic Lua script or WATCH/MULTI/EXEC loop; crates/temper-store-sim/src/lib.rs should move snapshots.insert after the history entry check.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/temper-store-redis/src/event_store.rs | Adds monotonic CAS guard before snapshot SET, but uses a non-atomic GET→check→SET pattern — concurrent callers can race past the guard and overwrite a higher-sequence snapshot with a stale one. |
| crates/temper-store-sim/src/lib.rs | Implements monotonic CAS and immutable history correctly at a logical level, but `snapshots.insert` fires before the history conflict check, so a history conflict would return an error with the snapshot map already mutated. |
| crates/temper-store-postgres/src/store.rs | Uses FOR UPDATE pessimistic lock, checks monotonicity in application code, then issues the guarded INSERT ON CONFLICT DO UPDATE WHERE within the same transaction — atomically correct. |
| crates/temper-store-turso/src/store/event_store.rs | Uses TransactionBehavior::Immediate to serialize the read-check-write cycle; logic mirrors Postgres correctly. |
| crates/temper-store-sim/src/tests.rs | Adds a test for stale rejection and idempotent same-content, but the same-sequence different-content branch is not covered. |
| docs/adrs/0164-snapshot-monotonic-cas.md | ADR concisely documents the four-case contract; minimal but sufficient for the scope of this change. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Caller
    participant B as Backend (Postgres/Turso)
    participant R as Backend (Redis)
    participant S as Backend (Sim)

    Note over B: Atomic path (correct)
    C->>B: save_snapshot(id, seq, bytes)
    B->>B: BEGIN TX / FOR UPDATE
    B->>B: Read current (locked)
    alt "seq < existing"
        B-->>C: ConcurrencyViolation
    else "seq == existing and same bytes"
        B->>B: COMMIT
        B-->>C: Ok (idempotent)
    else "seq == existing and different bytes"
        B-->>C: ConcurrencyViolation
    else "seq > existing"
        B->>B: "INSERT ON CONFLICT DO UPDATE WHERE seq < excluded"
        B->>B: INSERT history ON CONFLICT DO NOTHING
        B->>B: COMMIT
        B-->>C: Ok
    end

    Note over R: Non-atomic path (TOCTOU risk)
    C->>R: save_snapshot(id, seq, bytes)
    R->>R: GET current (no lock)
    R->>R: Check monotonicity in app code
    Note over R: concurrent writer can SET here
    R->>R: SET latest (unconditional)
    R-->>C: Ok (may have overwritten higher seq)

    Note over S: Sim path (mutation before guard)
    C->>S: save_snapshot(id, seq, bytes)
    S->>S: Lock Mutex
    S->>S: Check existing seq
    S->>S: snapshots.insert fires here
    S->>S: Check history entry
    alt history conflict
        S-->>C: ConcurrencyViolation (state already mutated)
    else no conflict
        S->>S: history.insert
        S-->>C: Ok
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Caller
    participant B as Backend (Postgres/Turso)
    participant R as Backend (Redis)
    participant S as Backend (Sim)

    Note over B: Atomic path (correct)
    C->>B: save_snapshot(id, seq, bytes)
    B->>B: BEGIN TX / FOR UPDATE
    B->>B: Read current (locked)
    alt "seq < existing"
        B-->>C: ConcurrencyViolation
    else "seq == existing and same bytes"
        B->>B: COMMIT
        B-->>C: Ok (idempotent)
    else "seq == existing and different bytes"
        B-->>C: ConcurrencyViolation
    else "seq > existing"
        B->>B: "INSERT ON CONFLICT DO UPDATE WHERE seq < excluded"
        B->>B: INSERT history ON CONFLICT DO NOTHING
        B->>B: COMMIT
        B-->>C: Ok
    end

    Note over R: Non-atomic path (TOCTOU risk)
    C->>R: save_snapshot(id, seq, bytes)
    R->>R: GET current (no lock)
    R->>R: Check monotonicity in app code
    Note over R: concurrent writer can SET here
    R->>R: SET latest (unconditional)
    R-->>C: Ok (may have overwritten higher seq)

    Note over S: Sim path (mutation before guard)
    C->>S: save_snapshot(id, seq, bytes)
    S->>S: Lock Mutex
    S->>S: Check existing seq
    S->>S: snapshots.insert fires here
    S->>S: Check history entry
    alt history conflict
        S-->>C: ConcurrencyViolation (state already mutated)
    else no conflict
        S->>S: history.insert
        S-->>C: Ok
    end
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftemper-store-redis%2Fsrc%2Fevent_store.rs%3A373-403%0A**Redis%20TOCTOU%3A%20non-atomic%20check-then-write%20can%20corrupt%20the%20latest%20snapshot**%0A%0AThe%20read-check-write%20sequence%20is%20not%20atomic%20in%20Redis%2C%20so%20two%20concurrent%20callers%20can%20both%20pass%20the%20monotonicity%20guard%20and%20both%20issue%20unconditional%20%60SET%60%20calls.%20Whichever%20%60SET%60%20lands%20last%20wins%20regardless%20of%20sequence%20ordering.%20Concretely%3A%20Writer%20A%20%28seq%3D7%29%20and%20Writer%20B%20%28seq%3D10%29%20both%20read%20current%3Dseq%205%20and%20both%20pass%20the%20%60%3E%20existing%60%20check%3B%20Writer%20B%20writes%20seq%3D10%2C%20then%20Writer%20A%20writes%20seq%3D7%2C%20and%20the%20latest%20snapshot%20now%20permanently%20records%20seq%3D7%20%E2%80%94%20a%20regression%20the%20monotonic%20contract%20was%20designed%20to%20prevent.%0A%0APostgres%20uses%20%60FOR%20UPDATE%60%20and%20Turso%20uses%20%60TransactionBehavior%3A%3AImmediate%60%20to%20make%20the%20read-check-write%20atomic.%20Redis%20needs%20the%20equivalent%3A%20either%20a%20Lua%20script%20%28%60EVAL%60%29%20that%20reads%20and%20conditionally%20sets%20in%20one%20atomic%20op%2C%20or%20a%20%60WATCH%60%2F%60MULTI%60%2F%60EXEC%60%20optimistic-locking%20loop.%20Without%20this%2C%20the%20Redis%20backend%20silently%20violates%20the%20ARN-239%20monotonicity%20guarantee%20under%20any%20concurrent%20load.%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftemper-store-sim%2Fsrc%2Flib.rs%3A956-978%0A**Snapshot%20state%20mutated%20before%20history%20conflict%20check%20completes**%0A%0A%60snapshots.insert%28...%29%60%20updates%20the%20latest-snapshot%20pointer%20unconditionally%20before%20the%20history%20%60Entry%3A%3AOccupied%60%20check%20can%20reject%20a%20conflict.%20If%20the%20history%20entry%20already%20holds%20different%20content%20at%20the%20incoming%20%60sequence_nr%60%20and%20returns%20%60ConcurrencyViolation%60%2C%20the%20%60snapshots%60%20map%20has%20already%20been%20advanced%20to%20the%20new%20%28sequence_nr%2C%20snapshot%29%20%E2%80%94%20leaving%20the%20store%20in%20a%20state%20where%20%60snapshots%60%20references%20content%20that%20was%20never%20successfully%20committed.%20TigerStyle%20requires%20%22fail%20fast%20before%20propagating%20corrupt%20state.%22%0A%0AThe%20fix%20is%20to%20move%20the%20%60snapshots.insert%60%20after%20the%20history%20entry%20check%20completes%20successfully.%20The%20Occupied%20path%20with%20different%20content%20is%20currently%20unreachable%20through%20normal%20operation%20%28the%20Mutex%20serializes%20all%20calls%20and%20the%20first%20check%20prevents%20re-entering%20an%20existing%20sequence%29%2C%20but%20the%20ordering%20assumption%20is%20fragile%20%E2%80%94%20any%20future%20refactor%20that%20loosens%20locking%20or%20adds%20a%20new%20entry%20point%20would%20silently%20activate%20this%20bug.%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftemper-store-sim%2Fsrc%2Ftests.rs%3A292-316%0A**Same-sequence%20different-content%20case%20is%20not%20covered%20by%20the%20test**%0A%0AThe%20test%20verifies%20the%20stale-sequence%20rejection%20and%20same-content%20idempotent%20path%2C%20but%20never%20exercises%20%60save_snapshot%28id%2C%205%2C%20b%22different_content%22%29%60%20after%20the%20initial%20%60save%205%60%20%E2%80%94%20i.e.%2C%20the%20%60sequence_nr%20%3D%3D%20existing_seq%20%26%26%20content%20!%3D%20existing_content%60%20branch.%20That%20branch%20is%20critical%20for%20correctness%20and%20is%20present%20in%20all%20four%20backends.%20Adding%20this%20case%20%28expecting%20%60ConcurrencyViolation%60%29%20would%20complete%20the%20matrix%20described%20in%20the%20PR%20description.%0A%0A&repo=nerdsane%2Ftemper&pr=366&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22grok%2Farn-239-snapshot-monotonic%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22grok%2Farn-239-snapshot-monotonic%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftemper-store-redis%2Fsrc%2Fevent_store.rs%3A373-403%0A**Redis%20TOCTOU%3A%20non-atomic%20check-then-write%20can%20corrupt%20the%20latest%20snapshot**%0A%0AThe%20read-check-write%20sequence%20is%20not%20atomic%20in%20Redis%2C%20so%20two%20concurrent%20callers%20can%20both%20pass%20the%20monotonicity%20guard%20and%20both%20issue%20unconditional%20%60SET%60%20calls.%20Whichever%20%60SET%60%20lands%20last%20wins%20regardless%20of%20sequence%20ordering.%20Concretely%3A%20Writer%20A%20%28seq%3D7%29%20and%20Writer%20B%20%28seq%3D10%29%20both%20read%20current%3Dseq%205%20and%20both%20pass%20the%20%60%3E%20existing%60%20check%3B%20Writer%20B%20writes%20seq%3D10%2C%20then%20Writer%20A%20writes%20seq%3D7%2C%20and%20the%20latest%20snapshot%20now%20permanently%20records%20seq%3D7%20%E2%80%94%20a%20regression%20the%20monotonic%20contract%20was%20designed%20to%20prevent.%0A%0APostgres%20uses%20%60FOR%20UPDATE%60%20and%20Turso%20uses%20%60TransactionBehavior%3A%3AImmediate%60%20to%20make%20the%20read-check-write%20atomic.%20Redis%20needs%20the%20equivalent%3A%20either%20a%20Lua%20script%20%28%60EVAL%60%29%20that%20reads%20and%20conditionally%20sets%20in%20one%20atomic%20op%2C%20or%20a%20%60WATCH%60%2F%60MULTI%60%2F%60EXEC%60%20optimistic-locking%20loop.%20Without%20this%2C%20the%20Redis%20backend%20silently%20violates%20the%20ARN-239%20monotonicity%20guarantee%20under%20any%20concurrent%20load.%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftemper-store-sim%2Fsrc%2Flib.rs%3A956-978%0A**Snapshot%20state%20mutated%20before%20history%20conflict%20check%20completes**%0A%0A%60snapshots.insert%28...%29%60%20updates%20the%20latest-snapshot%20pointer%20unconditionally%20before%20the%20history%20%60Entry%3A%3AOccupied%60%20check%20can%20reject%20a%20conflict.%20If%20the%20history%20entry%20already%20holds%20different%20content%20at%20the%20incoming%20%60sequence_nr%60%20and%20returns%20%60ConcurrencyViolation%60%2C%20the%20%60snapshots%60%20map%20has%20already%20been%20advanced%20to%20the%20new%20%28sequence_nr%2C%20snapshot%29%20%E2%80%94%20leaving%20the%20store%20in%20a%20state%20where%20%60snapshots%60%20references%20content%20that%20was%20never%20successfully%20committed.%20TigerStyle%20requires%20%22fail%20fast%20before%20propagating%20corrupt%20state.%22%0A%0AThe%20fix%20is%20to%20move%20the%20%60snapshots.insert%60%20after%20the%20history%20entry%20check%20completes%20successfully.%20The%20Occupied%20path%20with%20different%20content%20is%20currently%20unreachable%20through%20normal%20operation%20%28the%20Mutex%20serializes%20all%20calls%20and%20the%20first%20check%20prevents%20re-entering%20an%20existing%20sequence%29%2C%20but%20the%20ordering%20assumption%20is%20fragile%20%E2%80%94%20any%20future%20refactor%20that%20loosens%20locking%20or%20adds%20a%20new%20entry%20point%20would%20silently%20activate%20this%20bug.%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftemper-store-sim%2Fsrc%2Ftests.rs%3A292-316%0A**Same-sequence%20different-content%20case%20is%20not%20covered%20by%20the%20test**%0A%0AThe%20test%20verifies%20the%20stale-sequence%20rejection%20and%20same-content%20idempotent%20path%2C%20but%20never%20exercises%20%60save_snapshot%28id%2C%205%2C%20b%22different_content%22%29%60%20after%20the%20initial%20%60save%205%60%20%E2%80%94%20i.e.%2C%20the%20%60sequence_nr%20%3D%3D%20existing_seq%20%26%26%20content%20!%3D%20existing_content%60%20branch.%20That%20branch%20is%20critical%20for%20correctness%20and%20is%20present%20in%20all%20four%20backends.%20Adding%20this%20case%20%28expecting%20%60ConcurrencyViolation%60%29%20would%20complete%20the%20matrix%20described%20in%20the%20PR%20description.%0A%0A&repo=nerdsane%2Ftemper&pr=366&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftemper-store-redis%2Fsrc%2Fevent_store.rs%3A373-403%0A**Redis%20TOCTOU%3A%20non-atomic%20check-then-write%20can%20corrupt%20the%20latest%20snapshot**%0A%0AThe%20read-check-write%20sequence%20is%20not%20atomic%20in%20Redis%2C%20so%20two%20concurrent%20callers%20can%20both%20pass%20the%20monotonicity%20guard%20and%20both%20issue%20unconditional%20%60SET%60%20calls.%20Whichever%20%60SET%60%20lands%20last%20wins%20regardless%20of%20sequence%20ordering.%20Concretely%3A%20Writer%20A%20%28seq%3D7%29%20and%20Writer%20B%20%28seq%3D10%29%20both%20read%20current%3Dseq%205%20and%20both%20pass%20the%20%60%3E%20existing%60%20check%3B%20Writer%20B%20writes%20seq%3D10%2C%20then%20Writer%20A%20writes%20seq%3D7%2C%20and%20the%20latest%20snapshot%20now%20permanently%20records%20seq%3D7%20%E2%80%94%20a%20regression%20the%20monotonic%20contract%20was%20designed%20to%20prevent.%0A%0APostgres%20uses%20%60FOR%20UPDATE%60%20and%20Turso%20uses%20%60TransactionBehavior%3A%3AImmediate%60%20to%20make%20the%20read-check-write%20atomic.%20Redis%20needs%20the%20equivalent%3A%20either%20a%20Lua%20script%20%28%60EVAL%60%29%20that%20reads%20and%20conditionally%20sets%20in%20one%20atomic%20op%2C%20or%20a%20%60WATCH%60%2F%60MULTI%60%2F%60EXEC%60%20optimistic-locking%20loop.%20Without%20this%2C%20the%20Redis%20backend%20silently%20violates%20the%20ARN-239%20monotonicity%20guarantee%20under%20any%20concurrent%20load.%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftemper-store-sim%2Fsrc%2Flib.rs%3A956-978%0A**Snapshot%20state%20mutated%20before%20history%20conflict%20check%20completes**%0A%0A%60snapshots.insert%28...%29%60%20updates%20the%20latest-snapshot%20pointer%20unconditionally%20before%20the%20history%20%60Entry%3A%3AOccupied%60%20check%20can%20reject%20a%20conflict.%20If%20the%20history%20entry%20already%20holds%20different%20content%20at%20the%20incoming%20%60sequence_nr%60%20and%20returns%20%60ConcurrencyViolation%60%2C%20the%20%60snapshots%60%20map%20has%20already%20been%20advanced%20to%20the%20new%20%28sequence_nr%2C%20snapshot%29%20%E2%80%94%20leaving%20the%20store%20in%20a%20state%20where%20%60snapshots%60%20references%20content%20that%20was%20never%20successfully%20committed.%20TigerStyle%20requires%20%22fail%20fast%20before%20propagating%20corrupt%20state.%22%0A%0AThe%20fix%20is%20to%20move%20the%20%60snapshots.insert%60%20after%20the%20history%20entry%20check%20completes%20successfully.%20The%20Occupied%20path%20with%20different%20content%20is%20currently%20unreachable%20through%20normal%20operation%20%28the%20Mutex%20serializes%20all%20calls%20and%20the%20first%20check%20prevents%20re-entering%20an%20existing%20sequence%29%2C%20but%20the%20ordering%20assumption%20is%20fragile%20%E2%80%94%20any%20future%20refactor%20that%20loosens%20locking%20or%20adds%20a%20new%20entry%20point%20would%20silently%20activate%20this%20bug.%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftemper-store-sim%2Fsrc%2Ftests.rs%3A292-316%0A**Same-sequence%20different-content%20case%20is%20not%20covered%20by%20the%20test**%0A%0AThe%20test%20verifies%20the%20stale-sequence%20rejection%20and%20same-content%20idempotent%20path%2C%20but%20never%20exercises%20%60save_snapshot%28id%2C%205%2C%20b%22different_content%22%29%60%20after%20the%20initial%20%60save%205%60%20%E2%80%94%20i.e.%2C%20the%20%60sequence_nr%20%3D%3D%20existing_seq%20%26%26%20content%20!%3D%20existing_content%60%20branch.%20That%20branch%20is%20critical%20for%20correctness%20and%20is%20present%20in%20all%20four%20backends.%20Adding%20this%20case%20%28expecting%20%60ConcurrencyViolation%60%29%20would%20complete%20the%20matrix%20described%20in%20the%20PR%20description.%0A%0A&pr=366&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
crates/temper-store-redis/src/event_store.rs:373-403
**Redis TOCTOU: non-atomic check-then-write can corrupt the latest snapshot**

The read-check-write sequence is not atomic in Redis, so two concurrent callers can both pass the monotonicity guard and both issue unconditional `SET` calls. Whichever `SET` lands last wins regardless of sequence ordering. Concretely: Writer A (seq=7) and Writer B (seq=10) both read current=seq 5 and both pass the `> existing` check; Writer B writes seq=10, then Writer A writes seq=7, and the latest snapshot now permanently records seq=7 — a regression the monotonic contract was designed to prevent.

Postgres uses `FOR UPDATE` and Turso uses `TransactionBehavior::Immediate` to make the read-check-write atomic. Redis needs the equivalent: either a Lua script (`EVAL`) that reads and conditionally sets in one atomic op, or a `WATCH`/`MULTI`/`EXEC` optimistic-locking loop. Without this, the Redis backend silently violates the ARN-239 monotonicity guarantee under any concurrent load.

### Issue 2 of 3
crates/temper-store-sim/src/lib.rs:956-978
**Snapshot state mutated before history conflict check completes**

`snapshots.insert(...)` updates the latest-snapshot pointer unconditionally before the history `Entry::Occupied` check can reject a conflict. If the history entry already holds different content at the incoming `sequence_nr` and returns `ConcurrencyViolation`, the `snapshots` map has already been advanced to the new (sequence_nr, snapshot) — leaving the store in a state where `snapshots` references content that was never successfully committed. TigerStyle requires "fail fast before propagating corrupt state."

The fix is to move the `snapshots.insert` after the history entry check completes successfully. The Occupied path with different content is currently unreachable through normal operation (the Mutex serializes all calls and the first check prevents re-entering an existing sequence), but the ordering assumption is fragile — any future refactor that loosens locking or adds a new entry point would silently activate this bug.

### Issue 3 of 3
crates/temper-store-sim/src/tests.rs:292-316
**Same-sequence different-content case is not covered by the test**

The test verifies the stale-sequence rejection and same-content idempotent path, but never exercises `save_snapshot(id, 5, b"different_content")` after the initial `save 5` — i.e., the `sequence_nr == existing_seq && content != existing_content` branch. That branch is critical for correctness and is present in all four backends. Adding this case (expecting `ConcurrencyViolation`) would complete the matrix described in the PR description.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use Entry API for snapshot history ..."](https://github.com/nerdsane/temper/commit/f116c7be063e53507ed1554a75b2534e2413c2fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43651368)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->