### PR TITLE
fix(server): journal PATCH/PUT field updates fail-closed (ARN-189)

### DIFF
--- a/crates/temper-server/Cargo.toml
+++ b/crates/temper-server/Cargo.toml
@@ -79,7 +79,9 @@ criterion = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 wiremock = { workspace = true }
 tracing-subscriber = { workspace = true }
-opentelemetry_sdk = { workspace = true }
+# `testing` gives the in-memory metric exporter used by the ARN-189 replay-skip
+# test. Dev-only: not built into any production artifact.
+opentelemetry_sdk = { workspace = true, features = ["testing"] }
 temper-store-sim = { workspace = true }
 temper-server = { path = ".", features = ["sim"] }
 temper-wasm = { workspace = true, features = ["test-helpers"] }

--- a/crates/temper-server/src/entity_actor/actor.rs
+++ b/crates/temper-server/src/entity_actor/actor.rs
@@ -32,7 +32,7 @@ use temper_runtime::persistence::{
     COMPOSITE_EVENT_TYPE, EventMetadata, PersistenceEnvelope, PersistenceError,
 };
 use temper_runtime::scheduler::{sim_now, sim_uuid};
-use tokio::time::sleep as sleep_persistence_retry; // determinism-ok: production persistence retry backoff
+pub(super) use tokio::time::sleep as sleep_persistence_retry; // determinism-ok: production persistence retry backoff
 
 use crate::storage::{BackendLabel, BoxedEventStore};
 
