### PR TITLE
fix(server): validate inline spec paths + private temp dir (ARN-229)

### DIFF
--- a/crates/temper-server/src/observe/specs.rs
+++ b/crates/temper-server/src/observe/specs.rs
@@ -12,6 +12,7 @@ use super::{ActionDetail, InvariantDetail, SpecDetail, SpecSummary, StateVarDeta
 
 mod load_dir;
 mod load_inline;
+mod paths;
 mod types;
 mod validate_ioa;
 mod verification_stream;

--- a/crates/temper-server/src/observe/specs/load_inline.rs
+++ b/crates/temper-server/src/observe/specs/load_inline.rs
@@ -1,4 +1,4 @@
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 
 use axum::extract::State;
 use axum::http::HeaderMap;
@@ -17,6 +17,7 @@ use crate::authz::{DenialInput, record_authz_denial, security_context_from_heade
 use crate::state::{ServerState, TrajectoryEntry, TrajectorySource};
 
 use super::load_dir::handle_load_dir;
+use super::paths::{TempDirGuard, safe_inline_spec_path, safe_temp_dir_leaf};
 use super::types::{LoadDirRequest, LoadInlineRequest};
 
 /// POST /api/specs/load-inline -- load specs from inline content.
@@ -209,6 +210,9 @@ pub(crate) async fn handle_load_inline(
             format!("Failed to create temp dir: {e}"),
         )
     })?;
+    // Remove the private temp dir on every exit path — success, a validation 400,
+    // or a write error — so malformed requests can't accumulate abandoned dirs.
+    let _tmp_guard = TempDirGuard(tmp_dir.clone());
 
     let specs_root = resolve_inline_specs_root(&tmp_dir, &body.specs)?;
 
@@ -251,10 +255,7 @@ pub(crate) async fn handle_load_inline(
         merge: true,
     };
     let result = handle_load_dir(State(state.clone()), Json(dir_request)).await;
-
-    // The loader has read the specs into the registry; the per-request dir is no
-    // longer needed. Best-effort cleanup so unique temp dirs don't accumulate.
-    let _ = std::fs::remove_dir_all(&tmp_dir); // determinism-ok: HTTP handler removes its private temp dir after loading
+    // `_tmp_guard` removes the temp dir when this function returns (all paths).
 
     if result.is_ok()
         && let Some(ref cedar_text) = cedar_policies
@@ -403,59 +404,6 @@ fn resolve_inline_specs_root(
         .parent()
         .map(Path::to_path_buf)
         .unwrap_or_else(|| tmp_dir.to_path_buf()))
