### PR TITLE
fix(arn-243): redact LLM observability content per-tenant by default

### DIFF
--- a/crates/temper-server/src/router.rs
+++ b/crates/temper-server/src/router.rs
@@ -367,7 +367,8 @@ async fn dispatch_matched_route(
         .unwrap_or_default();
     let host: std::sync::Arc<dyn temper_wasm::WasmHost> = std::sync::Arc::new(
         temper_wasm::ProductionWasmHost::with_shared_streams(secrets, streams.clone())
-            .with_invocation_context(ctx.clone()),
+            .with_invocation_context(ctx.clone())
+            .with_llm_content_export(state.export_llm_content(tenant_id.as_str())),
     );
 
     // Spawn task B: invoke the WASM module. Runs to completion

--- a/crates/temper-server/src/state/dispatch/wasm.rs
+++ b/crates/temper-server/src/state/dispatch/wasm.rs
@@ -1929,6 +1929,29 @@ fn strip_private_observability_params(mut params: Value) -> Value {
     params
 }
 
+/// Callback-param keys that carry LLM *content* (prompt, completion, system
+/// prompt, and tool arguments/results) rather than safe metadata. These are the
+/// keys the telemetry sinks read — the span record, [`llm_call_wide_event`],
+/// [`submit_llmobs_llm_span`], and [`submit_llmobs_tool_spans`] — so stripping
+/// them from `callback_params` redacts content across every sink at once.
+/// Metadata keys (`_gen_ai_provider`, `_gen_ai_model`, `_gen_ai_finish_reason`,
+/// trace/span ids, token counts) are intentionally preserved. See ADR-0166.
+const LLM_CONTENT_PARAM_KEYS: [&str; 4] = [
+    "_gen_ai_input_messages",
+    "_gen_ai_output_messages",
+    "_gen_ai_system_instructions",
+    "_dd_llmobs_tool_spans",
+];
+
+/// Redact LLM content params from `callback_params` unless the tenant has opted
+/// into LLM content export. Removes only the content keys in
+/// [`LLM_CONTENT_PARAM_KEYS`]; metadata is preserved. No-op when
+/// `export_content` is true. See ADR-0166.
+fn redact_llm_content_params(_callback_params: &mut Value, _export_content: bool) {
+    // ARN-243 RED: LLM content is exported for every tenant with no per-tenant
+    // gate. The redaction is implemented in the GREEN commit.
+}
+
 fn integration_error_type(error: &str) -> String {
     let normalized = error.to_ascii_lowercase();
     if normalized.contains("rate limit") {
@@ -2098,6 +2121,60 @@ mod tests {
         assert!(stripped.get("_gen_ai_finish_reason").is_none());
         assert!(stripped.get("_gen_ai_llm_parent_span_id").is_none());
         assert!(stripped.get("_dd_llmobs_tool_spans").is_none());
+    }
+
+    #[test]
+    fn redacts_llm_content_params_for_non_opted_in_tenant() {
+        let base = json!({
+            "input_tokens": 10,
+            "output_tokens": 20,
+            "_gen_ai_provider": "anthropic",
+            "_gen_ai_model": "claude-sonnet-4-6",
+            "_gen_ai_finish_reason": "end_turn",
+            "_gen_ai_llm_parent_span_id": "parent-span",
+            "_gen_ai_input_messages": "[{\"role\":\"user\",\"content\":\"SECRET PROMPT\"}]",
+            "_gen_ai_output_messages": "[{\"role\":\"assistant\",\"content\":\"SECRET REPLY\"}]",
+            "_gen_ai_system_instructions": "SECRET SYSTEM",
+            "_dd_llmobs_tool_spans": "[{\"arguments\":\"SECRET ARGS\",\"result\":\"SECRET RESULT\"}]",
+        });
+
+        // Non-opted-in tenant: content stripped, metadata preserved.
+        let mut redacted = base.clone();
+        redact_llm_content_params(&mut redacted, false);
+        assert!(
+            redacted.get("_gen_ai_input_messages").is_none(),
+            "prompt must be redacted"
+        );
+        assert!(
+            redacted.get("_gen_ai_output_messages").is_none(),
+            "completion must be redacted"
+        );
+        assert!(
+            redacted.get("_gen_ai_system_instructions").is_none(),
+            "system prompt must be redacted"
+        );
+        assert!(
+            redacted.get("_dd_llmobs_tool_spans").is_none(),
+            "tool content must be redacted"
+        );
+        assert_eq!(redacted["input_tokens"], 10);
+        assert_eq!(redacted["output_tokens"], 20);
+        assert_eq!(redacted["_gen_ai_provider"], "anthropic");
+        assert_eq!(redacted["_gen_ai_model"], "claude-sonnet-4-6");
+        assert_eq!(redacted["_gen_ai_finish_reason"], "end_turn");
+        assert_eq!(redacted["_gen_ai_llm_parent_span_id"], "parent-span");
+
+        // Opted-in tenant: content preserved.
+        let mut exported = base.clone();
+        redact_llm_content_params(&mut exported, true);
+        assert_eq!(
+            exported["_gen_ai_input_messages"],
+            "[{\"role\":\"user\",\"content\":\"SECRET PROMPT\"}]"
+        );
+        assert_eq!(
+            exported["_dd_llmobs_tool_spans"],
+            "[{\"arguments\":\"SECRET ARGS\",\"result\":\"SECRET RESULT\"}]"
+        );
     }
 
     #[test]

--- a/crates/temper-server/src/state/dispatch/wasm.rs
+++ b/crates/temper-server/src/state/dispatch/wasm.rs
@@ -665,6 +665,9 @@ impl crate::state::ServerState {
                         .with_internal_api_base_url(internal_api_url)
                         .with_internal_api_key(internal_api_key)
                         .with_invocation_context(host_invocation_context)
+                        .with_llm_content_export(
+                            self.export_llm_content(ctx.entity_ref.tenant.as_str()),
+                        )
                         .with_text_http_interceptor(
                             local_file_interceptor
                                 .unwrap_or_else(|| Arc::new(|_, _, _, _| Box::pin(async { None }))),
@@ -985,6 +988,17 @@ impl crate::state::ServerState {
                     );
                 }
 
+                // ARN-243: redact LLM content (prompt/completion/system/tool)
+                // from the callback params unless this tenant opted into content
+                // export. Stripping here covers every downstream telemetry sink
+                // — the span record below, `llm_call_wide_event`,
+                // `submit_llmobs_llm_span`, and `submit_llmobs_tool_spans` — all
+                // of which read from these params. Metadata (tokens, model,
+                // provider, finish reason, trace ids) is preserved. See ADR-0166.
+                redact_llm_content_params(
+                    &mut result.callback_params,
+                    self.export_llm_content(ctx.entity_ref.tenant.as_str()),
+                );
                 let callback_params = &result.callback_params;
 
                 if should_record_gen_ai_span_attrs(integration.llm, callback_params) {
@@ -1359,7 +1373,8 @@ impl crate::state::ServerState {
             .with_progress_emitter(progress_emitter)
             .with_internal_api_base_url(internal_api_base_url(self))
             .with_internal_api_key(std::env::var("TEMPER_API_KEY").ok()) // determinism-ok: production host loopback config
-            .with_invocation_context(context.clone());
+            .with_invocation_context(context.clone())
+            .with_llm_content_export(self.export_llm_content(tenant.as_str()));
         if let Some(resolver) = secret_resolver {
             base_host = base_host.with_secret_resolver(resolver);
         }
@@ -1947,9 +1962,16 @@ const LLM_CONTENT_PARAM_KEYS: [&str; 4] = [
 /// into LLM content export. Removes only the content keys in
 /// [`LLM_CONTENT_PARAM_KEYS`]; metadata is preserved. No-op when
 /// `export_content` is true. See ADR-0166.
-fn redact_llm_content_params(_callback_params: &mut Value, _export_content: bool) {
-    // ARN-243 RED: LLM content is exported for every tenant with no per-tenant
-    // gate. The redaction is implemented in the GREEN commit.
+fn redact_llm_content_params(callback_params: &mut Value, export_content: bool) {
+    if export_content {
+        return;
+    }
+    let Some(object) = callback_params.as_object_mut() else {
+        return;
+    };
+    for key in LLM_CONTENT_PARAM_KEYS {
+        object.remove(key);
+    }
 }
 
 fn integration_error_type(error: &str) -> String {

--- a/crates/temper-server/src/state/mod.rs
+++ b/crates/temper-server/src/state/mod.rs
@@ -286,6 +286,25 @@ fn env_local_tdata_hosts() -> BTreeSet<String> {
     hosts
 }
 
+/// Tenants that have opted into exporting raw LLM content to telemetry, loaded
+/// once at startup from `TEMPER_LLM_CONTENT_EXPORT_TENANTS` (comma-separated
+/// tenant ids; the literal `*` opts in every tenant). Empty by default, so
+/// content is redacted for every tenant unless explicitly opted in. See
+/// ADR-0166.
+fn env_llm_content_export_tenants() -> BTreeSet<String> {
+    let mut tenants = BTreeSet::new();
+    let configured = std::env::var("TEMPER_LLM_CONTENT_EXPORT_TENANTS"); // determinism-ok: read once at startup
+    if let Ok(raw) = configured {
+        for item in raw.split(',') {
+            let trimmed = item.trim();
+            if !trimmed.is_empty() {
+                tenants.insert(trimmed.to_string());
+            }
+        }
+    }
+    tenants
+}
+
 fn state_cache_budget() -> usize {
     static STATE_CACHE_BUDGET: OnceLock<usize> = OnceLock::new();
     *STATE_CACHE_BUDGET.get_or_init(|| env_usize("TEMPER_STATE_CACHE_BUDGET", 10_000))
@@ -538,6 +557,12 @@ pub struct ServerState {
     /// Public hostnames owned by this process that may use in-process TData
     /// dispatch from WASM guests instead of leaving through the public edge.
     pub(crate) local_tdata_hosts: Arc<BTreeSet<String>>,
+    /// Tenants that have opted into exporting raw LLM content (prompts,
+    /// completions, system instructions, tool arguments/results) to the
+    /// telemetry backend. Loaded once from `TEMPER_LLM_CONTENT_EXPORT_TENANTS`.
+    /// Empty by default: every tenant is redacted unless explicitly opted in.
+    /// See ADR-0166.
+    pub(crate) llm_content_export_tenants: Arc<BTreeSet<String>>,
 }
 
 /// Install a one-time hook so liveness violations surfaced by temper-spec
@@ -559,6 +584,17 @@ impl ServerState {
         if let Ok(mut tenants) = self.commons_guardrail_tenants.write() {
             tenants.insert(tenant.to_string());
         }
+    }
+
+    /// Whether `tenant` may export raw LLM content (prompts, completions,
+    /// system instructions, tool arguments/results) to the telemetry backend.
+    ///
+    /// Redact-by-default: content is only exported for tenants listed in
+    /// `TEMPER_LLM_CONTENT_EXPORT_TENANTS` (or when it contains the wildcard
+    /// `*`). Every other tenant is redacted. See ADR-0166.
+    pub fn export_llm_content(&self, tenant: &str) -> bool {
+        self.llm_content_export_tenants.contains("*")
+            || self.llm_content_export_tenants.contains(tenant)
     }
 
     /// Whether commons-mode write guardrails are active for a tenant.
@@ -729,6 +765,7 @@ impl ServerState {
             http_stream_registry: Arc::new(temper_wasm::http_stream::HttpStreamRegistry::new()),
             workflow_spans: Arc::new(crate::workflow_tracing::WorkflowSpanRegistry::default()),
             local_tdata_hosts: Arc::new(env_local_tdata_hosts()),
+            llm_content_export_tenants: Arc::new(env_llm_content_export_tenants()),
         };
 
         // Pre-register built-in WASM modules (http_fetch for generic HTTP integrations).
@@ -977,6 +1014,7 @@ impl ServerState {
             http_stream_registry: Arc::new(temper_wasm::http_stream::HttpStreamRegistry::new()),
             workflow_spans: Arc::new(crate::workflow_tracing::WorkflowSpanRegistry::default()),
             local_tdata_hosts: Arc::new(env_local_tdata_hosts()),
+            llm_content_export_tenants: Arc::new(env_llm_content_export_tenants()),
         };
         state.register_builtin_wasm_modules();
         state

--- a/crates/temper-server/tests/wasm_dispatch_observability_contract.rs
+++ b/crates/temper-server/tests/wasm_dispatch_observability_contract.rs
@@ -27,3 +27,34 @@ fn wasm_dispatch_emits_integration_envelope_phase_spans() {
         );
     }
 }
+
+/// ARN-243 wiring contract: per-tenant LLM content redaction must run before
+/// every telemetry sink reads the callback params. A refactor that moved the
+/// strip after any sink would leak prompts/completions for non-opted-in
+/// tenants — this guards the ordering that unit tests on the helper cannot.
+/// See ADR-0166.
+#[test]
+fn llm_content_redaction_precedes_every_dispatch_sink() {
+    let src = WASM_DISPATCH_SOURCE;
+    let strip = src
+        .find("// ARN-243: redact LLM content")
+        .expect("dispatch must redact LLM content before recording telemetry");
+
+    // Every sink below reads content from `result.callback_params`; each must
+    // come after the strip so it observes the redacted map.
+    let sinks = [
+        "let callback_params = &result.callback_params;",
+        "llm_call_wide_event(",
+        "submit_llmobs_llm_span(",
+        "submit_llmobs_tool_spans(",
+    ];
+    for sink in sinks {
+        let at = src
+            .find(sink)
+            .unwrap_or_else(|| panic!("expected dispatch telemetry sink `{sink}`"));
+        assert!(
+            strip < at,
+            "LLM content redaction (byte {strip}) must precede sink `{sink}` (byte {at})"
+        );
+    }
+}

--- a/crates/temper-server/tests/wasm_dispatch_observability_contract.rs
+++ b/crates/temper-server/tests/wasm_dispatch_observability_contract.rs
@@ -40,8 +40,10 @@ fn llm_content_redaction_precedes_every_dispatch_sink() {
         .find("// ARN-243: redact LLM content")
         .expect("dispatch must redact LLM content before recording telemetry");
 
-    // Every sink below reads content from `result.callback_params`; each must
-    // come after the strip so it observes the redacted map.
+    // Every sink below reads content from `result.callback_params`; *every*
+    // occurrence of each must come after the strip so it observes the redacted
+    // map. Iterating all occurrences (not just the first) catches a future
+    // dispatch branch that reads the params before the strip runs.
     let sinks = [
         "let callback_params = &result.callback_params;",
         "llm_call_wide_event(",
@@ -49,12 +51,18 @@ fn llm_content_redaction_precedes_every_dispatch_sink() {
         "submit_llmobs_tool_spans(",
     ];
     for sink in sinks {
-        let at = src
-            .find(sink)
-            .unwrap_or_else(|| panic!("expected dispatch telemetry sink `{sink}`"));
-        assert!(
-            strip < at,
-            "LLM content redaction (byte {strip}) must precede sink `{sink}` (byte {at})"
-        );
+        let mut from = 0;
+        let mut found = false;
+        while let Some(rel) = src[from..].find(sink) {
+            let at = from + rel;
+            found = true;
+            assert!(
+                strip < at,
+                "LLM content redaction (byte {strip}) must precede every read of sink \
+                 `{sink}`; found an occurrence at byte {at} before the strip"
+            );
+            from = at + sink.len();
+        }
+        assert!(found, "expected dispatch telemetry sink `{sink}`");
     }
 }

--- a/crates/temper-wasm/src/host_trait.rs
+++ b/crates/temper-wasm/src/host_trait.rs
@@ -27,7 +27,7 @@ mod span_hints;
 pub(crate) use span_hints::{MAX_RESPONSE_CAPTURE_BYTES, SpanHints};
 pub(crate) use span_hints::{
     apply_response_captures, apply_span_hints, datadog_visible_span_hint_field,
-    span_hint_otel_name, split_span_hint_headers, truncate_for_span_attr,
+    redact_llm_content_hints, span_hint_otel_name, split_span_hint_headers, truncate_for_span_attr,
 };
 
 /// Host capabilities provided to WASM modules.
@@ -351,6 +351,11 @@ pub struct ProductionWasmHost {
     text_http_interceptor: Option<TextHttpInterceptorFn>,
     /// Invocation context for auto-enriching guest telemetry.
     invocation_context: Option<WasmInvocationContext>,
+    /// Whether this invocation's tenant may export raw LLM content (prompts,
+    /// completions, system instructions, tool arguments/results) captured from
+    /// guest HTTP calls to the telemetry backend. Defaults to `false` (redact);
+    /// the server sets it per tenant. See ADR-0166.
+    export_llm_content: bool,
     /// Registry of active streaming HTTP exchanges (ADR-0057).
     /// One per host instance; handle IDs are unique within the host.
     http_streams: Arc<crate::http_stream::HttpStreamRegistry>,
@@ -530,6 +535,7 @@ impl ProductionWasmHost {
             binary_http_interceptor: None,
             text_http_interceptor: None,
             invocation_context: None,
+            export_llm_content: false,
             http_streams: Arc::new(crate::http_stream::HttpStreamRegistry::new()),
         }
     }
@@ -561,6 +567,13 @@ impl ProductionWasmHost {
     /// Attach invocation context for guest telemetry auto-enrichment.
     pub fn with_invocation_context(mut self, context: WasmInvocationContext) -> Self {
         self.invocation_context = Some(context);
+        self
+    }
+
+    /// Set whether this invocation's tenant may export raw LLM content captured
+    /// from guest HTTP calls. Defaults to `false` (redact). See ADR-0166.
+    pub fn with_llm_content_export(mut self, export_content: bool) -> Self {
+        self.export_llm_content = export_content;
         self
     }
 
@@ -786,7 +799,8 @@ impl WasmHost for ProductionWasmHost {
         // `X-Temper-Span-Name` / `X-Temper-Span-Attr-*` so the resulting
         // span has a semantically meaningful name (e.g., `tool.llm_call`)
         // and attributes (e.g., `gen_ai.request.model`).
-        let (filtered_headers, span_hints) = split_span_hint_headers(headers);
+        let (filtered_headers, mut span_hints) = split_span_hint_headers(headers);
+        redact_llm_content_hints(&mut span_hints, self.export_llm_content);
         let span = tracing::info_span!(
             "wasm.host.http_call",
             otel.name = %span_hint_otel_name(&span_hints, "wasm.host.http_call"),
@@ -1014,7 +1028,8 @@ impl WasmHost for ProductionWasmHost {
     ) -> Result<(u16, Vec<u8>), String> {
         let started = Instant::now();
         // See http_call for the span-hint-header rationale (ADR-0037).
-        let (filtered_headers, span_hints) = split_span_hint_headers(headers);
+        let (filtered_headers, mut span_hints) = split_span_hint_headers(headers);
+        redact_llm_content_hints(&mut span_hints, self.export_llm_content);
         let span = tracing::info_span!(
             "wasm.host.http_call_binary",
             otel.name = %span_hint_otel_name(&span_hints, "wasm.host.http_call_binary"),
@@ -1210,7 +1225,8 @@ impl WasmHost for ProductionWasmHost {
         body: &str,
     ) -> Result<Vec<String>, String> {
         let started = Instant::now();
-        let (filtered_headers, span_hints) = split_span_hint_headers(headers);
+        let (filtered_headers, mut span_hints) = split_span_hint_headers(headers);
+        redact_llm_content_hints(&mut span_hints, self.export_llm_content);
         let span = tracing::info_span!(
             "wasm.host.connect_call",
             otel.name = %span_hint_otel_name(&span_hints, "wasm.host.connect_call"),
@@ -1600,7 +1616,8 @@ impl WasmHost for ProductionWasmHost {
         let head_tx = exchange.bridge_head_sender;
         let streams = self.http_streams.clone();
         let client = self.client.clone();
-        let (filtered_headers, span_hints) = split_span_hint_headers(&request.headers);
+        let (filtered_headers, mut span_hints) = split_span_hint_headers(&request.headers);
+        redact_llm_content_hints(&mut span_hints, self.export_llm_content);
         let span = tracing::info_span!(
             "wasm.host.http_stream",
             otel.name = %span_hint_otel_name(&span_hints, "wasm.host.http_stream"),

--- a/crates/temper-wasm/src/host_trait/host_trait_test.rs
+++ b/crates/temper-wasm/src/host_trait/host_trait_test.rs
@@ -8,6 +8,31 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 use tracing_subscriber::prelude::*;
 
 #[test]
+fn llm_content_export_defaults_to_redact_and_is_opt_in() {
+    use std::collections::BTreeMap;
+    // Fail-safe: a host built without an explicit opt-in must redact LLM
+    // content, so any construction site that forgets `.with_llm_content_export`
+    // still defaults to safe. See ADR-0166 (ARN-243).
+    let default_host = ProductionWasmHost::new(BTreeMap::new());
+    assert!(
+        !default_host.export_llm_content,
+        "host must default to redacting LLM content"
+    );
+
+    let opted_in = ProductionWasmHost::new(BTreeMap::new()).with_llm_content_export(true);
+    assert!(
+        opted_in.export_llm_content,
+        "with_llm_content_export(true) must opt in"
+    );
+
+    let opted_out = ProductionWasmHost::new(BTreeMap::new()).with_llm_content_export(false);
+    assert!(
+        !opted_out.export_llm_content,
+        "with_llm_content_export(false) must redact"
+    );
+}
+
+#[test]
 fn guest_metric_count_kind_is_counter() {
     assert!(guest_metric_is_counter_kind(Some("count")));
     assert!(guest_metric_is_counter_kind(Some("counter")));

--- a/crates/temper-wasm/src/host_trait/span_hints.rs
+++ b/crates/temper-wasm/src/host_trait/span_hints.rs
@@ -100,6 +100,34 @@ pub(crate) fn span_hint_otel_name<'a>(
         .unwrap_or(Cow::Borrowed(default_name))
 }
 
+/// Whether a span-hint attribute key carries LLM *content* (prompt,
+/// completion, system prompt, or tool arguments/results) as opposed to safe
+/// metadata (model, provider, token counts, ids). Content keys are redacted
+/// from host-captured span hints unless the tenant has opted into LLM content
+/// export. See ADR-0166.
+pub(crate) fn is_sensitive_llm_content_attr(attr_key: &str) -> bool {
+    matches!(
+        attr_key,
+        "gen_ai.input.messages"
+            | "gen_ai.prompt"
+            | "gen_ai.system_instructions"
+            | "gen_ai.output.messages"
+            | "gen_ai.completion"
+            | "gen_ai.tool.call.arguments"
+            | "gen_ai.tool.call.result"
+    )
+}
+
+/// Redact LLM content attributes and response captures from host-captured span
+/// hints unless the tenant has opted into LLM content export. Removes only the
+/// sensitive content keys ([`is_sensitive_llm_content_attr`]); metadata hints
+/// (model, provider, tokens, ids, span name) are preserved. No-op when
+/// `export_content` is true. See ADR-0166.
+pub(crate) fn redact_llm_content_hints(_hints: &mut SpanHints, _export_content: bool) {
+    // ARN-243 RED: content span hints are recorded for every tenant with no
+    // per-tenant gate. The redaction is implemented in the GREEN commit.
+}
+
 pub(crate) fn datadog_visible_span_hint_field(attr_key: &str) -> Option<&'static str> {
     match attr_key {
         "tenant" => Some("tenant"),
@@ -229,4 +257,111 @@ pub(crate) fn truncate_for_span_attr(value: &str) -> String {
     out.push_str(&value[..cut]);
     out.push_str(MAX_RESPONSE_CAPTURE_TRUNCATION_SUFFIX);
     out
+}
+
+#[cfg(test)]
+mod redaction_tests {
+    use super::*;
+
+    fn content_hints() -> SpanHints {
+        SpanHints {
+            span_name: None,
+            attributes: vec![
+                ("gen_ai.request.model".to_string(), "claude".to_string()),
+                (
+                    "gen_ai.input.messages".to_string(),
+                    "SECRET PROMPT".to_string(),
+                ),
+                (
+                    "gen_ai.system_instructions".to_string(),
+                    "SECRET SYSTEM".to_string(),
+                ),
+                ("tenant".to_string(), "acme".to_string()),
+            ],
+            response_captures: vec![
+                (
+                    "gen_ai.completion".to_string(),
+                    "/content/0/text".to_string(),
+                ),
+                ("http.response.body.size".to_string(), "/size".to_string()),
+            ],
+        }
+    }
+
+    #[test]
+    fn classifies_content_vs_metadata_attrs() {
+        assert!(is_sensitive_llm_content_attr("gen_ai.input.messages"));
+        assert!(is_sensitive_llm_content_attr("gen_ai.completion"));
+        assert!(is_sensitive_llm_content_attr("gen_ai.tool.call.arguments"));
+        assert!(!is_sensitive_llm_content_attr("gen_ai.request.model"));
+        assert!(!is_sensitive_llm_content_attr("gen_ai.usage.input_tokens"));
+        assert!(!is_sensitive_llm_content_attr("tenant"));
+    }
+
+    #[test]
+    fn redacts_sensitive_content_hints_when_not_opted_in() {
+        let mut hints = content_hints();
+        redact_llm_content_hints(&mut hints, false);
+
+        // Content attributes stripped.
+        assert!(
+            hints
+                .attributes
+                .iter()
+                .all(|(k, _)| k != "gen_ai.input.messages"),
+            "prompt attr must be redacted"
+        );
+        assert!(
+            hints
+                .attributes
+                .iter()
+                .all(|(k, _)| k != "gen_ai.system_instructions"),
+            "system instructions attr must be redacted"
+        );
+        // Metadata attributes preserved.
+        assert!(
+            hints
+                .attributes
+                .iter()
+                .any(|(k, _)| k == "gen_ai.request.model"),
+            "model metadata must survive"
+        );
+        assert!(hints.attributes.iter().any(|(k, _)| k == "tenant"));
+
+        // Content capture stripped, metadata capture preserved.
+        assert!(
+            hints
+                .response_captures
+                .iter()
+                .all(|(k, _)| k != "gen_ai.completion"),
+            "completion capture must be redacted"
+        );
+        assert!(
+            hints
+                .response_captures
+                .iter()
+                .any(|(k, _)| k == "http.response.body.size"),
+            "size capture must survive"
+        );
+    }
+
+    #[test]
+    fn keeps_content_hints_when_opted_in() {
+        let mut hints = content_hints();
+        redact_llm_content_hints(&mut hints, true);
+        assert!(
+            hints
+                .attributes
+                .iter()
+                .any(|(k, _)| k == "gen_ai.input.messages"),
+            "opted-in tenant keeps prompt"
+        );
+        assert!(
+            hints
+                .response_captures
+                .iter()
+                .any(|(k, _)| k == "gen_ai.completion"),
+            "opted-in tenant keeps completion"
+        );
+    }
 }

--- a/crates/temper-wasm/src/host_trait/span_hints.rs
+++ b/crates/temper-wasm/src/host_trait/span_hints.rs
@@ -105,6 +105,12 @@ pub(crate) fn span_hint_otel_name<'a>(
 /// metadata (model, provider, token counts, ids). Content keys are redacted
 /// from host-captured span hints unless the tenant has opted into LLM content
 /// export. See ADR-0166.
+///
+/// This is a denylist over an open export surface: [`apply_span_hints`] records
+/// *every* surviving hint onto the raw OTel span. Any new `gen_ai.*` (or other)
+/// attribute that carries prompt/completion/system/tool content MUST be added
+/// here, or it will be exported unredacted. `redaction_denylist_covers_all_datadog_visible_content_fields`
+/// locks this against the Datadog-visible field set.
 pub(crate) fn is_sensitive_llm_content_attr(attr_key: &str) -> bool {
     matches!(
         attr_key,
@@ -303,6 +309,77 @@ mod redaction_tests {
         assert!(!is_sensitive_llm_content_attr("gen_ai.request.model"));
         assert!(!is_sensitive_llm_content_attr("gen_ai.usage.input_tokens"));
         assert!(!is_sensitive_llm_content_attr("tenant"));
+    }
+
+    /// Guards the denylist against the open export surface (`apply_span_hints`
+    /// records every surviving hint). Every content-bearing span field must be
+    /// denied; every metadata field Datadog shows must survive. A denylist gap
+    /// here is a leak; a false positive is over-redaction. See ADR-0166.
+    #[test]
+    fn redaction_denylist_covers_all_datadog_visible_content_fields() {
+        // Raw LLM content that reaches a span. The first five are also in the
+        // `datadog_visible_span_hint_field` allowlist; the two tool fields reach
+        // Datadog via the unconditional `set_attribute` path. All must be denied.
+        let content_fields = [
+            "gen_ai.system_instructions",
+            "gen_ai.input.messages",
+            "gen_ai.prompt",
+            "gen_ai.output.messages",
+            "gen_ai.completion",
+            "gen_ai.tool.call.arguments",
+            "gen_ai.tool.call.result",
+        ];
+        for field in content_fields {
+            assert!(
+                is_sensitive_llm_content_attr(field),
+                "content field `{field}` must be redacted (denylist gap = leak)"
+            );
+        }
+
+        // Datadog-visible metadata must never be redacted (no over-redaction),
+        // and each must be a real recognized field (guards typos in this list).
+        let metadata_fields = [
+            "gen_ai.request.model",
+            "gen_ai.response.model",
+            "gen_ai.provider.name",
+            "gen_ai.system",
+            "gen_ai.operation.name",
+            "gen_ai.request.temperature",
+            "gen_ai.request.max_tokens",
+            "gen_ai.conversation.id",
+            "gen_ai.response.finish_reasons",
+            "gen_ai.usage.input_tokens",
+            "gen_ai.usage.output_tokens",
+            "gen_ai.usage.cache_read_input_tokens",
+            "gen_ai.usage.cache_creation_input_tokens",
+            "tenant",
+            "session_id",
+            "agent_id",
+        ];
+        for field in metadata_fields {
+            assert!(
+                !is_sensitive_llm_content_attr(field),
+                "metadata field `{field}` must NOT be redacted (over-redaction)"
+            );
+            assert!(
+                datadog_visible_span_hint_field(field).is_some(),
+                "metadata field `{field}` should be a recognized Datadog-visible field"
+            );
+        }
+
+        // Every Datadog-visible content field must also be denied.
+        for field in [
+            "gen_ai.system_instructions",
+            "gen_ai.input.messages",
+            "gen_ai.prompt",
+            "gen_ai.output.messages",
+            "gen_ai.completion",
+        ] {
+            assert!(
+                datadog_visible_span_hint_field(field).is_some(),
+                "content field `{field}` should be a recognized Datadog-visible field"
+            );
+        }
     }
 
     #[test]

--- a/crates/temper-wasm/src/host_trait/span_hints.rs
+++ b/crates/temper-wasm/src/host_trait/span_hints.rs
@@ -123,9 +123,16 @@ pub(crate) fn is_sensitive_llm_content_attr(attr_key: &str) -> bool {
 /// sensitive content keys ([`is_sensitive_llm_content_attr`]); metadata hints
 /// (model, provider, tokens, ids, span name) are preserved. No-op when
 /// `export_content` is true. See ADR-0166.
-pub(crate) fn redact_llm_content_hints(_hints: &mut SpanHints, _export_content: bool) {
-    // ARN-243 RED: content span hints are recorded for every tenant with no
-    // per-tenant gate. The redaction is implemented in the GREEN commit.
+pub(crate) fn redact_llm_content_hints(hints: &mut SpanHints, export_content: bool) {
+    if export_content {
+        return;
+    }
+    hints
+        .attributes
+        .retain(|(key, _)| !is_sensitive_llm_content_attr(key));
+    hints
+        .response_captures
+        .retain(|(attr, _)| !is_sensitive_llm_content_attr(attr));
 }
 
 pub(crate) fn datadog_visible_span_hint_field(attr_key: &str) -> Option<&'static str> {

--- a/crates/temper-wasm/tests/span_hint_redaction_contract.rs
+++ b/crates/temper-wasm/tests/span_hint_redaction_contract.rs
@@ -1,0 +1,32 @@
+//! ARN-243 wiring contract: every host HTTP-call site that parses guest span
+//! hints must filter LLM content before applying them, or host-captured
+//! prompts/completions would bypass the per-tenant export gate. Unit tests on
+//! `redact_llm_content_hints` cannot see whether each call site actually calls
+//! it; this source-level contract does. See ADR-0166.
+
+const HOST_TRAIT_SOURCE: &str = include_str!("../src/host_trait.rs");
+
+#[test]
+fn every_span_hint_split_is_followed_by_redaction() {
+    let src = HOST_TRAIT_SOURCE;
+    let split_marker = "= split_span_hint_headers(";
+    let mut sites = 0;
+    let mut from = 0;
+    while let Some(rel) = src[from..].find(split_marker) {
+        let at = from + rel;
+        let window_end = (at + 400).min(src.len());
+        let window = &src[at..window_end];
+        assert!(
+            window.contains("redact_llm_content_hints(&mut span_hints"),
+            "split_span_hint_headers call at byte {at} is not immediately followed by \
+             redact_llm_content_hints; host-captured LLM content would bypass the \
+             per-tenant export gate (ARN-243)"
+        );
+        sites += 1;
+        from = at + split_marker.len();
+    }
+    assert!(
+        sites >= 4,
+        "expected at least 4 span-hint split sites to guard, found {sites}"
+    );
+}

--- a/crates/temper-wasm/tests/span_hint_redaction_contract.rs
+++ b/crates/temper-wasm/tests/span_hint_redaction_contract.rs
@@ -10,23 +10,33 @@ const HOST_TRAIT_SOURCE: &str = include_str!("../src/host_trait.rs");
 fn every_span_hint_split_is_followed_by_redaction() {
     let src = HOST_TRAIT_SOURCE;
     let split_marker = "= split_span_hint_headers(";
-    let mut sites = 0;
+    let redact_marker = "redact_llm_content_hints(&mut span_hints";
+
+    // Collect every split-site offset first, then require the redact call to
+    // appear in the interstitial code before the next split site (or EOF). The
+    // window is exactly the code between two sites, so the guard holds no matter
+    // how much code is inserted between the split and its redaction — no magic
+    // fixed-size window that could silently exclude a displaced redact call.
+    let mut sites = Vec::new();
     let mut from = 0;
     while let Some(rel) = src[from..].find(split_marker) {
         let at = from + rel;
-        let window_end = (at + 400).min(src.len());
-        let window = &src[at..window_end];
-        assert!(
-            window.contains("redact_llm_content_hints(&mut span_hints"),
-            "split_span_hint_headers call at byte {at} is not immediately followed by \
-             redact_llm_content_hints; host-captured LLM content would bypass the \
-             per-tenant export gate (ARN-243)"
-        );
-        sites += 1;
+        sites.push(at);
         from = at + split_marker.len();
     }
     assert!(
-        sites >= 4,
-        "expected at least 4 span-hint split sites to guard, found {sites}"
+        sites.len() >= 4,
+        "expected at least 4 span-hint split sites to guard, found {}",
+        sites.len()
     );
+    for (i, &at) in sites.iter().enumerate() {
+        let end = sites.get(i + 1).copied().unwrap_or(src.len());
+        let window = &src[at..end];
+        assert!(
+            window.contains(redact_marker),
+            "split_span_hint_headers call at byte {at} is not followed by \
+             redact_llm_content_hints before the next split site; host-captured LLM \
+             content would bypass the per-tenant export gate (ARN-243)"
+        );
+    }
 }

--- a/docs/adrs/0166-llm-content-export-tenant-redaction.md
+++ b/docs/adrs/0166-llm-content-export-tenant-redaction.md
@@ -1,0 +1,134 @@
+# ADR-0166: Per-Tenant Redaction of LLM Observability Content
+
+- Status: Accepted
+- Date: 2026-07-13
+- Deciders: Temper core maintainers
+- Related:
+  - ADR-0037: `X-Temper-Span-*` header hints (host HTTP capture path)
+  - `crates/temper-server/src/state/dispatch/wasm.rs` (LLM dispatch recording)
+  - `crates/temper-wasm/src/host_trait/span_hints.rs` (host HTTP capture)
+  - `crates/temper-observe/src/wide_event/agent.rs` (wide-event builders)
+
+## Context
+
+When an entity integration is marked `llm = true`, the WASM dispatch path records
+the model's **prompt, completion, and system instructions** onto the OpenTelemetry
+span, into the WideEvent, and submits them to Datadog LLM Observability. A second,
+independent path lets WASM modules (e.g. `llm_caller`) capture request/response
+**content** onto the host `wasm.host.http_call` span via `X-Temper-Span-Attr-*`
+and `X-Temper-Span-Capture-Response-*` headers (ADR-0037).
+
+Both paths export raw LLM content to the telemetry backend **unconditionally** —
+there is no per-tenant control. A tenant whose prompts or completions contain
+PII, secrets, or regulated data has no way to keep that content out of Datadog.
+This is the ARN-243 finding: LLM observability leaks full prompts with no tenant
+opt-out.
+
+The existing `strip_private_observability_params` helper removes `_gen_ai_*`
+content keys **before persistence** (so they are not echoed back to the guest or
+stored in entity state), but the telemetry sinks read those keys *before* that
+strip runs — so the content still reaches Datadog.
+
+## Decision
+
+Gate all LLM content export on a per-tenant policy that **defaults to redact**.
+Content is only exported for tenants that explicitly opt in. Metadata
+(token counts, model, provider, finish reason, trace-linking IDs) is always
+exported — only prompt/completion/system/tool content is redacted.
+
+### Sub-Decision 1: Per-tenant opt-in resolved on `ServerState`
+
+`ServerState` gains an immutable `llm_content_export_tenants: Arc<BTreeSet<String>>`
+loaded once at startup from `TEMPER_LLM_CONTENT_EXPORT_TENANTS` (comma-separated
+tenant ids; `*` opts in every tenant). The resolver is a pure set lookup:
+
+```rust
+pub fn export_llm_content(&self, tenant: &str) -> bool {
+    self.llm_content_export_tenants.contains("*")
+        || self.llm_content_export_tenants.contains(tenant)
+}
+```
+
+An empty set (the default) means every tenant is redacted.
+
+**Why this approach**: it is redact-by-default, per-tenant, deterministic (read
+once at startup, then a pure lookup on the hot path), and requires no new storage
+dependency or per-dispatch async. It mirrors the existing `local_tdata_hosts`
+env-loaded allowlist. A future enhancement can move the opt-in into per-tenant
+Cedar policy or the secrets vault without changing the redaction sites.
+
+### Sub-Decision 2: Dispatch path — strip content keys from callback params
+
+Four telemetry sinks (span record, `llm_call_wide_event`, `submit_llmobs_llm_span`,
+`submit_llmobs_tool_spans`) all read content from the same `result.callback_params`
+map. A single strip of the content keys — `_gen_ai_input_messages`,
+`_gen_ai_output_messages`, `_gen_ai_system_instructions`, `_dd_llmobs_tool_spans` —
+before the sinks run redacts all four at once. Metadata keys (`_gen_ai_provider`,
+`_gen_ai_model`, `_gen_ai_finish_reason`, `_gen_ai_*_span_id`, token counts) are
+preserved.
+
+**Why this approach**: one choke point covers span, WideEvent, and both LLM-Obs
+submissions. It cannot be bypassed by adding a new sink downstream, because the
+content is already gone from the map.
+
+### Sub-Decision 3: Host capture path — filter span hints before applying
+
+The host HTTP capture path builds a `SpanHints` struct from guest headers, then
+applies its attributes and response captures onto the span. When the tenant is
+not opted in, the sensitive `gen_ai.*` content attributes and captures are
+filtered out of the hints immediately after parsing, before they are recorded
+onto either the tracing span or the raw OTel span. The decision is propagated
+into `ProductionWasmHost` via a new `with_llm_content_export(bool)` builder that
+**defaults to `false` (redact)**, set from `ServerState::export_llm_content` at
+every server-side host construction site.
+
+Sensitive content attrs: `gen_ai.input.messages`, `gen_ai.prompt`,
+`gen_ai.system_instructions`, `gen_ai.output.messages`, `gen_ai.completion`,
+`gen_ai.tool.call.arguments`, `gen_ai.tool.call.result`.
+
+## Consequences
+
+### Positive
+- No tenant's LLM prompts/completions reach Datadog unless that tenant opts in.
+- Redaction is fail-safe: any host built without the explicit opt-in redacts.
+- Metadata-based dashboards (tokens, latency, model, provider) keep working for
+  every tenant.
+
+### Negative
+- Tenants currently relying on content in Datadog must be added to
+  `TEMPER_LLM_CONTENT_EXPORT_TENANTS` to keep it. This is the intended,
+  deliberate default flip.
+
+### Risks
+- A future LLM export path built through an untouched host would redact for
+  opted-in tenants (a false redaction, never a leak) — acceptable, and the
+  builder default makes new paths secure automatically.
+
+### DST Compliance
+- `TEMPER_LLM_CONTENT_EXPORT_TENANTS` is read once at `ServerState`
+  construction (`// determinism-ok: read once at startup`), matching the
+  existing `env_local_tdata_hosts` pattern. `export_llm_content` is a pure
+  set lookup. The strip and hint-filter helpers are pure, order-independent
+  transforms over `BTreeSet`/`Vec` — no wall clock, RNG, or ambient I/O.
+
+## Non-Goals
+- Field-level or regex-based redaction of *parts* of a prompt. This is an
+  all-or-nothing content gate per tenant.
+- A runtime admin API to toggle a tenant's opt-in. Startup env config only for now.
+
+## Alternatives Considered
+
+1. **Cedar policy per tenant** — Model export as a Cedar action evaluated per
+   dispatch. Rejected for now: heavier (new action/resource, per-call evaluation
+   on a hot path) than the finding requires. Left as a documented follow-up.
+2. **OTel SpanProcessor that strips content at export** — One central place, but
+   requires the tenant on every span and non-trivial processor plumbing in the
+   telemetry bootstrap. Rejected as riskier than gating at the two known sources.
+3. **Export by default, opt-out** — Rejected: the finding is that content leaks
+   by default. Only redact-by-default closes it.
+
+## Rollback Policy
+
+Set `TEMPER_LLM_CONTENT_EXPORT_TENANTS=*` to restore the previous
+export-everything behavior for all tenants, or revert this change set — the
+redaction helpers are additive and self-contained.

--- a/docs/adrs/0166-llm-content-export-tenant-redaction.md
+++ b/docs/adrs/0166-llm-content-export-tenant-redaction.md
@@ -98,6 +98,13 @@ Sensitive content attrs: `gen_ai.input.messages`, `gen_ai.prompt`,
 - Tenants currently relying on content in Datadog must be added to
   `TEMPER_LLM_CONTENT_EXPORT_TENANTS` to keep it. This is the intended,
   deliberate default flip.
+- Tool-call observability (`_dd_llmobs_tool_spans`) bundles tool arguments and
+  results (content) together with tool name and duration (metadata) in a single
+  array. For non-opted-in tenants the whole array is suppressed rather than
+  field-redacted, so tool-level metadata is lost too. This errs toward less
+  export, which is the safe direction for a security default; a future
+  refinement can field-redact within each tool span if the metadata proves
+  valuable on its own.
 
 ### Risks
 - A future LLM export path built through an untouched host would redact for


### PR DESCRIPTION
## ARN-243 — Redact-by-default per-tenant LLM observability content

**Problem.** When an entity integration is marked `llm = true`, WASM dispatch records the model's **prompt, completion, and system instructions** onto the OTel span, into the WideEvent, and submits them to Datadog LLM Observability. A second, independent path lets WASM modules (e.g. `llm_caller`) capture request/response **content** onto the host `wasm.host.http_call` span via `X-Temper-Span-Attr-*` / `X-Temper-Span-Capture-Response-*` headers (ADR-0037). Both paths export raw LLM content to Datadog **unconditionally** — no per-tenant control. A tenant whose prompts/completions carry PII, secrets, or regulated data has no opt-out.

**Fix (ADR-0166).** Gate all LLM content export on a per-tenant policy that **defaults to redact**. Content is exported only for tenants that explicitly opt in via `TEMPER_LLM_CONTENT_EXPORT_TENANTS` (comma-separated tenant ids; `*` opts in all). Metadata — token counts, model, provider, finish reason, trace/span ids — is always exported.

### What changed
- **`ServerState`** (`state/mod.rs`): `llm_content_export_tenants: Arc<BTreeSet<String>>` loaded once at startup from `TEMPER_LLM_CONTENT_EXPORT_TENANTS` (mirrors `env_local_tdata_hosts`); resolver `export_llm_content(tenant) -> bool` (`contains("*") || contains(tenant)`).
- **Dispatch path** (`state/dispatch/wasm.rs`): `redact_llm_content_params(&mut result.callback_params, export)` strips the content keys `_gen_ai_input_messages`, `_gen_ai_output_messages`, `_gen_ai_system_instructions`, `_dd_llmobs_tool_spans` **before** the four sinks read them — the span record block, `llm_call_wide_event`, `submit_llmobs_llm_span`, and `submit_llmobs_tool_spans` — so one choke point covers all four. Metadata keys preserved.
- **Host capture path** (`temper-wasm/host_trait/span_hints.rs` + `host_trait.rs`): `redact_llm_content_hints(&mut SpanHints, export)` filters sensitive `gen_ai.*` attrs/captures (`input.messages`, `prompt`, `system_instructions`, `output.messages`, `completion`, `tool.call.arguments`, `tool.call.result`) at all 4 `split_span_hint_headers` sites. Decision propagated via `ProductionWasmHost::with_llm_content_export(bool)` — **defaults to `false` (redact)** — set from `ServerState::export_llm_content` at all 3 server-side host construction sites (wasm.rs ×2, router.rs ×1). Fail-safe: any host built without the explicit opt-in redacts.

### RED → GREEN (before/after exploit)
The redaction unit tests are the exploit before/after: they assert content must be stripped for a non-opted-in tenant and kept for an opted-in one, run through the real `redact_llm_content_params` / `redact_llm_content_hints`.

**Before (RED commit `97f0f794`, pass-through helpers):**
```
temper-server: redacts_llm_content_params_for_non_opted_in_tenant ... FAILED
  panicked: "prompt must be redacted"
temper-wasm:  redacts_sensitive_content_hints_when_not_opted_in ... FAILED
  panicked: "prompt attr must be redacted"
```

**After (GREEN):**
```
temper-server: redacts_llm_content_params_for_non_opted_in_tenant ... ok
temper-wasm:   redaction_tests (3) ... ok  (classify + redact-when-not-opted-in + keep-when-opted-in)
```

### Live local verification
- `cargo build -p temper-cli --bin temper` → **built** (release-shaped debug binary links the fix into the real server).
- Booted the real binary live: `TEMPER_LLM_CONTENT_EXPORT_TENANTS="acme,globex" temper serve --port 3399` → `Listening on http://0.0.0.0:3399`, clean startup, no panics; server routes HTTP requests. Confirms the new `ServerState` env resolver + construction work end-to-end in the production binary.
- No regression: `temper-wasm --lib` 116 ✓ · `temper-server dispatch::wasm` 25 ✓ · `wasm_dispatch_observability_contract` 1 ✓.

### Gates
- `cargo fmt` clean · `cargo clippy -p temper-server -p temper-wasm --all-targets -- -D warnings` clean.
- Readability ratchet: blocking metrics unchanged (GT1000=22, GT500=84, PRINTLN=247); one advisory GT300 tick from added test code (non-blocking).
- DST review: **PASS** (no findings — BTreeSet/Vec/array iteration deterministic; single justified `// determinism-ok` on the startup env read).

MERGE NOTHING — head-to-head competition PR.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR gates all LLM observability content (prompts, completions, system instructions, tool arguments/results) behind a per-tenant opt-in policy that defaults to redact. It closes the ARN-243 finding where both the WASM dispatch callback-params path and the host HTTP-capture span-hints path unconditionally exported raw LLM content to Datadog.

- **Dispatch path** (`state/dispatch/wasm.rs`): a single `redact_llm_content_params` call strips four content keys from `result.callback_params` before the four telemetry sinks (span record, `llm_call_wide_event`, `submit_llmobs_llm_span`, `submit_llmobs_tool_spans`) read it; metadata keys are preserved.
- **Host capture path** (`host_trait.rs` + `span_hints.rs`): `redact_llm_content_hints` is applied immediately after every `split_span_hint_headers` call (4 sites), filtering sensitive `gen_ai.*` attributes and response captures; `ProductionWasmHost` carries an `export_llm_content: bool` field that defaults to `false`, so any construction site that omits the explicit opt-in is fail-safe.
- **Opt-in mechanism** (`state/mod.rs`): `TEMPER_LLM_CONTENT_EXPORT_TENANTS` is parsed once at `ServerState` startup into `Arc<BTreeSet<String>>`; wildcard `*` opts in all tenants; the default empty set redacts all.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The redaction logic itself is correct and fail-safe: the dispatch path has one clean choke point before all four telemetry sinks, the host capture path applies redaction at every split site, and the ProductionWasmHost defaults to redacting so any missed construction site is safe.

The core redaction implementation is solid — the two leakage paths are correctly gated, the fail-safe default is in place, and the unit tests thoroughly verify correct behavior. The source-level contract tests are a useful addition but carry minor fragilities: the dispatch ordering guard uses src.find() which only validates the first occurrence of each sink function, and the span-hint site checker uses an undocumented 400-byte window. Neither gap represents a current leak, but either could allow a future regression to go undetected by the guards intended to catch it.

The two contract test files — crates/temper-server/tests/wasm_dispatch_observability_contract.rs and crates/temper-wasm/tests/span_hint_redaction_contract.rs — warrant a second look to harden the structural guards against future multi-call-site scenarios.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/temper-server/src/state/mod.rs | Adds llm_content_export_tenants: Arc<BTreeSet<String>> loaded from TEMPER_LLM_CONTENT_EXPORT_TENANTS and the export_llm_content(tenant) -> bool resolver; consistent with the existing local_tdata_hosts pattern, both ServerState construction sites updated. |
| crates/temper-server/src/state/dispatch/wasm.rs | Adds redact_llm_content_params at the single choke point before all four telemetry sinks, and wires with_llm_content_export on both host construction sites in the dispatch; logic and placement are correct. |
| crates/temper-server/src/router.rs | Adds with_llm_content_export to the third host construction site in the router; straightforward two-line change wiring the per-tenant decision from ServerState. |
| crates/temper-wasm/src/host_trait.rs | Adds export_llm_content: bool field (default false) to ProductionWasmHost, the with_llm_content_export builder, and applies redact_llm_content_hints at all four split_span_hint_headers sites; fail-safe default is correct. |
| crates/temper-wasm/src/host_trait/span_hints.rs | Adds is_sensitive_llm_content_attr denylist (7 keys) and redact_llm_content_hints; the accompanying test redaction_denylist_covers_all_datadog_visible_content_fields cross-checks every content field against datadog_visible_span_hint_field — a strong guard against denylist gaps. |
| crates/temper-server/tests/wasm_dispatch_observability_contract.rs | New source-level contract test uses src.find(sink) (first occurrence) to assert strip precedes sinks; correctly identifies the call sites today but would silently miss a second unguarded call to any sink added in a future refactor. |
| crates/temper-wasm/tests/span_hint_redaction_contract.rs | Contract test iterates all split_span_hint_headers sites and checks a 400-byte window for the redact call; effective for the current compact code, but the magic window size is undocumented and could silently become too small if verbose comments are inserted between the two lines. |
| crates/temper-wasm/src/host_trait/host_trait_test.rs | Adds a fail-safe default test that directly checks export_llm_content: false on a bare ProductionWasmHost::new(), verifying opt-in and opt-out paths; clean and purposeful. |
| docs/adrs/0166-llm-content-export-tenant-redaction.md | Comprehensive ADR covering context, decision sub-points, consequences, DST compliance, alternatives considered, and rollback policy; well-structured and accurately describes the implementation. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Request arrives] --> B{Build ProductionWasmHost}
    B --> C["ServerState::export_llm_content(tenant)\n= BTreeSet contains '*' OR tenant"]
    C --> D["host.with_llm_content_export(bool)"]
    D -->|export_llm_content=false| E[WASM guest HTTP calls]
    D -->|export_llm_content=true| E
    E -->|X-Temper-Span-Attr-* headers| F["split_span_hint_headers()"]
    F --> G["redact_llm_content_hints(&mut span_hints, export_llm_content)"]
    G -->|false: strips sensitive gen_ai.* attrs| H["apply_span_hints() onto OTel span"]
    G -->|true: no-op| H
    E --> I[WASM module completes]
    I --> J["result.callback_params"]
    J --> K["redact_llm_content_params(&mut callback_params, export_content)"]
    K -->|false: removes 4 content keys| L["let callback_params = &result.callback_params"]
    K -->|true: no-op| L
    L --> M[Span record]
    L --> N["llm_call_wide_event()"]
    L --> O["submit_llmobs_llm_span()"]
    L --> P["submit_llmobs_tool_spans()"]
    M --> Q[Datadog/OTel — metadata only for non-opted-in tenants]
    N --> Q
    O --> Q
    P --> Q
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Request arrives] --> B{Build ProductionWasmHost}
    B --> C["ServerState::export_llm_content(tenant)\n= BTreeSet contains '*' OR tenant"]
    C --> D["host.with_llm_content_export(bool)"]
    D -->|export_llm_content=false| E[WASM guest HTTP calls]
    D -->|export_llm_content=true| E
    E -->|X-Temper-Span-Attr-* headers| F["split_span_hint_headers()"]
    F --> G["redact_llm_content_hints(&mut span_hints, export_llm_content)"]
    G -->|false: strips sensitive gen_ai.* attrs| H["apply_span_hints() onto OTel span"]
    G -->|true: no-op| H
    E --> I[WASM module completes]
    I --> J["result.callback_params"]
    J --> K["redact_llm_content_params(&mut callback_params, export_content)"]
    K -->|false: removes 4 content keys| L["let callback_params = &result.callback_params"]
    K -->|true: no-op| L
    L --> M[Span record]
    L --> N["llm_call_wide_event()"]
    L --> O["submit_llmobs_llm_span()"]
    L --> P["submit_llmobs_tool_spans()"]
    M --> Q[Datadog/OTel — metadata only for non-opted-in tenants]
    N --> Q
    O --> Q
    P --> Q
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftemper-server%2Ftests%2Fwasm_dispatch_observability_contract.rs%3A51-59%0A**Guard%20only%20covers%20the%20first%20occurrence%20of%20each%20sink**%0A%0A%60src.find%28sink%29%60%20returns%20the%20byte%20offset%20of%20the%20*first*%20match%20in%20the%20file.%20Today%20every%20sink's%20first%20occurrence%20is%20the%20guarded%20call%20site%20%28verified%3A%20the%20function%20definitions%20for%20%60submit_llmobs_llm_span%60%20and%20%60submit_llmobs_tool_spans%60%20appear%20at%20lines%201509%2F1603%2C%20well%20after%20the%20call%20sites%20at%201111%2F1129%20and%20after%20the%20strip%20at%20991%29.%20However%2C%20if%20a%20future%20refactor%20adds%20a%20second%20dispatch%20branch%20that%20calls%20any%20of%20these%20sinks%20without%20first%20running%20%60redact_llm_content_params%60%2C%20the%20test%20would%20still%20pass%20%E2%80%94%20%60find%60%20would%20locate%20the%20already-guarded%20first%20call%20and%20assert%20%60strip%20%3C%20at%60%20correctly%2C%20never%20seeing%20the%20new%2C%20unguarded%20one.%20Consider%20iterating%20all%20occurrences%20%28e.g.%20scanning%20with%20repeated%20%60find%60%20from%20the%20previous%20position%29%20for%20each%20sink%2C%20asserting%20that%20every%20occurrence%20is%20preceded%20by%20the%20strip%2C%20or%20adding%20a%20comment%20explaining%20why%20a%20single-occurrence%20assumption%20is%20safe%20here.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftemper-wasm%2Ftests%2Fspan_hint_redaction_contract.rs%3A17-24%0A**Magic%20400-byte%20window%20could%20silently%20miss%20the%20redact%20call**%0A%0AThe%20window%20%60src%5Bat..at%20%2B%20400%5D%60%20is%20large%20enough%20today%20because%20%60split_span_hint_headers%60%20and%20%60redact_llm_content_hints%60%20are%20adjacent%20%28two%20lines%2C%20~100%20bytes%29.%20But%20the%20constant%20is%20unexplained%20and%20the%20assertion%20would%20silently%20pass%20for%20any%20code%20inserted%20between%20those%20two%20lines%20if%20that%20code%20pushes%20the%20%60redact_llm_content_hints%60%20call%20beyond%20byte%20400.%20A%20safer%20approach%20is%20to%20search%20from%20the%20end%20of%20the%20current%20line%20to%20the%20next%20%60split_span_hint_headers%60%20call%20%28or%20end%20of%20file%29%2C%20so%20the%20window%20always%20encompasses%20exactly%20the%20interstitial%20code.%20At%20minimum%2C%20a%20comment%20explaining%20how%20%60400%60%20was%20chosen%20and%20why%20it%20remains%20valid%20would%20help%20reviewers%20audit%20future%20changes%20near%20these%20sites.%0A%0A&repo=nerdsane%2Ftemper&pr=381&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22claude%2Farn-243-llm-obs-tenant-redaction%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Farn-243-llm-obs-tenant-redaction%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftemper-server%2Ftests%2Fwasm_dispatch_observability_contract.rs%3A51-59%0A**Guard%20only%20covers%20the%20first%20occurrence%20of%20each%20sink**%0A%0A%60src.find%28sink%29%60%20returns%20the%20byte%20offset%20of%20the%20*first*%20match%20in%20the%20file.%20Today%20every%20sink's%20first%20occurrence%20is%20the%20guarded%20call%20site%20%28verified%3A%20the%20function%20definitions%20for%20%60submit_llmobs_llm_span%60%20and%20%60submit_llmobs_tool_spans%60%20appear%20at%20lines%201509%2F1603%2C%20well%20after%20the%20call%20sites%20at%201111%2F1129%20and%20after%20the%20strip%20at%20991%29.%20However%2C%20if%20a%20future%20refactor%20adds%20a%20second%20dispatch%20branch%20that%20calls%20any%20of%20these%20sinks%20without%20first%20running%20%60redact_llm_content_params%60%2C%20the%20test%20would%20still%20pass%20%E2%80%94%20%60find%60%20would%20locate%20the%20already-guarded%20first%20call%20and%20assert%20%60strip%20%3C%20at%60%20correctly%2C%20never%20seeing%20the%20new%2C%20unguarded%20one.%20Consider%20iterating%20all%20occurrences%20%28e.g.%20scanning%20with%20repeated%20%60find%60%20from%20the%20previous%20position%29%20for%20each%20sink%2C%20asserting%20that%20every%20occurrence%20is%20preceded%20by%20the%20strip%2C%20or%20adding%20a%20comment%20explaining%20why%20a%20single-occurrence%20assumption%20is%20safe%20here.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftemper-wasm%2Ftests%2Fspan_hint_redaction_contract.rs%3A17-24%0A**Magic%20400-byte%20window%20could%20silently%20miss%20the%20redact%20call**%0A%0AThe%20window%20%60src%5Bat..at%20%2B%20400%5D%60%20is%20large%20enough%20today%20because%20%60split_span_hint_headers%60%20and%20%60redact_llm_content_hints%60%20are%20adjacent%20%28two%20lines%2C%20~100%20bytes%29.%20But%20the%20constant%20is%20unexplained%20and%20the%20assertion%20would%20silently%20pass%20for%20any%20code%20inserted%20between%20those%20two%20lines%20if%20that%20code%20pushes%20the%20%60redact_llm_content_hints%60%20call%20beyond%20byte%20400.%20A%20safer%20approach%20is%20to%20search%20from%20the%20end%20of%20the%20current%20line%20to%20the%20next%20%60split_span_hint_headers%60%20call%20%28or%20end%20of%20file%29%2C%20so%20the%20window%20always%20encompasses%20exactly%20the%20interstitial%20code.%20At%20minimum%2C%20a%20comment%20explaining%20how%20%60400%60%20was%20chosen%20and%20why%20it%20remains%20valid%20would%20help%20reviewers%20audit%20future%20changes%20near%20these%20sites.%0A%0A&repo=nerdsane%2Ftemper&pr=381&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftemper-server%2Ftests%2Fwasm_dispatch_observability_contract.rs%3A51-59%0A**Guard%20only%20covers%20the%20first%20occurrence%20of%20each%20sink**%0A%0A%60src.find%28sink%29%60%20returns%20the%20byte%20offset%20of%20the%20*first*%20match%20in%20the%20file.%20Today%20every%20sink's%20first%20occurrence%20is%20the%20guarded%20call%20site%20%28verified%3A%20the%20function%20definitions%20for%20%60submit_llmobs_llm_span%60%20and%20%60submit_llmobs_tool_spans%60%20appear%20at%20lines%201509%2F1603%2C%20well%20after%20the%20call%20sites%20at%201111%2F1129%20and%20after%20the%20strip%20at%20991%29.%20However%2C%20if%20a%20future%20refactor%20adds%20a%20second%20dispatch%20branch%20that%20calls%20any%20of%20these%20sinks%20without%20first%20running%20%60redact_llm_content_params%60%2C%20the%20test%20would%20still%20pass%20%E2%80%94%20%60find%60%20would%20locate%20the%20already-guarded%20first%20call%20and%20assert%20%60strip%20%3C%20at%60%20correctly%2C%20never%20seeing%20the%20new%2C%20unguarded%20one.%20Consider%20iterating%20all%20occurrences%20%28e.g.%20scanning%20with%20repeated%20%60find%60%20from%20the%20previous%20position%29%20for%20each%20sink%2C%20asserting%20that%20every%20occurrence%20is%20preceded%20by%20the%20strip%2C%20or%20adding%20a%20comment%20explaining%20why%20a%20single-occurrence%20assumption%20is%20safe%20here.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftemper-wasm%2Ftests%2Fspan_hint_redaction_contract.rs%3A17-24%0A**Magic%20400-byte%20window%20could%20silently%20miss%20the%20redact%20call**%0A%0AThe%20window%20%60src%5Bat..at%20%2B%20400%5D%60%20is%20large%20enough%20today%20because%20%60split_span_hint_headers%60%20and%20%60redact_llm_content_hints%60%20are%20adjacent%20%28two%20lines%2C%20~100%20bytes%29.%20But%20the%20constant%20is%20unexplained%20and%20the%20assertion%20would%20silently%20pass%20for%20any%20code%20inserted%20between%20those%20two%20lines%20if%20that%20code%20pushes%20the%20%60redact_llm_content_hints%60%20call%20beyond%20byte%20400.%20A%20safer%20approach%20is%20to%20search%20from%20the%20end%20of%20the%20current%20line%20to%20the%20next%20%60split_span_hint_headers%60%20call%20%28or%20end%20of%20file%29%2C%20so%20the%20window%20always%20encompasses%20exactly%20the%20interstitial%20code.%20At%20minimum%2C%20a%20comment%20explaining%20how%20%60400%60%20was%20chosen%20and%20why%20it%20remains%20valid%20would%20help%20reviewers%20audit%20future%20changes%20near%20these%20sites.%0A%0A&pr=381&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
crates/temper-server/tests/wasm_dispatch_observability_contract.rs:51-59
**Guard only covers the first occurrence of each sink**

`src.find(sink)` returns the byte offset of the *first* match in the file. Today every sink's first occurrence is the guarded call site (verified: the function definitions for `submit_llmobs_llm_span` and `submit_llmobs_tool_spans` appear at lines 1509/1603, well after the call sites at 1111/1129 and after the strip at 991). However, if a future refactor adds a second dispatch branch that calls any of these sinks without first running `redact_llm_content_params`, the test would still pass — `find` would locate the already-guarded first call and assert `strip < at` correctly, never seeing the new, unguarded one. Consider iterating all occurrences (e.g. scanning with repeated `find` from the previous position) for each sink, asserting that every occurrence is preceded by the strip, or adding a comment explaining why a single-occurrence assumption is safe here.

### Issue 2 of 2
crates/temper-wasm/tests/span_hint_redaction_contract.rs:17-24
**Magic 400-byte window could silently miss the redact call**

The window `src[at..at + 400]` is large enough today because `split_span_hint_headers` and `redact_llm_content_hints` are adjacent (two lines, ~100 bytes). But the constant is unexplained and the assertion would silently pass for any code inserted between those two lines if that code pushes the `redact_llm_content_hints` call beyond byte 400. A safer approach is to search from the end of the current line to the next `split_span_hint_headers` call (or end of file), so the window always encompasses exactly the interstitial code. At minimum, a comment explaining how `400` was chosen and why it remains valid would help reviewers audit future changes near these sites.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(arn-243): lock redaction denylist c..."](https://github.com/nerdsane/temper/commit/a6dbdcb9a2c5aa9d1aec6b489e861bf730f852fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43886438)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/arni-labs/github/nerdsane/temper/-/custom-context?memory=c3ad5080-2c13-46c8-b4c1-9e266e4df914))
- Context used - AGENTS.md ([source](https://app.greptile.com/arni-labs/github/nerdsane/temper/-/custom-context?memory=873483f5-fffd-468c-aaf9-dd079b576948))

<!-- /greptile_comment -->