@@ -47,7 +47,7 @@ use super::types::{
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum ReplayPolicy {
+pub(super) enum ReplayPolicy {
     LenientSnapshot,
     StrictSnapshot,
     StrictFullJournal,
@@ -67,7 +67,7 @@ impl ReplayPolicy {
     }
 }
 
-fn event_budget_workspace_id(state: &EntityState) -> String {
+pub(super) fn event_budget_workspace_id(state: &EntityState) -> String {
     if state.entity_type == "Workspace" {
         return state.entity_id.clone();
     }
@@ -117,20 +117,20 @@ fn duplicate_idempotency_custom_effects(
 /// Optionally persists events to the configured backend. Wide events are emitted
 /// via the OTEL SDK (no-op when OTEL is not initialised).
 pub struct EntityActor {
-    tenant: String,
-    entity_type: String,
+    pub(super) tenant: String,
+    pub(super) entity_type: String,
     entity_id: String,
     /// Live reference to the transition table. Reads through `RwLock` so that
     /// hot-swapped tables are visible on the next action dispatch without
     /// restarting the actor.
-    table: Arc<RwLock<TransitionTable>>,
-    initial_fields: serde_json::Value,
+    pub(super) table: Arc<RwLock<TransitionTable>>,
+    pub(super) initial_fields: serde_json::Value,
     /// Optional event journal for persistence. None = in-memory only.
-    event_journal: Option<BoxedEventStore>,
+    pub(super) event_journal: Option<BoxedEventStore>,
     /// Optional async snapshot writer. Event appends remain synchronous.
-    snapshot_queue: Option<Arc<SnapshotWriteQueue>>,
+    pub(super) snapshot_queue: Option<Arc<SnapshotWriteQueue>>,
     /// Persistence backend label used for metrics and backend-specific field sync.
-    event_backend: Option<BackendLabel>,
+    pub(super) event_backend: Option<BackendLabel>,
     /// Trace ID for correlating all events from this actor.
     trace_id: String,
     /// Shared idempotency cache (ADR-0048 sub-decision 5). Consulted before
@@ -138,11 +138,11 @@ pub struct EntityActor {
     /// retries that race past the caller's timeout cannot double-execute.
     idempotency_cache: Option<Arc<crate::idempotency::IdempotencyCache>>,
     /// Object store for field-overflow blob bytes. SQL stores only refs.
-    blob_store: Option<crate::blob_store::BlobStore>,
+    pub(super) blob_store: Option<crate::blob_store::BlobStore>,
 }
 
 impl EntityActor {
-    fn build_initial_state(
+    pub(super) fn build_initial_state(
         entity_type: &str,
         entity_id: &str,
         table: &TransitionTable,
@@ -335,7 +335,7 @@ impl EntityActor {
     }
 
     /// Persistence ID for this entity: "tenant:EntityType:EntityId".
-    fn persistence_id(&self) -> String {
+    pub(super) fn persistence_id(&self) -> String {
         format!("{}:{}:{}", self.tenant, self.entity_type, self.entity_id)
     }
 
@@ -353,7 +353,7 @@ impl EntityActor {
     }
 
     /// Persist an event to the configured event store.
-    async fn persist_event(
+    pub(super) async fn persist_event(
         &self,
         store: &BoxedEventStore,
         backend: BackendLabel,
@@ -465,7 +465,7 @@ impl EntityActor {
     }
 
     /// Save a snapshot when the configured interval is reached.
-    async fn maybe_save_snapshot(
+    pub(super) async fn maybe_save_snapshot(
         store: &BoxedEventStore,
         snapshot_queue: Option<&Arc<SnapshotWriteQueue>>,
         persistence_id: &str,
@@ -524,7 +524,7 @@ impl EntityActor {
     /// all state variables (status, counters, booleans). This is option 2 from
     /// the replay design: the TransitionTable is the authoritative source of
     /// effects, so replay produces the same state as the original execution.
-    async fn replay_events(
+    pub(super) async fn replay_events(
         table: &TransitionTable,
         store: &BoxedEventStore,
         backend: BackendLabel,
@@ -680,14 +680,50 @@ impl EntityActor {
                     {
                         match parsed_event {
                             Ok(event) => {
-                                super::effects::apply_field_update(
+                                let applied = super::effects::apply_field_update(
                                     state,
                                     &event.params,
                                     env.event_type == super::effects::FIELDS_REPLACED_EVENT,
                                 );
+                                if !applied {
+                                    // A journaled field update whose payload is not
+                                    // an object — only reachable from a build that
+                                    // predates the live guard. It is as dropped as
+                                    // one that failed to deserialize, so it fails
+                                    // or counts the same way.
+                                    if replay_policy.strict_event_validation() {
+                                        return Err(ActorError::custom(format!(
+                                            "non-object field-update event for {}:{} at sequence {}",
+                                            state.entity_type, state.entity_id, env.sequence_nr
+                                        )));
+                                    }
+                                    crate::event_budget_metrics::record_field_update_replay_skip(
+                                        tenant,
+                                        &state.entity_type,
+                                        &state.entity_id,
+                                    );
+                                }
                                 state.push_event_bounded(event);
                             }
                             Err(e) => {
+                                // Honor the replay policy, like the tombstone and
+                                // generic arms do. Under a strict policy the caller
+                                // is resolving authoritative state — identity and
+                                // authority decisions read from it — so silently
+                                // dropping a field update there can preserve
+                                // exactly the authority a `FieldsReplaced` was
+                                // meant to revoke. Fail instead of skipping.
+                                if replay_policy.strict_event_validation() {
+                                    return Err(ActorError::custom(format!(
+                                        "invalid field-update event for {}:{} at sequence {}: {e}",
+                                        state.entity_type, state.entity_id, env.sequence_nr
+                                    )));
+                                }
+                                crate::event_budget_metrics::record_field_update_replay_skip(
+                                    tenant,
+                                    &state.entity_type,
+                                    &state.entity_id,
+                                );
                                 tracing::warn!(
                                     entity = %state.entity_id,
                                     sequence_nr = env.sequence_nr,
@@ -1012,6 +1048,30 @@ impl Actor for EntityActor {
                 // Separate from `action_start` because metrics emission is
                 // outside the DST boundary; using Instant here is safe.
                 let ask_reply_start = Instant::now(); // determinism-ok: observability only
+
+                // ARN-189: the field-update event names are reserved. Replay
+                // dispatches them to `apply_field_update` before the generic
+                // action path, so a spec action of the same name would be
+                // hijacked on rehydration — its params would be merged into
+                // fields and its transition never replayed. Reserving them "by
+                // convention" is not a guarantee; refuse the collision here,
+                // where a domain action first enters the actor.
+                if name == super::effects::FIELDS_UPDATED_EVENT
+                    || name == super::effects::FIELDS_REPLACED_EVENT
+                {
+                    ctx.reply(EntityResponse {
+                        success: false,
+                        state: state.clone(),
+                        error: Some(format!(
+                            "action name `{name}` is reserved for journaled field updates"
+                        )),
+                        custom_effects: vec![],
+                        scheduled_actions: vec![],
+                        spawn_requests: vec![],
+                        spec_governed: true,
+                    });
+                    return Ok(());
+                }
 
                 // Snapshot the current table for this action dispatch.
                 // On the next action, any hot-swapped table will be picked up.
@@ -1607,146 +1667,28 @@ impl Actor for EntityActor {
                 replace,
                 expected_precondition,
             } => {
-                if let Some(expected_precondition) = expected_precondition
-                    && super::effects::entity_authorization_precondition(state)
-                        != expected_precondition
-                {
-                    ctx.reply(EntityResponse {
-                        success: false,
-                        state: state.clone(),
-                        error: Some(
-                            "field update authorization became stale; retry against current state"
-                                .to_string(),
-                        ),
-                        custom_effects: vec![],
-                        scheduled_actions: vec![],
-                        spawn_requests: vec![],
-                        spec_governed: true,
-                    });
-                    return Ok(());
-                }
-                if state.status == "Deleted" {
-                    ctx.reply(EntityResponse {
-                        success: false,
-                        state: state.clone(),
-                        error: Some("cannot update fields after entity deletion".to_string()),
-                        custom_effects: vec![],
-                        scheduled_actions: vec![],
-                        spawn_requests: vec![],
-                        spec_governed: true,
-                    });
-                    return Ok(());
-                }
-                // TigerStyle: same event budget that gates spec actions.
-                // Field updates append journal events too; ungated they could
-                // grow the snapshot replay tail past MAX_EVENTS_SINCE_SNAPSHOT
-                // while the snapshot path is stalled, after which the entity
-                // can never rehydrate. Reject BEFORE mutating.
-                if state.events_since_snapshot >= MAX_EVENTS_SINCE_SNAPSHOT {
-                    let workspace_id = event_budget_workspace_id(state);
-                    crate::event_budget_metrics::record_exhausted(
-                        &self.tenant,
-                        &state.entity_type,
-                        &state.entity_id,
-                        &workspace_id,
-                    );
-                    tracing::warn!(
-                        tenant = %self.tenant,
-                        entity_type = %state.entity_type,
-                        entity_id = %state.entity_id,
-                        workspace_id = %workspace_id,
-                        status = %state.status,
-                        replace,
-                        events_since_snapshot = state.events_since_snapshot,
-                        total_event_count = state.total_event_count,
-                        max_events_since_snapshot = MAX_EVENTS_SINCE_SNAPSHOT,
-                        "Event budget exhausted (field update rejected)"
-                    );
-                    ctx.reply(EntityResponse {
-                        success: false,
-                        state: state.clone(),
-                        error: Some(format!(
-                            "Event budget exhausted ({MAX_EVENTS_SINCE_SNAPSHOT} max since snapshot)"
-                        )),
-                        custom_effects: vec![],
-                        scheduled_actions: vec![],
-                        spawn_requests: vec![],
-                        spec_governed: true,
-                    });
-                    return Ok(());
-                }
-
-                // Apply the update first so the journal append co-commits
-                // key/vector index rows derived from the NEW fields, then
-                // journal it fail-closed (ARN-189): an update that is not
-                // durable must not be acknowledged, or eviction/restart
-                // silently loses it. Rolled back on append failure.
-                let previous_fields = state.fields.clone();
-                super::effects::apply_field_update(state, &fields, replace);
-
-                let event = EntityEvent {
-                    action: if replace {
-                        super::effects::FIELDS_REPLACED_EVENT
-                    } else {
-                        super::effects::FIELDS_UPDATED_EVENT
-                    }
-                    .to_string(),
-                    from_status: state.status.clone(),
-                    to_status: state.status.clone(),
-                    timestamp: sim_now(),
-                    params: fields,
-                    idempotency_key: None,
-                };
-
-                if let (Some(store), Some(backend)) =
-                    (self.event_journal.as_ref(), self.event_backend)
-                    && let Err(e) = self
-                        .persist_event(store, backend, &self.persistence_id(), state, &event)
-                        .await
-                {
-                    state.fields = previous_fields;
-                    ctx.reply(EntityResponse {
-                        success: false,
-                        state: state.clone(),
-                        error: Some(format!("persistence failed: {e}")),
-                        custom_effects: vec![],
-                        scheduled_actions: vec![],
-                        spawn_requests: vec![],
-                        spec_governed: true,
-                    });
-                    return Ok(());
-                }
-
-                state.push_event_bounded(event);
-
-                let persistence_id = self.persistence_id();
-                if let Some(ref store) = self.event_journal
-                    && let Err(e) = Self::maybe_save_snapshot(
-                        store,
-                        self.snapshot_queue.as_ref(),
-                        &persistence_id,
-                        state,
-                    )
-                    .await
-                {
-                    tracing::warn!(
-                        entity = %state.entity_id,
-                        seq = state.sequence_nr,
-                        error = %e,
-                        "failed to persist snapshot"
-                    );
-                }
-
+                // The whole durable transaction — validation, budget, journal
+                // append, conflict recovery — lives in `field_updates`. This arm
+                // only turns its outcome into a reply.
+                let outcome = super::field_updates::commit_field_update(
+                    self,
+                    state,
+                    fields,
+                    replace,
+                    expected_precondition,
+                )
+                .await;
                 ctx.reply(EntityResponse {
-                    success: true,
+                    success: outcome.is_ok(),
                     state: state.clone(),
-                    error: None,
+                    error: outcome.err(),
                     custom_effects: vec![],
                     scheduled_actions: vec![],
                     spawn_requests: vec![],
                     spec_governed: true,
                 });
             }
+
             EntityMsg::Delete {
                 expected_authorization_precondition,
             } => {

--- a/crates/temper-server/src/entity_actor/actor.rs
+++ b/crates/temper-server/src/entity_actor/actor.rs
@@ -669,6 +669,38 @@ impl EntityActor {
                         break;
                     }
 
+                    // PATCH/PUT field updates are journaled outside the spec's
+                    // action vocabulary (ARN-189). Re-apply them through the
+                    // same helper the live handler uses so a rehydrated entity
+                    // reaches exactly the live post-update state — including
+                    // PUT's replace semantics, which the generic param-sync
+                    // path below cannot express (it only merges).
+                    if env.event_type == super::effects::FIELDS_UPDATED_EVENT
+                        || env.event_type == super::effects::FIELDS_REPLACED_EVENT
+                    {
+                        match parsed_event {
+                            Ok(event) => {
+                                super::effects::apply_field_update(
+                                    state,
+                                    &event.params,
+                                    env.event_type == super::effects::FIELDS_REPLACED_EVENT,
+                                );
+                                state.push_event_bounded(event);
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    entity = %state.entity_id,
+                                    sequence_nr = env.sequence_nr,
+                                    event_type = %env.event_type,
+                                    error = %e,
+                                    "skipping field-update event with incompatible schema during replay"
+                                );
+                            }
+                        }
+                        state.sequence_nr = env.sequence_nr;
+                        continue;
+                    }
+
                     match parsed_event {
                         Ok(mut event) => {
                             if replay_policy.strict_event_validation() {
@@ -1605,24 +1637,106 @@ impl Actor for EntityActor {
                     });
                     return Ok(());
                 }
-                let fields = super::effects::sanitize_action_params(&fields);
-                if replace {
-                    state.fields = fields.into_owned();
-                } else {
-                    // PATCH: merge fields into existing
-                    if let (Some(existing), Some(updates)) =
-                        (state.fields.as_object_mut(), fields.as_ref().as_object())
-                    {
-                        for (k, v) in updates {
-                            existing.insert(k.clone(), v.clone());
-                        }
-                    }
+                // TigerStyle: same event budget that gates spec actions.
+                // Field updates append journal events too; ungated they could
+                // grow the snapshot replay tail past MAX_EVENTS_SINCE_SNAPSHOT
+                // while the snapshot path is stalled, after which the entity
+                // can never rehydrate. Reject BEFORE mutating.
+                if state.events_since_snapshot >= MAX_EVENTS_SINCE_SNAPSHOT {
+                    let workspace_id = event_budget_workspace_id(state);
+                    crate::event_budget_metrics::record_exhausted(
+                        &self.tenant,
+                        &state.entity_type,
+                        &state.entity_id,
+                        &workspace_id,
+                    );
+                    tracing::warn!(
+                        tenant = %self.tenant,
+                        entity_type = %state.entity_type,
+                        entity_id = %state.entity_id,
+                        workspace_id = %workspace_id,
+                        status = %state.status,
+                        replace,
+                        events_since_snapshot = state.events_since_snapshot,
+                        total_event_count = state.total_event_count,
+                        max_events_since_snapshot = MAX_EVENTS_SINCE_SNAPSHOT,
+                        "Event budget exhausted (field update rejected)"
+                    );
+                    ctx.reply(EntityResponse {
+                        success: false,
+                        state: state.clone(),
+                        error: Some(format!(
+                            "Event budget exhausted ({MAX_EVENTS_SINCE_SNAPSHOT} max since snapshot)"
+                        )),
+                        custom_effects: vec![],
+                        scheduled_actions: vec![],
+                        spawn_requests: vec![],
+                        spec_governed: true,
+                    });
+                    return Ok(());
                 }
-                super::effects::canonicalize_entity_fields(
-                    &mut state.fields,
-                    &state.entity_id,
-                    &state.status,
-                );
+
+                // Apply the update first so the journal append co-commits
+                // key/vector index rows derived from the NEW fields, then
+                // journal it fail-closed (ARN-189): an update that is not
+                // durable must not be acknowledged, or eviction/restart
+                // silently loses it. Rolled back on append failure.
+                let previous_fields = state.fields.clone();
+                super::effects::apply_field_update(state, &fields, replace);
+
+                let event = EntityEvent {
+                    action: if replace {
+                        super::effects::FIELDS_REPLACED_EVENT
+                    } else {
+                        super::effects::FIELDS_UPDATED_EVENT
+                    }
+                    .to_string(),
+                    from_status: state.status.clone(),
+                    to_status: state.status.clone(),
+                    timestamp: sim_now(),
+                    params: fields,
+                    idempotency_key: None,
+                };
+
+                if let (Some(store), Some(backend)) =
+                    (self.event_journal.as_ref(), self.event_backend)
+                    && let Err(e) = self
+                        .persist_event(store, backend, &self.persistence_id(), state, &event)
+                        .await
+                {
+                    state.fields = previous_fields;
+                    ctx.reply(EntityResponse {
+                        success: false,
+                        state: state.clone(),
+                        error: Some(format!("persistence failed: {e}")),
+                        custom_effects: vec![],
+                        scheduled_actions: vec![],
+                        spawn_requests: vec![],
+                        spec_governed: true,
+                    });
+                    return Ok(());
+                }
+
+                state.push_event_bounded(event);
+
+                let persistence_id = self.persistence_id();
+                if let Some(ref store) = self.event_journal
+                    && let Err(e) = Self::maybe_save_snapshot(
+                        store,
+                        self.snapshot_queue.as_ref(),
+                        &persistence_id,
+                        state,
+                    )
+                    .await
+                {
+                    tracing::warn!(
+                        entity = %state.entity_id,
+                        seq = state.sequence_nr,
+                        error = %e,
+                        "failed to persist snapshot"
+                    );
+                }
+
                 ctx.reply(EntityResponse {
                     success: true,
                     state: state.clone(),

--- a/crates/temper-server/src/entity_actor/actor_test.rs
+++ b/crates/temper-server/src/entity_actor/actor_test.rs
@@ -1421,6 +1421,7 @@ effect = [
 /// cannot restore `Id`/`Status` into a non-object, and `persist_event` would
 /// co-commit zero key and zero vector rows, purging the entity's index. Before
 /// journaling, that corruption was in-memory and healed on restart.
+#[cfg(feature = "sim")]
 #[tokio::test]
 async fn field_update_rejects_non_object_payload_before_journaling() {
     let store = Arc::new(AppendFuseStore::no_faults(23));
@@ -1495,6 +1496,7 @@ async fn field_update_rejects_non_object_payload_before_journaling() {
 /// `apply_field_update` is shared with journal replay — must survive rehydration
 /// identically. A sanitize step applied only on the live path would silently
 /// rewrite the entity the next time it replayed.
+#[cfg(feature = "sim")]
 #[tokio::test]
 async fn field_update_sanitization_is_reproduced_by_replay() {
     let store = Arc::new(AppendFuseStore::no_faults(29));
@@ -1602,6 +1604,7 @@ async fn field_update_sanitization_is_reproduced_by_replay() {
 /// the same name would be hijacked on rehydration: its params merged into
 /// fields, its transition never replayed. The ADR reserved the names by
 /// convention; this makes the reservation real.
+#[cfg(feature = "sim")]
 #[tokio::test]
 async fn reserved_field_update_event_names_are_refused_as_actions() {
     let store = Arc::new(AppendFuseStore::no_faults(31));
@@ -1670,6 +1673,7 @@ async fn reserved_field_update_event_names_are_refused_as_actions() {
 /// rehydrate with the authoritative sequence. The Action arm right above has had
 /// ADR-0046 replay-and-retry for exactly this; a field update needs the same,
 /// minus the guard re-evaluation it has no guards for.
+#[cfg(feature = "sim")]
 #[tokio::test]
 async fn field_update_recovers_from_a_concurrency_violation() {
     let store = Arc::new(AppendFuseStore::no_faults(37));
@@ -1765,6 +1769,7 @@ async fn field_update_recovers_from_a_concurrency_violation() {
 
 /// Beyond the retry budget the arm still fails closed rather than reporting a
 /// success it did not persist.
+#[cfg(feature = "sim")]
 #[tokio::test]
 async fn field_update_fails_closed_when_conflicts_exceed_the_retry_budget() {
     let store = Arc::new(AppendFuseStore::no_faults(41));
@@ -1932,6 +1937,7 @@ fn apply_field_update_merge_replace_and_runtime_owned_fields() {
 /// event on top of its own effects: the events deque grows, `total_event_count`
 /// and `events_since_snapshot` climb, and non-idempotent effects fire twice — and
 /// the result is returned to the caller, projected, and possibly snapshotted.
+#[cfg(feature = "sim")]
 #[tokio::test]
 async fn field_update_retry_does_not_double_apply_the_journal() {
     let store = Arc::new(AppendFuseStore::no_faults(43));
@@ -2034,6 +2040,7 @@ async fn field_update_retry_does_not_double_apply_the_journal() {
 /// to state the caller never saw and Cedar never evaluated. It must be refused,
 /// not retried — `entity_ops` caps preconditioned asks at one attempt for exactly
 /// this reason.
+#[cfg(feature = "sim")]
 #[tokio::test]
 async fn preconditioned_field_update_refuses_rather_than_retrying_a_conflict() {
     let store = Arc::new(AppendFuseStore::no_faults(47));
@@ -2140,6 +2147,7 @@ async fn preconditioned_field_update_refuses_rather_than_retrying_a_conflict() {
 ///
 /// Driven by a second actor on the same store, so the conflict is a real stale
 /// sequence rather than an injected one.
+#[cfg(feature = "sim")]
 #[tokio::test]
 async fn field_update_retry_refuses_when_the_race_deleted_the_entity() {
     let store = Arc::new(AppendFuseStore::no_faults(53));
@@ -2234,6 +2242,7 @@ async fn field_update_retry_refuses_when_the_race_deleted_the_entity() {
 /// `..._exceed_the_retry_budget` pins 3, so halving the budget to a single retry
 /// is invisible to both. This pins the boundary: exactly 2 conflicts must still
 /// recover.
+#[cfg(feature = "sim")]
 #[tokio::test]
 async fn field_update_recovers_at_the_full_retry_budget() {
     let store = Arc::new(AppendFuseStore::no_faults(59));
@@ -2338,6 +2347,7 @@ fn replaying_a_non_object_field_event_leaves_state_untouched() {
 /// would restore the *pre-replay* fields — erasing a concurrent writer's
 /// committed values from live state until the actor next rehydrates, so reads
 /// would serve data the journal says is stale.
+#[cfg(feature = "sim")]
 #[tokio::test]
 async fn exhausted_field_update_rolls_back_to_the_caught_up_state() {
     let store = Arc::new(AppendFuseStore::no_faults(61));
@@ -2427,6 +2437,7 @@ async fn exhausted_field_update_rolls_back_to_the_caught_up_state() {
 /// recheck the retry appends past `MAX_EVENTS_SINCE_SNAPSHOT`, growing the
 /// snapshot tail past the hydration budget the entry check exists to protect —
 /// which is how an entity becomes permanently unhydratable.
+#[cfg(feature = "sim")]
 #[tokio::test]
 async fn field_update_retry_refuses_when_the_race_spent_the_event_budget() {
     let store = Arc::new(AppendFuseStore::no_faults(67));
@@ -2528,6 +2539,7 @@ async fn field_update_retry_refuses_when_the_race_spent_the_event_budget() {
 /// from the rebuilt state. A `tracing::warn!` alone leaves that undetectable in
 /// aggregate, so it is also counted. Asserted through a real meter, because a
 /// counter nobody reads is indistinguishable from one that is never incremented.
+#[cfg(feature = "sim")]
 #[tokio::test]
 async fn replay_skip_of_a_field_update_event_is_counted() {
     use opentelemetry_sdk::metrics::{InMemoryMetricExporter, SdkMeterProvider};

--- a/crates/temper-server/src/entity_actor/actor_test.rs
+++ b/crates/temper-server/src/entity_actor/actor_test.rs
@@ -922,7 +922,11 @@ async fn patched_fields_survive_actor_restart() {
         .await
         .unwrap();
     assert_eq!(
-        rehydrated.state.fields.get("Title").and_then(|v| v.as_str()),
+        rehydrated
+            .state
+            .fields
+            .get("Title")
+            .and_then(|v| v.as_str()),
         Some("durable title"),
         "PATCHed field must survive restart via journal replay (pid {pid})"
     );
@@ -1004,7 +1008,11 @@ async fn replaced_fields_survive_actor_restart_with_replace_semantics() {
         .await
         .unwrap();
     assert_eq!(
-        rehydrated.state.fields.get("Title").and_then(|v| v.as_str()),
+        rehydrated
+            .state
+            .fields
+            .get("Title")
+            .and_then(|v| v.as_str()),
         Some("after"),
         "replaced field value must survive restart"
     );
@@ -1019,17 +1027,27 @@ async fn replaced_fields_survive_actor_restart_with_replace_semantics() {
     );
 }
 
-/// Delegating event store whose appends fail once `armed` is set. Lets a test
-/// start an actor normally (bootstrap Created append succeeds) and then fail
-/// exactly the append under test, deterministically.
+/// Delegating event store whose appends fail once `armed` is set (so a test
+/// can start an actor normally and then fail exactly the append under test)
+/// and whose snapshot saves fail once `fail_snapshots` is set (so a test can
+/// model a stalled snapshot path while appends keep succeeding).
 #[cfg(feature = "sim")]
 struct AppendFuseStore {
     inner: temper_store_sim::SimEventStore,
     armed: std::sync::atomic::AtomicBool,
+    fail_snapshots: std::sync::atomic::AtomicBool,
 }
 
 #[cfg(feature = "sim")]
 impl AppendFuseStore {
+    fn no_faults(seed: u64) -> Self {
+        Self {
+            inner: temper_store_sim::SimEventStore::no_faults(seed),
+            armed: std::sync::atomic::AtomicBool::new(false),
+            fail_snapshots: std::sync::atomic::AtomicBool::new(false),
+        }
+    }
+
     fn fuse_err(&self) -> Option<temper_runtime::persistence::PersistenceError> {
         if self.armed.load(std::sync::atomic::Ordering::SeqCst) {
             Some(temper_runtime::persistence::PersistenceError::Storage(
@@ -1108,6 +1126,14 @@ impl temper_runtime::persistence::EventStore for AppendFuseStore {
         sequence_nr: u64,
         snapshot: &[u8],
     ) -> Result<(), temper_runtime::persistence::PersistenceError> {
+        if self
+            .fail_snapshots
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
+            return Err(temper_runtime::persistence::PersistenceError::Storage(
+                "injected snapshot failure (stalled snapshot path)".to_string(),
+            ));
+        }
         self.inner
             .save_snapshot(persistence_id, sequence_nr, snapshot)
             .await
@@ -1132,7 +1158,9 @@ impl temper_runtime::persistence::EventStore for AppendFuseStore {
         tenant: &str,
         entity_type: &str,
     ) -> Result<Vec<String>, temper_runtime::persistence::PersistenceError> {
-        self.inner.list_entity_ids_by_type(tenant, entity_type).await
+        self.inner
+            .list_entity_ids_by_type(tenant, entity_type)
+            .await
     }
 }
 
@@ -1142,12 +1170,7 @@ impl temper_runtime::persistence::EventStore for AppendFuseStore {
 #[cfg(feature = "sim")]
 #[tokio::test]
 async fn field_update_with_failed_journal_append_does_not_report_success() {
-    use temper_store_sim::SimEventStore;
-
-    let store = Arc::new(AppendFuseStore {
-        inner: SimEventStore::no_faults(13),
-        armed: std::sync::atomic::AtomicBool::new(false),
-    });
+    let store = Arc::new(AppendFuseStore::no_faults(13));
     let entity_id = "arn189-fail-1";
 
     let system = ActorSystem::new("sim-arn189-fail");
@@ -1187,6 +1210,80 @@ async fn field_update_with_failed_journal_append_does_not_report_success() {
     assert!(
         response.state.fields.get("Title").is_none(),
         "failed update must not leave half-applied in-memory state"
+    );
+
+    // The actor's RETAINED state must also be unmutated — not just the
+    // error reply's snapshot.
+    let retained: EntityResponse = actor_ref
+        .ask(EntityMsg::GetState, Duration::from_secs(5))
+        .await
+        .unwrap();
+    assert!(
+        retained.state.fields.get("Title").is_none(),
+        "failed update must not persist in the actor's retained state"
+    );
+}
+
+/// ARN-189: field updates consume the same event budget as spec actions.
+/// With the snapshot path stalled (all snapshot failures are soft), sustained
+/// PATCH traffic must be REJECTED at MAX_EVENTS_SINCE_SNAPSHOT instead of
+/// growing a replay tail that makes the entity permanently unhydratable.
+#[cfg(feature = "sim")]
+#[tokio::test]
+async fn field_updates_reject_when_event_budget_exhausted() {
+    let store = Arc::new(AppendFuseStore::no_faults(17));
+    // Snapshots fail from the start: models a stalled snapshot path while
+    // appends keep succeeding.
+    store
+        .fail_snapshots
+        .store(true, std::sync::atomic::Ordering::SeqCst);
+    let entity_id = "arn189-budget-1";
+
+    let system = ActorSystem::new("sim-arn189-budget");
+    let actor = EntityActor::with_persistence(
+        "Order",
+        entity_id,
+        order_table(),
+        serde_json::json!({}),
+        crate::storage::BoxedEventStore::from_arc(store.clone()),
+        crate::storage::BackendLabel::Sim,
+    );
+    let actor_ref = system.spawn(actor, entity_id);
+
+    let mut rejected_at = None;
+    for i in 0..=MAX_EVENTS_SINCE_SNAPSHOT {
+        let response: EntityResponse = actor_ref
+            .ask(
+                EntityMsg::UpdateFields {
+                    fields: serde_json::json!({"counter": i}),
+                    replace: false,
+                },
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+        if !response.success {
+            assert!(
+                response
+                    .error
+                    .as_deref()
+                    .unwrap_or_default()
+                    .contains("Event budget exhausted"),
+                "rejection must be the event budget, got: {:?}",
+                response.error
+            );
+            assert!(
+                response.state.events_since_snapshot >= MAX_EVENTS_SINCE_SNAPSHOT,
+                "rejection must fire only at the budget boundary"
+            );
+            rejected_at = Some(i);
+            break;
+        }
+    }
+    assert!(
+        rejected_at.is_some(),
+        "sustained field updates with a stalled snapshot path must hit the event budget, \
+         not grow the replay tail unboundedly"
     );
 }
 

--- a/crates/temper-server/src/entity_actor/actor_test.rs
+++ b/crates/temper-server/src/entity_actor/actor_test.rs
@@ -2038,33 +2038,67 @@ async fn field_update_retry_does_not_double_apply_the_journal() {
 async fn preconditioned_field_update_refuses_rather_than_retrying_a_conflict() {
     let store = Arc::new(AppendFuseStore::no_faults(47));
     let entity_id = "arn189-cas-no-retry";
-    let persistence_id = format!("default:Order:{entity_id}");
+    let boxed = || crate::storage::BoxedEventStore::from_arc(store.clone());
 
     let system = ActorSystem::new("sim-arn189-cas");
-    let actor = EntityActor::with_persistence(
-        "Order",
+    let holder = system.spawn(
+        EntityActor::with_persistence(
+            "Order",
+            entity_id,
+            order_table(),
+            serde_json::json!({"Customer": "Alice"}),
+            boxed(),
+            crate::storage::BackendLabel::Sim,
+        ),
         entity_id,
-        order_table(),
-        serde_json::json!({"Customer": "Alice"}),
-        crate::storage::BoxedEventStore::from_arc(store.clone()),
-        crate::storage::BackendLabel::Sim,
     );
-    let actor_ref = system.spawn(actor, entity_id);
-
-    let current: EntityResponse = actor_ref
-        .ask(EntityMsg::GetState, Duration::from_secs(5))
+    let seeded: EntityResponse = holder
+        .ask(
+            EntityMsg::UpdateFields {
+                fields: serde_json::json!({"Customer": "Seed"}),
+                replace: false,
+                expected_precondition: None,
+            },
+            Duration::from_secs(5),
+        )
         .await
-        .expect("state");
+        .expect("seed");
+    assert!(seeded.success);
+
+    // The digest the caller authorizes against — computed from the state this
+    // actor can currently see.
     let precondition =
-        crate::entity_actor::effects::entity_authorization_precondition(&current.state);
+        crate::entity_actor::effects::entity_authorization_precondition(&seeded.state);
 
-    // A single conflict — within the retry budget an unpreconditioned update
-    // would recover from it.
-    store
-        .inner
-        .inject_concurrency_violations(&persistence_id, 1);
+    // A genuine journal-advancing race: a second actor commits, so the holder's
+    // in-memory sequence goes stale. Its entry-time digest still matches its own
+    // memory, so only the append reveals the conflict — which is exactly the
+    // window in which a retry would commit against state the caller never saw.
+    let other = system.spawn(
+        EntityActor::with_persistence(
+            "Order",
+            entity_id,
+            order_table(),
+            serde_json::json!({"Customer": "Alice"}),
+            boxed(),
+            crate::storage::BackendLabel::Sim,
+        ),
+        format!("{entity_id}-other"),
+    );
+    let concurrent: EntityResponse = other
+        .ask(
+            EntityMsg::UpdateFields {
+                fields: serde_json::json!({"Region": "eu"}),
+                replace: false,
+                expected_precondition: None,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("concurrent write");
+    assert!(concurrent.success);
 
-    let response: EntityResponse = actor_ref
+    let response: EntityResponse = holder
         .ask(
             EntityMsg::UpdateFields {
                 fields: serde_json::json!({"Customer": "Bob"}),
@@ -2078,8 +2112,9 @@ async fn preconditioned_field_update_refuses_rather_than_retrying_a_conflict() {
 
     assert!(
         !response.success,
-        "a compare-and-set must not be silently retried onto state the caller \
-         never authorized"
+        "a compare-and-set must not be retried onto state the caller never \
+         authorized: {:?}",
+        response.error
     );
     assert!(
         response

--- a/crates/temper-server/src/entity_actor/actor_test.rs
+++ b/crates/temper-server/src/entity_actor/actor_test.rs
@@ -865,6 +865,331 @@ async fn replay_skips_schema_mismatched_events() {
     assert_eq!(response.state.total_event_count, 1);
 }
 
+/// ARN-189: PATCH-style field updates must be journaled — a merge applied via
+/// `EntityMsg::UpdateFields` has to survive actor eviction/restart, or any
+/// OData PATCH is silently lost the moment the actor rehydrates from the
+/// event store.
+#[cfg(feature = "sim")]
+#[tokio::test]
+async fn patched_fields_survive_actor_restart() {
+    use temper_store_sim::SimEventStore;
+
+    let store = Arc::new(SimEventStore::no_faults(7));
+    let entity_id = "arn189-patch-1";
+    let pid = format!("default:Order:{entity_id}");
+
+    // Generation 1: live actor accepts the PATCH merge.
+    let system = ActorSystem::new("sim-arn189-patch-a");
+    let actor = EntityActor::with_persistence(
+        "Order",
+        entity_id,
+        order_table(),
+        serde_json::json!({}),
+        crate::storage::BoxedEventStore::from_arc(store.clone()),
+        crate::storage::BackendLabel::Sim,
+    );
+    let actor_ref = system.spawn(actor, entity_id);
+    let response: EntityResponse = actor_ref
+        .ask(
+            EntityMsg::UpdateFields {
+                fields: serde_json::json!({"Title": "durable title", "Priority": 3}),
+                replace: false,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+    assert!(response.success);
+    assert_eq!(
+        response.state.fields.get("Title").and_then(|v| v.as_str()),
+        Some("durable title"),
+        "live merge must apply"
+    );
+
+    // Generation 2: fresh actor over the same store — replay is the only input.
+    let system2 = ActorSystem::new("sim-arn189-patch-b");
+    let actor2 = EntityActor::with_persistence(
+        "Order",
+        entity_id,
+        order_table(),
+        serde_json::json!({}),
+        crate::storage::BoxedEventStore::from_arc(store.clone()),
+        crate::storage::BackendLabel::Sim,
+    );
+    let actor_ref2 = system2.spawn(actor2, entity_id);
+    let rehydrated: EntityResponse = actor_ref2
+        .ask(EntityMsg::GetState, Duration::from_secs(5))
+        .await
+        .unwrap();
+    assert_eq!(
+        rehydrated.state.fields.get("Title").and_then(|v| v.as_str()),
+        Some("durable title"),
+        "PATCHed field must survive restart via journal replay (pid {pid})"
+    );
+    assert_eq!(
+        rehydrated
+            .state
+            .fields
+            .get("Priority")
+            .and_then(|v| v.as_i64()),
+        Some(3),
+        "all merged fields must survive restart"
+    );
+}
+
+/// ARN-189: PUT-style replacement must also be journaled with REPLACE
+/// semantics — after restart the replaced field set must match the live
+/// result, including the absence of keys the replacement dropped.
+#[cfg(feature = "sim")]
+#[tokio::test]
+async fn replaced_fields_survive_actor_restart_with_replace_semantics() {
+    use temper_store_sim::SimEventStore;
+
+    let store = Arc::new(SimEventStore::no_faults(11));
+    let entity_id = "arn189-put-1";
+
+    let system = ActorSystem::new("sim-arn189-put-a");
+    let actor = EntityActor::with_persistence(
+        "Order",
+        entity_id,
+        order_table(),
+        serde_json::json!({}),
+        crate::storage::BoxedEventStore::from_arc(store.clone()),
+        crate::storage::BackendLabel::Sim,
+    );
+    let actor_ref = system.spawn(actor, entity_id);
+
+    // First a merge that introduces a key the later replacement drops.
+    let merged: EntityResponse = actor_ref
+        .ask(
+            EntityMsg::UpdateFields {
+                fields: serde_json::json!({"Title": "before", "Legacy": "drop me"}),
+                replace: false,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+    assert!(merged.success);
+
+    // PUT: full replacement (Id/Status are preserved by the live path).
+    let replaced: EntityResponse = actor_ref
+        .ask(
+            EntityMsg::UpdateFields {
+                fields: serde_json::json!({"Title": "after"}),
+                replace: true,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+    assert!(replaced.success);
+    assert!(
+        replaced.state.fields.get("Legacy").is_none(),
+        "live replacement must drop absent keys"
+    );
+
+    let system2 = ActorSystem::new("sim-arn189-put-b");
+    let actor2 = EntityActor::with_persistence(
+        "Order",
+        entity_id,
+        order_table(),
+        serde_json::json!({}),
+        crate::storage::BoxedEventStore::from_arc(store.clone()),
+        crate::storage::BackendLabel::Sim,
+    );
+    let actor_ref2 = system2.spawn(actor2, entity_id);
+    let rehydrated: EntityResponse = actor_ref2
+        .ask(EntityMsg::GetState, Duration::from_secs(5))
+        .await
+        .unwrap();
+    assert_eq!(
+        rehydrated.state.fields.get("Title").and_then(|v| v.as_str()),
+        Some("after"),
+        "replaced field value must survive restart"
+    );
+    assert!(
+        rehydrated.state.fields.get("Legacy").is_none(),
+        "replacement semantics must survive restart — dropped keys must not resurrect"
+    );
+    assert_eq!(
+        rehydrated.state.fields.get("Id").and_then(|v| v.as_str()),
+        Some(entity_id),
+        "Id must be preserved through replace + replay"
+    );
+}
+
+/// Delegating event store whose appends fail once `armed` is set. Lets a test
+/// start an actor normally (bootstrap Created append succeeds) and then fail
+/// exactly the append under test, deterministically.
+#[cfg(feature = "sim")]
+struct AppendFuseStore {
+    inner: temper_store_sim::SimEventStore,
+    armed: std::sync::atomic::AtomicBool,
+}
+
+#[cfg(feature = "sim")]
+impl AppendFuseStore {
+    fn fuse_err(&self) -> Option<temper_runtime::persistence::PersistenceError> {
+        if self.armed.load(std::sync::atomic::Ordering::SeqCst) {
+            Some(temper_runtime::persistence::PersistenceError::Storage(
+                "injected append failure (fuse armed)".to_string(),
+            ))
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(feature = "sim")]
+impl temper_runtime::persistence::EventStore for AppendFuseStore {
+    async fn append(
+        &self,
+        persistence_id: &str,
+        expected_sequence: u64,
+        events: &[PersistenceEnvelope],
+    ) -> Result<u64, temper_runtime::persistence::PersistenceError> {
+        if let Some(e) = self.fuse_err() {
+            return Err(e);
+        }
+        self.inner
+            .append(persistence_id, expected_sequence, events)
+            .await
+    }
+
+    async fn append_with_index_rows(
+        &self,
+        persistence_id: &str,
+        expected_sequence: u64,
+        events: &[PersistenceEnvelope],
+        key_rows: &[temper_runtime::persistence::EntityKeyRow],
+        vector_rows: &[temper_runtime::persistence::EntityVectorRow],
+        reconcile_vectors: bool,
+    ) -> Result<u64, temper_runtime::persistence::PersistenceError> {
+        if let Some(e) = self.fuse_err() {
+            return Err(e);
+        }
+        self.inner
+            .append_with_index_rows(
+                persistence_id,
+                expected_sequence,
+                events,
+                key_rows,
+                vector_rows,
+                reconcile_vectors,
+            )
+            .await
+    }
+
+    async fn append_batch(
+        &self,
+        appends: &[temper_runtime::persistence::PersistenceAppend],
+    ) -> Result<
+        Vec<temper_runtime::persistence::PersistenceAppendResult>,
+        temper_runtime::persistence::PersistenceError,
+    > {
+        if let Some(e) = self.fuse_err() {
+            return Err(e);
+        }
+        self.inner.append_batch(appends).await
+    }
+
+    async fn read_events(
+        &self,
+        persistence_id: &str,
+        from_sequence: u64,
+    ) -> Result<Vec<PersistenceEnvelope>, temper_runtime::persistence::PersistenceError> {
+        self.inner.read_events(persistence_id, from_sequence).await
+    }
+
+    async fn save_snapshot(
+        &self,
+        persistence_id: &str,
+        sequence_nr: u64,
+        snapshot: &[u8],
+    ) -> Result<(), temper_runtime::persistence::PersistenceError> {
+        self.inner
+            .save_snapshot(persistence_id, sequence_nr, snapshot)
+            .await
+    }
+
+    async fn load_snapshot(
+        &self,
+        persistence_id: &str,
+    ) -> Result<Option<(u64, Vec<u8>)>, temper_runtime::persistence::PersistenceError> {
+        self.inner.load_snapshot(persistence_id).await
+    }
+
+    async fn list_entity_ids(
+        &self,
+        tenant: &str,
+    ) -> Result<Vec<(String, String)>, temper_runtime::persistence::PersistenceError> {
+        self.inner.list_entity_ids(tenant).await
+    }
+
+    async fn list_entity_ids_by_type(
+        &self,
+        tenant: &str,
+        entity_type: &str,
+    ) -> Result<Vec<String>, temper_runtime::persistence::PersistenceError> {
+        self.inner.list_entity_ids_by_type(tenant, entity_type).await
+    }
+}
+
+/// ARN-189 fail-closed: when the journal append fails, a field update must
+/// NOT report success — otherwise the caller believes a write is durable
+/// while restart will lose it.
+#[cfg(feature = "sim")]
+#[tokio::test]
+async fn field_update_with_failed_journal_append_does_not_report_success() {
+    use temper_store_sim::SimEventStore;
+
+    let store = Arc::new(AppendFuseStore {
+        inner: SimEventStore::no_faults(13),
+        armed: std::sync::atomic::AtomicBool::new(false),
+    });
+    let entity_id = "arn189-fail-1";
+
+    let system = ActorSystem::new("sim-arn189-fail");
+    let actor = EntityActor::with_persistence(
+        "Order",
+        entity_id,
+        order_table(),
+        serde_json::json!({}),
+        crate::storage::BoxedEventStore::from_arc(store.clone()),
+        crate::storage::BackendLabel::Sim,
+    );
+    let actor_ref = system.spawn(actor, entity_id);
+
+    // Let startup (bootstrap Created append) succeed, then arm the fuse so the
+    // field-update append is the one that fails.
+    let started: EntityResponse = actor_ref
+        .ask(EntityMsg::GetState, Duration::from_secs(5))
+        .await
+        .unwrap();
+    assert!(started.success);
+    store.armed.store(true, std::sync::atomic::Ordering::SeqCst);
+
+    let response: EntityResponse = actor_ref
+        .ask(
+            EntityMsg::UpdateFields {
+                fields: serde_json::json!({"Title": "never durable"}),
+                replace: false,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+    assert!(
+        !response.success,
+        "a field update whose journal append failed must not claim success"
+    );
+    assert!(
+        response.state.fields.get("Title").is_none(),
+        "failed update must not leave half-applied in-memory state"
+    );
+}
+
 /// A committed cross-entity-guarded transition must survive replay.
 ///
 /// Regression: `File.StreamUpdated` carries a `cross_entity_state` guard on the

--- a/crates/temper-server/src/entity_actor/actor_test.rs
+++ b/crates/temper-server/src/entity_actor/actor_test.rs
@@ -894,6 +894,7 @@ async fn patched_fields_survive_actor_restart() {
             EntityMsg::UpdateFields {
                 fields: serde_json::json!({"Title": "durable title", "Priority": 3}),
                 replace: false,
+                expected_precondition: None,
             },
             Duration::from_secs(5),
         )
@@ -969,6 +970,7 @@ async fn replaced_fields_survive_actor_restart_with_replace_semantics() {
             EntityMsg::UpdateFields {
                 fields: serde_json::json!({"Title": "before", "Legacy": "drop me"}),
                 replace: false,
+                expected_precondition: None,
             },
             Duration::from_secs(5),
         )
@@ -982,6 +984,7 @@ async fn replaced_fields_survive_actor_restart_with_replace_semantics() {
             EntityMsg::UpdateFields {
                 fields: serde_json::json!({"Title": "after"}),
                 replace: true,
+                expected_precondition: None,
             },
             Duration::from_secs(5),
         )
@@ -1198,6 +1201,7 @@ async fn field_update_with_failed_journal_append_does_not_report_success() {
             EntityMsg::UpdateFields {
                 fields: serde_json::json!({"Title": "never durable"}),
                 replace: false,
+                expected_precondition: None,
             },
             Duration::from_secs(5),
         )
@@ -1257,6 +1261,7 @@ async fn field_updates_reject_when_event_budget_exhausted() {
                 EntityMsg::UpdateFields {
                     fields: serde_json::json!({"counter": i}),
                     replace: false,
+                    expected_precondition: None,
                 },
                 Duration::from_secs(5),
             )
@@ -1408,4 +1413,1155 @@ effect = [
     // Its effects were re-applied: content flag set, version bumped.
     assert_eq!(response.state.booleans.get("has_content"), Some(&true));
     assert_eq!(response.state.counters.get("version_count"), Some(&1));
+}
+
+/// ARN-189. `parse_json_body_or_400` accepts any valid JSON, so a `PUT` body of
+/// `[1,2,3]` reaches the actor. Once field updates are journaled, letting a
+/// non-object through would make the damage permanent: `apply_field_update`
+/// cannot restore `Id`/`Status` into a non-object, and `persist_event` would
+/// co-commit zero key and zero vector rows, purging the entity's index. Before
+/// journaling, that corruption was in-memory and healed on restart.
+#[tokio::test]
+async fn field_update_rejects_non_object_payload_before_journaling() {
+    let store = Arc::new(AppendFuseStore::no_faults(23));
+    let entity_id = "arn189-non-object";
+
+    let system = ActorSystem::new("sim-arn189-non-object");
+    let actor = EntityActor::with_persistence(
+        "Order",
+        entity_id,
+        order_table(),
+        serde_json::json!({"Customer": "Alice"}),
+        crate::storage::BoxedEventStore::from_arc(store.clone()),
+        crate::storage::BackendLabel::Sim,
+    );
+    let actor_ref = system.spawn(actor, entity_id);
+
+    let baseline: EntityResponse = actor_ref
+        .ask(EntityMsg::GetState, Duration::from_secs(5))
+        .await
+        .expect("baseline state");
+    let baseline_events = baseline.state.total_event_count;
+    let baseline_sequence = baseline.state.sequence_nr;
+
+    for body in [
+        serde_json::json!([1, 2, 3]),
+        serde_json::json!("a string"),
+        serde_json::json!(null),
+        serde_json::json!(7),
+    ] {
+        for replace in [true, false] {
+            let response: EntityResponse = actor_ref
+                .ask(
+                    EntityMsg::UpdateFields {
+                        fields: body.clone(),
+                        replace,
+                        expected_precondition: None,
+                    },
+                    Duration::from_secs(5),
+                )
+                .await
+                .expect("field update response");
+            assert!(
+                !response.success,
+                "non-object body {body:?} (replace={replace}) must be rejected"
+            );
+            assert!(
+                response
+                    .error
+                    .as_deref()
+                    .unwrap_or_default()
+                    .contains("must be a JSON object"),
+                "unexpected error for {body:?}: {:?}",
+                response.error
+            );
+            // The entity is untouched — not emptied, not stripped of identity,
+            // and nothing reached the journal or the index rows it co-commits.
+            assert_eq!(response.state.fields["Customer"], "Alice");
+            assert_eq!(response.state.fields["Id"], entity_id);
+            assert_eq!(
+                response.state.total_event_count, baseline_events,
+                "a refused payload must not be journaled"
+            );
+            assert_eq!(
+                response.state.sequence_nr, baseline_sequence,
+                "a refused payload must not advance the durable sequence"
+            );
+        }
+    }
+}
+
+/// ARN-189. Runtime-owned fields must survive a field update, and — because
+/// `apply_field_update` is shared with journal replay — must survive rehydration
+/// identically. A sanitize step applied only on the live path would silently
+/// rewrite the entity the next time it replayed.
+#[tokio::test]
+async fn field_update_sanitization_is_reproduced_by_replay() {
+    let store = Arc::new(AppendFuseStore::no_faults(29));
+    let entity_id = "arn189-sanitize-replay";
+
+    let system = ActorSystem::new("sim-arn189-sanitize");
+    let actor = EntityActor::with_persistence(
+        "Order",
+        entity_id,
+        order_table(),
+        serde_json::json!({"Customer": "Alice"}),
+        crate::storage::BoxedEventStore::from_arc(store.clone()),
+        crate::storage::BackendLabel::Sim,
+    );
+    let actor_ref = system.spawn(actor, entity_id);
+
+    let response: EntityResponse = actor_ref
+        .ask(
+            EntityMsg::UpdateFields {
+                fields: serde_json::json!({
+                    "Customer": "Bob",
+                    "Id": "forged-id",
+                    "Status": "Delivered",
+                    "has_spec": true,
+                    "ctx_owner_status": "Privileged",
+                }),
+                replace: false,
+                expected_precondition: None,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("field update response");
+    assert!(
+        response.success,
+        "update should succeed: {:?}",
+        response.error
+    );
+
+    let live_fields = response.state.fields.clone();
+    assert_eq!(live_fields["Id"], entity_id, "forged Id must not stick");
+    assert_eq!(live_fields["Customer"], "Bob");
+    for reserved in ["has_spec", "ctx_owner_status"] {
+        assert!(
+            live_fields.get(reserved).is_none(),
+            "runtime-owned `{reserved}` must be stripped, got {live_fields:?}"
+        );
+    }
+
+    // The journal itself must not carry the forged runtime-owned keys. Sanitizing
+    // only on the way into state would leave them in the event, where a future
+    // reader (an audit, a projection, a replay under different code) still sees a
+    // second claimed truth for identity and lifecycle.
+    use temper_runtime::persistence::EventStore as _;
+    let envelopes = store
+        .inner
+        .read_events(&format!("default:Order:{entity_id}"), 0)
+        .await
+        .expect("read journal");
+    assert!(!envelopes.is_empty(), "the update must have been journaled");
+    let mut saw_field_event = false;
+    for envelope in &envelopes {
+        let Ok(event) = serde_json::from_value::<EntityEvent>(envelope.payload.clone()) else {
+            continue;
+        };
+        if event.action != crate::entity_actor::effects::FIELDS_UPDATED_EVENT
+            && event.action != crate::entity_actor::effects::FIELDS_REPLACED_EVENT
+        {
+            continue;
+        }
+        saw_field_event = true;
+        for reserved in ["has_spec", "ctx_owner_status"] {
+            assert!(
+                event.params.get(reserved).is_none(),
+                "journaled `{}` still carries runtime-owned `{reserved}`: {:?}",
+                event.action,
+                event.params
+            );
+        }
+    }
+    assert!(saw_field_event, "expected a journaled field-update event");
+
+    // Rehydrate from the journal: replay must land on exactly the same fields.
+    let replayed = EntityActor::with_persistence(
+        "Order",
+        entity_id,
+        order_table(),
+        serde_json::json!({"Customer": "Alice"}),
+        crate::storage::BoxedEventStore::from_arc(store.clone()),
+        crate::storage::BackendLabel::Sim,
+    );
+    let replayed_ref = system.spawn(replayed, entity_id);
+    let after: EntityResponse = replayed_ref
+        .ask(EntityMsg::GetState, Duration::from_secs(5))
+        .await
+        .expect("state after rehydration");
+    assert_eq!(
+        after.state.fields, live_fields,
+        "replay must reproduce the live result exactly"
+    );
+}
+
+/// ARN-189. Replay dispatches the field-update event names to
+/// `apply_field_update` before the generic action path, so a spec action with
+/// the same name would be hijacked on rehydration: its params merged into
+/// fields, its transition never replayed. The ADR reserved the names by
+/// convention; this makes the reservation real.
+#[tokio::test]
+async fn reserved_field_update_event_names_are_refused_as_actions() {
+    let store = Arc::new(AppendFuseStore::no_faults(31));
+    let entity_id = "arn189-reserved-name";
+
+    let system = ActorSystem::new("sim-arn189-reserved");
+    let actor = EntityActor::with_persistence(
+        "Order",
+        entity_id,
+        order_table(),
+        serde_json::json!({"Customer": "Alice"}),
+        crate::storage::BoxedEventStore::from_arc(store.clone()),
+        crate::storage::BackendLabel::Sim,
+    );
+    let actor_ref = system.spawn(actor, entity_id);
+
+    let baseline: EntityResponse = actor_ref
+        .ask(EntityMsg::GetState, Duration::from_secs(5))
+        .await
+        .expect("baseline state");
+    let baseline_events = baseline.state.total_event_count;
+
+    for reserved in [
+        crate::entity_actor::effects::FIELDS_UPDATED_EVENT,
+        crate::entity_actor::effects::FIELDS_REPLACED_EVENT,
+    ] {
+        let response: EntityResponse = actor_ref
+            .ask(
+                EntityMsg::Action {
+                    name: reserved.to_string(),
+                    params: serde_json::json!({"Customer": "Mallory"}),
+                    cross_entity_booleans: BTreeMap::new(),
+                    idempotency_key: None,
+                    expected_authorization_precondition: None,
+                },
+                Duration::from_secs(5),
+            )
+            .await
+            .expect("action response");
+        assert!(
+            !response.success,
+            "`{reserved}` must not be dispatchable as a domain action"
+        );
+        assert!(
+            response
+                .error
+                .as_deref()
+                .unwrap_or_default()
+                .contains("reserved"),
+            "unexpected error for `{reserved}`: {:?}",
+            response.error
+        );
+        assert_eq!(
+            response.state.fields["Customer"], "Alice",
+            "a refused action must not have merged its params into fields"
+        );
+        assert_eq!(
+            response.state.total_event_count, baseline_events,
+            "a refused action must not journal anything"
+        );
+    }
+}
+
+/// ARN-189. A sequence conflict on the field-update append used to wedge the
+/// arm: every later update failed with an error until the actor happened to
+/// rehydrate with the authoritative sequence. The Action arm right above has had
+/// ADR-0046 replay-and-retry for exactly this; a field update needs the same,
+/// minus the guard re-evaluation it has no guards for.
+#[tokio::test]
+async fn field_update_recovers_from_a_concurrency_violation() {
+    let store = Arc::new(AppendFuseStore::no_faults(37));
+    let entity_id = "arn189-concurrency";
+    let persistence_id = format!("default:Order:{entity_id}");
+
+    let system = ActorSystem::new("sim-arn189-concurrency");
+    let actor = EntityActor::with_persistence(
+        "Order",
+        entity_id,
+        order_table(),
+        serde_json::json!({"Customer": "Alice"}),
+        crate::storage::BoxedEventStore::from_arc(store.clone()),
+        crate::storage::BackendLabel::Sim,
+    );
+    let actor_ref = system.spawn(actor, entity_id);
+
+    // Warm up first: spawning/creating the entity itself appends, and an
+    // injection armed before that would be spent on the creation append instead
+    // of the update under test — leaving the test green for the wrong reason.
+    let warmup: EntityResponse = actor_ref
+        .ask(
+            EntityMsg::UpdateFields {
+                fields: serde_json::json!({"Customer": "Warmup"}),
+                replace: false,
+                expected_precondition: None,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("warmup response");
+    assert!(warmup.success, "warmup update should succeed");
+
+    // One deterministic conflict on the next append: within the retry budget.
+    store
+        .inner
+        .inject_concurrency_violations(&persistence_id, 1);
+
+    let response: EntityResponse = actor_ref
+        .ask(
+            EntityMsg::UpdateFields {
+                fields: serde_json::json!({"Customer": "Bob"}),
+                replace: false,
+                expected_precondition: None,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("field update response");
+
+    assert!(
+        response.success,
+        "a single conflict must be recovered, not surfaced: {:?}",
+        response.error
+    );
+    assert_eq!(response.state.fields["Customer"], "Bob");
+
+    // And the arm is not wedged: the next update still succeeds.
+    let next: EntityResponse = actor_ref
+        .ask(
+            EntityMsg::UpdateFields {
+                fields: serde_json::json!({"Customer": "Carol"}),
+                replace: false,
+                expected_precondition: None,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("second field update response");
+    assert!(
+        next.success,
+        "the arm must not be wedged after a recovered conflict: {:?}",
+        next.error
+    );
+    assert_eq!(next.state.fields["Customer"], "Carol");
+
+    // The update is durable: rehydrate and read it back.
+    let replayed = EntityActor::with_persistence(
+        "Order",
+        entity_id,
+        order_table(),
+        serde_json::json!({"Customer": "Alice"}),
+        crate::storage::BoxedEventStore::from_arc(store.clone()),
+        crate::storage::BackendLabel::Sim,
+    );
+    let replayed_ref = system.spawn(replayed, entity_id);
+    let after: EntityResponse = replayed_ref
+        .ask(EntityMsg::GetState, Duration::from_secs(5))
+        .await
+        .expect("state after rehydration");
+    assert_eq!(after.state.fields["Customer"], "Carol");
+}
+
+/// Beyond the retry budget the arm still fails closed rather than reporting a
+/// success it did not persist.
+#[tokio::test]
+async fn field_update_fails_closed_when_conflicts_exceed_the_retry_budget() {
+    let store = Arc::new(AppendFuseStore::no_faults(41));
+    let entity_id = "arn189-concurrency-exhausted";
+    let persistence_id = format!("default:Order:{entity_id}");
+
+    let system = ActorSystem::new("sim-arn189-exhausted");
+    let actor = EntityActor::with_persistence(
+        "Order",
+        entity_id,
+        order_table(),
+        serde_json::json!({"Customer": "Alice"}),
+        crate::storage::BoxedEventStore::from_arc(store.clone()),
+        crate::storage::BackendLabel::Sim,
+    );
+    let actor_ref = system.spawn(actor, entity_id);
+
+    // Warm up first: spawning/creating the entity itself appends, and an
+    // injection armed before that would be spent on the creation append instead
+    // of the update under test — leaving the test green for the wrong reason.
+    let warmup: EntityResponse = actor_ref
+        .ask(
+            EntityMsg::UpdateFields {
+                fields: serde_json::json!({"Customer": "Warmup"}),
+                replace: false,
+                expected_precondition: None,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("warmup response");
+    assert!(warmup.success, "warmup update should succeed");
+
+    let before: EntityResponse = actor_ref
+        .ask(EntityMsg::GetState, Duration::from_secs(5))
+        .await
+        .expect("state before");
+
+    // 3 conflicts: 1 initial attempt + 2 retries all fail.
+    store
+        .inner
+        .inject_concurrency_violations(&persistence_id, 3);
+
+    let response: EntityResponse = actor_ref
+        .ask(
+            EntityMsg::UpdateFields {
+                fields: serde_json::json!({"Customer": "Bob"}),
+                replace: false,
+                expected_precondition: None,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("field update response");
+
+    assert!(
+        !response.success,
+        "an unpersisted update must never be reported as success"
+    );
+    assert_eq!(
+        response.state.fields["Customer"], "Warmup",
+        "the speculative merge must be rolled back to the last durable value"
+    );
+    assert_eq!(
+        response.state.sequence_nr, before.state.sequence_nr,
+        "a failed append must not advance the durable sequence"
+    );
+    assert_eq!(
+        response.state.total_event_count, before.state.total_event_count,
+        "a failed append must not add an event"
+    );
+}
+
+/// ARN-189. `apply_field_update` is the one place PATCH and PUT semantics are
+/// decided, and it runs on both the live path and journal replay. Pinned
+/// directly, without an actor system, so a change to merge/replace or to the
+/// runtime-owned field handling fails here first and unambiguously.
+#[test]
+fn apply_field_update_merge_replace_and_runtime_owned_fields() {
+    fn state_with(fields: serde_json::Value) -> EntityState {
+        EntityState {
+            entity_type: "Order".to_string(),
+            entity_id: "order-1".to_string(),
+            status: "Draft".to_string(),
+            item_count: 0,
+            counters: BTreeMap::new(),
+            booleans: BTreeMap::new(),
+            lists: BTreeMap::new(),
+            fields,
+            events: std::collections::VecDeque::new(),
+            total_event_count: 0,
+            events_since_snapshot: 0,
+            last_snapshot_sequence_nr: 0,
+            sequence_nr: 0,
+            processed_idempotency_keys: BTreeMap::new(),
+        }
+    }
+
+    // PATCH merges and leaves untouched keys alone.
+    let mut state = state_with(serde_json::json!({"Customer": "Alice", "Region": "eu"}));
+    assert!(crate::entity_actor::effects::apply_field_update(
+        &mut state,
+        &serde_json::json!({"Customer": "Bob"}),
+        false,
+    ));
+    assert_eq!(state.fields["Customer"], "Bob");
+    assert_eq!(
+        state.fields["Region"], "eu",
+        "PATCH must not drop other keys"
+    );
+
+    // PUT replaces wholesale — the unmentioned key is gone.
+    let mut state = state_with(serde_json::json!({"Customer": "Alice", "Region": "eu"}));
+    assert!(crate::entity_actor::effects::apply_field_update(
+        &mut state,
+        &serde_json::json!({"Customer": "Bob"}),
+        true,
+    ));
+    assert_eq!(state.fields["Customer"], "Bob");
+    assert!(
+        state.fields.get("Region").is_none(),
+        "PUT must replace, not merge: {:?}",
+        state.fields
+    );
+
+    // Identity and lifecycle stay authoritative under both, and a caller cannot
+    // forge them or the runtime-owned fields.
+    for replace in [true, false] {
+        let mut state = state_with(serde_json::json!({"Customer": "Alice"}));
+        assert!(crate::entity_actor::effects::apply_field_update(
+            &mut state,
+            &serde_json::json!({
+                "Id": "forged",
+                "Status": "Delivered",
+                "has_spec": true,
+                "ctx_owner_status": "Privileged",
+            }),
+            replace,
+        ));
+        assert_eq!(state.fields["Id"], "order-1", "replace={replace}");
+        assert_eq!(state.fields["Status"], "Draft", "replace={replace}");
+        for reserved in ["has_spec", "ctx_owner_status"] {
+            assert!(
+                state.fields.get(reserved).is_none(),
+                "runtime-owned `{reserved}` must be stripped (replace={replace})"
+            );
+        }
+    }
+
+    // Idempotent: replay applies the same event again and must not drift.
+    let mut state = state_with(serde_json::json!({"Customer": "Alice"}));
+    let update = serde_json::json!({"Customer": "Bob"});
+    assert!(crate::entity_actor::effects::apply_field_update(
+        &mut state, &update, false
+    ));
+    let once = state.fields.clone();
+    assert!(crate::entity_actor::effects::apply_field_update(
+        &mut state, &update, false
+    ));
+    assert_eq!(state.fields, once, "re-applying an event must not drift");
+}
+
+/// ARN-189 / F1. The retry catches up by rebuilding from a fresh initial state,
+/// not by replaying onto the live state. Replaying additively re-applies every
+/// event on top of its own effects: the events deque grows, `total_event_count`
+/// and `events_since_snapshot` climb, and non-idempotent effects fire twice — and
+/// the result is returned to the caller, projected, and possibly snapshotted.
+#[tokio::test]
+async fn field_update_retry_does_not_double_apply_the_journal() {
+    let store = Arc::new(AppendFuseStore::no_faults(43));
+    let entity_id = "arn189-additive-replay";
+    let persistence_id = format!("default:Order:{entity_id}");
+
+    let system = ActorSystem::new("sim-arn189-additive");
+    let actor = EntityActor::with_persistence(
+        "Order",
+        entity_id,
+        order_table(),
+        serde_json::json!({"Customer": "Alice"}),
+        crate::storage::BoxedEventStore::from_arc(store.clone()),
+        crate::storage::BackendLabel::Sim,
+    );
+    let actor_ref = system.spawn(actor, entity_id);
+
+    // Build a little history so a replay has something to double-apply.
+    for customer in ["First", "Second", "Third"] {
+        let response: EntityResponse = actor_ref
+            .ask(
+                EntityMsg::UpdateFields {
+                    fields: serde_json::json!({"Customer": customer}),
+                    replace: false,
+                    expected_precondition: None,
+                },
+                Duration::from_secs(5),
+            )
+            .await
+            .expect("seed update");
+        assert!(response.success);
+    }
+    let before: EntityResponse = actor_ref
+        .ask(EntityMsg::GetState, Duration::from_secs(5))
+        .await
+        .expect("state before conflict");
+    let events_before = before.state.total_event_count;
+    let since_snapshot_before = before.state.events_since_snapshot;
+
+    // One conflict: the retry replays.
+    store
+        .inner
+        .inject_concurrency_violations(&persistence_id, 1);
+    let recovered: EntityResponse = actor_ref
+        .ask(
+            EntityMsg::UpdateFields {
+                fields: serde_json::json!({"Customer": "Fourth"}),
+                replace: false,
+                expected_precondition: None,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("recovered update");
+    assert!(
+        recovered.success,
+        "conflict should be recovered: {:?}",
+        recovered.error
+    );
+
+    // Exactly one event was added, not the whole journal over again.
+    assert_eq!(
+        recovered.state.total_event_count,
+        events_before + 1,
+        "a recovered retry must add one event, not re-apply the journal \
+         (before={events_before}, after={})",
+        recovered.state.total_event_count
+    );
+    assert_eq!(
+        recovered.state.events_since_snapshot,
+        since_snapshot_before + 1,
+        "replaying onto live state would inflate the snapshot tail and can wedge \
+         the entity on the event budget"
+    );
+    assert_eq!(recovered.state.fields["Customer"], "Fourth");
+
+    // And the rehydrated state agrees with what the caller was told.
+    let replayed = EntityActor::with_persistence(
+        "Order",
+        entity_id,
+        order_table(),
+        serde_json::json!({"Customer": "Alice"}),
+        crate::storage::BoxedEventStore::from_arc(store.clone()),
+        crate::storage::BackendLabel::Sim,
+    );
+    let replayed_ref = system.spawn(replayed, entity_id);
+    let after: EntityResponse = replayed_ref
+        .ask(EntityMsg::GetState, Duration::from_secs(5))
+        .await
+        .expect("state after rehydration");
+    assert_eq!(
+        after.state.total_event_count,
+        recovered.state.total_event_count
+    );
+    assert_eq!(after.state.fields["Customer"], "Fourth");
+}
+
+/// ARN-189 / F2. A preconditioned update is a compare-and-set. A conflict proves
+/// the journal moved under it, so replaying and committing would apply the write
+/// to state the caller never saw and Cedar never evaluated. It must be refused,
+/// not retried — `entity_ops` caps preconditioned asks at one attempt for exactly
+/// this reason.
+#[tokio::test]
+async fn preconditioned_field_update_refuses_rather_than_retrying_a_conflict() {
+    let store = Arc::new(AppendFuseStore::no_faults(47));
+    let entity_id = "arn189-cas-no-retry";
+    let persistence_id = format!("default:Order:{entity_id}");
+
+    let system = ActorSystem::new("sim-arn189-cas");
+    let actor = EntityActor::with_persistence(
+        "Order",
+        entity_id,
+        order_table(),
+        serde_json::json!({"Customer": "Alice"}),
+        crate::storage::BoxedEventStore::from_arc(store.clone()),
+        crate::storage::BackendLabel::Sim,
+    );
+    let actor_ref = system.spawn(actor, entity_id);
+
+    let current: EntityResponse = actor_ref
+        .ask(EntityMsg::GetState, Duration::from_secs(5))
+        .await
+        .expect("state");
+    let precondition =
+        crate::entity_actor::effects::entity_authorization_precondition(&current.state);
+
+    // A single conflict — within the retry budget an unpreconditioned update
+    // would recover from it.
+    store
+        .inner
+        .inject_concurrency_violations(&persistence_id, 1);
+
+    let response: EntityResponse = actor_ref
+        .ask(
+            EntityMsg::UpdateFields {
+                fields: serde_json::json!({"Customer": "Bob"}),
+                replace: false,
+                expected_precondition: Some(precondition),
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("field update response");
+
+    assert!(
+        !response.success,
+        "a compare-and-set must not be silently retried onto state the caller \
+         never authorized"
+    );
+    assert!(
+        response
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("authorization became stale"),
+        "unexpected error: {:?}",
+        response.error
+    );
+    assert_ne!(
+        response.state.fields["Customer"], "Bob",
+        "the speculative merge must be rolled back"
+    );
+}
+
+/// ARN-189 / F4.1. The race the retry loop exists for can also delete the entity.
+/// The deletion check runs before the first attempt against the actor's memory;
+/// after a replay the journal may hold a tombstone the actor had not seen. Without
+/// rechecking, the retry appends a field update *after* the tombstone, and strict
+/// replay then rejects the whole journal as events-after-terminal — the entity
+/// becomes unrecoverable by the authoritative path.
+///
+/// Driven by a second actor on the same store, so the conflict is a real stale
+/// sequence rather than an injected one.
+#[tokio::test]
+async fn field_update_retry_refuses_when_the_race_deleted_the_entity() {
+    let store = Arc::new(AppendFuseStore::no_faults(53));
+    let entity_id = "arn189-deleted-in-race";
+    let boxed = || crate::storage::BoxedEventStore::from_arc(store.clone());
+
+    let system = ActorSystem::new("sim-arn189-deleted-race");
+    let writer = system.spawn(
+        EntityActor::with_persistence(
+            "Order",
+            entity_id,
+            order_table(),
+            serde_json::json!({"Customer": "Alice"}),
+            boxed(),
+            crate::storage::BackendLabel::Sim,
+        ),
+        entity_id,
+    );
+    // Give the writer a durable baseline it has seen.
+    let seeded: EntityResponse = writer
+        .ask(
+            EntityMsg::UpdateFields {
+                fields: serde_json::json!({"Customer": "Seed"}),
+                replace: false,
+                expected_precondition: None,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("seed");
+    assert!(seeded.success);
+
+    // A second actor on the same journal deletes the entity. The first actor's
+    // in-memory sequence is now stale and knows nothing about the tombstone.
+    let deleter = system.spawn(
+        EntityActor::with_persistence(
+            "Order",
+            entity_id,
+            order_table(),
+            serde_json::json!({"Customer": "Alice"}),
+            boxed(),
+            crate::storage::BackendLabel::Sim,
+        ),
+        format!("{entity_id}-deleter"),
+    );
+    let deleted: EntityResponse = deleter
+        .ask(
+            EntityMsg::Delete {
+                expected_authorization_precondition: None,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("delete");
+    assert!(
+        deleted.success,
+        "delete should succeed: {:?}",
+        deleted.error
+    );
+
+    // The stale writer now tries to update. Its append conflicts, it replays,
+    // and it must see the tombstone and refuse.
+    let response: EntityResponse = writer
+        .ask(
+            EntityMsg::UpdateFields {
+                fields: serde_json::json!({"Customer": "TooLate"}),
+                replace: false,
+                expected_precondition: None,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("post-delete update response");
+
+    assert!(
+        !response.success,
+        "a field update must not be appended after the entity was deleted"
+    );
+    assert!(
+        response
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("after entity deletion"),
+        "unexpected error: {:?}",
+        response.error
+    );
+}
+
+/// ARN-189 / F4.4. The advertised budget is 1 initial attempt + 2 retries.
+/// `field_update_recovers_from_a_concurrency_violation` pins 1 conflict and
+/// `..._exceed_the_retry_budget` pins 3, so halving the budget to a single retry
+/// is invisible to both. This pins the boundary: exactly 2 conflicts must still
+/// recover.
+#[tokio::test]
+async fn field_update_recovers_at_the_full_retry_budget() {
+    let store = Arc::new(AppendFuseStore::no_faults(59));
+    let entity_id = "arn189-budget-boundary";
+    let persistence_id = format!("default:Order:{entity_id}");
+
+    let system = ActorSystem::new("sim-arn189-boundary");
+    let actor_ref = system.spawn(
+        EntityActor::with_persistence(
+            "Order",
+            entity_id,
+            order_table(),
+            serde_json::json!({"Customer": "Alice"}),
+            crate::storage::BoxedEventStore::from_arc(store.clone()),
+            crate::storage::BackendLabel::Sim,
+        ),
+        entity_id,
+    );
+    let warmup: EntityResponse = actor_ref
+        .ask(
+            EntityMsg::UpdateFields {
+                fields: serde_json::json!({"Customer": "Warmup"}),
+                replace: false,
+                expected_precondition: None,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("warmup");
+    assert!(warmup.success);
+
+    // 2 conflicts: the second retry is the last one allowed.
+    store
+        .inner
+        .inject_concurrency_violations(&persistence_id, 2);
+
+    let response: EntityResponse = actor_ref
+        .ask(
+            EntityMsg::UpdateFields {
+                fields: serde_json::json!({"Customer": "Bob"}),
+                replace: false,
+                expected_precondition: None,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("field update response");
+
+    assert!(
+        response.success,
+        "two conflicts are within the advertised 1 + 2 budget: {:?}",
+        response.error
+    );
+    assert_eq!(response.state.fields["Customer"], "Bob");
+}
+
+/// ARN-189. A historical `FieldsReplaced` event carrying a non-object payload —
+/// written by a build that predates the live guard — must not be able to replace
+/// an entity's fields with an array during replay. The guard lives in
+/// `apply_field_update`, so live and replay screen the same inputs.
+#[test]
+fn replaying_a_non_object_field_event_leaves_state_untouched() {
+    let mut state = EntityState {
+        entity_type: "Order".to_string(),
+        entity_id: "order-1".to_string(),
+        status: "Draft".to_string(),
+        item_count: 0,
+        counters: BTreeMap::new(),
+        booleans: BTreeMap::new(),
+        lists: BTreeMap::new(),
+        fields: serde_json::json!({"Customer": "Alice", "Id": "order-1"}),
+        events: std::collections::VecDeque::new(),
+        total_event_count: 0,
+        events_since_snapshot: 0,
+        last_snapshot_sequence_nr: 0,
+        sequence_nr: 0,
+        processed_idempotency_keys: BTreeMap::new(),
+    };
+    let before = state.fields.clone();
+
+    for payload in [
+        serde_json::json!([1, 2, 3]),
+        serde_json::json!("a string"),
+        serde_json::json!(null),
+    ] {
+        for replace in [true, false] {
+            assert!(
+                !crate::entity_actor::effects::apply_field_update(&mut state, &payload, replace),
+                "a non-object payload must be declined, not applied"
+            );
+            assert_eq!(
+                state.fields, before,
+                "a non-object payload must not touch state (replace={replace}, \
+                 payload={payload:?})"
+            );
+        }
+    }
+}
+
+/// ARN-189 / F4.3. `previous_fields` is re-captured from the caught-up state on
+/// every retry. If it were not, the terminal rollback after an exhausted retry
+/// would restore the *pre-replay* fields — erasing a concurrent writer's
+/// committed values from live state until the actor next rehydrates, so reads
+/// would serve data the journal says is stale.
+#[tokio::test]
+async fn exhausted_field_update_rolls_back_to_the_caught_up_state() {
+    let store = Arc::new(AppendFuseStore::no_faults(61));
+    let entity_id = "arn189-rollback-base";
+    let persistence_id = format!("default:Order:{entity_id}");
+    let boxed = || crate::storage::BoxedEventStore::from_arc(store.clone());
+
+    let system = ActorSystem::new("sim-arn189-rollback-base");
+    let writer = system.spawn(
+        EntityActor::with_persistence(
+            "Order",
+            entity_id,
+            order_table(),
+            serde_json::json!({"Customer": "Alice"}),
+            boxed(),
+            crate::storage::BackendLabel::Sim,
+        ),
+        entity_id,
+    );
+    let seeded: EntityResponse = writer
+        .ask(
+            EntityMsg::UpdateFields {
+                fields: serde_json::json!({"Customer": "Seed"}),
+                replace: false,
+                expected_precondition: None,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("seed");
+    assert!(seeded.success);
+
+    // A second actor commits a value the first has never seen.
+    let other = system.spawn(
+        EntityActor::with_persistence(
+            "Order",
+            entity_id,
+            order_table(),
+            serde_json::json!({"Customer": "Alice"}),
+            boxed(),
+            crate::storage::BackendLabel::Sim,
+        ),
+        format!("{entity_id}-other"),
+    );
+    let concurrent: EntityResponse = other
+        .ask(
+            EntityMsg::UpdateFields {
+                fields: serde_json::json!({"Customer": "Concurrent"}),
+                replace: false,
+                expected_precondition: None,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("concurrent write");
+    assert!(concurrent.success);
+
+    // The stale writer conflicts naturally on its first attempt, replays and
+    // picks up "Concurrent"; the injected conflicts then exhaust its retries.
+    store
+        .inner
+        .inject_concurrency_violations(&persistence_id, 4);
+
+    let response: EntityResponse = writer
+        .ask(
+            EntityMsg::UpdateFields {
+                fields: serde_json::json!({"Customer": "Loser"}),
+                replace: false,
+                expected_precondition: None,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("exhausted update response");
+
+    assert!(!response.success, "the update should have failed");
+    assert_eq!(
+        response.state.fields["Customer"], "Concurrent",
+        "rollback must restore the caught-up state, not the pre-replay one: {:?}",
+        response.state.fields
+    );
+}
+
+/// ARN-189 / F4.2. The event budget is checked before the first attempt against
+/// the actor's memory. A concurrent writer can spend the budget while this update
+/// is in flight, so the check is re-run after each catch-up replay. Without the
+/// recheck the retry appends past `MAX_EVENTS_SINCE_SNAPSHOT`, growing the
+/// snapshot tail past the hydration budget the entry check exists to protect —
+/// which is how an entity becomes permanently unhydratable.
+#[tokio::test]
+async fn field_update_retry_refuses_when_the_race_spent_the_event_budget() {
+    let store = Arc::new(AppendFuseStore::no_faults(67));
+    // Snapshots never succeed: models the stalled snapshot path that lets the
+    // tail grow in the first place.
+    store
+        .fail_snapshots
+        .store(true, std::sync::atomic::Ordering::SeqCst);
+    let entity_id = "arn189-budget-race";
+    let boxed = || crate::storage::BoxedEventStore::from_arc(store.clone());
+
+    let system = ActorSystem::new("sim-arn189-budget-race");
+    let stale = system.spawn(
+        EntityActor::with_persistence(
+            "Order",
+            entity_id,
+            order_table(),
+            serde_json::json!({"Customer": "Alice"}),
+            boxed(),
+            crate::storage::BackendLabel::Sim,
+        ),
+        entity_id,
+    );
+    // The stale writer sees one durable event and nothing after it.
+    let seeded: EntityResponse = stale
+        .ask(
+            EntityMsg::UpdateFields {
+                fields: serde_json::json!({"Customer": "Seed"}),
+                replace: false,
+                expected_precondition: None,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("seed");
+    assert!(seeded.success);
+
+    // A second actor on the same journal spends the whole budget.
+    let hog = system.spawn(
+        EntityActor::with_persistence(
+            "Order",
+            entity_id,
+            order_table(),
+            serde_json::json!({"Customer": "Alice"}),
+            boxed(),
+            crate::storage::BackendLabel::Sim,
+        ),
+        format!("{entity_id}-hog"),
+    );
+    for i in 0..MAX_EVENTS_SINCE_SNAPSHOT {
+        let response: EntityResponse = hog
+            .ask(
+                EntityMsg::UpdateFields {
+                    fields: serde_json::json!({"filler": i}),
+                    replace: false,
+                    expected_precondition: None,
+                },
+                Duration::from_secs(5),
+            )
+            .await
+            .expect("filler update");
+        if !response.success {
+            break;
+        }
+    }
+
+    // The stale writer now attempts an update: its append conflicts, it replays
+    // and finds the budget already spent.
+    let response: EntityResponse = stale
+        .ask(
+            EntityMsg::UpdateFields {
+                fields: serde_json::json!({"Customer": "TooLate"}),
+                replace: false,
+                expected_precondition: None,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("post-race update response");
+
+    assert!(
+        !response.success,
+        "an update must not append past the event budget after catching up"
+    );
+    assert!(
+        response
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("Event budget exhausted"),
+        "unexpected error: {:?}",
+        response.error
+    );
+}
+
+/// ARN-189 / F4.5. Under a lenient replay policy a field-update event whose
+/// payload no longer deserializes is skipped so hydration survives spec
+/// evolution — but that means an update the caller was told was durable is absent
+/// from the rebuilt state. A `tracing::warn!` alone leaves that undetectable in
+/// aggregate, so it is also counted. Asserted through a real meter, because a
+/// counter nobody reads is indistinguishable from one that is never incremented.
+#[tokio::test]
+async fn replay_skip_of_a_field_update_event_is_counted() {
+    use opentelemetry_sdk::metrics::{InMemoryMetricExporter, SdkMeterProvider};
+    use temper_runtime::persistence::EventStore;
+    use temper_store_sim::SimEventStore;
+
+    let exporter = InMemoryMetricExporter::default();
+    let provider = SdkMeterProvider::builder()
+        .with_periodic_exporter(exporter.clone())
+        .build();
+    opentelemetry::global::set_meter_provider(provider.clone());
+
+    let store = Arc::new(SimEventStore::no_faults(71));
+    let pid = "default:Order:arn189-replay-skip-metric";
+
+    // A journaled field update whose payload does not deserialize as an
+    // `EntityEvent` — the shape a build under a previous schema could have left.
+    let bad_env = PersistenceEnvelope {
+        sequence_nr: 0,
+        event_type: crate::entity_actor::effects::FIELDS_UPDATED_EVENT.to_string(),
+        payload: serde_json::json!({
+            "action": 999,
+            "params": {"Customer": "Bob"}
+        }),
+        metadata: EventMetadata {
+            event_id: sim_uuid(),
+            causation_id: sim_uuid(),
+            correlation_id: sim_uuid(),
+            timestamp: sim_now(),
+            actor_id: pid.to_string(),
+        },
+    };
+    store
+        .append(pid, 0, std::slice::from_ref(&bad_env))
+        .await
+        .expect("append malformed field-update event");
+
+    // Rehydrate: the malformed event is skipped (lenient policy) and counted.
+    let system = ActorSystem::new("sim-arn189-skip-metric");
+    let actor_ref = system.spawn(
+        EntityActor::with_persistence(
+            "Order",
+            "arn189-replay-skip-metric",
+            order_table(),
+            serde_json::json!({"Customer": "Alice"}),
+            crate::storage::BoxedEventStore::from_arc(store.clone()),
+            crate::storage::BackendLabel::Sim,
+        ),
+        "arn189-replay-skip-metric",
+    );
+    let after: EntityResponse = actor_ref
+        .ask(EntityMsg::GetState, Duration::from_secs(5))
+        .await
+        .expect("state after rehydration");
+    assert_eq!(
+        after.state.fields["Customer"], "Alice",
+        "the malformed update must be skipped, not applied"
+    );
+
+    provider.force_flush().expect("flush metrics");
+    let counted = exporter
+        .get_finished_metrics()
+        .expect("metrics")
+        .iter()
+        .flat_map(|rm| rm.scope_metrics.iter())
+        .flat_map(|sm| sm.metrics.iter())
+        .any(|m| m.name == "temper_entity_field_update_replay_skipped_total");
+    assert!(
+        counted,
+        "a skipped field-update event must be counted, not only logged"
+    );
 }

--- a/crates/temper-server/src/entity_actor/authoritative_replay_test.rs
+++ b/crates/temper-server/src/entity_actor/authoritative_replay_test.rs
@@ -285,3 +285,84 @@ async fn authoritative_replay_rejects_misbound_actor_metadata() {
 
     assert!(error.to_string().contains("bound to actor"));
 }
+
+/// ARN-189. Authoritative replay backs identity and authority resolution, so a
+/// malformed field-update event must FAIL it, not be skipped: a `FieldsReplaced`
+/// that was written to revoke authority — clearing a privileged field — would
+/// otherwise be dropped, and the "authoritative" state would preserve exactly the
+/// authority it was meant to remove. The lenient path skips and counts; this pins
+/// the strict path.
+#[tokio::test]
+async fn authoritative_replay_rejects_malformed_field_update_events() {
+    for event_type in [
+        crate::entity_actor::effects::FIELDS_UPDATED_EVENT,
+        crate::entity_actor::effects::FIELDS_REPLACED_EVENT,
+    ] {
+        let malformed = PersistenceEnvelope {
+            sequence_nr: 1,
+            event_type: event_type.to_string(),
+            // Not deserializable as an EntityEvent: `action` is a number.
+            payload: serde_json::json!({
+                "action": 999,
+                "params": {"Privileged": true}
+            }),
+            metadata: EventMetadata {
+                event_id: sim_uuid(),
+                causation_id: sim_uuid(),
+                correlation_id: sim_uuid(),
+                timestamp: sim_now(),
+                actor_id: "default:Order:security-replay".to_string(),
+            },
+        };
+        let error = authoritative_replay(StaticEventStore {
+            events: vec![malformed],
+            read_error: None,
+            snapshot: None,
+        })
+        .await
+        .expect_err("a malformed field-update event must fail authoritative replay");
+        assert!(
+            error.to_string().contains("field-update"),
+            "unexpected error for {event_type}: {error}"
+        );
+    }
+}
+
+/// Same property for a payload that deserializes but is not an object: a
+/// journaled non-object `FieldsReplaced` (only writable by a build predating the
+/// live guard) cannot be applied, so strict replay must fail rather than
+/// pretending the journal was fully replayed.
+#[tokio::test]
+async fn authoritative_replay_rejects_non_object_field_update_payloads() {
+    let event = EntityEvent {
+        action: crate::entity_actor::effects::FIELDS_REPLACED_EVENT.to_string(),
+        from_status: "Draft".to_string(),
+        to_status: "Draft".to_string(),
+        timestamp: sim_now(),
+        params: serde_json::json!([1, 2, 3]),
+        idempotency_key: None,
+    };
+    let non_object = PersistenceEnvelope {
+        sequence_nr: 1,
+        event_type: event.action.clone(),
+        payload: serde_json::to_value(event).expect("serialize"),
+        metadata: EventMetadata {
+            event_id: sim_uuid(),
+            causation_id: sim_uuid(),
+            correlation_id: sim_uuid(),
+            timestamp: sim_now(),
+            actor_id: "default:Order:security-replay".to_string(),
+        },
+    };
+    let error = authoritative_replay(StaticEventStore {
+        events: vec![non_object],
+        read_error: None,
+        snapshot: None,
+    })
+    .await
+    .expect_err("a non-object field-update payload must fail authoritative replay");
+    assert!(
+        error.to_string().contains("field-update"),
+        "unexpected error: {error}"
+    );
+}

--- a/crates/temper-server/src/entity_actor/effects.rs
+++ b/crates/temper-server/src/entity_actor/effects.rs
@@ -19,6 +19,44 @@ use crate::blobs::{FIELD_OVERFLOW_BLOB_PREFIX, OverflowBlobWrite, blob_ref_value
 
 use super::types::{EntityEvent, EntityState, MAX_EVENTS_SINCE_SNAPSHOT};
 
+/// Journal event type for a PATCH-style field merge (ARN-189).
+pub(crate) const FIELDS_UPDATED_EVENT: &str = "FieldsUpdated";
+/// Journal event type for a PUT-style field replacement (ARN-189).
+pub(crate) const FIELDS_REPLACED_EVENT: &str = "FieldsReplaced";
+
+/// Apply a PATCH/PUT field update to entity state (ARN-189).
+///
+/// The single source of truth for field-update semantics, called by BOTH the
+/// live `EntityMsg::UpdateFields` handler and journal replay, so a rehydrated
+/// entity reaches exactly the state the live update produced.
+///
+/// - `replace == false` (PATCH): merge `fields` into the existing object.
+///   A non-object existing/incoming value leaves state unchanged, matching
+///   the historical live behavior.
+/// - `replace == true` (PUT): replace all fields, preserving `Id` and
+///   `Status` from the entity itself.
+pub(crate) fn apply_field_update(
+    state: &mut EntityState,
+    fields: &serde_json::Value,
+    replace: bool,
+) {
+    if replace {
+        let id = state.entity_id.clone();
+        let status = state.status.clone();
+        state.fields = fields.clone();
+        if let Some(obj) = state.fields.as_object_mut() {
+            obj.insert("Id".to_string(), serde_json::Value::String(id));
+            obj.insert("Status".to_string(), serde_json::Value::String(status));
+        }
+    } else if let (Some(existing), Some(updates)) =
+        (state.fields.as_object_mut(), fields.as_object())
+    {
+        for (k, v) in updates {
+            existing.insert(k.clone(), v.clone());
+        }
+    }
+}
+
 /// A scheduled action to fire after a delay.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScheduledAction {

--- a/crates/temper-server/src/entity_actor/effects.rs
+++ b/crates/temper-server/src/entity_actor/effects.rs
@@ -35,19 +35,34 @@ pub(crate) const FIELDS_REPLACED_EVENT: &str = "FieldsReplaced";
 ///   the historical live behavior.
 /// - `replace == true` (PUT): replace all fields, preserving `Id` and
 ///   `Status` from the entity itself.
+#[must_use = "a field update that did not apply is a dropped update; count or refuse it"]
 pub(crate) fn apply_field_update(
     state: &mut EntityState,
     fields: &serde_json::Value,
     replace: bool,
-) {
+) -> bool {
+    // One helper for both the live `UpdateFields` arm and journal replay
+    // (ARN-189). Replay must reproduce the live result exactly, so every
+    // transformation belongs here — a sanitize step applied only on the live
+    // path would silently rewrite the entity on the next rehydration.
+    //
+    // `sanitize_action_params` strips runtime-owned fields a caller must not set
+    // (`has_spec`, `ctx_owner_status`, ...), and `canonicalize_entity_fields`
+    // restores the authoritative `Id`/`Status` (and their lowercase aliases)
+    // afterwards.
+    // Guard here, not only at the live arm: replay feeds this the `params` of
+    // whatever is in the journal, including events written by a build that
+    // predates the live guard. A `FieldsReplaced` carrying `[1,2,3]` would set
+    // `fields` to an array, after which `canonicalize_entity_fields` cannot
+    // restore `Id`/`Status` — there is no object to insert into. Refusing in the
+    // shared helper is what makes live and replay agree on every input, not just
+    // the ones the live path screens.
+    if !fields.is_object() {
+        return false;
+    }
+    let fields = sanitize_action_params(fields);
     if replace {
-        let id = state.entity_id.clone();
-        let status = state.status.clone();
-        state.fields = fields.clone();
-        if let Some(obj) = state.fields.as_object_mut() {
-            obj.insert("Id".to_string(), serde_json::Value::String(id));
-            obj.insert("Status".to_string(), serde_json::Value::String(status));
-        }
+        state.fields = fields.into_owned();
     } else if let (Some(existing), Some(updates)) =
         (state.fields.as_object_mut(), fields.as_object())
     {
@@ -55,6 +70,8 @@ pub(crate) fn apply_field_update(
             existing.insert(k.clone(), v.clone());
         }
     }
+    canonicalize_entity_fields(&mut state.fields, &state.entity_id, &state.status);
+    true
 }
 
 /// A scheduled action to fire after a delay.

--- a/crates/temper-server/src/entity_actor/effects.rs
+++ b/crates/temper-server/src/entity_actor/effects.rs
@@ -43,13 +43,17 @@ pub(crate) fn apply_field_update(
 ) -> bool {
     // One helper for both the live `UpdateFields` arm and journal replay
     // (ARN-189). Replay must reproduce the live result exactly, so every
-    // transformation belongs here — a sanitize step applied only on the live
-    // path would silently rewrite the entity on the next rehydration.
+    // transformation belongs here — a step applied only on the live path would
+    // silently rewrite the entity on the next rehydration.
     //
-    // `sanitize_action_params` strips runtime-owned fields a caller must not set
-    // (`has_spec`, `ctx_owner_status`, ...), and `canonicalize_entity_fields`
-    // restores the authoritative `Id`/`Status` (and their lowercase aliases)
-    // afterwards.
+    // `canonicalize_entity_fields` is the single enforcement point for
+    // runtime-owned fields: it both strips the keys a caller must not set
+    // (`has_spec`, `ctx_owner_status`, ...) and restores the authoritative
+    // `Id`/`Status` (and their lowercase aliases). The live arm additionally
+    // sanitizes the *event payload* before journaling (see
+    // `field_updates::commit_field_update`) so the journal never records a forged
+    // key, which canonicalizing `state.fields` alone would not prevent.
+    //
     // Guard here, not only at the live arm: replay feeds this the `params` of
     // whatever is in the journal, including events written by a build that
     // predates the live guard. A `FieldsReplaced` carrying `[1,2,3]` would set
@@ -60,9 +64,8 @@ pub(crate) fn apply_field_update(
     if !fields.is_object() {
         return false;
     }
-    let fields = sanitize_action_params(fields);
     if replace {
-        state.fields = fields.into_owned();
+        state.fields = fields.clone();
     } else if let (Some(existing), Some(updates)) =
         (state.fields.as_object_mut(), fields.as_object())
     {

--- a/crates/temper-server/src/entity_actor/field_updates.rs
+++ b/crates/temper-server/src/entity_actor/field_updates.rs
@@ -1,0 +1,285 @@
+//! The durable transaction behind OData PATCH/PUT (ARN-189, ADR-0157).
+//!
+//! Field updates bypass the spec's action vocabulary — no guards, no effects,
+//! no transition — but they still change entity state, so they have to be
+//! journaled or they vanish on eviction and restart. That makes this a small
+//! transaction with the same obligations as the `Action` arm: refuse before
+//! mutating, never acknowledge what was not persisted, and converge with what
+//! replay will rebuild.
+//!
+//! It lives beside the actor rather than inside the message match because it is
+//! ~250 lines of policy, and because the caller's only job is to turn the
+//! outcome into a reply.
+
+use serde_json::Value;
+use temper_runtime::persistence::PersistenceError;
+use temper_runtime::scheduler::sim_now;
+
+use super::actor::{EntityActor, ReplayPolicy};
+use super::effects;
+use super::types::{EntityEvent, EntityState, MAX_EVENTS_SINCE_SNAPSHOT};
+
+/// Attempts allowed after the first, matching the `Action` arm's ADR-0046 budget.
+const MAX_RETRIES: u32 = 2;
+
+/// Apply a field update and make it durable, or refuse it.
+///
+/// `Ok(())` means the update is in the journal. `Err(reason)` means it is not,
+/// and `state` has been restored — a refusal never leaves a partial write. The
+/// caller replies with the reason verbatim.
+pub(super) async fn commit_field_update(
+    actor: &EntityActor,
+    state: &mut EntityState,
+    fields: Value,
+    replace: bool,
+    expected_precondition: Option<String>,
+) -> Result<(), String> {
+    let has_precondition = expected_precondition.is_some();
+    if let Some(expected) = expected_precondition
+        && effects::entity_authorization_precondition(state) != expected
+    {
+        return Err(STALE_AUTHORIZATION.to_string());
+    }
+    if state.status == "Deleted" {
+        return Err("cannot update fields after entity deletion".to_string());
+    }
+    // `parse_json_body_or_400` accepts any valid JSON, so a `PUT` body of
+    // `[1,2,3]` reaches here. With `replace`, `apply_field_update` would set
+    // `fields` to the array and then fail to restore `Id`/`Status` — there is no
+    // object to insert into — and the append would co-commit zero key and zero
+    // vector rows, purging the entity's index. Before field updates were
+    // journaled that corruption was in-memory and healed on restart; persisting
+    // it would make it permanent.
+    if !fields.is_object() {
+        return Err("entity field update must be a JSON object".to_string());
+    }
+    // The same budget that gates spec actions. Field updates append journal
+    // events too, so ungated they could grow the snapshot replay tail past
+    // `MAX_EVENTS_SINCE_SNAPSHOT` while the snapshot path is stalled, after which
+    // the entity can never rehydrate. Rejected before mutating.
+    if let Some(reason) = budget_refusal(actor, state, replace) {
+        return Err(reason);
+    }
+
+    // Sanitize once and use the same value for state and journal.
+    // `apply_field_update` sanitizes internally as well — it must, so that
+    // replaying an event written before this guard still lands on clean state —
+    // but the event written now must not carry a caller's forged `has_spec` or
+    // `ctx_owner_status` into the journal in the first place.
+    let fields = effects::sanitize_action_params(&fields).into_owned();
+
+    let action = if replace {
+        effects::FIELDS_REPLACED_EVENT
+    } else {
+        effects::FIELDS_UPDATED_EVENT
+    };
+
+    // Apply speculatively so the append co-commits key/vector index rows derived
+    // from the NEW fields, then journal fail-closed: an update that is not
+    // durable must not be acknowledged. Rolled back on failure.
+    let mut previous_fields = state.fields.clone();
+    // Bind the result: `debug_assert!` does not evaluate its argument in release
+    // builds, so asserting the call directly would skip the update in production.
+    let applied = effects::apply_field_update(state, &fields, replace);
+    debug_assert!(
+        applied,
+        "object-ness was checked above; the apply cannot decline"
+    );
+    let mut event = field_event(action, state, &fields);
+
+    let (Some(store), Some(backend)) = (actor.event_journal.as_ref(), actor.event_backend) else {
+        // No configured persistence: memory-only, as in every other handler.
+        return Ok(());
+    };
+
+    let mut attempt: u32 = 0;
+    loop {
+        match actor
+            .persist_event(store, backend, &actor.persistence_id(), state, &event)
+            .await
+        {
+            Ok(_) => break,
+            // A preconditioned update is a compare-and-set: the caller authorized
+            // this write against one exact state digest. A conflict is proof the
+            // journal held state the actor's memory did not, so replaying and
+            // re-applying would commit against state the caller never saw and
+            // Cedar never evaluated. `entity_ops` already caps preconditioned asks
+            // at a single attempt for that reason; retrying here would reintroduce
+            // one layer down the retry the layer above forbids.
+            Err(PersistenceError::ConcurrencyViolation { .. }) if has_precondition => {
+                state.fields = previous_fields;
+                return Err(STALE_AUTHORIZATION.to_string());
+            }
+            Err(PersistenceError::ConcurrencyViolation { actual, .. }) if attempt < MAX_RETRIES => {
+                attempt += 1;
+                match catch_up(actor, state, attempt, actual, action).await {
+                    Ok(()) => {}
+                    Err(reason) => {
+                        state.fields = previous_fields;
+                        return Err(reason);
+                    }
+                }
+                if let Some(reason) = post_replay_refusal(actor, state, replace) {
+                    return Err(reason);
+                }
+                // Re-apply onto the caught-up state and rebuild the event against
+                // its (possibly new) status.
+                previous_fields = state.fields.clone();
+                let applied = effects::apply_field_update(state, &fields, replace);
+                debug_assert!(
+                    applied,
+                    "object-ness was checked above; the apply cannot decline"
+                );
+                event = field_event(action, state, &fields);
+            }
+            Err(e) => {
+                state.fields = previous_fields;
+                return Err(format!("persistence failed: {e}"));
+            }
+        }
+    }
+
+    state.push_event_bounded(event);
+
+    let persistence_id = actor.persistence_id();
+    if let Err(e) = EntityActor::maybe_save_snapshot(
+        store,
+        actor.snapshot_queue.as_ref(),
+        &persistence_id,
+        state,
+    )
+    .await
+    {
+        tracing::warn!(
+            entity = %state.entity_id,
+            seq = state.sequence_nr,
+            error = %e,
+            "failed to persist snapshot"
+        );
+    }
+
+    Ok(())
+}
+
+/// The refusal an update gets when the state it was authorized against moved.
+/// Shared by the entry check and the conflict path so a caller cannot tell the
+/// two apart — both mean "re-read and retry".
+const STALE_AUTHORIZATION: &str =
+    "field update authorization became stale; retry against current state";
+
+fn field_event(action: &str, state: &EntityState, fields: &Value) -> EntityEvent {
+    EntityEvent {
+        action: action.to_string(),
+        from_status: state.status.clone(),
+        to_status: state.status.clone(),
+        timestamp: sim_now(),
+        params: fields.clone(),
+        idempotency_key: None,
+    }
+}
+
+fn budget_refusal(actor: &EntityActor, state: &EntityState, replace: bool) -> Option<String> {
+    if state.events_since_snapshot < MAX_EVENTS_SINCE_SNAPSHOT {
+        return None;
+    }
+    let workspace_id = super::actor::event_budget_workspace_id(state);
+    crate::event_budget_metrics::record_exhausted(
+        &actor.tenant,
+        &state.entity_type,
+        &state.entity_id,
+        &workspace_id,
+    );
+    tracing::warn!(
+        tenant = %actor.tenant,
+        entity_type = %state.entity_type,
+        entity_id = %state.entity_id,
+        workspace_id = %workspace_id,
+        status = %state.status,
+        replace,
+        events_since_snapshot = state.events_since_snapshot,
+        total_event_count = state.total_event_count,
+        max_events_since_snapshot = MAX_EVENTS_SINCE_SNAPSHOT,
+        "Event budget exhausted (field update rejected)"
+    );
+    Some(format!(
+        "Event budget exhausted ({MAX_EVENTS_SINCE_SNAPSHOT} max since snapshot)"
+    ))
+}
+
+/// Rebuild `state` from the journal after a sequence conflict.
+///
+/// Rebuilds from a *fresh* initial state, exactly as
+/// `recover_entity_state_from_store` does. `replay_events` applies onto whatever
+/// state it is handed and never resets it, so replaying onto the live state
+/// re-applies every event on top of its own effects: the events deque grows,
+/// `total_event_count` / `events_since_snapshot` climb, and non-idempotent
+/// effects (counter increments) fire twice. That corruption would be returned to
+/// the caller, upserted into the query projection, and made durable by the next
+/// snapshot. Rolling back `fields` alone cannot help — those other fields were
+/// never part of the speculative update.
+async fn catch_up(
+    actor: &EntityActor,
+    state: &mut EntityState,
+    attempt: u32,
+    actual: u64,
+    action: &str,
+) -> Result<(), String> {
+    // Back off first, or against a live concurrent writer the whole budget burns
+    // in microseconds and the retry buys nothing.
+    super::actor::sleep_persistence_retry(std::time::Duration::from_millis(if attempt == 1 {
+        10
+    } else {
+        50
+    }))
+    .await;
+    tracing::warn!(
+        entity = %state.entity_id,
+        action = %action,
+        actual_seq = actual,
+        attempt,
+        "field update hit optimistic-concurrency violation; replaying and retrying"
+    );
+
+    let (Some(store), Some(backend)) = (actor.event_journal.as_ref(), actor.event_backend) else {
+        return Err("persistence unavailable during conflict recovery".to_string());
+    };
+    let table = actor.table.read().expect("table lock poisoned").clone();
+    let mut caught_up = EntityActor::build_initial_state(
+        &actor.entity_type,
+        &state.entity_id,
+        &table,
+        &actor.initial_fields,
+    );
+    // A replay failure is returned as a refusal rather than propagated: bailing
+    // out of the message handler would leave the caller's `ask` unanswered until
+    // it times out, with the entity mid-rollback.
+    EntityActor::replay_events(
+        &table,
+        store,
+        backend,
+        &mut caught_up,
+        &actor.tenant,
+        actor.blob_store.as_ref(),
+        ReplayPolicy::LenientSnapshot,
+    )
+    .await
+    .map_err(|e| format!("conflict recovery replay failed: {e}"))?;
+    debug_assert!(
+        caught_up.sequence_nr >= actual,
+        "POSTCONDITION: field-update replay under-reached the authoritative sequence \
+         (sequence_nr={} < actual={actual})",
+        caught_up.sequence_nr
+    );
+    *state = caught_up;
+    Ok(())
+}
+
+/// Re-run the refusals that were checked before the first attempt. The race may
+/// have deleted the entity or spent the budget, and both were only ever checked
+/// against the actor's pre-conflict memory.
+fn post_replay_refusal(actor: &EntityActor, state: &EntityState, replace: bool) -> Option<String> {
+    if state.status == "Deleted" {
+        return Some("cannot update fields after entity deletion".to_string());
+    }
+    budget_refusal(actor, state, replace)
+}

--- a/crates/temper-server/src/entity_actor/mod.rs
+++ b/crates/temper-server/src/entity_actor/mod.rs
@@ -6,6 +6,7 @@
 
 mod actor;
 pub mod effects;
+mod field_updates;
 mod replay_validation;
 pub mod sim_handler;
 mod snapshot_queue;

--- a/crates/temper-server/src/event_budget_metrics.rs
+++ b/crates/temper-server/src/event_budget_metrics.rs
@@ -33,3 +33,33 @@ pub fn record_exhausted(tenant: &str, entity_type: &str, entity_id: &str, worksp
         ],
     );
 }
+
+fn field_update_replay_skip_counter() -> &'static Counter<u64> {
+    static COUNTER: OnceLock<Counter<u64>> = OnceLock::new();
+    COUNTER.get_or_init(|| {
+        global::meter("temper.runtime")
+            .u64_counter("temper_entity_field_update_replay_skipped_total")
+            .with_description(
+                "Journaled field-update events dropped during replay because their payload \
+                 did not deserialize. Each one is a silently lost PATCH/PUT.",
+            )
+            .build()
+    })
+}
+
+/// Record a field-update event skipped during replay (ARN-189).
+///
+/// The skip is the fail-safe branch — a malformed payload must not abort
+/// rehydration — but it means a field update the caller was told had been
+/// durably applied is now absent from the rebuilt state. A `tracing::warn!`
+/// alone leaves that undetectable in aggregate; this makes it alertable.
+pub fn record_field_update_replay_skip(tenant: &str, entity_type: &str, entity_id: &str) {
+    field_update_replay_skip_counter().add(
+        1,
+        &[
+            KeyValue::new("tenant", tenant.to_string()),
+            KeyValue::new("entity_type", entity_type.to_string()),
+            KeyValue::new("entity_id", entity_id.to_string()),
+        ],
+    );
+}

--- a/crates/temper-server/tests/odata_read.rs
+++ b/crates/temper-server/tests/odata_read.rs
@@ -794,3 +794,122 @@ async fn patch_and_put_authorize_the_prospective_resource() {
 
     let _ = std::fs::remove_file(db_path);
 }
+
+/// ARN-189. The actor is fail-closed on the journal append, but
+/// `update_tenant_entity_fields` returned `Ok(response)` regardless of
+/// `response.success`, and the handler only maps `Err` to a non-2xx — so a
+/// rejected or unpersisted update was answered `200 OK`. Fail-closed actor,
+/// fail-open API, which defeats the point of journaling the update at all.
+///
+/// Driven through the real HTTP router rather than the actor, because the defect
+/// lived in the seam between them: every actor-level test passed while the client
+/// was still told the write had succeeded.
+#[tokio::test]
+async fn patch_returns_an_error_status_when_the_update_is_refused() {
+    let (state, sim) = build_default_state(4711, "odata-patch-fail-closed");
+    install_order_crud_test_policy(&state);
+    // HTTP writes are gated on verification status; the sim harness leaves it
+    // pending, so mark it Completed exactly as `build_turso_state` does.
+    {
+        let mut registry = state.registry.write().unwrap();
+        registry.set_verification_status(
+            &TenantId::default(),
+            "Order",
+            VerificationStatus::Completed(EntityVerificationResult {
+                all_passed: true,
+                levels: vec![EntityLevelSummary {
+                    level: "L0 SMT".to_string(),
+                    passed: true,
+                    summary: "OK".to_string(),
+                    details: None,
+                }],
+                verified_at: "2026-04-15T00:00:00Z".to_string(),
+            }),
+        );
+    }
+    let tenant = TenantId::default();
+
+    dispatch(
+        &state,
+        &tenant,
+        "Order",
+        "ord-fail-closed",
+        "Create",
+        serde_json::json!({}),
+    )
+    .await
+    .expect("create ord-fail-closed");
+
+    // A PATCH the actor cannot journal. The entity exists and the request is
+    // well-formed, so it reaches the actor and is refused there. The OData
+    // handler maps a refused response to an error status itself, so this does not
+    // exercise `update_tenant_entity_fields`' own propagation — see
+    // `field_update_failure_is_reported_to_callers_that_do_not_inspect_success`
+    // for that. What it pins is the end-to-end property: an update that was not
+    // persisted is never answered 2xx.
+    sim.inject_concurrency_violations("default:Order:ord-fail-closed", 8);
+
+    let (status, body) = patch_json(
+        &state,
+        "/tdata/Orders('ord-fail-closed')",
+        serde_json::json!({ "Currency": "USD" }),
+    )
+    .await;
+    assert!(
+        !status.is_success(),
+        "an update the actor could not persist must not answer 2xx; got {status} {body:?}"
+    );
+
+    // And the entity is unchanged — the refusal was not a partial write.
+    sim.inject_concurrency_violations("default:Order:ord-fail-closed", 0);
+    let (status, body) = get_json(&state, "/tdata/Orders('ord-fail-closed')").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_ne!(
+        body["fields"]["Currency"].as_str(),
+        Some("USD"),
+        "a refused update must leave the entity untouched: {body:?}"
+    );
+}
+
+/// ARN-189 regression guard. `update_tenant_entity_fields` converts a refused
+/// actor response into `Err`, which is what callers that do not inspect
+/// `response.success` rely on — `os_apps::entity_aliases` calls this and does
+/// `.map(|_| ())`, so if `Ok` ever stopped meaning "the update happened", a
+/// refused alias repair would be silently treated as done. Journaling field
+/// updates adds a new way for them to fail, so this pins that a failed append
+/// travels the same path.
+#[tokio::test]
+async fn field_update_failure_is_reported_to_callers_that_do_not_inspect_success() {
+    let (state, sim) = build_default_state(4713, "entity-ops-fail-closed");
+    let tenant = TenantId::default();
+
+    dispatch(
+        &state,
+        &tenant,
+        "Order",
+        "ord-ops-fail-closed",
+        "Create",
+        serde_json::json!({}),
+    )
+    .await
+    .expect("create ord-ops-fail-closed");
+
+    // Enough conflicts to outlast the retry budget, so the append genuinely fails.
+    sim.inject_concurrency_violations("default:Order:ord-ops-fail-closed", 8);
+
+    let result = state
+        .update_tenant_entity_fields(
+            &tenant,
+            "Order",
+            "ord-ops-fail-closed",
+            serde_json::json!({ "Currency": "USD" }),
+            false,
+        )
+        .await;
+
+    assert!(
+        result.is_err(),
+        "an update that was not persisted must not be returned as Ok: {:?}",
+        result.map(|r| (r.success, r.error))
+    );
+}

--- a/crates/temper-server/tests/odata_read.rs
+++ b/crates/temper-server/tests/odata_read.rs
@@ -913,3 +913,116 @@ async fn field_update_failure_is_reported_to_callers_that_do_not_inspect_success
         result.map(|r| (r.success, r.error))
     );
 }
+
+/// ARN-189 live end-to-end: the exact scenario the bug loses data in, driven
+/// through the real OData HTTP router over a real Turso file, across a full
+/// `ServerState` teardown and rebuild on the same database — a process restart in
+/// all but name (fresh actor system, fresh registry, fresh in-memory state; only
+/// the durable journal survives).
+///
+/// Before the fix, a PATCH mutated actor memory and journaled nothing, so the
+/// second `ServerState` — rehydrating purely from the journal — would not see it.
+#[tokio::test]
+async fn patched_fields_survive_a_server_restart_over_the_http_stack() {
+    let db_path =
+        std::env::temp_dir().join(format!("temper-arn189-live-{}.db", uuid::Uuid::new_v4()));
+    let db_url = format!("file:{}", db_path.display());
+
+    // --- Run 1: create, then PATCH a field over HTTP. ---
+    {
+        let store = TursoEventStore::new(&db_url, None)
+            .await
+            .expect("create turso db");
+        let state = build_turso_state("arn189-live-run1", store);
+
+        let (status, body) = post_json(
+            &state,
+            "/tdata/Orders",
+            serde_json::json!({ "id": "ord-arn189-live", "Currency": "EUR" }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::CREATED, "create failed: {body:?}");
+
+        let (status, body) = patch_json(
+            &state,
+            "/tdata/Orders('ord-arn189-live')",
+            serde_json::json!({ "Currency": "USD", "Notes": "patched before restart" }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "patch failed: {body:?}");
+
+        // Confirm run 1 sees the patch in memory.
+        let (status, body) = get_json(&state, "/tdata/Orders('ord-arn189-live')").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["fields"]["Currency"].as_str(), Some("USD"));
+        assert_eq!(
+            body["fields"]["Notes"].as_str(),
+            Some("patched before restart")
+        );
+    }
+
+    // --- The journal itself must carry the update. ---
+    //
+    // The read above is served from the durable query projection, which is a
+    // read-model *cache* written alongside the update. The source of truth is the
+    // event journal, and it is what a projection backfill (ARN-216) rebuilds from:
+    // before this fix the backfill dropped patched fields the live projection
+    // still had. So the discriminating assertion is that the append happened —
+    // read the raw journal back and find the field-update event with the new
+    // value. This is what fails if `commit_field_update` stops journaling.
+    {
+        use temper_runtime::persistence::EventStore as _;
+        let store = TursoEventStore::new(&db_url, None)
+            .await
+            .expect("reopen turso db for journal read");
+        let envelopes = store
+            .read_events("default:Order:ord-arn189-live", 0)
+            .await
+            .expect("read journal");
+        let patched = envelopes.iter().any(|env| {
+            let is_field_event =
+                env.event_type == "FieldsUpdated" || env.event_type == "FieldsReplaced";
+            is_field_event
+                && env
+                    .payload
+                    .get("params")
+                    .and_then(|p| p.get("Currency"))
+                    .and_then(|c| c.as_str())
+                    == Some("USD")
+        });
+        assert!(
+            patched,
+            "the PATCH must be durably journaled, not only cached in the projection; \
+             journal held {} events: {:?}",
+            envelopes.len(),
+            envelopes.iter().map(|e| &e.event_type).collect::<Vec<_>>()
+        );
+    }
+
+    // --- Run 2: a brand-new ServerState on the same journal reads it back. ---
+    {
+        let store = TursoEventStore::new(&db_url, None)
+            .await
+            .expect("reopen turso db");
+        let state = build_turso_state("arn189-live-run2", store);
+
+        let (status, body) = get_json(&state, "/tdata/Orders('ord-arn189-live')").await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "entity missing after restart: {body:?}"
+        );
+        assert_eq!(
+            body["fields"]["Currency"].as_str(),
+            Some("USD"),
+            "the PATCHed field must survive a restart: {body:?}"
+        );
+        assert_eq!(
+            body["fields"]["Notes"].as_str(),
+            Some("patched before restart"),
+            "the PATCHed field must survive a restart: {body:?}"
+        );
+    }
+
+    let _ = std::fs::remove_file(db_path);
+}

--- a/docs/adrs/0157-journaled-field-updates.md
+++ b/docs/adrs/0157-journaled-field-updates.md
@@ -1,0 +1,80 @@
+# ADR-0157: Journaled PATCH/PUT Field Updates
+
+## Status
+
+Accepted (2026-07-12)
+
+## Context
+
+OData PATCH and PUT reach the entity actor as `EntityMsg::UpdateFields`, which
+mutated `state.fields` in memory and replied success without appending anything
+to the event journal (ARN-189). Entity state is rebuilt exclusively from the
+journal (snapshot + event replay) on actor eviction, server restart, and query
+projection backfill — so every PATCH/PUT was silently lost the moment any of
+those ran. The adjacent `Delete` handler already journals fail-closed
+(persist first, mutate on success), making the gap an inconsistency rather
+than a design choice.
+
+## Decision
+
+1. **Two new journal event types**, emitted by the `UpdateFields` handler:
+   `FieldsUpdated` (PATCH merge) and `FieldsReplaced` (PUT replacement), with
+   the update payload carried in `params` and `from_status == to_status`.
+   They live outside the spec's action vocabulary, like the existing
+   `Deleted` event.
+2. **Fail-closed acknowledgment.** The handler applies the update, appends
+   the event (co-committing key/vector index rows derived from the NEW
+   fields, per ADR-0153/0155), and only then replies success. On append
+   failure the in-memory fields are rolled back and the reply is an error —
+   an update that is not durable is not acknowledged.
+3. **One shared application function.** `apply_field_update` in
+   `entity_actor::effects` implements merge/replace semantics (PUT preserves
+   `Id` and `Status`) and is called by both the live handler and journal
+   replay, so a rehydrated entity reaches exactly the live post-update state.
+   Replay handles the two event types explicitly: the generic param-sync path
+   can only merge and would resurrect keys a PUT dropped.
+4. **Duplicate events are acceptable; conflicting appends fail safe.** The
+   real duplicate path is a dispatch-layer ask timeout after a fully
+   successful handle: `ask_with_backoff` re-sends `UpdateFields`, and the
+   actor appends a second event. Both event types are idempotent in effect
+   (replaying the same merge or replacement twice converges), so duplicates
+   cost one journal row, never correctness. An actor-level retry after a
+   persisted-but-unacknowledged append cannot double-append: every store
+   enforces `expected_sequence`, so that retry fails with a sequence conflict
+   until the actor rehydrates — availability degradation, no durability loss,
+   the same exposure as the existing `Delete` path.
+5. **Field updates consume the event budget.** The handler enforces the same
+   `MAX_EVENTS_SINCE_SNAPSHOT` gate as spec actions, rejecting before
+   mutating. Without it, sustained PATCH traffic while the snapshot path is
+   stalled (queue full, stalled writer, save errors — all soft failures)
+   would grow the snapshot replay tail past the budget and make the entity
+   permanently unhydratable.
+
+## Consequences
+
+- PATCH/PUT survive actor eviction, server restart, and projection backfill;
+  the backfill previously rebuilt projections without the patched fields even
+  when the live projection had them.
+- Entities without configured persistence keep the previous in-memory-only
+  behavior (the append is skipped, as in every other handler).
+- A spec action literally named `FieldsUpdated`/`FieldsReplaced` would collide
+  with the replay dispatch, matching the pre-existing `Deleted` precedent;
+  the names are reserved by convention.
+- Journals written by older builds simply lack the new events; replay of old
+  journals is unchanged.
+- A sequence conflict on the append (concurrent writer or a crashed ack)
+  wedges further updates with errors until the actor rehydrates with the
+  authoritative sequence — the deliberate fail-safe direction; ADR-0046-style
+  conflict recovery for this arm is possible follow-up work if it ever shows
+  up in metrics.
+- ADR numbering: 0156 is used by the concurrently open ARN-179 change
+  (`docs/adrs/0156-pg-actor-runtime-effect-vocabulary.md` on PR #370).
+
+## Alternatives Considered
+
+- **Journal a synthetic spec action.** Would push PATCH/PUT through guard
+  evaluation and effect derivation that field updates deliberately bypass,
+  and would collide with real spec vocabularies.
+- **Snapshot-only durability.** Snapshots are throttled (`maybe_save_snapshot`)
+  and best-effort; relying on them would leave a loss window and break the
+  journal-as-source-of-truth invariant that replay and backfill assume.

--- a/docs/adrs/0157-journaled-field-updates.md
+++ b/docs/adrs/0157-journaled-field-updates.md
@@ -40,9 +40,8 @@ than a design choice.
    (replaying the same merge or replacement twice converges), so duplicates
    cost one journal row, never correctness. An actor-level retry after a
    persisted-but-unacknowledged append cannot double-append: every store
-   enforces `expected_sequence`, so that retry fails with a sequence conflict
-   until the actor rehydrates — availability degradation, no durability loss,
-   the same exposure as the existing `Delete` path.
+   enforces `expected_sequence`, so that retry hits a sequence conflict, which
+   is now recovered rather than surfaced (see Consequences).
 5. **Field updates consume the event budget.** The handler enforces the same
    `MAX_EVENTS_SINCE_SNAPSHOT` gate as spec actions, rejecting before
    mutating. Without it, sustained PATCH traffic while the snapshot path is
@@ -57,18 +56,95 @@ than a design choice.
   when the live projection had them.
 - Entities without configured persistence keep the previous in-memory-only
   behavior (the append is skipped, as in every other handler).
-- A spec action literally named `FieldsUpdated`/`FieldsReplaced` would collide
-  with the replay dispatch, matching the pre-existing `Deleted` precedent;
-  the names are reserved by convention.
+- `FieldsUpdated`/`FieldsReplaced` are reserved action names, and the reservation
+  is **enforced**, not conventional: replay dispatches those names to
+  `apply_field_update` before the generic action path, so a spec action of the
+  same name would be hijacked on rehydration — its params merged into fields, its
+  transition never replayed. The `Action` arm refuses both names.
 - Journals written by older builds simply lack the new events; replay of old
   journals is unchanged.
-- A sequence conflict on the append (concurrent writer or a crashed ack)
-  wedges further updates with errors until the actor rehydrates with the
-  authoritative sequence — the deliberate fail-safe direction; ADR-0046-style
-  conflict recovery for this arm is possible follow-up work if it ever shows
-  up in metrics.
+- A sequence conflict on the append (concurrent writer, or a crashed ack whose
+  append landed) is **recovered**, not surfaced: the arm rolls back the
+  speculative merge, replays to the authoritative sequence, re-applies onto the
+  caught-up state, and retries, for the same 1 + 2 attempt budget the `Action`
+  arm uses under ADR-0046. Without it a single conflict wedged every later update
+  until the actor happened to rehydrate. The refusals checked before the first
+  attempt — deletion and the event budget — are rechecked after each replay,
+  because the race may have deleted the entity or spent the budget. Beyond the
+  retry budget the arm fails closed and rolls back to the caught-up state.
+
+  Two properties of that loop are load-bearing and easy to lose:
+  - **Catching up rebuilds from a fresh initial state**, as
+    `recover_entity_state_from_store` does. `replay_events` applies onto whatever
+    state it is handed and never resets it, so replaying onto the live state
+    re-applies every event on top of its own effects — the events deque grows,
+    `total_event_count` / `events_since_snapshot` climb, and non-idempotent
+    effects (counter increments) fire twice. That corruption would be returned to
+    the caller, upserted into the query projection, and made durable by the next
+    snapshot.
+  - **A conflict under a live `expected_precondition` is refused, not retried.**
+    That precondition is a compare-and-set: the caller authorized this write
+    against one exact digest. A conflict proves the journal held state the actor's
+    memory did not, so replaying and committing would apply the write to state the
+    caller never saw and Cedar never evaluated. `entity_ops` already caps
+    preconditioned asks at a single attempt for the same reason.
+
+- A field-update event whose payload no longer deserializes is skipped under a
+  lenient replay policy (so hydration survives spec evolution) and **fails** under
+  a strict one, matching the tombstone and generic-event arms. Strict replay backs
+  authoritative state resolution, where identity and authority are read: silently
+  dropping a `FieldsReplaced` there could preserve exactly the authority it was
+  written to revoke. Lenient skips are counted
+  (`temper_entity_field_update_replay_skipped_total`).
+
+- **Commit ambiguity is not resolved.** If the store commits the append but returns
+  a generic error (a client timeout after commit), the arm rolls back and reports
+  failure while the journal holds the update. A quiet entity then serves
+  pre-update fields from memory until it next rehydrates, at which point the
+  "failed" write appears. Inherent to a non-idempotent append over an unreliable
+  channel; called out so it is not discovered as a surprise.
+
+- **A rolling deploy can transiently mis-replay a PUT.** An older build replaying a
+  `FieldsReplaced` event has no arm for it, so it falls to the generic param-sync
+  path, which only merges — keys the PUT dropped reappear until a new-build actor
+  hydrates the entity.
+
+- **Reserved names are enforced at invocation, not at deployment.** The `Action`
+  arm refuses `FieldsUpdated` / `FieldsReplaced`, which stops new collisions. It
+  does not help a tenant whose spec already declared such an action and whose
+  journal already holds those events; separating them needs a discriminator on the
+  event envelope, which is a migration, not a guard.
 - ADR numbering: 0156 is used by the concurrently open ARN-179 change
   (`docs/adrs/0156-pg-actor-runtime-effect-vocabulary.md` on PR #370).
+
+## Invariants this arm must keep
+
+Stated as invariants rather than as a changelog, because each one was violated by
+at least one implementation of this fix and none of them is obvious from reading
+the happy path.
+
+1. **A non-object payload never reaches state or the journal.** `parse_json_body_or_400`
+   accepts any valid JSON, so a `PUT` body of `[1,2,3]` arrives here. With
+   `replace` it would set `fields` to the array, `canonicalize_entity_fields`
+   could not restore `Id`/`Status` (no object to insert into), and the append
+   would co-commit zero key and zero vector rows — purging the entity's index.
+   Journaling is what makes that permanent, so the guard is a precondition of
+   this decision, not an extra.
+2. **Live and replay run the same transformation.** `apply_field_update` is
+   shared, sanitizes runtime-owned fields, and canonicalizes identity/lifecycle.
+   Any step applied on only one of the two paths silently rewrites the entity at
+   the next rehydration. It returns whether it applied, so a caller cannot treat
+   a declined update as a successful one.
+3. **The event is sanitized before it is written**, not only on the way into
+   state, so the journal never records a second claimed truth for identity or
+   lifecycle.
+4. **Catching up after a conflict rebuilds from a fresh initial state.**
+   `replay_events` applies onto whatever state it is given and never resets it.
+5. **A conflict under a live `expected_precondition` is refused, not retried.**
+6. **Every refusal checked before the first attempt is rechecked after a replay** —
+   deletion and the event budget — because the race may have caused either.
+7. **A dropped update is counted, never silent** — malformed payload or
+   non-object payload, under a lenient policy; under a strict policy it fails.
 
 ## Alternatives Considered
 


### PR DESCRIPTION
Fixes ARN-189 (`OData PATCH/PUT field updates are never journaled → lost on eviction/restart`).

## Defect

`EntityMsg::UpdateFields` (the actor message behind OData PATCH and PUT) mutated `state.fields` in memory and replied success without appending anything to the event journal — in direct contrast to the `Delete` arm beside it, which persists fail-closed before mutating. Entity state is rebuilt exclusively from the journal on actor eviction, server restart, and query-projection backfill, so every PATCH/PUT was silently lost on any of those. The fail-closed contract was also violated: an update whose append would have failed still claimed success.

## Fix (root cause)

- **Two journal event types** — `FieldsUpdated` (PATCH merge) and `FieldsReplaced` (PUT replacement) — emitted by the `UpdateFields` handler. The update is applied first so the append co-commits key/vector index rows derived from the NEW fields (ADR-0153/0155), then journaled **fail-closed**: on append failure the fields are rolled back and the reply is an error.
- **One shared application function.** `apply_field_update` in `entity_actor/effects.rs` is called by both the live handler and journal replay, so rehydration reproduces exact live semantics — including PUT-dropped keys not resurrecting (the generic replay param-sync can only merge, which is why the replay arm is explicit).
- **Event budget enforced** (review finding): field updates now hit the same `MAX_EVENTS_SINCE_SNAPSHOT` gate as spec actions, rejecting before mutation — otherwise sustained PATCH traffic under a stalled snapshot path would grow a replay tail that makes the entity permanently unhydratable.
- ADR-0157 records the design, the dispatch-retry duplicate semantics (idempotent convergence; actor-level retries fail safe on `expected_sequence` conflicts), and the budget decision.

## TDD

- RED commit `43f2d13f` (committed alone, failures documented): PATCHed fields vanish on restart; PUT semantics don't survive; failed appends still claim success. Includes a deterministic `AppendFuseStore` double (fails appends/snapshots only when armed).
- GREEN commit `847a10cd` turns all of them green and adds the budget-gate regression test (stalled-snapshot scenario).

## DST

`temper-server` is simulation-visible: all four regression tests run against the seeded `SimEventStore` through the two-generation replay harness; the DST reviewer verified code-path unity (live and replay share `apply_field_update`), `sim_now()` usage, and both `// determinism-ok` annotations added to pre-existing unannotated lines (production-only metric timing; retry backoff collapsed to one line with identical behavior).

## Verification

- `cargo test -p temper-server --lib --features sim` — 578 pass + 4 new ARN-189 tests (582 total on head); one pre-existing SQLite projection test is flaky under full-parallel load only (passes in isolation and on re-run, identical on clean main — not introduced here).
- Pre-commit code + DST reviews: PASS after one FAIL round — the code reviewer's findings (ungated event budget; ADR duplicate-append mechanism) were fixed and re-reviewed.
- Live local E2E (restart survival, before/after): posted as a PR comment.

## Residual / follow-ups

- Reserved event names (`FieldsUpdated`, `FieldsReplaced`, `Deleted`) are convention-only; a spec action with those names would be hijacked by the replay dispatch. Follow-up: an L0 verification rule rejecting reserved names (will be filed on Linear when it reconnects — currently down with an expired token).
- ADR-0046-style sequence-conflict recovery for the `UpdateFields` arm if conflict-wedge behavior ever shows in metrics.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes ARN-189: OData PATCH and PUT field updates were mutating in-memory state and replying success without writing to the event journal, so every update was silently lost on actor eviction, server restart, or projection backfill. The fix journals each update fail-closed (rolling back and returning an error on append failure) and shares a single `apply_field_update` function between the live handler and journal replay so rehydrated state is identical to the live post-update state.

- **`field_updates.rs` (new)** — the durable transaction: validates payload, enforces the event budget, applies speculatively so key/vector index rows co-commit against new fields, then journals fail-closed with ADR-0046-style replay-and-retry on concurrency conflicts.
- **`effects.rs`** — adds `apply_field_update` (shared live + replay helper), `FIELDS_UPDATED_EVENT`, and `FIELDS_REPLACED_EVENT` constants; the shared function guards against non-object payloads so replay and live paths agree on every input.
- **`actor.rs`** — adds a reserved-name guard rejecting `FieldsUpdated`/`FieldsReplaced` as domain action names (which would otherwise be hijacked by the replay router), routes those event types during replay to `apply_field_update`, and delegates the `UpdateFields` arm to `field_updates::commit_field_update`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- Safe to merge. The core journaling transaction is fail-closed and well-tested; the shared `apply_field_update` function guarantees live and replay paths are identical; the event budget gate prevents replay-tail growth under stalled snapshots.
- The fix is mechanically straightforward: a new `field_updates::commit_field_update` function wraps the persist-or-rollback contract that the `Delete` arm already uses as prior art. The previously-flagged compilation issue (four tests missing `#[cfg(feature = "sim")]`) is fully resolved in the current head. The remaining open item — `spec_governed: true` on the UpdateFields response, which misreports that the spec state machine was consulted — is the same semantic inaccuracy as the pre-existing `Delete` arm and does not affect runtime correctness.
- No files require special attention. `actor.rs` carries the one open P2 noted above, but the change itself is isolated to the new `UpdateFields` delegation and replay routing.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/temper-server/src/entity_actor/field_updates.rs | New file implementing the durable PATCH/PUT transaction. Correctly applies updates speculatively, journals fail-closed, rolls back on failure, and handles concurrency violations with ADR-0046-style replay-and-retry. `previous_fields` is re-captured after each catch_up, the `debug_assert!` binding pattern correctly avoids eliding the call in release builds, and all early-exit paths restore `state.fields` before returning. |
| crates/temper-server/src/entity_actor/effects.rs | Adds `apply_field_update` (the single shared function for PATCH/PUT semantics used by both live handler and journal replay), plus the `FIELDS_UPDATED_EVENT` / `FIELDS_REPLACED_EVENT` constants. The non-object guard is correctly placed inside the shared helper so replay and live paths agree on every input, not just those the live path screens. |
| crates/temper-server/src/entity_actor/actor.rs | Adds reserved-name guard for FieldsUpdated/FieldsReplaced in the Action arm, replay routing for those event types (before the generic path), and the new UpdateFields arm that delegates entirely to field_updates::commit_field_update. The response still carries spec_governed: true despite UpdateFields bypassing the spec state machine — a semantic accuracy issue noted in the previous review that persists after the refactor. |
| crates/temper-server/src/entity_actor/actor_test.rs | All four previously-flagged ARN-189 tests (field_update_rejects_non_object_payload_before_journaling, field_update_sanitization_is_reproduced_by_replay, reserved_field_update_event_names_are_refused_as_actions, field_update_recovers_from_a_concurrency_violation) now carry #[cfg(feature = "sim")] — the previous P1 compilation-without-feature issue is resolved. Comprehensive coverage of the fail-closed contract, budget gate, retry budget, precondition CAS, and replay semantics. |
| crates/temper-server/src/event_budget_metrics.rs | New file. Exports record_exhausted and record_field_update_replay_skip. Standard OnceLock singleton pattern for OTEL counters; not part of simulation state so does not need a determinism-ok annotation. |
| crates/temper-server/tests/odata_read.rs | Adds a live HTTP-stack regression test (patched_fields_survive_a_server_restart_over_the_http_stack) and a failure-reporting smoke test. Confirms journal entries with the new event types appear in the store, which would fail before this fix. |
| crates/temper-server/Cargo.toml | Adds the `testing` feature to the dev-dependency on opentelemetry_sdk for the in-memory metric exporter used by the replay-skip test. Correctly scoped to dev-only; not built into any production artifact. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as OData Client
    participant A as EntityActor
    participant J as EventJournal (AppendWithIndex)
    participant S as SnapshotQueue

    C->>A: "EntityMsg::UpdateFields { fields, replace }"
    A->>A: validate (non-object guard, deleted guard, budget gate)
    A->>A: apply_field_update(state, fields, replace) [speculative]
    A->>J: persist_event (FieldsUpdated / FieldsReplaced + key/vector rows)
    alt persist OK
        J-->>A: Ok(new_seq) → state.sequence_nr updated
        A->>A: state.push_event_bounded(event)
        A->>S: maybe_save_snapshot
        A-->>C: "EntityResponse { success: true }"
    else ConcurrencyViolation (preconditioned)
        J-->>A: Err(ConcurrencyViolation)
        A->>A: "rollback state.fields = previous_fields"
        A-->>C: "EntityResponse { success: false, "stale authorization" }"
    else ConcurrencyViolation (retry ≤ MAX_RETRIES)
        J-->>A: "Err(ConcurrencyViolation { actual })"
        A->>A: sleep (10ms / 50ms backoff)
        A->>J: "replay_events → *state = caught_up"
        A->>A: post_replay_refusal check
        A->>A: re-apply apply_field_update on caught-up state
        A->>J: persist_event (retry)
        J-->>A: Ok(new_seq)
        A-->>C: "EntityResponse { success: true }"
    else Other error
        J-->>A: Err(e)
        A->>A: "rollback state.fields = previous_fields"
        A-->>C: "EntityResponse { success: false, "persistence failed" }"
    end

    note over A,J: Replay path (rehydration / restart)
    A->>J: read_events
    J-->>A: envelopes
    A->>A: "if event_type == FieldsUpdated/FieldsReplaced → apply_field_update"
    A->>A: else → generic replay_effects path
```
</details>

<sub>Reviews (4): Last reviewed commit: ["test(server): gate the new field-update ..."](https://github.com/nerdsane/temper/commit/6e55ac814dc37da3a501dad6c562d583fb80fd77) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43685990)</sub>

<!-- /greptile_comment -->