### PR TITLE
fix(server): journal PATCH/PUT field updates fail-closed (ARN-189)

### DIFF
--- a/crates/temper-server/src/entity_actor/actor.rs
+++ b/crates/temper-server/src/entity_actor/actor.rs
@@ -603,6 +603,11 @@ impl EntityActor {
                                 state.push_event_bounded(event);
                             }
                             Err(e) => {
+                                crate::event_budget_metrics::record_field_update_replay_skip(
+                                    tenant,
+                                    &state.entity_type,
+                                    &state.entity_id,
+                                );
                                 tracing::warn!(
                                     entity = %state.entity_id,
                                     sequence_nr = env.sequence_nr,
@@ -1473,6 +1478,24 @@ impl Actor for EntityActor {
                         error: Some(format!(
                             "Event budget exhausted ({MAX_EVENTS_SINCE_SNAPSHOT} max since snapshot)"
                         )),
+                        custom_effects: vec![],
+                        scheduled_actions: vec![],
+                        spawn_requests: vec![],
+                        spec_governed: true,
+                    });
+                    return Ok(());
+                }
+
+                // Reject non-object bodies before mutating or journaling —
+                // otherwise a PATCH array/null would no-op with success:true
+                // and still consume the event budget (Greptile P2 on ARN-189).
+                if !fields.is_object() {
+                    ctx.reply(EntityResponse {
+                        success: false,
+                        state: state.clone(),
+                        error: Some(
+                            "field update requires a JSON object body".to_string(),
+                        ),
                         custom_effects: vec![],
                         scheduled_actions: vec![],
                         spawn_requests: vec![],

--- a/crates/temper-server/src/entity_actor/actor.rs
+++ b/crates/temper-server/src/entity_actor/actor.rs
@@ -587,6 +587,35 @@ impl EntityActor {
                         break;
                     }
 
+                    // ARN-189 / ADR-0169: PATCH/PUT field updates are journaled
+                    // outside the spec action vocabulary. Re-apply via the same
+                    // helper as the live handler (PUT replace is not a merge).
+                    if env.event_type == super::effects::FIELDS_UPDATED_EVENT
+                        || env.event_type == super::effects::FIELDS_REPLACED_EVENT
+                    {
+                        match parsed_event {
+                            Ok(event) => {
+                                super::effects::apply_field_update(
+                                    state,
+                                    &event.params,
+                                    env.event_type == super::effects::FIELDS_REPLACED_EVENT,
+                                );
+                                state.push_event_bounded(event);
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    entity = %state.entity_id,
+                                    sequence_nr = env.sequence_nr,
+                                    event_type = %env.event_type,
+                                    error = %e,
+                                    "skipping field-update event with incompatible schema during replay"
+                                );
+                            }
+                        }
+                        state.sequence_nr = env.sequence_nr;
+                        continue;
+                    }
+
                     match parsed_event {
                         Ok(event) => {
                             // A persisted event is a historical fact: its guard
@@ -1420,25 +1449,96 @@ impl Actor for EntityActor {
                 ctx.reply(value);
             }
             EntityMsg::UpdateFields { fields, replace } => {
-                if replace {
-                    // PUT: replace all fields (preserve Id and Status)
-                    let id = state.entity_id.clone();
-                    let status = state.status.clone();
-                    state.fields = fields;
-                    if let Some(obj) = state.fields.as_object_mut() {
-                        obj.insert("Id".to_string(), serde_json::Value::String(id));
-                        obj.insert("Status".to_string(), serde_json::Value::String(status));
-                    }
-                } else {
-                    // PATCH: merge fields into existing
-                    if let (Some(existing), Some(updates)) =
-                        (state.fields.as_object_mut(), fields.as_object())
-                    {
-                        for (k, v) in updates {
-                            existing.insert(k.clone(), v.clone());
-                        }
-                    }
+                // TigerStyle: field updates append journal events (ADR-0169).
+                // Ungated they could grow the snapshot replay tail past budget.
+                if state.events_since_snapshot >= MAX_EVENTS_SINCE_SNAPSHOT {
+                    let workspace_id = event_budget_workspace_id(state);
+                    crate::event_budget_metrics::record_exhausted(
+                        &self.tenant,
+                        &state.entity_type,
+                        &state.entity_id,
+                        &workspace_id,
+                    );
+                    tracing::warn!(
+                        tenant = %self.tenant,
+                        entity_type = %state.entity_type,
+                        entity_id = %state.entity_id,
+                        replace,
+                        events_since_snapshot = state.events_since_snapshot,
+                        "Event budget exhausted (field update rejected)"
+                    );
+                    ctx.reply(EntityResponse {
+                        success: false,
+                        state: state.clone(),
+                        error: Some(format!(
+                            "Event budget exhausted ({MAX_EVENTS_SINCE_SNAPSHOT} max since snapshot)"
+                        )),
+                        custom_effects: vec![],
+                        scheduled_actions: vec![],
+                        spawn_requests: vec![],
+                        spec_governed: true,
+                    });
+                    return Ok(());
                 }
+
+                // Apply first so persist co-commits key/vector rows from NEW
+                // fields; roll back on append failure (fail-closed ARN-189).
+                let previous_fields = state.fields.clone();
+                super::effects::apply_field_update(state, &fields, replace);
+
+                let event = EntityEvent {
+                    action: if replace {
+                        super::effects::FIELDS_REPLACED_EVENT
+                    } else {
+                        super::effects::FIELDS_UPDATED_EVENT
+                    }
+                    .to_string(),
+                    from_status: state.status.clone(),
+                    to_status: state.status.clone(),
+                    timestamp: sim_now(),
+                    params: fields,
+                    idempotency_key: None,
+                };
+
+                if let (Some(store), Some(backend)) =
+                    (self.event_journal.as_ref(), self.event_backend)
+                    && let Err(e) = self
+                        .persist_event(store, backend, &self.persistence_id(), state, &event)
+                        .await
+                {
+                    state.fields = previous_fields;
+                    ctx.reply(EntityResponse {
+                        success: false,
+                        state: state.clone(),
+                        error: Some(format!("persistence failed: {e}")),
+                        custom_effects: vec![],
+                        scheduled_actions: vec![],
+                        spawn_requests: vec![],
+                        spec_governed: true,
+                    });
+                    return Ok(());
+                }
+
+                state.push_event_bounded(event);
+
+                let persistence_id = self.persistence_id();
+                if let Some(ref store) = self.event_journal
+                    && let Err(e) = Self::maybe_save_snapshot(
+                        store,
+                        self.snapshot_queue.as_ref(),
+                        &persistence_id,
+                        state,
+                    )
+                    .await
+                {
+                    tracing::warn!(
+                        entity = %state.entity_id,
+                        seq = state.sequence_nr,
+                        error = %e,
+                        "failed to persist snapshot after field update"
+                    );
+                }
+
                 ctx.reply(EntityResponse {
                     success: true,
                     state: state.clone(),

--- a/crates/temper-server/src/entity_actor/actor.rs
+++ b/crates/temper-server/src/entity_actor/actor.rs
@@ -1493,9 +1493,7 @@ impl Actor for EntityActor {
                     ctx.reply(EntityResponse {
                         success: false,
                         state: state.clone(),
-                        error: Some(
-                            "field update requires a JSON object body".to_string(),
-                        ),
+                        error: Some("field update requires a JSON object body".to_string()),
                         custom_effects: vec![],
                         scheduled_actions: vec![],
                         spawn_requests: vec![],

--- a/crates/temper-server/src/entity_actor/actor_test.rs
+++ b/crates/temper-server/src/entity_actor/actor_test.rs
@@ -926,3 +926,49 @@ async fn field_update_with_failed_journal_append_does_not_report_success() {
         "failed update must not persist in retained actor state"
     );
 }
+
+/// ARN-189 Greptile P2: non-object PATCH body must not claim success or journal.
+#[cfg(feature = "sim")]
+#[tokio::test]
+async fn field_update_rejects_non_object_body() {
+    use std::sync::Arc;
+    use temper_store_sim::SimEventStore;
+
+    let store = Arc::new(SimEventStore::no_faults(17));
+    let entity_id = "arn189-bad-body";
+
+    let system = ActorSystem::new("sim-arn189-bad-body");
+    let actor = EntityActor::with_persistence(
+        "Order",
+        entity_id,
+        order_table(),
+        serde_json::json!({}),
+        crate::storage::BoxedEventStore::from_arc(store),
+        crate::storage::BackendLabel::Sim,
+    );
+    let actor_ref = system.spawn(actor, entity_id);
+
+    let response: EntityResponse = actor_ref
+        .ask(
+            EntityMsg::UpdateFields {
+                fields: serde_json::json!(["not", "an", "object"]),
+                replace: false,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+    assert!(
+        !response.success,
+        "non-object field update must fail: {:?}",
+        response.error
+    );
+    assert!(
+        response
+            .error
+            .as_deref()
+            .is_some_and(|e| e.contains("JSON object")),
+        "expected object-body error, got {:?}",
+        response.error
+    );
+}

--- a/crates/temper-server/src/entity_actor/actor_test.rs
+++ b/crates/temper-server/src/entity_actor/actor_test.rs
@@ -672,3 +672,185 @@ effect = [
     assert_eq!(response.state.booleans.get("has_content"), Some(&true));
     assert_eq!(response.state.counters.get("version_count"), Some(&1));
 }
+
+/// ARN-189: PATCH field updates must survive actor eviction/restart.
+#[cfg(feature = "sim")]
+#[tokio::test]
+async fn patched_fields_survive_actor_restart() {
+    use std::sync::Arc;
+    use temper_store_sim::SimEventStore;
+
+    let store = Arc::new(SimEventStore::no_faults(7));
+    let entity_id = "arn189-patch-1";
+
+    let system = ActorSystem::new("sim-arn189-patch-a");
+    let actor = EntityActor::with_persistence(
+        "Order",
+        entity_id,
+        order_table(),
+        serde_json::json!({}),
+        crate::storage::BoxedEventStore::from_arc(store.clone()),
+        crate::storage::BackendLabel::Sim,
+    );
+    let actor_ref = system.spawn(actor, entity_id);
+
+    let patch: EntityResponse = actor_ref
+        .ask(
+            EntityMsg::UpdateFields {
+                fields: serde_json::json!({"Title": "persisted-title", "Priority": 3}),
+                replace: false,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("patch ask");
+    assert!(patch.success, "patch should succeed: {:?}", patch.error);
+    assert_eq!(
+        patch.state.fields.get("Title").and_then(|v| v.as_str()),
+        Some("persisted-title")
+    );
+
+    // Drop generation 1; rehydrate from journal only.
+    drop(actor_ref);
+    drop(system);
+
+    let system2 = ActorSystem::new("sim-arn189-patch-b");
+    let actor2 = EntityActor::with_persistence(
+        "Order",
+        entity_id,
+        order_table(),
+        serde_json::json!({}),
+        crate::storage::BoxedEventStore::from_arc(store),
+        crate::storage::BackendLabel::Sim,
+    );
+    let actor_ref2 = system2.spawn(actor2, entity_id);
+    let after: EntityResponse = actor_ref2
+        .ask(EntityMsg::GetState, Duration::from_secs(5))
+        .await
+        .expect("get after restart");
+    assert!(after.success);
+    assert_eq!(
+        after.state.fields.get("Title").and_then(|v| v.as_str()),
+        Some("persisted-title"),
+        "PATCH fields must survive restart (ARN-189)"
+    );
+    assert_eq!(
+        after.state.fields.get("Priority").and_then(|v| v.as_i64()),
+        Some(3)
+    );
+}
+
+/// ARN-189: PUT replace must survive restart and drop omitted fields.
+#[cfg(feature = "sim")]
+#[tokio::test]
+async fn replaced_fields_survive_actor_restart_with_replace_semantics() {
+    use std::sync::Arc;
+    use temper_store_sim::SimEventStore;
+
+    let store = Arc::new(SimEventStore::no_faults(11));
+    let entity_id = "arn189-put-1";
+
+    let system = ActorSystem::new("sim-arn189-put-a");
+    let actor = EntityActor::with_persistence(
+        "Order",
+        entity_id,
+        order_table(),
+        serde_json::json!({"Title": "old", "KeepMe": "x"}),
+        crate::storage::BoxedEventStore::from_arc(store.clone()),
+        crate::storage::BackendLabel::Sim,
+    );
+    let actor_ref = system.spawn(actor, entity_id);
+
+    let put: EntityResponse = actor_ref
+        .ask(
+            EntityMsg::UpdateFields {
+                fields: serde_json::json!({"Title": "new-only"}),
+                replace: true,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("put ask");
+    assert!(put.success, "{:?}", put.error);
+    assert_eq!(
+        put.state.fields.get("Title").and_then(|v| v.as_str()),
+        Some("new-only")
+    );
+    assert!(
+        put.state.fields.get("KeepMe").is_none(),
+        "PUT replace drops omitted fields"
+    );
+
+    drop(actor_ref);
+    drop(system);
+
+    let system2 = ActorSystem::new("sim-arn189-put-b");
+    let actor2 = EntityActor::with_persistence(
+        "Order",
+        entity_id,
+        order_table(),
+        serde_json::json!({}),
+        crate::storage::BoxedEventStore::from_arc(store),
+        crate::storage::BackendLabel::Sim,
+    );
+    let actor_ref2 = system2.spawn(actor2, entity_id);
+    let after: EntityResponse = actor_ref2
+        .ask(EntityMsg::GetState, Duration::from_secs(5))
+        .await
+        .expect("get after restart");
+    assert_eq!(
+        after.state.fields.get("Title").and_then(|v| v.as_str()),
+        Some("new-only"),
+        "PUT fields must survive restart (ARN-189)"
+    );
+    assert!(
+        after.state.fields.get("KeepMe").is_none(),
+        "PUT replace semantics must survive restart"
+    );
+}
+
+#[test]
+fn apply_field_update_merge_and_replace() {
+    let mut state = EntityState {
+        entity_type: "Order".into(),
+        entity_id: "o1".into(),
+        status: "Draft".into(),
+        item_count: 0,
+        counters: Default::default(),
+        booleans: Default::default(),
+        lists: Default::default(),
+        fields: serde_json::json!({"Title": "a", "Extra": 1}),
+        events: Default::default(),
+        total_event_count: 0,
+        events_since_snapshot: 0,
+        last_snapshot_sequence_nr: 0,
+        sequence_nr: 0,
+        processed_idempotency_keys: Default::default(),
+    };
+    crate::entity_actor::effects::apply_field_update(
+        &mut state,
+        &serde_json::json!({"Title": "b"}),
+        false,
+    );
+    assert_eq!(
+        state.fields.get("Title").and_then(|v| v.as_str()),
+        Some("b")
+    );
+    assert_eq!(state.fields.get("Extra").and_then(|v| v.as_i64()), Some(1));
+
+    crate::entity_actor::effects::apply_field_update(
+        &mut state,
+        &serde_json::json!({"Title": "c"}),
+        true,
+    );
+    assert_eq!(
+        state.fields.get("Title").and_then(|v| v.as_str()),
+        Some("c")
+    );
+    assert!(state.fields.get("Extra").is_none());
+    assert_eq!(state.fields.get("Id").and_then(|v| v.as_str()), Some("o1"));
+    assert_eq!(
+        state.fields.get("Status").and_then(|v| v.as_str()),
+        Some("Draft")
+    );
+}

--- a/crates/temper-server/src/entity_actor/actor_test.rs
+++ b/crates/temper-server/src/entity_actor/actor_test.rs
@@ -854,3 +854,75 @@ fn apply_field_update_merge_and_replace() {
         Some("Draft")
     );
 }
+
+/// ARN-189: journal append failure must not acknowledge or retain the update.
+#[cfg(feature = "sim")]
+#[tokio::test]
+async fn field_update_with_failed_journal_append_does_not_report_success() {
+    use std::sync::Arc;
+    use temper_store_sim::SimEventStore;
+
+    let store = Arc::new(SimEventStore::no_faults(13));
+    let entity_id = "arn189-fail-1";
+    let pid = format!("default:Order:{entity_id}");
+
+    let system = ActorSystem::new("sim-arn189-fail");
+    let actor = EntityActor::with_persistence(
+        "Order",
+        entity_id,
+        order_table(),
+        serde_json::json!({}),
+        crate::storage::BoxedEventStore::from_arc(store.clone()),
+        crate::storage::BackendLabel::Sim,
+    );
+    let actor_ref = system.spawn(actor, entity_id);
+
+    // Bootstrap Created append succeeds first.
+    let started: EntityResponse = actor_ref
+        .ask(EntityMsg::GetState, Duration::from_secs(5))
+        .await
+        .unwrap();
+    assert!(started.success);
+
+    // Next append fails once with concurrency violation.
+    store.inject_concurrency_violations(&pid, 1);
+
+    let response: EntityResponse = actor_ref
+        .ask(
+            EntityMsg::UpdateFields {
+                fields: serde_json::json!({"Title": "never durable"}),
+                replace: false,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+    assert!(
+        !response.success,
+        "field update whose journal append failed must not claim success: {:?}",
+        response.error
+    );
+    assert!(
+        response
+            .state
+            .fields
+            .get("Title")
+            .and_then(|v| v.as_str())
+            .is_none_or(|t| t != "never durable"),
+        "failed update must not leave half-applied Title in reply state"
+    );
+
+    let retained: EntityResponse = actor_ref
+        .ask(EntityMsg::GetState, Duration::from_secs(5))
+        .await
+        .unwrap();
+    assert!(
+        retained
+            .state
+            .fields
+            .get("Title")
+            .and_then(|v| v.as_str())
+            .is_none_or(|t| t != "never durable"),
+        "failed update must not persist in retained actor state"
+    );
+}

--- a/crates/temper-server/src/entity_actor/effects.rs
+++ b/crates/temper-server/src/entity_actor/effects.rs
@@ -19,6 +19,35 @@ use crate::blobs::{FIELD_OVERFLOW_BLOB_PREFIX, OverflowBlobWrite, blob_ref_value
 
 use super::types::{EntityEvent, EntityState, MAX_EVENTS_SINCE_SNAPSHOT};
 
+/// Journal event type for OData PATCH field merges (ARN-189 / ADR-0169).
+pub const FIELDS_UPDATED_EVENT: &str = "FieldsUpdated";
+/// Journal event type for OData PUT field replacement (ARN-189 / ADR-0169).
+pub const FIELDS_REPLACED_EVENT: &str = "FieldsReplaced";
+
+/// Apply a PATCH merge or PUT replace to `state.fields`, preserving `Id`/`Status`
+/// on replace. Shared by the live `UpdateFields` handler and journal replay.
+pub(crate) fn apply_field_update(
+    state: &mut EntityState,
+    fields: &serde_json::Value,
+    replace: bool,
+) {
+    if replace {
+        let id = state.entity_id.clone();
+        let status = state.status.clone();
+        state.fields = fields.clone();
+        if let Some(obj) = state.fields.as_object_mut() {
+            obj.insert("Id".to_string(), serde_json::Value::String(id));
+            obj.insert("Status".to_string(), serde_json::Value::String(status));
+        }
+    } else if let (Some(existing), Some(updates)) =
+        (state.fields.as_object_mut(), fields.as_object())
+    {
+        for (k, v) in updates {
+            existing.insert(k.clone(), v.clone());
+        }
+    }
+}
+
 /// A scheduled action to fire after a delay.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScheduledAction {

--- a/crates/temper-server/src/event_budget_metrics.rs
+++ b/crates/temper-server/src/event_budget_metrics.rs
@@ -33,3 +33,27 @@ pub fn record_exhausted(tenant: &str, entity_type: &str, entity_id: &str, worksp
         ],
     );
 }
+
+fn field_update_replay_skip_counter() -> &'static Counter<u64> {
+    static COUNTER: OnceLock<Counter<u64>> = OnceLock::new();
+    COUNTER.get_or_init(|| {
+        global::meter("temper.runtime")
+            .u64_counter("temper_entity_field_update_replay_skip_total")
+            .with_description(
+                "FieldsUpdated/FieldsReplaced journal envelopes skipped during actor replay (schema parse failure).",
+            )
+            .build()
+    })
+}
+
+/// Metric for ARN-189 replay path when a journaled field update cannot be deserialized.
+pub fn record_field_update_replay_skip(tenant: &str, entity_type: &str, entity_id: &str) {
+    field_update_replay_skip_counter().add(
+        1,
+        &[
+            KeyValue::new("tenant", tenant.to_string()),
+            KeyValue::new("entity_type", entity_type.to_string()),
+            KeyValue::new("entity_id", entity_id.to_string()),
+        ],
+    );
+}

--- a/docs/adrs/0169-journaled-field-updates.md
+++ b/docs/adrs/0169-journaled-field-updates.md
@@ -1,0 +1,66 @@
+# ADR-0169: Journaled PATCH/PUT field updates (ARN-189)
+
+- Status: Accepted
+- Date: 2026-07-13
+- Deciders: Temper core maintainers
+- Related:
+  - ARN-189: OData PATCH/PUT field updates never journaled
+  - `crates/temper-server/src/entity_actor/actor.rs` (`EntityMsg::UpdateFields`)
+  - Delete-path journaling (tombstone fail-closed pattern)
+  - ADR-0153 / ADR-0155 (index co-commit on append)
+
+## Context
+
+`EntityMsg::UpdateFields` (OData PATCH merge and PUT replace) mutated
+`state.fields` in memory and replied success without appending to the event
+journal. Entity state is rebuilt only from snapshot + event replay on
+eviction/restart, so field-only edits were silently lost.
+
+The Delete path already journals fail-closed (persist, then mutate). Spec
+actions journal + snapshot. Field updates were the inconsistent gap.
+
+## Decision
+
+### Sub-Decision 1: Dedicated journal event types
+
+Emit `FieldsUpdated` (PATCH) and `FieldsReplaced` (PUT) with:
+
+- `from_status == to_status` (status unchanged)
+- `params` = the update payload (merge keys for PATCH; full field object for PUT)
+
+These sit outside the IOA action vocabulary (like `Deleted`).
+
+### Sub-Decision 2: Fail-closed acknowledgment
+
+Apply the field update, then `persist_event` (so key/vector index rows co-commit
+from the **new** fields). On append failure, roll back in-memory fields and
+reply error. Never acknowledge a non-durable update.
+
+### Sub-Decision 3: Replay
+
+`replay_events` recognizes `FieldsUpdated` / `FieldsReplaced` and re-applies via
+the same `apply_field_update` helper used live (PUT replace cannot be expressed
+by generic action-param merge alone).
+
+### Sub-Decision 4: Event budget
+
+Field updates consume the same `MAX_EVENTS_SINCE_SNAPSHOT` budget as actions;
+reject before mutate when exhausted.
+
+## Consequences
+
+### Positive
+
+- PATCH/PUT survive eviction and restart.
+- Index co-commit stays correct for field-only writes.
+- Fail-closed matches Delete.
+
+### Negative
+
+- Extra journal volume for chatty PATCH clients (mitigated by snapshot interval
+  and event budget).
+
+## Non-Goals
+
+- Changing OData HTTP shapes.
+- Idempotency keys on field updates (follow-up if needed).


### PR DESCRIPTION
## Summary

OData PATCH/PUT (`EntityMsg::UpdateFields`) mutated memory without journaling, so edits were lost on eviction/restart (ARN-189).

## Fix (ADR-0169)

- Journal `FieldsUpdated` (PATCH) / `FieldsReplaced` (PUT) with fail-closed persist
- Shared `apply_field_update` for live + replay
- Event budget gate + snapshot after successful append

## Tests

- `patched_fields_survive_actor_restart` (sim store, gen1 PATCH → gen2 GetState)
- `replaced_fields_survive_actor_restart_with_replace_semantics`
- `apply_field_update_merge_and_replace`

## Arena

Branch `grok/arn-189-patch-journal` · Linear ARN-189 · draft, no merge

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR journals `FieldsUpdated` (PATCH) and `FieldsReplaced` (PUT) events with a fail-closed pattern, fixing field updates that were previously lost on actor eviction or restart (ARN-189). The re-check after `f208d4b7`/`5b80bac1` confirms both follow-up fixes are correct: non-object bodies are rejected before any mutation or budget consumption, and the replay skip path now emits a `record_field_update_replay_skip` metric in addition to the warn log.

- **Journaling flow** (`actor.rs`): budget gate → non-object guard → `apply_field_update` → `persist_event` → rollback-on-failure → `push_event_bounded` → snapshot; `persist_event` only advances `state.sequence_nr` on success, so no sequence drift on rollback.
- **Shared helper** (`effects.rs`): `apply_field_update` is the single mutation point for both the live handler and replay, preserving `Id`/`Status` on PUT replace.
- **Tests** (`actor_test.rs`): four targeted tests cover restart durability for PATCH and PUT, journal-append failure rollback (state not leaked), and non-object body rejection.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the journaling path, fail-closed rollback, replay detection, and both follow-up fixes are all correctly implemented with targeted test coverage.

The core fix is mechanically correct: persist_event only advances state.sequence_nr on success, so a failed append leaves both fields and sequence number consistent. The replay branch correctly uses env.event_type to identify field-update events and re-applies them through apply_field_update. The non-object guard is placed correctly after the budget check and before mutation. No issues found in the re-check.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/temper-server/src/entity_actor/actor.rs | Core journaling logic for UpdateFields; budget gate to non-object guard to apply to persist to rollback-on-failure to push to snapshot chain is correct, and both fixes (non-object reject at line 1492, replay skip metric at line 606) are properly integrated. |
| crates/temper-server/src/entity_actor/effects.rs | Introduces apply_field_update and FIELDS_UPDATED/REPLACED_EVENT constants; PATCH merge and PUT replace (with Id/Status preservation) are correct and shared cleanly between live handler and replay. |
| crates/temper-server/src/entity_actor/actor_test.rs | Adds four tests covering restart durability (PATCH and PUT), journal-append failure rollback, and non-object body rejection; assertions are tight and semantics are correct. |
| crates/temper-server/src/event_budget_metrics.rs | Adds record_field_update_replay_skip counter with tenant/entity_type/entity_id dimensions, consistent with the existing record_exhausted pattern. |
| docs/adrs/0169-journaled-field-updates.md | Documents the four sub-decisions (event types, fail-closed ack, replay, budget gate) accurately reflecting the implementation. |

</details>

<sub>Reviews (2): Last reviewed commit: ["style(server): rustfmt field-update erro..."](https://github.com/nerdsane/temper/commit/5b80bac1d3dadbddf6749b68032e48497c85c98e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43906175)</sub>

<!-- /greptile_comment -->