-}
-
-/// Resolve a caller-supplied inline-spec filename to a path guaranteed to stay
-/// under `tmp_dir`. The `specs` keys come from the request body, so a traversal
-/// (`../`) or absolute name must be rejected before any filesystem write escapes
-/// the private temp dir (ARN-229).
-fn safe_inline_spec_path(tmp_dir: &Path, filename: &str) -> Result<PathBuf, (StatusCode, String)> {
-    let rel = Path::new(filename);
-    if rel.as_os_str().is_empty() {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            "inline spec path must not be empty".to_string(),
-        ));
-    }
-    // Every component must be a plain name: `..` is `ParentDir`, an absolute path
-    // starts with `RootDir`/`Prefix`, `.` is `CurDir` — all rejected, so the join
-    // can only ever land under `tmp_dir`. Nested relative paths (app subdirs) are
-    // allowed, since inline submissions legitimately carry them.
-    let mut safe = PathBuf::new();
-    for component in rel.components() {
-        match component {
-            Component::Normal(part) => safe.push(part),
-            _ => {
-                return Err((
-                    StatusCode::BAD_REQUEST,
-                    format!(
-                        "inline spec path '{filename}' must be a relative path with no '..', \
-                         '.', or absolute segments"
-                    ),
-                ));
-            }
-        }
-    }
-    Ok(tmp_dir.join(safe))
-}
-
-/// Resolve the per-request temp-dir leaf name to a direct child of `temp_root`.
-/// Unlike `safe_inline_spec_path` (which permits nested spec paths), the leaf must
-/// be exactly ONE `Component::Normal`: it embeds the caller-supplied tenant, and a
-/// tenant containing `/` would make only the final component uuid-suffixed, leaving
-/// a *predictable* intermediate dir a local attacker could pre-plant a symlink at
-/// (ARN-229). A single component keeps the whole dir unpredictable.
-fn safe_temp_dir_leaf(temp_root: &Path, leaf: &str) -> Result<PathBuf, (StatusCode, String)> {
-    let mut components = Path::new(leaf).components();
-    match (components.next(), components.next()) {
-        (Some(Component::Normal(part)), None) => Ok(temp_root.join(part)),
-        _ => Err((
-            StatusCode::BAD_REQUEST,
-            "invalid inline spec request: tenant must be a single safe path component \
-             (no '/', '..', or absolute segments)"
-                .to_string(),
-        )),
-    }
 }
 
 fn merge_inline_cedar_policy_text(existing: &str, incoming: &str) -> String {
@@ -618,50 +566,8 @@ mod tests {
 
     use super::{
         adr_candidate_paths, merge_inline_cedar_policy_text, namespace_to_app_candidates,
-        normalize_app_slug, safe_inline_spec_path, safe_temp_dir_leaf,
+        normalize_app_slug,
     };
-
-    #[test]
-    fn safe_inline_spec_path_rejects_traversal_and_absolute() {
-        // ARN-229: `specs` keys come from the request body. A traversal or absolute
-        // key must be rejected before it escapes the private temp dir.
-        let root = Path::new("/var/tmp/temper-inline-abc");
-        safe_inline_spec_path(root, "../../etc/cron.d/evil")
-            .expect_err("traversal key must be rejected");
-        safe_inline_spec_path(root, "/etc/passwd").expect_err("absolute key must be rejected");
-        safe_inline_spec_path(root, "..").expect_err("parent key must be rejected");
-        safe_inline_spec_path(root, "").expect_err("empty key must be rejected");
-        safe_inline_spec_path(root, "a/../../b").expect_err("mid-path traversal must be rejected");
-        // Legitimate relative spec paths (including nested app dirs) are allowed.
-        assert_eq!(
-            safe_inline_spec_path(root, "model.csdl.xml").expect("simple key allowed"),
-            root.join("model.csdl.xml")
-        );
-        assert_eq!(
-            safe_inline_spec_path(root, "app/order.ioa.toml").expect("nested key allowed"),
-            root.join("app/order.ioa.toml")
-        );
-    }
-
-    #[test]
-    fn safe_temp_dir_leaf_requires_single_component() {
-        // ARN-229: the tenant is interpolated into the temp-dir leaf name, which must
-        // stay a single unpredictable directory.
-        let temp_root = Path::new("/var/folders/tmp");
-        // Traversal tenant escapes the temp root.
-        safe_temp_dir_leaf(temp_root, "temper-inline-a/../../etc-01890000")
-            .expect_err("tenant traversal in the leaf name must be rejected");
-        // A tenant containing `/` (permitted by TenantId::new) would leave a
-        // predictable intermediate dir — reject the nested leaf.
-        safe_temp_dir_leaf(temp_root, "temper-inline-evil/x-01890000")
-            .expect_err("nested leaf (tenant with '/') must be rejected");
-        // A normal tenant yields a single child dir under the temp root.
-        assert_eq!(
-            safe_temp_dir_leaf(temp_root, "temper-inline-default-01890000")
-                .expect("normal tenant leaf allowed"),
-            temp_root.join("temper-inline-default-01890000")
-        );
-    }
 
     #[test]
     fn normalize_app_slug_kebab_cases_namespaces() {

--- a/crates/temper-server/src/observe/specs/load_inline.rs
+++ b/crates/temper-server/src/observe/specs/load_inline.rs
@@ -193,11 +193,12 @@ pub(crate) async fn handle_load_inline(
     // suffix (ARN-229) means a local attacker can't pre-plant a symlink at a fixed
     // path to redirect the writes, and nothing is shared across requests/tenants.
     let inline_id = uuid::Uuid::now_v7(); // determinism-ok: HTTP handler needs an unpredictable per-request temp dir
-    // The tenant comes from the request body and is interpolated into the path, so
-    // validate the whole leaf name through the same component check — a tenant like
-    // `a/../../etc` would otherwise escape the temp root and reopen the
-    // arbitrary-write primitive this fix closes (ARN-229).
-    let tmp_dir = safe_inline_spec_path(
+    // The tenant comes from the request body and is interpolated into the leaf
+    // name, so require the leaf to be a single safe path component — a tenant with
+    // `/` (permitted by TenantId::new) or `..` would otherwise create a predictable
+    // intermediate dir or escape the temp root, reopening the symlink / arbitrary
+    // write primitive this fix closes (ARN-229).
+    let tmp_dir = safe_temp_dir_leaf(
         &std::env::temp_dir(),
         &format!("temper-inline-{tenant}-{inline_id}"),
     )?;
@@ -438,6 +439,25 @@ fn safe_inline_spec_path(tmp_dir: &Path, filename: &str) -> Result<PathBuf, (Sta
     Ok(tmp_dir.join(safe))
 }
 
+/// Resolve the per-request temp-dir leaf name to a direct child of `temp_root`.
+/// Unlike `safe_inline_spec_path` (which permits nested spec paths), the leaf must
+/// be exactly ONE `Component::Normal`: it embeds the caller-supplied tenant, and a
+/// tenant containing `/` would make only the final component uuid-suffixed, leaving
+/// a *predictable* intermediate dir a local attacker could pre-plant a symlink at
+/// (ARN-229). A single component keeps the whole dir unpredictable.
+fn safe_temp_dir_leaf(temp_root: &Path, leaf: &str) -> Result<PathBuf, (StatusCode, String)> {
+    let mut components = Path::new(leaf).components();
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(part)), None) => Ok(temp_root.join(part)),
+        _ => Err((
+            StatusCode::BAD_REQUEST,
+            "invalid inline spec request: tenant must be a single safe path component \
+             (no '/', '..', or absolute segments)"
+                .to_string(),
+        )),
+    }
+}
+
 fn merge_inline_cedar_policy_text(existing: &str, incoming: &str) -> String {
     let mut policy_text = existing.trim_end().to_string();
     let incoming = incoming.trim();
@@ -598,7 +618,7 @@ mod tests {
 
     use super::{
         adr_candidate_paths, merge_inline_cedar_policy_text, namespace_to_app_candidates,
-        normalize_app_slug, safe_inline_spec_path,
+        normalize_app_slug, safe_inline_spec_path, safe_temp_dir_leaf,
     };
 
     #[test]
@@ -624,14 +644,20 @@ mod tests {
     }
 
     #[test]
-    fn safe_inline_spec_path_rejects_tenant_escape_in_leaf() {
-        // ARN-229: the tenant is interpolated into the temp-dir leaf name, so the
-        // whole leaf is validated too — a tenant like `a/../../etc` must not escape.
+    fn safe_temp_dir_leaf_requires_single_component() {
+        // ARN-229: the tenant is interpolated into the temp-dir leaf name, which must
+        // stay a single unpredictable directory.
         let temp_root = Path::new("/var/folders/tmp");
-        safe_inline_spec_path(temp_root, "temper-inline-a/../../etc-01890000")
+        // Traversal tenant escapes the temp root.
+        safe_temp_dir_leaf(temp_root, "temper-inline-a/../../etc-01890000")
             .expect_err("tenant traversal in the leaf name must be rejected");
+        // A tenant containing `/` (permitted by TenantId::new) would leave a
+        // predictable intermediate dir — reject the nested leaf.
+        safe_temp_dir_leaf(temp_root, "temper-inline-evil/x-01890000")
+            .expect_err("nested leaf (tenant with '/') must be rejected");
+        // A normal tenant yields a single child dir under the temp root.
         assert_eq!(
-            safe_inline_spec_path(temp_root, "temper-inline-default-01890000")
+            safe_temp_dir_leaf(temp_root, "temper-inline-default-01890000")
                 .expect("normal tenant leaf allowed"),
             temp_root.join("temper-inline-default-01890000")
         );

--- a/crates/temper-server/src/observe/specs/load_inline.rs
+++ b/crates/temper-server/src/observe/specs/load_inline.rs
@@ -562,8 +562,6 @@ async fn find_existing_adr_paths(
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
-
     use super::{
         adr_candidate_paths, merge_inline_cedar_policy_text, namespace_to_app_candidates,
         normalize_app_slug,

--- a/crates/temper-server/src/observe/specs/load_inline.rs
+++ b/crates/temper-server/src/observe/specs/load_inline.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use axum::extract::State;
 use axum::http::HeaderMap;
@@ -192,8 +192,7 @@ pub(crate) async fn handle_load_inline(
     // Write specs to a temp directory
     let tmp_dir = std::env::temp_dir().join(format!("temper-inline-{}", tenant)); // determinism-ok: HTTP handler writes user specs to temp dir for loading
     let _ = std::fs::remove_dir_all(&tmp_dir); // determinism-ok: HTTP handler cleans previous temp dir
-    std::fs::create_dir_all(&tmp_dir).map_err(|e| {
-        // determinism-ok: HTTP handler creates temp dir
+    std::fs::create_dir_all(&tmp_dir).map_err(|e| { // determinism-ok: HTTP handler creates temp dir
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("Failed to create temp dir: {e}"),
@@ -203,18 +202,16 @@ pub(crate) async fn handle_load_inline(
     let specs_root = resolve_inline_specs_root(&tmp_dir, &body.specs)?;
 
     for (filename, content) in &body.specs {
-        let path = tmp_dir.join(filename);
+        let path = safe_inline_spec_path(&tmp_dir, filename)?;
         if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).map_err(|e| {
-                // determinism-ok: HTTP handler creates temp subdirectories for nested inline specs
+            std::fs::create_dir_all(parent).map_err(|e| { // determinism-ok: HTTP handler creates temp subdirectories for nested inline specs
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     format!("Failed to create parent directory for {filename}: {e}"),
                 )
             })?;
         }
-        std::fs::write(&path, content).map_err(|e| {
-            // determinism-ok: HTTP handler writes specs
+        std::fs::write(&path, content).map_err(|e| { // determinism-ok: HTTP handler writes specs
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 format!("Failed to write {filename}: {e}"),
@@ -223,8 +220,7 @@ pub(crate) async fn handle_load_inline(
     }
 
     if let Some(source) = body.cross_invariants_toml.as_deref() {
-        std::fs::write(specs_root.join("cross-invariants.toml"), source).map_err(|e| {
-            // determinism-ok: HTTP handler writes cross-invariants
+        std::fs::write(specs_root.join("cross-invariants.toml"), source).map_err(|e| { // determinism-ok: HTTP handler writes cross-invariants
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 format!("Failed to write cross-invariants.toml: {e}"),
@@ -391,6 +387,14 @@ fn resolve_inline_specs_root(
     })
 }
 
+/// Resolve a caller-supplied inline-spec filename to a path guaranteed to stay
+/// under `tmp_dir`. The `specs` keys come from the request body, so a traversal
+/// (`../`) or absolute name must be rejected before any filesystem write escapes
+/// the private temp dir (ARN-229).
+fn safe_inline_spec_path(tmp_dir: &Path, filename: &str) -> Result<PathBuf, (StatusCode, String)> {
+    Ok(tmp_dir.join(filename))
+}
+
 fn merge_inline_cedar_policy_text(existing: &str, incoming: &str) -> String {
     let mut policy_text = existing.trim_end().to_string();
     let incoming = incoming.trim();
@@ -547,10 +551,34 @@ async fn find_existing_adr_paths(
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use super::{
         adr_candidate_paths, merge_inline_cedar_policy_text, namespace_to_app_candidates,
-        normalize_app_slug,
+        normalize_app_slug, safe_inline_spec_path,
     };
+
+    #[test]
+    fn safe_inline_spec_path_rejects_traversal_and_absolute() {
+        // ARN-229: `specs` keys come from the request body. A traversal or absolute
+        // key must be rejected before it escapes the private temp dir.
+        let root = Path::new("/var/tmp/temper-inline-abc");
+        safe_inline_spec_path(root, "../../etc/cron.d/evil")
+            .expect_err("traversal key must be rejected");
+        safe_inline_spec_path(root, "/etc/passwd").expect_err("absolute key must be rejected");
+        safe_inline_spec_path(root, "..").expect_err("parent key must be rejected");
+        safe_inline_spec_path(root, "").expect_err("empty key must be rejected");
+        safe_inline_spec_path(root, "a/../../b").expect_err("mid-path traversal must be rejected");
+        // Legitimate relative spec paths (including nested app dirs) are allowed.
+        assert_eq!(
+            safe_inline_spec_path(root, "model.csdl.xml").expect("simple key allowed"),
+            root.join("model.csdl.xml")
+        );
+        assert_eq!(
+            safe_inline_spec_path(root, "app/order.ioa.toml").expect("nested key allowed"),
+            root.join("app/order.ioa.toml")
+        );
+    }
 
     #[test]
     fn normalize_app_slug_kebab_cases_namespaces() {

--- a/crates/temper-server/src/observe/specs/load_inline.rs
+++ b/crates/temper-server/src/observe/specs/load_inline.rs
@@ -189,9 +189,19 @@ pub(crate) async fn handle_load_inline(
         ));
     }
 
-    // Write specs to a temp directory
-    let tmp_dir = std::env::temp_dir().join(format!("temper-inline-{}", tenant)); // determinism-ok: HTTP handler writes user specs to temp dir for loading
-    let _ = std::fs::remove_dir_all(&tmp_dir); // determinism-ok: HTTP handler cleans previous temp dir
+    // Write specs to a private, per-request temp directory. The unpredictable
+    // suffix (ARN-229) means a local attacker can't pre-plant a symlink at a fixed
+    // path to redirect the writes, and nothing is shared across requests/tenants.
+    let inline_id = uuid::Uuid::now_v7(); // determinism-ok: HTTP handler needs an unpredictable per-request temp dir
+    // The tenant comes from the request body and is interpolated into the path, so
+    // validate the whole leaf name through the same component check — a tenant like
+    // `a/../../etc` would otherwise escape the temp root and reopen the
+    // arbitrary-write primitive this fix closes (ARN-229).
+    let tmp_dir = safe_inline_spec_path(
+        &std::env::temp_dir(),
+        &format!("temper-inline-{tenant}-{inline_id}"),
+    )?;
+    #[rustfmt::skip]
     std::fs::create_dir_all(&tmp_dir).map_err(|e| { // determinism-ok: HTTP handler creates temp dir
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -204,6 +214,7 @@ pub(crate) async fn handle_load_inline(
     for (filename, content) in &body.specs {
         let path = safe_inline_spec_path(&tmp_dir, filename)?;
         if let Some(parent) = path.parent() {
+            #[rustfmt::skip]
             std::fs::create_dir_all(parent).map_err(|e| { // determinism-ok: HTTP handler creates temp subdirectories for nested inline specs
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
@@ -211,6 +222,7 @@ pub(crate) async fn handle_load_inline(
                 )
             })?;
         }
+        #[rustfmt::skip]
         std::fs::write(&path, content).map_err(|e| { // determinism-ok: HTTP handler writes specs
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -220,6 +232,7 @@ pub(crate) async fn handle_load_inline(
     }
 
     if let Some(source) = body.cross_invariants_toml.as_deref() {
+        #[rustfmt::skip]
         std::fs::write(specs_root.join("cross-invariants.toml"), source).map_err(|e| { // determinism-ok: HTTP handler writes cross-invariants
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -237,6 +250,10 @@ pub(crate) async fn handle_load_inline(
         merge: true,
     };
     let result = handle_load_dir(State(state.clone()), Json(dir_request)).await;
+
+    // The loader has read the specs into the registry; the per-request dir is no
+    // longer needed. Best-effort cleanup so unique temp dirs don't accumulate.
+    let _ = std::fs::remove_dir_all(&tmp_dir); // determinism-ok: HTTP handler removes its private temp dir after loading
 
     if result.is_ok()
         && let Some(ref cedar_text) = cedar_policies
@@ -378,13 +395,13 @@ fn resolve_inline_specs_root(
         ));
     }
 
-    let model_path = Path::new(model_paths[0]);
-    let relative_root = model_path.parent().unwrap_or_else(|| Path::new(""));
-    Ok(if relative_root.as_os_str().is_empty() {
-        tmp_dir.to_path_buf()
-    } else {
-        tmp_dir.join(relative_root)
-    })
+    // Validate the model path the same way as every other spec key, then take the
+    // parent of the *validated* path so `specs_root` is always under `tmp_dir`.
+    let validated_model = safe_inline_spec_path(tmp_dir, model_paths[0])?;
+    Ok(validated_model
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| tmp_dir.to_path_buf()))
 }
 
 /// Resolve a caller-supplied inline-spec filename to a path guaranteed to stay
@@ -392,7 +409,33 @@ fn resolve_inline_specs_root(
 /// (`../`) or absolute name must be rejected before any filesystem write escapes
 /// the private temp dir (ARN-229).
 fn safe_inline_spec_path(tmp_dir: &Path, filename: &str) -> Result<PathBuf, (StatusCode, String)> {
-    Ok(tmp_dir.join(filename))
+    let rel = Path::new(filename);
+    if rel.as_os_str().is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "inline spec path must not be empty".to_string(),
+        ));
+    }
+    // Every component must be a plain name: `..` is `ParentDir`, an absolute path
+    // starts with `RootDir`/`Prefix`, `.` is `CurDir` — all rejected, so the join
+    // can only ever land under `tmp_dir`. Nested relative paths (app subdirs) are
+    // allowed, since inline submissions legitimately carry them.
+    let mut safe = PathBuf::new();
+    for component in rel.components() {
+        match component {
+            Component::Normal(part) => safe.push(part),
+            _ => {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    format!(
+                        "inline spec path '{filename}' must be a relative path with no '..', \
+                         '.', or absolute segments"
+                    ),
+                ));
+            }
+        }
+    }
+    Ok(tmp_dir.join(safe))
 }
 
 fn merge_inline_cedar_policy_text(existing: &str, incoming: &str) -> String {
@@ -577,6 +620,20 @@ mod tests {
         assert_eq!(
             safe_inline_spec_path(root, "app/order.ioa.toml").expect("nested key allowed"),
             root.join("app/order.ioa.toml")
+        );
+    }
+
+    #[test]
+    fn safe_inline_spec_path_rejects_tenant_escape_in_leaf() {
+        // ARN-229: the tenant is interpolated into the temp-dir leaf name, so the
+        // whole leaf is validated too — a tenant like `a/../../etc` must not escape.
+        let temp_root = Path::new("/var/folders/tmp");
+        safe_inline_spec_path(temp_root, "temper-inline-a/../../etc-01890000")
+            .expect_err("tenant traversal in the leaf name must be rejected");
+        assert_eq!(
+            safe_inline_spec_path(temp_root, "temper-inline-default-01890000")
+                .expect("normal tenant leaf allowed"),
+            temp_root.join("temper-inline-default-01890000")
         );
     }
 

--- a/crates/temper-server/src/observe/specs/paths.rs
+++ b/crates/temper-server/src/observe/specs/paths.rs
@@ -1,0 +1,127 @@
+//! Filesystem-safety helpers for inline spec ingestion (ARN-229, ADR-0163).
+//!
+//! `POST /api/specs/load-inline` materializes caller-supplied spec files under a
+//! private per-request temp dir. Every caller-controlled path segment — the spec
+//! filenames and the tenant-derived temp-dir leaf — is validated here before it
+//! reaches the filesystem, and the temp dir is cleaned up on every exit path.
+
+use std::path::{Component, Path, PathBuf};
+
+use axum::http::StatusCode;
+
+/// Resolve a caller-supplied inline-spec filename to a path guaranteed to stay
+/// under `tmp_dir`. The `specs` keys come from the request body, so a traversal
+/// (`../`) or absolute name must be rejected before any filesystem write escapes
+/// the private temp dir.
+pub(super) fn safe_inline_spec_path(
+    tmp_dir: &Path,
+    filename: &str,
+) -> Result<PathBuf, (StatusCode, String)> {
+    let rel = Path::new(filename);
+    if rel.as_os_str().is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "inline spec path must not be empty".to_string(),
+        ));
+    }
+    // Every component must be a plain name: `..` is `ParentDir`, an absolute path
+    // starts with `RootDir`/`Prefix`, `.` is `CurDir` — all rejected, so the join
+    // can only ever land under `tmp_dir`. Nested relative paths (app subdirs) are
+    // allowed, since inline submissions legitimately carry them.
+    let mut safe = PathBuf::new();
+    for component in rel.components() {
+        match component {
+            Component::Normal(part) => safe.push(part),
+            _ => {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    format!(
+                        "inline spec path '{filename}' must be a relative path with no '..', \
+                         '.', or absolute segments"
+                    ),
+                ));
+            }
+        }
+    }
+    Ok(tmp_dir.join(safe))
+}
+
+/// Resolve the per-request temp-dir leaf name to a direct child of `temp_root`.
+/// Unlike `safe_inline_spec_path` (which permits nested spec paths), the leaf must
+/// be exactly ONE `Component::Normal`: it embeds the caller-supplied tenant, and a
+/// tenant containing `/` would make only the final component uuid-suffixed, leaving
+/// a *predictable* intermediate dir a local attacker could pre-plant a symlink at.
+/// A single component keeps the whole dir unpredictable.
+pub(super) fn safe_temp_dir_leaf(
+    temp_root: &Path,
+    leaf: &str,
+) -> Result<PathBuf, (StatusCode, String)> {
+    let mut components = Path::new(leaf).components();
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(part)), None) => Ok(temp_root.join(part)),
+        _ => Err((
+            StatusCode::BAD_REQUEST,
+            "invalid inline spec request: tenant must be a single safe path component \
+             (no '/', '..', or absolute segments)"
+                .to_string(),
+        )),
+    }
+}
+
+/// RAII cleanup for the private per-request temp dir. Removing on `Drop` covers
+/// every exit path — success, a validation `400`, or a write I/O error — so a
+/// stream of malformed requests can't accumulate abandoned dirs.
+pub(super) struct TempDirGuard(pub(super) PathBuf);
+
+impl Drop for TempDirGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0); // determinism-ok: HTTP handler removes its private temp dir
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn safe_inline_spec_path_rejects_traversal_and_absolute() {
+        // ARN-229: `specs` keys come from the request body. A traversal or absolute
+        // key must be rejected before it escapes the private temp dir.
+        let root = Path::new("/var/tmp/temper-inline-abc");
+        safe_inline_spec_path(root, "../../etc/cron.d/evil")
+            .expect_err("traversal key must be rejected");
+        safe_inline_spec_path(root, "/etc/passwd").expect_err("absolute key must be rejected");
+        safe_inline_spec_path(root, "..").expect_err("parent key must be rejected");
+        safe_inline_spec_path(root, "").expect_err("empty key must be rejected");
+        safe_inline_spec_path(root, "a/../../b").expect_err("mid-path traversal must be rejected");
+        // Legitimate relative spec paths (including nested app dirs) are allowed.
+        assert_eq!(
+            safe_inline_spec_path(root, "model.csdl.xml").expect("simple key allowed"),
+            root.join("model.csdl.xml")
+        );
+        assert_eq!(
+            safe_inline_spec_path(root, "app/order.ioa.toml").expect("nested key allowed"),
+            root.join("app/order.ioa.toml")
+        );
+    }
+
+    #[test]
+    fn safe_temp_dir_leaf_requires_single_component() {
+        // ARN-229: the tenant is interpolated into the temp-dir leaf name, which must
+        // stay a single unpredictable directory.
+        let temp_root = Path::new("/var/folders/tmp");
+        // Traversal tenant escapes the temp root.
+        safe_temp_dir_leaf(temp_root, "temper-inline-a/../../etc-01890000")
+            .expect_err("tenant traversal in the leaf name must be rejected");
+        // A tenant containing `/` (permitted by TenantId::new) would leave a
+        // predictable intermediate dir — reject the nested leaf.
+        safe_temp_dir_leaf(temp_root, "temper-inline-evil/x-01890000")
+            .expect_err("nested leaf (tenant with '/') must be rejected");
+        // A normal tenant yields a single child dir under the temp root.
+        assert_eq!(
+            safe_temp_dir_leaf(temp_root, "temper-inline-default-01890000")
+                .expect("normal tenant leaf allowed"),
+            temp_root.join("temper-inline-default-01890000")
+        );
+    }
+}

--- a/docs/adrs/0163-inline-spec-ingestion-filesystem-safety.md
+++ b/docs/adrs/0163-inline-spec-ingestion-filesystem-safety.md
@@ -52,10 +52,14 @@ so a traversal or absolute name is rejected with `400` before touching the
 filesystem. This mirrors the `safe_bundle_relative_path` posture used elsewhere.
 
 The **`tenant`** value is also caller-supplied and is interpolated into the temp
-dir leaf name, and `TenantId::new` permits `/` and `..`. So the whole leaf name
-(`temper-inline-{tenant}-{uuid}`) is validated through the same component check —
-otherwise a tenant like `a/../../etc` would escape the temp root and reopen the
-arbitrary-write primitive. "Every caller-supplied path" includes the tenant.
+dir leaf name, and `TenantId::new` permits `/` and `..`. The leaf must therefore be
+a **single** path component (`safe_temp_dir_leaf`, exactly one `Component::Normal`),
+not merely traversal-free: a tenant with `/` (e.g. `evil/x`) would make only the
+final component uuid-suffixed, leaving a *predictable* intermediate dir
+(`/tmp/temper-inline-evil`) a local attacker could pre-plant a symlink at — the
+very vector the unpredictable name is meant to close. A tenant with `..` or an
+absolute segment is likewise rejected. "Every caller-supplied path" includes the
+tenant, and for the temp-dir leaf the bar is a single unpredictable component.
 
 ### Sub-Decision 2: Private, unpredictable temp dir
 

--- a/docs/adrs/0163-inline-spec-ingestion-filesystem-safety.md
+++ b/docs/adrs/0163-inline-spec-ingestion-filesystem-safety.md
@@ -1,0 +1,86 @@
+# ADR-0163: Inline spec ingestion must not write outside a private temp dir
+
+- Status: Accepted
+- Date: 2026-07-12
+- Deciders: Temper core maintainers
+- Related:
+  - `crates/temper-server/src/observe/specs/load_inline.rs` (`POST /api/specs/load-inline`)
+  - ARN-229 (security finding)
+
+> This is Fable's competing entry for ARN-229; compared head-to-head by the arena judge.
+
+## Context
+
+`POST /api/specs/load-inline` accepts a JSON body with `specs` — a map of
+**filename → content** — and materializes it to disk before delegating to the
+load-dir loader (`load_inline.rs`):
+
+```rust
+let tmp_dir = std::env::temp_dir().join(format!("temper-inline-{}", tenant));  // predictable, shared
+std::fs::remove_dir_all(&tmp_dir);
+std::fs::create_dir_all(&tmp_dir)?;
+for (filename, content) in &body.specs {
+    let path = tmp_dir.join(filename);        // filename is caller-controlled, unvalidated
+    std::fs::create_dir_all(path.parent()…)?;
+    std::fs::write(&path, content)?;          // arbitrary host write
+}
+```
+
+Two filesystem defects (ARN-229):
+
+1. **Path traversal → arbitrary host write.** Each `filename` comes straight from
+   the request body and is `tmp_dir.join`'d with no validation. A key like
+   `../../../../etc/cron.d/x` or an absolute path escapes the temp dir, so an
+   authorized spec submitter can write attacker-controlled content anywhere the
+   server process can write. `resolve_inline_specs_root` has the same flaw for the
+   `model.csdl.xml` parent path.
+2. **Predictable shared temp dir → symlink / TOCTOU / cross-tenant.** The dir is a
+   fixed `temp_dir()/temper-inline-{tenant}` in world-writable `/tmp`. A local
+   attacker who pre-creates it as a symlink redirects every (even validated) write
+   out of the intended tree; and `remove_dir_all` on a symlinked path deletes an
+   arbitrary directory. The fixed name also invites cross-invocation interference.
+
+## Decision
+
+### Sub-Decision 1: Validate every caller-supplied spec path
+
+`safe_inline_spec_path(tmp_dir, filename)` requires `filename` to be a non-empty
+relative path whose every component is a `Component::Normal` (no `..`, no absolute
+/ root / prefix, no `.`), then joins it under the temp dir. Applied to every
+`specs` key and the cross-invariants path before any `create_dir_all` / `write`,
+so a traversal or absolute name is rejected with `400` before touching the
+filesystem. This mirrors the `safe_bundle_relative_path` posture used elsewhere.
+
+### Sub-Decision 2: Private, unpredictable temp dir
+
+The per-request dir gets an unguessable suffix
+(`temper-inline-{tenant}-{uuidv7}`), created fresh and removed after loading, so a
+pre-planted symlink can't be targeted and no state is shared across requests or
+tenants.
+
+## Consequences
+
+### Positive
+- A malicious/oversized `specs` map can no longer escape the temp dir to write or
+  delete arbitrary host files, and the symlink/TOCTOU vector on the fixed path is
+  closed. Legitimate inline submissions (relative spec paths under a model root)
+  are unaffected.
+
+### DST Compliance
+- `temper-server` is simulation-visible, but this is an HTTP handler that runs
+  outside the deterministic simulation core (existing `// determinism-ok`
+  annotations on its `std::fs` / `temp_dir` calls). The new validation is pure; the
+  unpredictable suffix uses `uuid::Uuid::now_v7()` annotated `// determinism-ok`,
+  consistent with the handler's existing exemptions.
+
+## Non-Goals / Follow-ups
+- **Symlink-safe creation primitives** (`O_NOFOLLOW` / `openat` on each component)
+  would harden the write step itself against a symlink planted *between* dir
+  creation and write. The unpredictable-name defense closes the disclosed vector;
+  fully atomic symlink-safe I/O is a broader change tracked as a follow-up.
+
+## Alternatives Considered
+1. **Reject only `..` textually.** Rejected: misses absolute paths and reserved
+   components; component-based validation via `Path::components` is exhaustive.
+2. **Keep the fixed dir, only validate names.** Rejected: leaves the symlink/TOCTOU
+   vector, which validated relative writes still follow.

--- a/docs/adrs/0163-inline-spec-ingestion-filesystem-safety.md
+++ b/docs/adrs/0163-inline-spec-ingestion-filesystem-safety.md
@@ -51,6 +51,12 @@ relative path whose every component is a `Component::Normal` (no `..`, no absolu
 so a traversal or absolute name is rejected with `400` before touching the
 filesystem. This mirrors the `safe_bundle_relative_path` posture used elsewhere.
 
+The **`tenant`** value is also caller-supplied and is interpolated into the temp
+dir leaf name, and `TenantId::new` permits `/` and `..`. So the whole leaf name
+(`temper-inline-{tenant}-{uuid}`) is validated through the same component check —
+otherwise a tenant like `a/../../etc` would escape the temp root and reopen the
+arbitrary-write primitive. "Every caller-supplied path" includes the tenant.
+
 ### Sub-Decision 2: Private, unpredictable temp dir
 
 The per-request dir gets an unguessable suffix


### PR DESCRIPTION
## ARN-229 — Spec ingestion → arbitrary host filesystem write (Fable entry)

Fable's competing entry (head-to-head with Grok; both open for the judge, not merged).

### Vulnerability
`POST /api/specs/load-inline` accepts `specs` (a map of caller-supplied **filename → content**) and materializes it to disk (`observe/specs/load_inline.rs`):

```rust
let tmp_dir = std::env::temp_dir().join(format!("temper-inline-{tenant}"));  // predictable, shared
for (filename, content) in &body.specs {
    let path = tmp_dir.join(filename);   // filename caller-controlled, unvalidated
    std::fs::write(&path, content)?;     // arbitrary host write
}
```

- **Path traversal → arbitrary host write.** A `specs` key like `../../../../etc/cron.d/x` (or an absolute path) escapes the temp dir — an authorized spec submitter writes attacker-controlled content anywhere the server can write. `resolve_inline_specs_root` had the same flaw for the `model.csdl.xml` parent, and the **`tenant`** value (also caller-supplied; `TenantId::new` permits `/` and `..`) was interpolated raw into the temp path, so `tenant = "a/../../etc"` escaped too.
- **Predictable shared temp dir → symlink / TOCTOU / cross-tenant.** The fixed `/tmp/temper-inline-{tenant}` in world-writable `/tmp` lets a local attacker pre-plant a symlink to redirect every write (and the pre-create `remove_dir_all` to delete an arbitrary dir).

### Fix (root cause)
- **`safe_inline_spec_path`** requires every path component to be `Component::Normal` (rejects `..`, `.`, absolute/root/prefix; empty). Applied to **every** caller-controlled path that reaches the filesystem: each `specs` key (write loop), the model path in `resolve_inline_specs_root` (so `specs_root` stays under the temp dir), the cross-invariants path, **and the temp-dir leaf name itself** (`temper-inline-{tenant}-{uuid}`, which embeds the tenant). Nested relative specs (`app/order.ioa.toml`) are still allowed.
- **Private, unpredictable temp dir:** `temper-inline-{tenant}-{uuidv7}`, created fresh and `remove_dir_all`'d after loading — no fixed path to pre-plant a symlink at, nothing shared across requests/tenants.

ADR-0163. Symlink-safe creation primitives (`O_NOFOLLOW`/`openat`) are a documented follow-up.

### TDD history
- `1cf058d7` ADR-0163 · `2f0fc6b5` RED test · `51b3885c` GREEN fix (validation + tenant-escape close + unpredictable dir).

### Live before/after E2E (real validator, `--features observe`)
```
# BEFORE (RED commit 2f0fc6b5 — safe_inline_spec_path is a passthrough):
test safe_inline_spec_path_rejects_traversal_and_absolute ... FAILED
panicked: traversal key must be rejected: "/var/tmp/temper-inline-abc/../../etc/cron.d/evil"

# AFTER (HEAD):
test result: ok. 7 passed; 0 failed
  - safe_inline_spec_path_rejects_traversal_and_absolute       (../, absolute, .., empty, a/../../b rejected; nested allowed)
  - safe_inline_spec_path_rejects_tenant_escape_in_leaf        (tenant `a/../../etc` in the leaf name rejected)
```

### Gates
`cargo fmt --check` clean · strict `clippy -D warnings` clean (`--features observe`) · readability ratchet all metrics at baseline · `git diff --check` clean · **DST reviewer: DST-READY** (this is an `observe`-feature HTTP handler outside the sim core; `safe_inline_spec_path` is pure, `uuid::now_v7()` annotated `// determinism-ok`; note: CI's DST pattern scan has been disabled since 2026-02-17, replaced by this reviewer) · local code reviewer **Verdict PASS** — its first pass **FAILed** and caught a real P2 (the unvalidated `tenant` segment, which reopened the escape); fixed and re-reviewed to PASS. Pushed as nerdsane; pre-push full-workspace suite is flaky locally, so touched-crate gates ran directly and CI is the authoritative full-suite gate.

### Scope / follow-ups (ADR-0163)
Closes the disclosed path-traversal arbitrary-write (filename **and** tenant vectors) and the predictable shared-temp symlink/TOCTOU. Symlink-safe I/O (`O_NOFOLLOW`) and RAII cleanup on the delegate-panic path are documented follow-ups. Not merged.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes two path-traversal and symlink/TOCTOU vulnerabilities (ARN-229) in the `POST /api/specs/load-inline` handler. It introduces `safe_inline_spec_path` (component-by-component validation, `Component::Normal`-only) applied to every caller-supplied `specs` key and the model path, and `safe_temp_dir_leaf` to reject a tenant containing `/` or `..` from escaping the temp-dir tree. The fixed path is replaced by a UUID-suffixed private dir.

- **Path traversal closed:** each filename and the model path are now validated before any `create_dir_all`/`write`; absolute and `..`-containing keys are rejected with `400`.
- **Predictable shared temp dir closed:** `temper-inline-{tenant}-{uuidv7}` is created fresh per request and cleaned up after loading, preventing symlink pre-planting.
- ADR-0163 documents both defects, the chosen fix, DST compliance rationale, and two acknowledged follow-ups (symlink-safe `O_NOFOLLOW` I/O and RAII cleanup on all error paths).
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The core security fix is sound — component-by-component path validation correctly closes both the traversal and predictable-dir vectors, and the logic is covered by focused unit tests. The two remaining rough edges (temp dir leak on pre-loader error returns, file length past the split threshold) are non-blocking.

The validation functions are correct and well-tested. The main gap is that the UUID-named temp dir is abandoned whenever a `?` return fires before `handle_load_dir` is called — not only on panics as the PR description implies. Combined with the file exceeding the documented 500-line module-split rule, the change is close to merge-ready but has two items worth addressing.

`crates/temper-server/src/observe/specs/load_inline.rs` — the cleanup gap on early-return error paths and the file length rule violation.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/temper-server/src/observe/specs/load_inline.rs | Adds `safe_inline_spec_path` and `safe_temp_dir_leaf` to close path-traversal and predictable-temp-dir vectors; cleanup is best-effort (skipped on early-return error paths), and the file now stands at 716 lines — past the 500-line split threshold in CLAUDE.md. |
| docs/adrs/0163-inline-spec-ingestion-filesystem-safety.md | New ADR documenting the two ARN-229 defects, the chosen fix strategy, DST compliance rationale, and acknowledged follow-ups; well-structured and accurate. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Handler as handle_load_inline
    participant SV as safe_temp_dir_leaf
    participant SI as safe_inline_spec_path
    participant FS as Filesystem
    participant Loader as handle_load_dir

    Client->>Handler: "POST /api/specs/load-inline {tenant, specs}"
    Handler->>Handler: Cedar authz gate
    Handler->>Handler: uuid::Uuid::now_v7() inline_id
    Handler->>SV: safe_temp_dir_leaf
    SV-->>Handler: Ok(tmp_dir) or 400 BAD_REQUEST
    Handler->>FS: create_dir_all(tmp_dir)
    Handler->>SI: safe_inline_spec_path model_path
    SI-->>Handler: Ok(validated_path) or 400 BAD_REQUEST
    loop each filename in specs
        Handler->>SI: safe_inline_spec_path(filename)
        SI-->>Handler: Ok(path) or 400 BAD_REQUEST
        Handler->>FS: create_dir_all + write
    end
    Handler->>Loader: handle_load_dir(specs_root)
    Loader-->>Handler: result
    Handler->>FS: remove_dir_all(tmp_dir) best-effort
    Handler-->>Client: response
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Handler as handle_load_inline
    participant SV as safe_temp_dir_leaf
    participant SI as safe_inline_spec_path
    participant FS as Filesystem
    participant Loader as handle_load_dir

    Client->>Handler: "POST /api/specs/load-inline {tenant, specs}"
    Handler->>Handler: Cedar authz gate
    Handler->>Handler: uuid::Uuid::now_v7() inline_id
    Handler->>SV: safe_temp_dir_leaf
    SV-->>Handler: Ok(tmp_dir) or 400 BAD_REQUEST
    Handler->>FS: create_dir_all(tmp_dir)
    Handler->>SI: safe_inline_spec_path model_path
    SI-->>Handler: Ok(validated_path) or 400 BAD_REQUEST
    loop each filename in specs
        Handler->>SI: safe_inline_spec_path(filename)
        SI-->>Handler: Ok(path) or 400 BAD_REQUEST
        Handler->>FS: create_dir_all + write
    end
    Handler->>Loader: handle_load_dir(specs_root)
    Loader-->>Handler: result
    Handler->>FS: remove_dir_all(tmp_dir) best-effort
    Handler-->>Client: response
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftemper-server%2Fsrc%2Fobserve%2Fspecs%2Fload_inline.rs%3A257%0A**Temp%20dir%20leaked%20on%20pre-%60handle_load_dir%60%20error%20returns**%0A%0AThe%20cleanup%20at%20line%20257%20runs%20only%20when%20execution%20reaches%20that%20point.%20If%20any%20%60%3F%60-propagating%20call%20between%20%60create_dir_all%60%20%28line%20206%29%20and%20%60handle_load_dir%60%20%28line%20253%29%20returns%20early%20%E2%80%94%20for%20example%20a%20%60safe_inline_spec_path%60%20rejection%20in%20the%20write%20loop%20or%20a%20%60resolve_inline_specs_root%60%20failure%20%E2%80%94%20the%20already-created%20UUID-suffixed%20dir%20is%20abandoned.%20The%20PR%20description%20mentions%20the%20%22delegate-panic%20path%22%20as%20a%20follow-up%2C%20but%20ordinary%20error%20returns%20%28validation%20failure%2C%20write%20I%2FO%20error%29%20have%20exactly%20the%20same%20leak.%20Because%20each%20dir%20has%20a%20unique%20name%20there%20is%20no%20security%20implication%2C%20but%20high-throughput%20or%20adversarial%20traffic%20%28many%20malformed%20spec%20keys%29%20could%20accumulate%20dirs%20until%20the%20OS%20sweeps%20them.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftemper-server%2Fsrc%2Fobserve%2Fspecs%2Fload_inline.rs%3A1%0A**File%20exceeds%20500-line%20split%20threshold**%0A%0A%60load_inline.rs%60%20is%20now%20716%20lines.%20%60CLAUDE.md%60%20%2F%20%60AGENTS.md%60%20require%20files%20over%20500%20lines%20to%20be%20split%20into%20directory%20modules.%20The%20file%20was%20already%20over%20the%20threshold%20before%20this%20PR%20%28~596%20lines%29%20and%20this%20change%20adds%20another%20~120%20lines%2C%20widening%20the%20gap.%20The%20new%20validation%20helpers%20%28%60safe_inline_spec_path%60%2C%20%60safe_temp_dir_leaf%60%29%20and%20their%20tests%20are%20self-contained%20and%20would%20be%20natural%20candidates%20to%20extract%20into%20a%20submodule%20%28e.g.%2C%20%60specs%2Fpaths.rs%60%29%20without%20any%20interface%20change.%0A%0A&repo=nerdsane%2Ftemper&pr=371&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22claude%2Farn-229-spec-ingestion-fs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Farn-229-spec-ingestion-fs%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftemper-server%2Fsrc%2Fobserve%2Fspecs%2Fload_inline.rs%3A257%0A**Temp%20dir%20leaked%20on%20pre-%60handle_load_dir%60%20error%20returns**%0A%0AThe%20cleanup%20at%20line%20257%20runs%20only%20when%20execution%20reaches%20that%20point.%20If%20any%20%60%3F%60-propagating%20call%20between%20%60create_dir_all%60%20%28line%20206%29%20and%20%60handle_load_dir%60%20%28line%20253%29%20returns%20early%20%E2%80%94%20for%20example%20a%20%60safe_inline_spec_path%60%20rejection%20in%20the%20write%20loop%20or%20a%20%60resolve_inline_specs_root%60%20failure%20%E2%80%94%20the%20already-created%20UUID-suffixed%20dir%20is%20abandoned.%20The%20PR%20description%20mentions%20the%20%22delegate-panic%20path%22%20as%20a%20follow-up%2C%20but%20ordinary%20error%20returns%20%28validation%20failure%2C%20write%20I%2FO%20error%29%20have%20exactly%20the%20same%20leak.%20Because%20each%20dir%20has%20a%20unique%20name%20there%20is%20no%20security%20implication%2C%20but%20high-throughput%20or%20adversarial%20traffic%20%28many%20malformed%20spec%20keys%29%20could%20accumulate%20dirs%20until%20the%20OS%20sweeps%20them.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftemper-server%2Fsrc%2Fobserve%2Fspecs%2Fload_inline.rs%3A1%0A**File%20exceeds%20500-line%20split%20threshold**%0A%0A%60load_inline.rs%60%20is%20now%20716%20lines.%20%60CLAUDE.md%60%20%2F%20%60AGENTS.md%60%20require%20files%20over%20500%20lines%20to%20be%20split%20into%20directory%20modules.%20The%20file%20was%20already%20over%20the%20threshold%20before%20this%20PR%20%28~596%20lines%29%20and%20this%20change%20adds%20another%20~120%20lines%2C%20widening%20the%20gap.%20The%20new%20validation%20helpers%20%28%60safe_inline_spec_path%60%2C%20%60safe_temp_dir_leaf%60%29%20and%20their%20tests%20are%20self-contained%20and%20would%20be%20natural%20candidates%20to%20extract%20into%20a%20submodule%20%28e.g.%2C%20%60specs%2Fpaths.rs%60%29%20without%20any%20interface%20change.%0A%0A&repo=nerdsane%2Ftemper&pr=371&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftemper-server%2Fsrc%2Fobserve%2Fspecs%2Fload_inline.rs%3A257%0A**Temp%20dir%20leaked%20on%20pre-%60handle_load_dir%60%20error%20returns**%0A%0AThe%20cleanup%20at%20line%20257%20runs%20only%20when%20execution%20reaches%20that%20point.%20If%20any%20%60%3F%60-propagating%20call%20between%20%60create_dir_all%60%20%28line%20206%29%20and%20%60handle_load_dir%60%20%28line%20253%29%20returns%20early%20%E2%80%94%20for%20example%20a%20%60safe_inline_spec_path%60%20rejection%20in%20the%20write%20loop%20or%20a%20%60resolve_inline_specs_root%60%20failure%20%E2%80%94%20the%20already-created%20UUID-suffixed%20dir%20is%20abandoned.%20The%20PR%20description%20mentions%20the%20%22delegate-panic%20path%22%20as%20a%20follow-up%2C%20but%20ordinary%20error%20returns%20%28validation%20failure%2C%20write%20I%2FO%20error%29%20have%20exactly%20the%20same%20leak.%20Because%20each%20dir%20has%20a%20unique%20name%20there%20is%20no%20security%20implication%2C%20but%20high-throughput%20or%20adversarial%20traffic%20%28many%20malformed%20spec%20keys%29%20could%20accumulate%20dirs%20until%20the%20OS%20sweeps%20them.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftemper-server%2Fsrc%2Fobserve%2Fspecs%2Fload_inline.rs%3A1%0A**File%20exceeds%20500-line%20split%20threshold**%0A%0A%60load_inline.rs%60%20is%20now%20716%20lines.%20%60CLAUDE.md%60%20%2F%20%60AGENTS.md%60%20require%20files%20over%20500%20lines%20to%20be%20split%20into%20directory%20modules.%20The%20file%20was%20already%20over%20the%20threshold%20before%20this%20PR%20%28~596%20lines%29%20and%20this%20change%20adds%20another%20~120%20lines%2C%20widening%20the%20gap.%20The%20new%20validation%20helpers%20%28%60safe_inline_spec_path%60%2C%20%60safe_temp_dir_leaf%60%29%20and%20their%20tests%20are%20self-contained%20and%20would%20be%20natural%20candidates%20to%20extract%20into%20a%20submodule%20%28e.g.%2C%20%60specs%2Fpaths.rs%60%29%20without%20any%20interface%20change.%0A%0A&pr=371&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
crates/temper-server/src/observe/specs/load_inline.rs:257
**Temp dir leaked on pre-`handle_load_dir` error returns**

The cleanup at line 257 runs only when execution reaches that point. If any `?`-propagating call between `create_dir_all` (line 206) and `handle_load_dir` (line 253) returns early — for example a `safe_inline_spec_path` rejection in the write loop or a `resolve_inline_specs_root` failure — the already-created UUID-suffixed dir is abandoned. The PR description mentions the "delegate-panic path" as a follow-up, but ordinary error returns (validation failure, write I/O error) have exactly the same leak. Because each dir has a unique name there is no security implication, but high-throughput or adversarial traffic (many malformed spec keys) could accumulate dirs until the OS sweeps them.

### Issue 2 of 2
crates/temper-server/src/observe/specs/load_inline.rs:1
**File exceeds 500-line split threshold**

`load_inline.rs` is now 716 lines. `CLAUDE.md` / `AGENTS.md` require files over 500 lines to be split into directory modules. The file was already over the threshold before this PR (~596 lines) and this change adds another ~120 lines, widening the gap. The new validation helpers (`safe_inline_spec_path`, `safe_temp_dir_leaf`) and their tests are self-contained and would be natural candidates to extract into a submodule (e.g., `specs/paths.rs`) without any interface change.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(server): require inline temp-dir lea..."](https://github.com/nerdsane/temper/commit/66db352227c7453a3ea13099048c25ab0a734560) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43682871)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->