### PR TITLE
fix(server): release declared-key ownership on delete and null (ARN-238)

### DIFF
--- a/crates/temper-runtime/src/persistence/mod.rs
+++ b/crates/temper-runtime/src/persistence/mod.rs
@@ -92,6 +92,11 @@ pub struct EntityKeyRow {
     /// The declared key's identifier (the `[[key]]` block's `name`).
     pub key_name: String,
     /// The canonical, type-tagged hash of the key's values.
+    ///
+    /// An EMPTY hash is the RELEASE marker (ARN-238): the store drops the
+    /// entity's existing row for `key_name` and inserts nothing, so a
+    /// tombstoned entity or a fully-nulled key stops owning the value in the
+    /// same transaction as the journal append.
     pub key_hash: String,
 }
 

--- a/crates/temper-server/src/entity_actor/actor.rs
+++ b/crates/temper-server/src/entity_actor/actor.rs
@@ -363,17 +363,32 @@ impl EntityActor {
             let reconcile_vectors = !table.vectors.is_empty();
             let mut key_rows = Vec::new();
             let mut vector_rows = Vec::new();
-            if let Some(field_map) = state.fields.as_object() {
-                for key in &table.keys {
-                    if let Some(hash) =
+            // ARN-238: a tombstoning write must RELEASE the entity's declared
+            // keys, not re-claim them from the still-populated fields —
+            // otherwise the dead entity holds the key values forever (keyed
+            // reads resolve to it, and new claimants are rejected as
+            // duplicates). The Delete arm persists before mutating status, so
+            // the event's to_status carries the tombstone signal. Release does
+            // not need the fields at all, so it is not gated on them.
+            let tombstoned = state.status == "Deleted" || event.to_status == "Deleted";
+            for key in &table.keys {
+                let key_hash = if tombstoned {
+                    None
+                } else {
+                    state.fields.as_object().and_then(|field_map| {
                         crate::key_index::canonical_key_hash(&key.name, &key.properties, field_map)
-                    {
-                        key_rows.push(temper_runtime::persistence::EntityKeyRow {
-                            key_name: key.name.clone(),
-                            key_hash: hash,
-                        });
-                    }
-                }
+                    })
+                };
+                // An empty hash is the RELEASE marker (see EntityKeyRow):
+                // the store drops the entity's row for this key_name and
+                // inserts nothing, so tombstoned or fully-nulled keys are
+                // purged in the same transaction as the journal append.
+                key_rows.push(temper_runtime::persistence::EntityKeyRow {
+                    key_name: key.name.clone(),
+                    key_hash: key_hash.unwrap_or_default(),
+                });
+            }
+            if let Some(field_map) = state.fields.as_object() {
                 // A soft-deleted (tombstone) entity is never indexed — it emits no
                 // vector rows, so the reconcile below PURGES any it had, even though
                 // its embedding field may still be present. Mirrors how the field-index

--- a/crates/temper-server/src/state/projection_backfill.rs
+++ b/crates/temper-server/src/state/projection_backfill.rs
@@ -41,9 +41,13 @@ pub(super) fn transition_table_for(
 pub(super) enum EntityLoadOutcome {
     /// Loaded — index it from these fields.
     Fields(serde_json::Value),
-    /// Definitively skippable: deleted, or a phantom with no events. Correctly NOT
+    /// Definitively skippable: a phantom with no events. Correctly NOT
     /// indexed, and NOT a failure (it must not block the watermark).
     Skip,
+    /// Tombstoned (status == "Deleted"). Not indexed — and the key backfill
+    /// RELEASES any rows the dead entity still holds (ARN-238 healing pass
+    /// for deletes that predate release-on-delete).
+    Tombstoned,
     /// The entity exists (it was enumerated from the durable store) but its current
     /// state could not be loaded — no transition table to replay with, an unreadable
     /// snapshot, or a replay error. Indexing it is impossible, so the type must NOT be
@@ -82,7 +86,7 @@ pub(super) async fn load_entity_current_fields(
     .await
     {
         Err(_) => EntityLoadOutcome::LoadFailed,
-        Ok(state) if state.status == "Deleted" => EntityLoadOutcome::Skip,
+        Ok(state) if state.status == "Deleted" => EntityLoadOutcome::Tombstoned,
         Ok(state) if state.total_event_count == 0 => EntityLoadOutcome::Skip,
         Ok(state) => EntityLoadOutcome::Fields(state.fields),
     }

--- a/crates/temper-server/src/state/projection_backfill/key_index.rs
+++ b/crates/temper-server/src/state/projection_backfill/key_index.rs
@@ -18,9 +18,12 @@ use super::{EntityLoadOutcome, load_entity_current_fields, transition_table_for}
 /// boot — the original bug that left ~0 of N entities keyed.
 ///
 /// Robustness at scale (tenants hold 10k–100k+ entities of a keyed type):
-/// - **Resumable**: already-keyed entities are skipped (the costly step is loading
-///   each entity's state), so a re-run after a partial pass only processes the
-///   remainder instead of re-loading all N.
+/// - **Resumable, with a healing exception (ARN-238)**: every entity is loaded
+///   (pre-watermark only — the watermark still ends all re-runs), because an
+///   already-keyed entity may hold STALE ownership: a tombstone, or a key whose
+///   components were nulled before release-on-delete/null existed. Living,
+///   fully-resolvable already-keyed entities skip the index write, so a resumed
+///   pass re-loads but does not re-write the finished remainder.
 /// - **Sound**: a type is watermarked only if EVERY existing entity was either keyed
 ///   or is definitively skippable (deleted/phantom). One entity that exists but
 ///   cannot be loaded fails the type — it is not watermarked, and keyed misses keep
@@ -105,15 +108,21 @@ pub(in crate::state) async fn populate_key_index_from_snapshots(
         // Resumability: on a FIRST-TIME backfill, skip entities already keyed (avoids
         // re-loading their state). On a key-set change we must re-key already-keyed
         // entities with the new key, so process all.
-        let already_keyed: BTreeSet<String> = if force_full_rekey {
-            BTreeSet::new()
+        // `membership_known` tracks whether the empty/filled set is AUTHORITATIVE.
+        // On force_full_rekey and on a membership fetch error the set is empty by
+        // construction, which must mean "process everything" — including releasing
+        // stale rows of entities whose keys are all unresolvable — not "known to
+        // be unindexed" (ARN-238: skipping them here would let the watermark end
+        // their healing silently).
+        let (already_keyed, membership_known): (BTreeSet<String>, bool) = if force_full_rekey {
+            (BTreeSet::new(), false)
         } else {
             match store
                 .keyed_entity_ids_for_type(tenant.as_str(), entity_type)
                 .await
             {
-                Ok(ids) => ids.into_iter().collect(),
-                Err(_) => BTreeSet::new(), // cannot resume → process all (correct, slower)
+                Ok(ids) => (ids.into_iter().collect(), true),
+                Err(_) => (BTreeSet::new(), false), // cannot resume → process all
             }
         };
 
@@ -121,15 +130,18 @@ pub(in crate::state) async fn populate_key_index_from_snapshots(
         let blob_store = state.blob_store_for_tenant(tenant).ok();
         let total = entity_ids.len();
         let mut newly_keyed = 0usize;
+        let mut healed = 0usize;
         let mut already = 0usize;
         let mut skipped = 0usize;
         let mut failed = 0usize;
 
         for entity_id in &entity_ids {
-            if already_keyed.contains(entity_id) {
-                already += 1;
-                continue;
-            }
+            // ARN-238: an already-keyed entity cannot be fast-skipped without
+            // loading it — its rows may be STALE ownership from a delete that
+            // predates release-on-delete, and healing requires seeing the
+            // tombstone. Living already-keyed entities still skip the upsert
+            // below; only the cheap membership shortcut moved.
+            let was_already_keyed = already_keyed.contains(entity_id);
             match load_entity_current_fields(
                 tenant,
                 entity_type,
@@ -146,22 +158,49 @@ pub(in crate::state) async fn populate_key_index_from_snapshots(
                         skipped += 1;
                         continue;
                     };
-                    let mut key_rows = Vec::new();
-                    for key in keys {
-                        if let Some(hash) = crate::key_index::canonical_key_hash(
-                            &key.name,
-                            &key.properties,
-                            field_map,
-                        ) {
-                            key_rows.push(temper_runtime::persistence::EntityKeyRow {
-                                key_name: key.name.clone(),
-                                key_hash: hash,
-                            });
-                        }
+                    // One row per declared key: a real hash when the key resolves,
+                    // a RELEASE marker when it does not (ARN-238 — a key whose
+                    // components were nulled must stop owning its old value; the
+                    // stale row is exactly why the entity looks already-keyed).
+                    let mut any_release = false;
+                    let mut any_hash = false;
+                    let key_rows: Vec<temper_runtime::persistence::EntityKeyRow> = keys
+                        .iter()
+                        .map(|key| {
+                            let hash = crate::key_index::canonical_key_hash(
+                                &key.name,
+                                &key.properties,
+                                field_map,
+                            );
+                            match hash {
+                                Some(hash) => {
+                                    any_hash = true;
+                                    temper_runtime::persistence::EntityKeyRow {
+                                        key_name: key.name.clone(),
+                                        key_hash: hash,
+                                    }
+                                }
+                                None => {
+                                    any_release = true;
+                                    temper_runtime::persistence::EntityKeyRow {
+                                        key_name: key.name.clone(),
+                                        key_hash: String::new(),
+                                    }
+                                }
+                            }
+                        })
+                        .collect();
+                    if was_already_keyed && !any_release {
+                        // Alive, fully resolvable, already indexed — nothing to write.
+                        already += 1;
+                        continue;
                     }
-                    if key_rows.is_empty() {
-                        // No resolvable key (all key components absent/null) — the
-                        // entity is not addressable by this key, so skipping is sound.
+                    if !any_hash && !was_already_keyed && membership_known {
+                        // Authoritatively not indexed and nothing resolvable — the
+                        // entity is not addressable by any declared key. Without
+                        // membership authority we fall through and write the
+                        // release markers (bounded no-op deletes), because the
+                        // entity may hold stale rows we cannot see from here.
                         skipped += 1;
                         continue;
                     }
@@ -169,7 +208,11 @@ pub(in crate::state) async fn populate_key_index_from_snapshots(
                         .backfill_entity_keys(tenant.as_str(), entity_type, entity_id, &key_rows)
                         .await
                     {
-                        Ok(()) => newly_keyed += 1,
+                        // A write with at least one real hash is a claim; a
+                        // release-only write is a heal — kept separate so the
+                        // completion log's newly_keyed stays an honest claim count.
+                        Ok(()) if any_hash => newly_keyed += 1,
+                        Ok(()) => healed += 1,
                         Err(e) => {
                             failed += 1;
                             tracing::warn!(
@@ -180,6 +223,36 @@ pub(in crate::state) async fn populate_key_index_from_snapshots(
                     }
                 }
                 EntityLoadOutcome::Skip => skipped += 1,
+                EntityLoadOutcome::Tombstoned => {
+                    // ARN-238 healing pass: a deleted entity must not keep its
+                    // declared keys. Emit a release marker per declared key so
+                    // rows written before release-on-delete are purged.
+                    let release_rows: Vec<temper_runtime::persistence::EntityKeyRow> = keys
+                        .iter()
+                        .map(|key| temper_runtime::persistence::EntityKeyRow {
+                            key_name: key.name.clone(),
+                            key_hash: String::new(),
+                        })
+                        .collect();
+                    match store
+                        .backfill_entity_keys(
+                            tenant.as_str(),
+                            entity_type,
+                            entity_id,
+                            &release_rows,
+                        )
+                        .await
+                    {
+                        Ok(()) => healed += 1,
+                        Err(e) => {
+                            failed += 1;
+                            tracing::warn!(
+                                error = %e, entity_type = %entity_type, entity_id = %entity_id,
+                                "key index backfill: tombstone release failed"
+                            );
+                        }
+                    }
+                }
                 EntityLoadOutcome::LoadFailed => {
                     failed += 1;
                     tracing::warn!(
@@ -200,13 +273,13 @@ pub(in crate::state) async fn populate_key_index_from_snapshots(
                 .await;
             tracing::info!(
                 tenant = %tenant, entity_type = %entity_type, key_set = %current_key_set,
-                total, newly_keyed, already, skipped,
+                total, newly_keyed, healed, already, skipped,
                 "entity_key_index backfill complete; type watermarked"
             );
         } else {
             tracing::warn!(
                 tenant = %tenant, entity_type = %entity_type,
-                total, newly_keyed, already, skipped, failed,
+                total, newly_keyed, healed, already, skipped, failed,
                 "key index backfill: {failed} entities unresolved; type NOT watermarked (keyed misses keep scanning; will resume next run)"
             );
         }

--- a/crates/temper-server/src/state/projection_backfill/vector_index.rs
+++ b/crates/temper-server/src/state/projection_backfill/vector_index.rs
@@ -179,7 +179,7 @@ pub(in crate::state) async fn populate_vector_index_from_snapshots(
                         }
                     }
                 }
-                EntityLoadOutcome::Skip => {
+                EntityLoadOutcome::Skip | EntityLoadOutcome::Tombstoned => {
                     // A deleted (or phantom) entity must hold no vector rows — purge
                     // any it still has so a soft-deleted entity is never ranked
                     // (reconcile with an empty row set). Harmless when there is nothing

--- a/crates/temper-server/tests/dst_entity_key_index.rs
+++ b/crates/temper-server/tests/dst_entity_key_index.rs
@@ -332,3 +332,182 @@ async fn dst_deleted_entity_releases_declared_key() {
         );
     }
 }
+
+/// ARN-238 healing pass: deletes that happened BEFORE release-on-delete left
+/// stale `entity_key_index` rows behind. The key backfill must release a
+/// tombstoned entity's rows instead of skipping them, so legacy stale
+/// ownership heals on the next boot backfill.
+#[tokio::test]
+async fn dst_key_backfill_releases_stale_rows_of_deleted_entities() {
+    use temper_server::registry::SpecRegistry;
+    use temper_server::state::ServerState;
+    use temper_spec::csdl::parse_csdl;
+
+    const CSDL_XML: &str = include_str!("../../../test-fixtures/specs/model.csdl.xml");
+
+    for seed in [7u64, 42u64] {
+        let (_guard, _clock, _id) = install_deterministic_context(seed);
+        let sim = SimEventStore::no_faults(seed);
+        let store: BoxedEventStore = BoxedEventStore::new(sim.clone());
+        let entity_id = format!("legacy-doc-{seed}");
+        let pid = format!("default:Doc:{entity_id}");
+
+        // Simulate the LEGACY sequence directly against the store (bypassing
+        // the fixed actor): a Create that claims the key, then a Deleted
+        // event whose co-commit re-claims it (the pre-fix behavior).
+        let stale_key = EntityKeyRow {
+            key_name: "path".to_string(),
+            key_hash: doc_key_hash("ws1", "/legacy.md"),
+        };
+        let mk_env = |seq: u64, event_type: &str, payload: serde_json::Value| PersistenceEnvelope {
+            sequence_nr: seq,
+            event_type: event_type.to_string(),
+            payload,
+            metadata: EventMetadata {
+                event_id: sim_uuid(),
+                causation_id: sim_uuid(),
+                correlation_id: sim_uuid(),
+                timestamp: sim_now(),
+                actor_id: pid.clone(),
+            },
+        };
+        store
+            .append_with_keys(
+                &pid,
+                0,
+                &[mk_env(
+                    1,
+                    "Create",
+                    serde_json::json!({
+                        "action": "Create", "from_status": "New", "to_status": "Ready",
+                        "timestamp": sim_now(), "params": {"WorkspaceId": "ws1", "Path": "/legacy.md"}
+                    }),
+                )],
+                std::slice::from_ref(&stale_key),
+            )
+            .await
+            .expect("legacy create");
+        store
+            .append_with_keys(
+                &pid,
+                1,
+                &[mk_env(
+                    2,
+                    "Deleted",
+                    serde_json::json!({
+                        "action": "Deleted", "from_status": "Ready", "to_status": "Deleted",
+                        "timestamp": sim_now(), "params": {}
+                    }),
+                )],
+                std::slice::from_ref(&stale_key), // pre-fix: tombstone re-claims
+            )
+            .await
+            .expect("legacy delete with stale re-claim");
+
+        // The stale row exists (the legacy bug's footprint).
+        let stale = store
+            .lookup_by_key("default", "Doc", "path", &stale_key.key_hash)
+            .await
+            .expect("lookup ok");
+        assert_eq!(
+            stale,
+            Some(entity_id.clone()),
+            "seed {seed}: stale row seeded"
+        );
+
+        // Boot-style backfill over a ServerState sharing this store.
+        let csdl = parse_csdl(CSDL_XML).expect("CSDL parses");
+        let mut registry = SpecRegistry::new();
+        registry.register_tenant("default", csdl, CSDL_XML.to_string(), &[("Doc", DOC_IOA)]);
+        let mut server = ServerState::from_registry(ActorSystem::new("dst-key-heal"), registry);
+        server.set_storage_stack(temper_server::storage::StorageStack::from_sim(sim, None));
+        let tenant = temper_runtime::tenant::TenantId::from("default".to_string());
+        server.populate_index_from_store(&tenant).await;
+        server.populate_key_index_from_snapshots(&tenant).await;
+
+        // The healing pass must have released the dead entity's key.
+        let healed = store
+            .lookup_by_key("default", "Doc", "path", &stale_key.key_hash)
+            .await
+            .expect("lookup ok");
+        assert_eq!(
+            healed, None,
+            "seed {seed}: the key backfill must release stale rows held by deleted entities"
+        );
+    }
+}
+
+/// ARN-238 healing pass, nulled-key leg: a LIVING entity whose stale row
+/// predates release-on-null (its declared key no longer resolves from its
+/// current fields) must have that row released by the backfill.
+#[tokio::test]
+async fn dst_key_backfill_releases_stale_rows_of_living_unresolvable_keys() {
+    use temper_server::registry::SpecRegistry;
+    use temper_server::state::ServerState;
+    use temper_spec::csdl::parse_csdl;
+
+    const CSDL_XML: &str = include_str!("../../../test-fixtures/specs/model.csdl.xml");
+
+    let seed = 11u64;
+    let (_guard, _clock, _id) = install_deterministic_context(seed);
+    let sim = SimEventStore::no_faults(seed);
+    let store: BoxedEventStore = BoxedEventStore::new(sim.clone());
+    let entity_id = "legacy-null-doc".to_string();
+    let pid = format!("default:Doc:{entity_id}");
+
+    // Legacy footprint: a Create whose event params DO NOT carry the key
+    // components (so the replayed current state cannot resolve the key),
+    // while a stale key row was still committed — the pre-fix behavior for
+    // a key later nulled.
+    let stale_key = EntityKeyRow {
+        key_name: "path".to_string(),
+        key_hash: doc_key_hash("ws1", "/nulled.md"),
+    };
+    store
+        .append_with_keys(
+            &pid,
+            0,
+            &[PersistenceEnvelope {
+                sequence_nr: 1,
+                event_type: "Create".to_string(),
+                payload: serde_json::json!({
+                    "action": "Create", "from_status": "New", "to_status": "Ready",
+                    "timestamp": sim_now(), "params": {}
+                }),
+                metadata: EventMetadata {
+                    event_id: sim_uuid(),
+                    causation_id: sim_uuid(),
+                    correlation_id: sim_uuid(),
+                    timestamp: sim_now(),
+                    actor_id: pid.clone(),
+                },
+            }],
+            std::slice::from_ref(&stale_key),
+        )
+        .await
+        .expect("legacy create with stale key row");
+
+    let stale = store
+        .lookup_by_key("default", "Doc", "path", &stale_key.key_hash)
+        .await
+        .expect("lookup ok");
+    assert_eq!(stale, Some(entity_id.clone()), "stale row seeded");
+
+    let csdl = parse_csdl(CSDL_XML).expect("CSDL parses");
+    let mut registry = SpecRegistry::new();
+    registry.register_tenant("default", csdl, CSDL_XML.to_string(), &[("Doc", DOC_IOA)]);
+    let mut server = ServerState::from_registry(ActorSystem::new("dst-key-heal-null"), registry);
+    server.set_storage_stack(temper_server::storage::StorageStack::from_sim(sim, None));
+    let tenant = temper_runtime::tenant::TenantId::from("default".to_string());
+    server.populate_index_from_store(&tenant).await;
+    server.populate_key_index_from_snapshots(&tenant).await;
+
+    let healed = store
+        .lookup_by_key("default", "Doc", "path", &stale_key.key_hash)
+        .await
+        .expect("lookup ok");
+    assert_eq!(
+        healed, None,
+        "the key backfill must release a living entity's stale row when its key no longer resolves"
+    );
+}

--- a/crates/temper-server/tests/dst_entity_key_index.rs
+++ b/crates/temper-server/tests/dst_entity_key_index.rs
@@ -240,3 +240,95 @@ async fn dst_co_commit_atomic_on_uniqueness_reject() {
         );
     }
 }
+
+/// ARN-238: deleting an entity must RELEASE its declared-key ownership.
+///
+/// The Deleted event's co-commit recomputes key rows from the entity's fields
+/// (which still hold the key values), so the tombstoned entity keeps its
+/// `entity_key_index` rows: keyed reads resolve to a dead entity, and — the
+/// durable damage — any NEW entity claiming the same key value is rejected
+/// with a uniqueness violation forever.
+#[tokio::test]
+async fn dst_deleted_entity_releases_declared_key() {
+    for seed in 0..NUM_SEEDS {
+        let (_guard, _clock, _id) = install_deterministic_context(seed);
+        let store: BoxedEventStore = BoxedEventStore::new(SimEventStore::no_faults(seed));
+        let table = doc_table();
+        let system = ActorSystem::new("dst-keyed-delete");
+
+        // Doc A claims the key, then is deleted.
+        let id_a = format!("doc-a-{seed}");
+        let actor_a = EntityActor::with_persistence(
+            "Doc",
+            &id_a,
+            table.clone(),
+            serde_json::json!({}),
+            store.clone(),
+            BackendLabel::Sim,
+        )
+        .with_tenant("default");
+        let ref_a = system.spawn(actor_a, &id_a);
+        let r = dispatch(
+            &ref_a,
+            "Create",
+            serde_json::json!({ "WorkspaceId": "ws1", "Path": "/a.md" }),
+        )
+        .await;
+        assert!(r.success, "seed {seed}: Create A failed: {:?}", r.error);
+
+        let deleted: EntityResponse = ref_a
+            .ask(EntityMsg::Delete, Duration::from_secs(5))
+            .await
+            .expect("delete responds");
+        assert!(
+            deleted.success,
+            "seed {seed}: Delete failed: {:?}",
+            deleted.error
+        );
+
+        // 1) The dead entity must no longer own the key.
+        let owner = store
+            .lookup_by_key("default", "Doc", "path", &doc_key_hash("ws1", "/a.md"))
+            .await
+            .expect("lookup ok");
+        assert_eq!(
+            owner, None,
+            "seed {seed}: a deleted entity must release its declared key, got {owner:?}"
+        );
+
+        // 2) A new entity must be able to claim the released key value.
+        let id_b = format!("doc-b-{seed}");
+        let actor_b = EntityActor::with_persistence(
+            "Doc",
+            &id_b,
+            table.clone(),
+            serde_json::json!({}),
+            store.clone(),
+            BackendLabel::Sim,
+        )
+        .with_tenant("default");
+        let ref_b = system.spawn(actor_b, &id_b);
+        let r = dispatch(
+            &ref_b,
+            "Create",
+            serde_json::json!({ "WorkspaceId": "ws1", "Path": "/a.md" }),
+        )
+        .await;
+        assert!(
+            r.success,
+            "seed {seed}: a new entity must be able to claim a key released by deletion, got: {:?}",
+            r.error
+        );
+
+        // 3) And the key resolves to the new owner.
+        let owner = store
+            .lookup_by_key("default", "Doc", "path", &doc_key_hash("ws1", "/a.md"))
+            .await
+            .expect("lookup ok");
+        assert_eq!(
+            owner,
+            Some(id_b.clone()),
+            "seed {seed}: the key must resolve to its new living owner"
+        );
+    }
+}

--- a/crates/temper-store-postgres/src/store.rs
+++ b/crates/temper-store-postgres/src/store.rs
@@ -143,6 +143,10 @@ impl EventStore for PostgresEventStore {
         // a reject is atomic (the journal does not advance). A different entity
         // already holding the key is the violation (reject + surface).
         for key in key_rows {
+            // Release markers (empty hash, ARN-238) claim nothing.
+            if key.key_hash.is_empty() {
+                continue;
+            }
             let holder: Option<(String,)> = crate::dbm::postgres_query_as!(
                 "SELECT entity_id FROM entity_key_index \
                  WHERE tenant = $1 AND entity_type = $2 AND key_name = $3 AND key_hash = $4",
@@ -229,6 +233,10 @@ impl EventStore for PostgresEventStore {
             .execute(&mut *tx)
             .await
             .map_err(|e| PersistenceError::Storage(e.to_string()))?;
+            // A release marker (ARN-238) only drops the prior row.
+            if key.key_hash.is_empty() {
+                continue;
+            }
             crate::dbm::postgres_query!(
                 "INSERT INTO entity_key_index \
                  (tenant, entity_type, key_name, key_hash, entity_id, sequence_nr) \
@@ -316,6 +324,21 @@ impl EventStore for PostgresEventStore {
             .await
             .map_err(|e| PersistenceError::Storage(e.to_string()))?;
         for key in key_rows {
+            // A release marker (empty hash, ARN-238) only drops the entity's row.
+            if key.key_hash.is_empty() {
+                crate::dbm::postgres_query!(
+                    "DELETE FROM entity_key_index \
+                     WHERE tenant = $1 AND entity_type = $2 AND key_name = $3 AND entity_id = $4",
+                )
+                .bind(tenant)
+                .bind(entity_type)
+                .bind(&key.key_name)
+                .bind(entity_id)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| PersistenceError::Storage(e.to_string()))?;
+                continue;
+            }
             // A different entity already holding this key is a pre-existing data
             // conflict — log and skip (don't fail the whole backfill on one row;
             // the conflict surfaces via the metric and a keyed read still resolves

--- a/crates/temper-store-sim/src/lib.rs
+++ b/crates/temper-store-sim/src/lib.rs
@@ -459,6 +459,10 @@ impl EventStore for SimEventStore {
             let entity_type = parts.next().unwrap_or("");
             let entity_id = parts.next().unwrap_or("");
             for row in key_rows {
+                // Release markers (empty hash, ARN-238) claim nothing.
+                if row.key_hash.is_empty() {
+                    continue;
+                }
                 if let Some(existing) = inner.key_index.get(&(
                     tenant.to_string(),
                     entity_type.to_string(),
@@ -542,6 +546,10 @@ impl EventStore for SimEventStore {
                         && kn.as_str() == row.key_name.as_str()
                         && eid.as_str() == entity_id)
                 });
+                // A release marker (ARN-238) only drops the prior row.
+                if row.key_hash.is_empty() {
+                    continue;
+                }
                 inner.key_index.insert(
                     (
                         tenant.to_string(),
@@ -600,6 +608,16 @@ impl EventStore for SimEventStore {
                 row.key_name.clone(),
                 row.key_hash.clone(),
             );
+            // A release marker (empty hash, ARN-238) only drops the prior row.
+            if row.key_hash.is_empty() {
+                inner.key_index.retain(|(t, et, kn, _), eid| {
+                    !(t.as_str() == tenant
+                        && et.as_str() == entity_type
+                        && kn.as_str() == row.key_name.as_str()
+                        && eid.as_str() == entity_id)
+                });
+                continue;
+            }
             match inner.key_index.get(&slot) {
                 // A different entity holds it — pre-existing conflict; skip (don't
                 // clobber, don't fail the backfill).

--- a/docs/adrs/0159-declared-key-release.md
+++ b/docs/adrs/0159-declared-key-release.md
@@ -1,0 +1,72 @@
+# ADR-0159: Declared-Key Release on Delete
+
+## Status
+
+Accepted (2026-07-12)
+
+## Context
+
+The ADR-0153 `entity_key_index` co-commit derives an entity's key rows from
+its post-transition fields on every journal append. A tombstoning write
+(`Deleted`) still has the key values in its fields, so the co-commit
+re-claimed them: the dead entity kept owning its declared keys (ARN-238).
+Keyed reads resolved to a tombstone, and — the durable damage — any new
+entity claiming the same key value was rejected with a uniqueness violation
+forever, because the uniqueness pre-check found the dead holder. Vectors
+already handled this (`index_vectors = status != "Deleted"` plus
+delete-then-insert reconcile); keys had no equivalent.
+
+## Decision
+
+1. **Release markers.** `EntityKeyRow.key_hash == ""` now means RELEASE: the
+   store drops the entity's existing row for that `key_name` and inserts
+   nothing, in the same transaction as the journal append. `persist_event`
+   emits one row per declared key on every keyed write — a real hash for
+   living entities with resolvable keys, a release marker when the write
+   tombstones the entity (`state.status == "Deleted"` or
+   `event.to_status == "Deleted"` — the Delete arm persists before mutating
+   status) or when the key's components are all null/absent. This also
+   releases ownership when a key is fully nulled, the issue's second leg.
+2. **Stores skip markers everywhere they claim.** The uniqueness pre-check
+   and the insert skip empty hashes; the per-key-name delete always runs.
+   Applied to the postgres and sim stores (Turso does not maintain the key
+   index live; its reads route through the same store impls).
+3. **Backfill heals legacy stale rows — both legs.** Tombstoned entities
+   emit release markers for every declared key, and LIVING entities emit a
+   release marker for any declared key that no longer resolves (nulled
+   components) alongside real hashes for the keys that do — computed before
+   the already-keyed resume shortcut, since a stale row is exactly what
+   makes such an entity look already-keyed. `EntityLoadOutcome` gained a
+   `Tombstoned` variant for the delete leg; the already-keyed resume
+   shortcut loads the entity before deciding (pre-watermark only), while
+   living, fully-resolvable already-keyed entities still skip the write.
+
+## Consequences
+
+- Deleting an entity frees its declared key values for reuse immediately and
+  atomically with the tombstone event.
+- Legacy stale rows heal on the next boot backfill for types that are not
+  yet watermarked. Types already watermarked do not re-run the backfill, so
+  their stale rows persist until a manual re-backfill — recorded here
+  honestly; the live release prevents any new staleness.
+- The backfill's resume path loads already-keyed entities once per run
+  (pre-watermark only) instead of fast-skipping on membership; the watermark
+  still prevents any post-completion cost.
+- **Composite-write residual:** composite sub-writes append through
+  `append_batch`, whose `PersistenceAppend` carries no key rows — composites
+  never claimed declared keys, and after this change they do not release
+  them either. An actor-keyed entity tombstoned via a composite therefore
+  still leaves a stale row (healable by the backfill pre-watermark). This is
+  a pre-existing ADR-0153 gap on the composite path, recorded here as a
+  tracked follow-up (Linear issue to be filed when it reconnects).
+
+## Alternatives Considered
+
+- **`reconcile_keys` flag mirroring `reconcile_vectors`** (delete ALL the
+  entity's key rows per write, insert emitted): changes the `EventStore`
+  trait signature across every implementor for the same outcome the release
+  marker expresses per key, and loses the per-key granularity.
+- **Filtering tombstones at read time** (`lookup_by_key` joining status):
+  leaves the uniqueness pre-check rejecting new claimants — the durable
+  damage — and puts tombstone knowledge in every reader instead of fixing
+  ownership at the write.


### PR DESCRIPTION
Fixes ARN-238 (`Declared-key ownership remains stale after an entity is deleted or key nulled`).

## Defect

The ADR-0153 `entity_key_index` co-commit derives key rows from the entity's post-transition fields on every append. A tombstoning `Deleted` event still has the key values in its fields, so the co-commit **re-claimed** them (vectors have a `status != "Deleted"` guard; keys had none). Consequences:

- Keyed reads resolve to a tombstone.
- **The durable damage:** any new entity claiming the same key value is rejected by the uniqueness pre-check forever — `duplicate declared key 'path' for Doc: held by doc-1` where doc-1 is deleted. The live E2E comment shows this verbatim.
- The sibling leg: a key whose components are all nulled emits no row, leaving the stale prior row in place.

## Fix (root cause)

**Release markers.** `EntityKeyRow.key_hash == ""` now means RELEASE (documented on the type): the store drops the entity's row for that `key_name` and inserts nothing, in the same transaction as the journal append. `persist_event` emits one row per declared key on every keyed write — a real hash for living entities, a release marker when the write tombstones the entity or the key resolves to no hash. The uniqueness pre-check and inserts skip markers (postgres + sim stores; Turso does not maintain the index live).

**Backfill heals legacy rows.** `EntityLoadOutcome` gained `Tombstoned`; the key backfill emits release markers for tombstoned entities instead of skipping them, purging stale rows from deletes that predate this change. The already-keyed resume shortcut now loads the entity before skipping — a stale-keyed tombstone *is* an already-keyed entity — while living already-keyed entities still skip the upsert. Honest limit (in ADR-0159): types already watermarked don't re-run the backfill, so their legacy rows persist until a manual re-backfill; live release prevents all new staleness.

ADR-0159 records the design and why a `reconcile_keys` trait flag was rejected.

## TDD

- RED `98a7ea4c` (committed alone): 100-seed DST — delete → `lookup_by_key` must return None, a new claimant must succeed, the key must resolve to the new owner. Fails on main at leg 1 with `Some("doc-a-0")`.
- GREEN: turns it green and adds the healing-pass DST (`dst_key_backfill_releases_stale_rows_of_deleted_entities`, legacy footprint seeded via direct store appends).

## Verification

- `dst_entity_key_index` 5/5 (100-seed); lib suite 575/575 (2 flaky-class failures once under parallel load, clean on immediate re-run — same pre-existing class as documented on #373/#375); 7 adjacent integration suites 40/40; clippy `-D warnings`, ratchet, fmt clean.
- Pre-commit code + DST reviews on both commits.
- Live local E2E (the verbatim duplicate-key rejection before, successful re-claim after): PR comment below.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a durable data-integrity bug (ARN-238) where deleting an entity or nulling all components of a declared key left a stale `entity_key_index` row, permanently blocking any new entity from claiming the same key value. The fix introduces an empty `key_hash` as an in-band RELEASE marker that instructs each store to DELETE the entity's row for that `key_name` without inserting a replacement, all within the same transaction as the journal append.

- **Live path (`actor.rs`):** `persist_event` now emits one `EntityKeyRow` per declared key on every keyed write — a real hash when the entity is alive and the key resolves, an empty-hash release marker when the write tombstones the entity or when the key's components are absent/null. Postgres and sim stores skip empty hashes in the uniqueness pre-check and INSERT, but always run the per-key-name DELETE first.
- **Backfill healing path (`key_index.rs`):** `EntityLoadOutcome` gains a `Tombstoned` variant; the backfill emits all-release-marker rows for tombstoned entities to purge stale rows left by pre-fix deletes. The already-keyed fast-skip is applied after loading (not before), since a stale-keyed tombstone is precisely what makes an entity look already-keyed.
- **Known limitation (documented):** Entity types already marked with a backfill watermark will not re-run the backfill automatically; their legacy stale rows persist until a manual re-backfill. New staleness is fully prevented by the live-path fix.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The core fix is correct and atomically integrated into both the live co-commit and the backfill; the durable damage scenario described in the bug is fully addressed for all new writes.

In the backfill's Tombstoned arm, release markers are always emitted regardless of whether the entity is known to be absent from the key index (membership_known && !was_already_keyed). The result is no-op DELETEs and an inflated healed counter for tombstoned entities that never had stale rows. This is harmless in practice but worth a second look before merge given that this backfill runs at boot over potentially large tenant datasets.

crates/temper-server/src/state/projection_backfill/key_index.rs — specifically the Tombstoned arm and the interaction between membership_known and the healed counter.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/temper-runtime/src/persistence/mod.rs | Adds documentation to EntityKeyRow clarifying the empty-hash release-marker contract; no logic changes. |
| crates/temper-server/src/entity_actor/actor.rs | Tombstone detection and release-marker emission on every declared key; the old hash-only path now correctly emits empty-hash rows on deletion or null-key events. Correct detection using both state.status and event.to_status. |
| crates/temper-server/src/state/projection_backfill.rs | Adds EntityLoadOutcome::Tombstoned variant and returns it for status==Deleted entities; vector backfill treats Tombstoned like Skip. |
| crates/temper-server/src/state/projection_backfill/key_index.rs | Adds membership_known flag, removes the fast-skip before entity load, adds Tombstoned arm emitting release markers, and the living-entity shortcut accounts for stale rows. Logic is correct but Tombstoned entities with no stale rows always issue no-op DELETEs. |
| crates/temper-server/src/state/projection_backfill/vector_index.rs | One-line change to match Tombstoned in the same arm as Skip; the existing purge-on-delete logic handles both correctly. |
| crates/temper-store-postgres/src/store.rs | Skips empty-hash rows in uniqueness pre-check; in live co-commit DELETE always runs then INSERT is skipped for empty hash; backfill path issues DELETE-only for empty hash. All three paths atomically handle release markers. |
| crates/temper-store-sim/src/lib.rs | Mirrors postgres logic for release markers across append_with_keys and backfill_entity_keys; uniqueness pre-check skips empty-hash rows, co-commit retain+skip on empty hash, backfill retain+continue on empty hash. |
| crates/temper-server/tests/dst_entity_key_index.rs | Three new DST tests covering delete-then-claim, healing stale rows of deleted entities via backfill, and healing stale rows of living entities with nulled keys via backfill. Good seed coverage and clear assertions. |
| docs/adrs/0159-declared-key-release.md | New ADR documenting the release-marker design, alternatives considered, and honest limitations (composite-write gap, already-watermarked types). |

</details>


<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[persist_event called] --> B{tombstoned?\nstate.status==Deleted\nor event.to_status==Deleted}
    B -- yes --> C[emit empty key_hash\nRELEASE marker per declared key]
    B -- no --> D{key fields\nresolvable?}
    D -- yes --> E[emit real key_hash]
    D -- no --> C
    C --> F[Store: DELETE existing row\nfor key_name + entity_id]
    E --> G[Store: uniqueness pre-check\nskips empty hash]
    G --> H[Store: DELETE old row\nthen INSERT new hash]
    F --> I[Key ownership released\natom with journal append]
    H --> I
    J[Backfill loop] --> K{load_entity_\ncurrent_fields}
    K -- Fields --> L{was_already_keyed\nAND no any_release?}
    L -- yes --> M[fast-skip\nalready correct]
    L -- no --> N[emit real hashes and\nrelease markers]
    K -- Tombstoned --> O[emit all-release markers\nhealed++]
    K -- Skip --> P[skipped++]
    K -- LoadFailed --> Q[failed++]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[persist_event called] --> B{tombstoned?\nstate.status==Deleted\nor event.to_status==Deleted}
    B -- yes --> C[emit empty key_hash\nRELEASE marker per declared key]
    B -- no --> D{key fields\nresolvable?}
    D -- yes --> E[emit real key_hash]
    D -- no --> C
    C --> F[Store: DELETE existing row\nfor key_name + entity_id]
    E --> G[Store: uniqueness pre-check\nskips empty hash]
    G --> H[Store: DELETE old row\nthen INSERT new hash]
    F --> I[Key ownership released\natom with journal append]
    H --> I
    J[Backfill loop] --> K{load_entity_\ncurrent_fields}
    K -- Fields --> L{was_already_keyed\nAND no any_release?}
    L -- yes --> M[fast-skip\nalready correct]
    L -- no --> N[emit real hashes and\nrelease markers]
    K -- Tombstoned --> O[emit all-release markers\nhealed++]
    K -- Skip --> P[skipped++]
    K -- LoadFailed --> Q[failed++]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/temper-server/src/state/projection_backfill/key_index.rs`, line 226-272 ([link](https://github.com/nerdsane/temper/blob/ebe0624951b02141c59b39c0a5c18f83e19a3f9c/crates/temper-server/src/state/projection_backfill/key_index.rs#L226-L272)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Tombstone healing issues no-op DELETEs for entities known to be unindexed**

   When `membership_known` is `true` and `was_already_keyed` is `false`, the store already confirms this tombstoned entity has no rows in `entity_key_index`. The `Tombstoned` arm currently skips that check and always calls `backfill_entity_keys` with release markers, which become no-op DELETEs in both stores. These round-trips are harmless but they also increment `healed` in the completion log, so boot-time output will show `healed=N` for N tombstones even when no actual stale rows existed. Adding a `!was_already_keyed && membership_known` guard here (symmetric with the `Fields` arm's skip at line 198) would eliminate the unnecessary store calls and keep the counter honest.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: crates/temper-server/src/state/projection_backfill/key_index.rs
   Line: 226-272

   Comment:
   **Tombstone healing issues no-op DELETEs for entities known to be unindexed**

   When `membership_known` is `true` and `was_already_keyed` is `false`, the store already confirms this tombstoned entity has no rows in `entity_key_index`. The `Tombstoned` arm currently skips that check and always calls `backfill_entity_keys` with release markers, which become no-op DELETEs in both stores. These round-trips are harmless but they also increment `healed` in the completion log, so boot-time output will show `healed=N` for N tombstones even when no actual stale rows existed. Adding a `!was_already_keyed && membership_known` guard here (symmetric with the `Fields` arm's skip at line 198) would eliminate the unnecessary store calls and keep the counter honest.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-server%2Fsrc%2Fstate%2Fprojection_backfill%2Fkey_index.rs%0ALine%3A%20226-272%0A%0AComment%3A%0A**Tombstone%20healing%20issues%20no-op%20DELETEs%20for%20entities%20known%20to%20be%20unindexed**%0A%0AWhen%20%60membership_known%60%20is%20%60true%60%20and%20%60was_already_keyed%60%20is%20%60false%60%2C%20the%20store%20already%20confirms%20this%20tombstoned%20entity%20has%20no%20rows%20in%20%60entity_key_index%60.%20The%20%60Tombstoned%60%20arm%20currently%20skips%20that%20check%20and%20always%20calls%20%60backfill_entity_keys%60%20with%20release%20markers%2C%20which%20become%20no-op%20DELETEs%20in%20both%20stores.%20These%20round-trips%20are%20harmless%20but%20they%20also%20increment%20%60healed%60%20in%20the%20completion%20log%2C%20so%20boot-time%20output%20will%20show%20%60healed%3DN%60%20for%20N%20tombstones%20even%20when%20no%20actual%20stale%20rows%20existed.%20Adding%20a%20%60!was_already_keyed%20%26%26%20membership_known%60%20guard%20here%20%28symmetric%20with%20the%20%60Fields%60%20arm's%20skip%20at%20line%20198%29%20would%20eliminate%20the%20unnecessary%20store%20calls%20and%20keep%20the%20counter%20honest.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=nerdsane%2Ftemper&pr=376&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22claude%2Farn-238-stale-key-ownership%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Farn-238-stale-key-ownership%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-server%2Fsrc%2Fstate%2Fprojection_backfill%2Fkey_index.rs%0ALine%3A%20226-272%0A%0AComment%3A%0A**Tombstone%20healing%20issues%20no-op%20DELETEs%20for%20entities%20known%20to%20be%20unindexed**%0A%0AWhen%20%60membership_known%60%20is%20%60true%60%20and%20%60was_already_keyed%60%20is%20%60false%60%2C%20the%20store%20already%20confirms%20this%20tombstoned%20entity%20has%20no%20rows%20in%20%60entity_key_index%60.%20The%20%60Tombstoned%60%20arm%20currently%20skips%20that%20check%20and%20always%20calls%20%60backfill_entity_keys%60%20with%20release%20markers%2C%20which%20become%20no-op%20DELETEs%20in%20both%20stores.%20These%20round-trips%20are%20harmless%20but%20they%20also%20increment%20%60healed%60%20in%20the%20completion%20log%2C%20so%20boot-time%20output%20will%20show%20%60healed%3DN%60%20for%20N%20tombstones%20even%20when%20no%20actual%20stale%20rows%20existed.%20Adding%20a%20%60!was_already_keyed%20%26%26%20membership_known%60%20guard%20here%20%28symmetric%20with%20the%20%60Fields%60%20arm's%20skip%20at%20line%20198%29%20would%20eliminate%20the%20unnecessary%20store%20calls%20and%20keep%20the%20counter%20honest.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=nerdsane%2Ftemper&pr=376&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftemper-server%2Fsrc%2Fstate%2Fprojection_backfill%2Fkey_index.rs%0ALine%3A%20226-272%0A%0AComment%3A%0A**Tombstone%20healing%20issues%20no-op%20DELETEs%20for%20entities%20known%20to%20be%20unindexed**%0A%0AWhen%20%60membership_known%60%20is%20%60true%60%20and%20%60was_already_keyed%60%20is%20%60false%60%2C%20the%20store%20already%20confirms%20this%20tombstoned%20entity%20has%20no%20rows%20in%20%60entity_key_index%60.%20The%20%60Tombstoned%60%20arm%20currently%20skips%20that%20check%20and%20always%20calls%20%60backfill_entity_keys%60%20with%20release%20markers%2C%20which%20become%20no-op%20DELETEs%20in%20both%20stores.%20These%20round-trips%20are%20harmless%20but%20they%20also%20increment%20%60healed%60%20in%20the%20completion%20log%2C%20so%20boot-time%20output%20will%20show%20%60healed%3DN%60%20for%20N%20tombstones%20even%20when%20no%20actual%20stale%20rows%20existed.%20Adding%20a%20%60!was_already_keyed%20%26%26%20membership_known%60%20guard%20here%20%28symmetric%20with%20the%20%60Fields%60%20arm's%20skip%20at%20line%20198%29%20would%20eliminate%20the%20unnecessary%20store%20calls%20and%20keep%20the%20counter%20honest.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=376&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftemper-server%2Fsrc%2Fstate%2Fprojection_backfill%2Fkey_index.rs%3A226-272%0A**Tombstone%20healing%20issues%20no-op%20DELETEs%20for%20entities%20known%20to%20be%20unindexed**%0A%0AWhen%20%60membership_known%60%20is%20%60true%60%20and%20%60was_already_keyed%60%20is%20%60false%60%2C%20the%20store%20already%20confirms%20this%20tombstoned%20entity%20has%20no%20rows%20in%20%60entity_key_index%60.%20The%20%60Tombstoned%60%20arm%20currently%20skips%20that%20check%20and%20always%20calls%20%60backfill_entity_keys%60%20with%20release%20markers%2C%20which%20become%20no-op%20DELETEs%20in%20both%20stores.%20These%20round-trips%20are%20harmless%20but%20they%20also%20increment%20%60healed%60%20in%20the%20completion%20log%2C%20so%20boot-time%20output%20will%20show%20%60healed%3DN%60%20for%20N%20tombstones%20even%20when%20no%20actual%20stale%20rows%20existed.%20Adding%20a%20%60!was_already_keyed%20%26%26%20membership_known%60%20guard%20here%20%28symmetric%20with%20the%20%60Fields%60%20arm's%20skip%20at%20line%20198%29%20would%20eliminate%20the%20unnecessary%20store%20calls%20and%20keep%20the%20counter%20honest.%0A%0A&repo=nerdsane%2Ftemper&pr=376&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22claude%2Farn-238-stale-key-ownership%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Farn-238-stale-key-ownership%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftemper-server%2Fsrc%2Fstate%2Fprojection_backfill%2Fkey_index.rs%3A226-272%0A**Tombstone%20healing%20issues%20no-op%20DELETEs%20for%20entities%20known%20to%20be%20unindexed**%0A%0AWhen%20%60membership_known%60%20is%20%60true%60%20and%20%60was_already_keyed%60%20is%20%60false%60%2C%20the%20store%20already%20confirms%20this%20tombstoned%20entity%20has%20no%20rows%20in%20%60entity_key_index%60.%20The%20%60Tombstoned%60%20arm%20currently%20skips%20that%20check%20and%20always%20calls%20%60backfill_entity_keys%60%20with%20release%20markers%2C%20which%20become%20no-op%20DELETEs%20in%20both%20stores.%20These%20round-trips%20are%20harmless%20but%20they%20also%20increment%20%60healed%60%20in%20the%20completion%20log%2C%20so%20boot-time%20output%20will%20show%20%60healed%3DN%60%20for%20N%20tombstones%20even%20when%20no%20actual%20stale%20rows%20existed.%20Adding%20a%20%60!was_already_keyed%20%26%26%20membership_known%60%20guard%20here%20%28symmetric%20with%20the%20%60Fields%60%20arm's%20skip%20at%20line%20198%29%20would%20eliminate%20the%20unnecessary%20store%20calls%20and%20keep%20the%20counter%20honest.%0A%0A&repo=nerdsane%2Ftemper&pr=376&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftemper-server%2Fsrc%2Fstate%2Fprojection_backfill%2Fkey_index.rs%3A226-272%0A**Tombstone%20healing%20issues%20no-op%20DELETEs%20for%20entities%20known%20to%20be%20unindexed**%0A%0AWhen%20%60membership_known%60%20is%20%60true%60%20and%20%60was_already_keyed%60%20is%20%60false%60%2C%20the%20store%20already%20confirms%20this%20tombstoned%20entity%20has%20no%20rows%20in%20%60entity_key_index%60.%20The%20%60Tombstoned%60%20arm%20currently%20skips%20that%20check%20and%20always%20calls%20%60backfill_entity_keys%60%20with%20release%20markers%2C%20which%20become%20no-op%20DELETEs%20in%20both%20stores.%20These%20round-trips%20are%20harmless%20but%20they%20also%20increment%20%60healed%60%20in%20the%20completion%20log%2C%20so%20boot-time%20output%20will%20show%20%60healed%3DN%60%20for%20N%20tombstones%20even%20when%20no%20actual%20stale%20rows%20existed.%20Adding%20a%20%60!was_already_keyed%20%26%26%20membership_known%60%20guard%20here%20%28symmetric%20with%20the%20%60Fields%60%20arm's%20skip%20at%20line%20198%29%20would%20eliminate%20the%20unnecessary%20store%20calls%20and%20keep%20the%20counter%20honest.%0A%0A&pr=376&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
crates/temper-server/src/state/projection_backfill/key_index.rs:226-272
**Tombstone healing issues no-op DELETEs for entities known to be unindexed**

When `membership_known` is `true` and `was_already_keyed` is `false`, the store already confirms this tombstoned entity has no rows in `entity_key_index`. The `Tombstoned` arm currently skips that check and always calls `backfill_entity_keys` with release markers, which become no-op DELETEs in both stores. These round-trips are harmless but they also increment `healed` in the completion log, so boot-time output will show `healed=N` for N tombstones even when no actual stale rows existed. Adding a `!was_already_keyed && membership_known` guard here (symmetric with the `Fields` arm's skip at line 198) would eliminate the unnecessary store calls and keep the counter honest.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(server): release declared-key owners..."](https://github.com/nerdsane/temper/commit/ebe0624951b02141c59b39c0a5c18f83e19a3f9c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43714468)</sub>

<!-- /greptile_comment -->