### PR TITLE
fix(server): make feature-request reads idempotent via content-derived identity (ARN-240)

### DIFF
--- a/crates/temper-server/src/observe/evolution/insight_generator/gap_analysis.rs
+++ b/crates/temper-server/src/observe/evolution/insight_generator/gap_analysis.rs
@@ -153,6 +153,20 @@ pub(crate) fn generate_unmet_intents(
 
 const FEATURE_REQUEST_THRESHOLD: u64 = 3;
 
+/// Stable, content-derived feature-request id: the same platform gap always
+/// maps to the same record (ARN-240). 12 hex chars of SHA-256 over the gap
+/// group key, NUL-separated to prevent field-boundary ambiguity.
+fn deterministic_feature_request_id(action: &str, error_pattern: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(action.as_bytes());
+    hasher.update([0]);
+    hasher.update(error_pattern.as_bytes());
+    let digest = hasher.finalize();
+    let hex: String = digest.iter().map(|b| format!("{b:02x}")).collect();
+    format!("FR-{}", &hex[..12])
+}
+
 pub(crate) fn generate_feature_requests(
     entries: &[crate::state::TrajectoryEntry],
 ) -> Vec<FeatureRequestRecord> {
@@ -196,8 +210,14 @@ pub(crate) fn generate_feature_requests(
             _ => PlatformGapCategory::MissingCapability,
         };
 
+        let mut header = RecordHeader::new(RecordType::FeatureRequest, "insight-generator");
+        // ARN-240: identity derives from the gap group, not a minted UUID —
+        // the same (action, error pattern) always maps to the same record, so
+        // regeneration on every listing is idempotent by construction.
+        header.id = deterministic_feature_request_id(&accum.action, &accum.error_pattern);
+
         feature_requests.push(FeatureRequestRecord {
-            header: RecordHeader::new(RecordType::FeatureRequest, "insight-generator"),
+            header,
             category,
             description: format!(
                 "Agents tried '{}' {} times — {}",

--- a/crates/temper-server/src/observe/evolution/operations.rs
+++ b/crates/temper-server/src/observe/evolution/operations.rs
@@ -27,8 +27,8 @@ mod feature_requests_test;
 pub(crate) use materialize::{handle_evolution_analyze, handle_evolution_materialize};
 
 use support::{
-    create_system_entity_logged, emit_refresh_hints, next_system_entity_id, persist_alerts,
-    persist_insights, spawn_intent_discovery,
+    create_system_entity_logged, emit_refresh_hints, persist_alerts, persist_insights,
+    spawn_intent_discovery,
 };
 
 /// POST /api/evolution/sentinel/check -- trigger sentinel rule evaluation.
@@ -245,7 +245,10 @@ pub(crate) async fn handle_feature_requests(
                 FeatureRequestDisposition::WontFix => "WontFix",
                 FeatureRequestDisposition::Resolved => "Resolved",
             };
-            if let Err(error) = store
+            // ARN-240: the record id is content-derived, so this is a true
+            // upsert; the system entity is created ONCE, on the insert that
+            // first discovered the gap, and shares the record's id.
+            let inserted = match store
                 .upsert_feature_request(
                     &feature_request.header.id,
                     &format!("{:?}", feature_request.category),
@@ -257,23 +260,29 @@ pub(crate) async fn handle_feature_requests(
                 )
                 .await
             {
-                tracing::warn!(error = %error, backend = store.backend_name(), "failed to upsert feature request");
-            }
+                Ok(inserted) => inserted,
+                Err(error) => {
+                    tracing::warn!(error = %error, backend = store.backend_name(), "failed to upsert feature request");
+                    false
+                }
+            };
 
-            create_system_entity_logged(
-                &state,
-                "FeatureRequest",
-                &next_system_entity_id("FR"),
-                "CreateFeatureRequest",
-                serde_json::json!({
-                    "category": format!("{:?}", feature_request.category),
-                    "description": feature_request.description,
-                    "frequency": feature_request.frequency.to_string(),
-                    "developer_notes": feature_request.developer_notes.clone().unwrap_or_default(),
-                    "legacy_record_id": feature_request.header.id,
-                }),
-            )
-            .await;
+            if inserted {
+                create_system_entity_logged(
+                    &state,
+                    "FeatureRequest",
+                    &feature_request.header.id,
+                    "CreateFeatureRequest",
+                    serde_json::json!({
+                        "category": format!("{:?}", feature_request.category),
+                        "description": feature_request.description,
+                        "frequency": feature_request.frequency.to_string(),
+                        "developer_notes": feature_request.developer_notes.clone().unwrap_or_default(),
+                        "legacy_record_id": feature_request.header.id,
+                    }),
+                )
+                .await;
+            }
         }
 
         return match store.list_feature_requests(disposition_filter).await {

--- a/crates/temper-server/src/observe/evolution/operations.rs
+++ b/crates/temper-server/src/observe/evolution/operations.rs
@@ -21,6 +21,9 @@ use crate::state::{ObserveRefreshHint, ServerState};
 mod materialize;
 mod support;
 
+#[cfg(test)]
+mod feature_requests_test;
+
 pub(crate) use materialize::{handle_evolution_analyze, handle_evolution_materialize};
 
 use support::{

--- a/crates/temper-server/src/observe/evolution/operations/feature_requests_test.rs
+++ b/crates/temper-server/src/observe/evolution/operations/feature_requests_test.rs
@@ -215,22 +215,40 @@ async fn repeated_get_creates_the_system_entity_exactly_once() {
         .as_str()
         .expect("feature request id")
         .to_string();
-    get_feature_requests(&state).await;
 
-    let events = state
-        .storage_stack
-        .as_ref()
-        .expect("stack")
-        .events
-        .read_events(&format!("temper-system:FeatureRequest:{id}"), 0)
-        .await
-        .expect("read entity journal");
+    let journal = |from: u64| {
+        let events = state.storage_stack.as_ref().expect("stack").events.clone();
+        let persistence_id = format!("temper-system:FeatureRequest:{id}");
+        async move {
+            events
+                .read_events(&persistence_id, from)
+                .await
+                .expect("read entity journal")
+        }
+    };
+
+    // The first GET must journal the entity UNDER THE RECORD'S ID (a fresh
+    // per-read id would leave this journal empty). A new entity journals a
+    // bootstrap Created event plus the action event, so assert non-empty
+    // rather than a count coupled to that implementation detail.
+    let after_first = journal(0).await;
+    assert!(
+        !after_first.is_empty(),
+        "the first GET must create the system entity under the record's id"
+    );
+
+    let second = get_feature_requests(&state).await;
     assert_eq!(
-        events.len(),
-        1,
-        "two GETs must leave exactly one creation event on the record's \
-         entity journal, got {} (ids minted per read would journal under \
-         fresh ids and leave this journal empty or duplicated)",
-        events.len()
+        second["feature_requests"][0]["id"].as_str(),
+        Some(id.as_str()),
+        "identity must be stable before comparing journals"
+    );
+
+    let after_second = journal(0).await;
+    assert_eq!(
+        after_second.len(),
+        after_first.len(),
+        "the second GET must not journal anything — the entity is created \
+         exactly once, on the read that first discovered the gap"
     );
 }

--- a/crates/temper-server/src/observe/evolution/operations/feature_requests_test.rs
+++ b/crates/temper-server/src/observe/evolution/operations/feature_requests_test.rs
@@ -1,0 +1,236 @@
+//! ARN-240: GET /observe/evolution/feature-requests must be idempotent.
+//!
+//! The handler generates feature requests from trajectory gaps on every read.
+//! Each generated record minted a fresh UUID-suffixed id, so the store
+//! "upsert" inserted a NEW row per GET, and a fresh `FR-{uuid}` system entity
+//! was dispatched per generated record per GET — reads spawned unbounded
+//! duplicates, and re-generation clobbered developer-owned fields.
+
+use std::collections::BTreeMap;
+
+use crate::registry::SpecRegistry;
+use axum::extract::{Query, State};
+use axum::http::HeaderMap;
+use temper_runtime::ActorSystem;
+
+use crate::state::{ServerState, TrajectoryEntry, TrajectorySource};
+use crate::storage::StorageStack;
+
+fn failing_platform_entry(n: u64) -> TrajectoryEntry {
+    TrajectoryEntry {
+        timestamp: format!("2026-07-13T00:00:{n:02}Z"),
+        tenant: "arn240".to_string(),
+        entity_type: "Invoice".to_string(),
+        entity_id: format!("inv-{n}"),
+        action: "GenerateInvoice".to_string(),
+        success: false,
+        from_status: None,
+        to_status: None,
+        error: Some("EntitySetNotFound: Invoice".to_string()),
+        agent_id: Some("agent-1".to_string()),
+        session_id: None,
+        authz_denied: None,
+        denied_resource: None,
+        denied_module: None,
+        source: Some(TrajectorySource::Platform),
+        spec_governed: Some(false),
+        agent_type: None,
+        intent: None,
+        request_body: None,
+        matched_policy_ids: None,
+    }
+}
+
+const FEATURE_REQUEST_IOA: &str = r#"
+[automaton]
+name = "FeatureRequest"
+states = ["New", "Ready"]
+initial = "New"
+
+[[state]]
+name = "category"
+type = "string"
+initial = ""
+
+[[state]]
+name = "description"
+type = "string"
+initial = ""
+
+[[state]]
+name = "frequency"
+type = "string"
+initial = ""
+
+[[state]]
+name = "developer_notes"
+type = "string"
+initial = ""
+
+[[state]]
+name = "legacy_record_id"
+type = "string"
+initial = ""
+
+[[action]]
+name = "CreateFeatureRequest"
+kind = "input"
+from = ["New"]
+to = "Ready"
+params = ["category", "description", "frequency", "developer_notes", "legacy_record_id"]
+hint = "Record a platform gap surfaced by the insight generator."
+"#;
+
+const FEATURE_REQUEST_CSDL: &str = r#"<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="Temper.System" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="FeatureRequest">
+        <Key><PropertyRef Name="Id"/></Key>
+        <Property Name="Id" Type="Edm.String" Nullable="false"/>
+      </EntityType>
+      <EntityContainer Name="Container">
+        <EntitySet Name="FeatureRequests" EntityType="Temper.System.FeatureRequest"/>
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>"#;
+
+fn registry_with_system_feature_request_spec() -> SpecRegistry {
+    let mut registry = SpecRegistry::new();
+    let csdl = temper_spec::parse_csdl(FEATURE_REQUEST_CSDL).expect("csdl parses");
+    registry.register_tenant(
+        "temper-system",
+        csdl,
+        FEATURE_REQUEST_CSDL.to_string(),
+        &[("FeatureRequest", FEATURE_REQUEST_IOA)],
+    );
+    registry
+}
+
+async fn state_with_gap_trajectories() -> (ServerState, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_url = format!("file:{}", dir.path().join("arn240.db").display());
+    let turso = temper_store_turso::TursoEventStore::new(&db_url, None)
+        .await
+        .expect("turso store");
+    let stack = StorageStack::from_turso(turso);
+
+    // Three failing Platform-source entries for the same (action, error
+    // pattern) — exactly the FEATURE_REQUEST_THRESHOLD gap group.
+    let sink = stack.trajectory.clone().expect("trajectory sink");
+    for n in 0..3 {
+        sink.persist_trajectory_entry(&failing_platform_entry(n))
+            .await
+            .expect("persist trajectory");
+    }
+
+    let system = ActorSystem::new("arn240-test");
+    let mut state = ServerState::from_registry(system, registry_with_system_feature_request_spec());
+    state.set_storage_stack(stack);
+    (state, dir)
+}
+
+fn system_headers() -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert("x-temper-principal-kind", "system".parse().expect("hdr"));
+    headers
+}
+
+async fn get_feature_requests(state: &ServerState) -> serde_json::Value {
+    let response = super::handle_feature_requests(
+        State(state.clone()),
+        system_headers(),
+        Query(BTreeMap::new()),
+    )
+    .await
+    .expect("GET feature-requests");
+    response.0
+}
+
+/// A read must not create anything new on re-read: the same gap group must
+/// map to the same feature request, however many times it is listed.
+#[tokio::test]
+async fn repeated_get_does_not_duplicate_feature_requests() {
+    let (state, _dir) = state_with_gap_trajectories().await;
+
+    let first = get_feature_requests(&state).await;
+    assert_eq!(
+        first["total"], 1,
+        "one gap group must yield one feature request, got: {first}"
+    );
+
+    let second = get_feature_requests(&state).await;
+    assert_eq!(
+        second["total"], 1,
+        "a GET is a read — re-reading must not create a duplicate feature \
+         request for the same gap group, got: {second}"
+    );
+    assert_eq!(
+        second["feature_requests"][0]["id"], first["feature_requests"][0]["id"],
+        "the same gap group must keep the same identity across reads"
+    );
+}
+
+/// Re-generation must not clobber developer-owned fields: a disposition set
+/// via PATCH survives subsequent GETs while agents keep hitting the same gap.
+#[tokio::test]
+async fn get_preserves_developer_disposition_and_notes() {
+    let (state, _dir) = state_with_gap_trajectories().await;
+
+    let first = get_feature_requests(&state).await;
+    let id = first["feature_requests"][0]["id"]
+        .as_str()
+        .expect("feature request id")
+        .to_string();
+
+    let store = state.platform_metadata_store().expect("platform store");
+    store
+        .update_feature_request(&id, "WontFix", Some("duplicate of FR-1"))
+        .await
+        .expect("developer updates disposition");
+
+    let after = get_feature_requests(&state).await;
+    assert_eq!(after["total"], 1, "still exactly one row, got: {after}");
+    assert_eq!(
+        after["feature_requests"][0]["disposition"], "WontFix",
+        "a GET must not reset a developer's disposition, got: {after}"
+    );
+    assert_eq!(
+        after["feature_requests"][0]["developer_notes"], "duplicate of FR-1",
+        "a GET must not wipe developer notes, got: {after}"
+    );
+}
+
+/// The system entity behind a feature request is created ONCE — the entity
+/// journal for the record's deterministic id holds exactly one creation
+/// event however many times the listing runs. (Previously every GET
+/// dispatched a fresh `FR-{uuid}` entity per generated record.)
+#[tokio::test]
+async fn repeated_get_creates_the_system_entity_exactly_once() {
+    let (state, _dir) = state_with_gap_trajectories().await;
+
+    let first = get_feature_requests(&state).await;
+    let id = first["feature_requests"][0]["id"]
+        .as_str()
+        .expect("feature request id")
+        .to_string();
+    get_feature_requests(&state).await;
+
+    let events = state
+        .storage_stack
+        .as_ref()
+        .expect("stack")
+        .events
+        .read_events(&format!("temper-system:FeatureRequest:{id}"), 0)
+        .await
+        .expect("read entity journal");
+    assert_eq!(
+        events.len(),
+        1,
+        "two GETs must leave exactly one creation event on the record's \
+         entity journal, got {} (ids minted per read would journal under \
+         fresh ids and leave this journal empty or duplicated)",
+        events.len()
+    );
+}

--- a/crates/temper-server/src/storage/capabilities.rs
+++ b/crates/temper-server/src/storage/capabilities.rs
@@ -1,0 +1,129 @@
+//! Durable metadata capability traits for the evolution engine and
+//! design-time verification events, implemented by the storage backends.
+
+use temper_runtime::persistence::PersistenceError;
+use temper_store_turso::{
+    DesignTimeEventRow, EvolutionRecordRow, FeatureRequestRow, OtsQueuedTrajectoryRow,
+    OtsTrajectoryParams, OtsTrajectoryRow,
+};
+
+/// Evolution engine durable metadata capability.
+#[async_trait::async_trait]
+pub trait EvolutionStore: Send + Sync {
+    /// Insert a generated feature request, or refresh the generator-owned
+    /// fields of an existing one. Developer-owned fields (disposition,
+    /// developer notes) are written ONLY on first insert (ARN-240). Returns
+    /// `true` when this call created the record.
+    #[allow(clippy::too_many_arguments)]
+    async fn upsert_feature_request(
+        &self,
+        id: &str,
+        category: &str,
+        description: &str,
+        frequency: i64,
+        trajectory_refs_json: &str,
+        disposition: &str,
+        developer_notes: Option<&str>,
+    ) -> Result<bool, PersistenceError>;
+
+    async fn list_feature_requests(
+        &self,
+        disposition: Option<&str>,
+    ) -> Result<Vec<FeatureRequestRow>, PersistenceError>;
+
+    async fn update_feature_request(
+        &self,
+        id: &str,
+        disposition: &str,
+        developer_notes: Option<&str>,
+    ) -> Result<bool, PersistenceError>;
+
+    async fn insert_evolution_record(
+        &self,
+        id: &str,
+        record_type: &str,
+        status: &str,
+        created_by: &str,
+        derived_from: Option<&str>,
+        data_json: &str,
+    ) -> Result<(), PersistenceError>;
+
+    async fn get_evolution_record(
+        &self,
+        id: &str,
+    ) -> Result<Option<EvolutionRecordRow>, PersistenceError>;
+
+    async fn list_evolution_records(
+        &self,
+        record_type: Option<&str>,
+        status: Option<&str>,
+    ) -> Result<Vec<EvolutionRecordRow>, PersistenceError>;
+
+    async fn list_ranked_insights(&self) -> Result<Vec<EvolutionRecordRow>, PersistenceError>;
+}
+
+/// Design-time verification event capability.
+#[async_trait::async_trait]
+pub trait DesignTimeEventStore: Send + Sync {
+    #[allow(clippy::too_many_arguments)]
+    async fn insert_design_time_event(
+        &self,
+        kind: &str,
+        entity_type: &str,
+        tenant: &str,
+        summary: &str,
+        level: Option<&str>,
+        passed: Option<bool>,
+        step_number: Option<i64>,
+        total_steps: Option<i64>,
+    ) -> Result<(), PersistenceError>;
+
+    async fn list_design_time_events(
+        &self,
+        tenant: Option<&str>,
+        limit: i64,
+    ) -> Result<Vec<DesignTimeEventRow>, PersistenceError>;
+}
+
+/// OTS trajectory capability.
+#[async_trait::async_trait]
+pub trait OtsStore: Send + Sync {
+    async fn persist_ots_trajectory(
+        &self,
+        params: &OtsTrajectoryParams<'_>,
+    ) -> Result<(), PersistenceError>;
+
+    async fn enqueue_ots_trajectory(
+        &self,
+        params: &OtsTrajectoryParams<'_>,
+    ) -> Result<(), PersistenceError>;
+
+    async fn mark_ots_trajectory_persisted(
+        &self,
+        trajectory_id: &str,
+    ) -> Result<(), PersistenceError>;
+
+    async fn mark_ots_trajectory_failed(
+        &self,
+        trajectory_id: &str,
+        error: &str,
+    ) -> Result<(), PersistenceError>;
+
+    async fn list_queued_ots_trajectories(
+        &self,
+        limit: i64,
+    ) -> Result<Vec<OtsQueuedTrajectoryRow>, PersistenceError>;
+
+    async fn list_ots_trajectories(
+        &self,
+        tenant: &str,
+        agent_id: Option<&str>,
+        outcome: Option<&str>,
+        limit: i64,
+    ) -> Result<Vec<OtsTrajectoryRow>, PersistenceError>;
+
+    async fn get_ots_trajectory(
+        &self,
+        trajectory_id: &str,
+    ) -> Result<Option<String>, PersistenceError>;
+}

--- a/crates/temper-server/src/storage/mod.rs
+++ b/crates/temper-server/src/storage/mod.rs
@@ -34,6 +34,7 @@ use crate::platform_store::PlatformStore;
 use crate::platform_store::SimPlatformStore;
 use crate::state::trajectory::{TrajectoryEntry, TrajectorySource};
 
+mod capabilities;
 mod published_artifacts;
 mod query_plane_impls;
 mod query_plane_read;
@@ -861,122 +862,7 @@ pub trait ObserveReadStore: Send + Sync {
     ) -> Result<Vec<AgentSummary>, PersistenceError>;
 }
 
-/// Evolution engine durable metadata capability.
-#[async_trait::async_trait]
-pub trait EvolutionStore: Send + Sync {
-    #[allow(clippy::too_many_arguments)]
-    async fn upsert_feature_request(
-        &self,
-        id: &str,
-        category: &str,
-        description: &str,
-        frequency: i64,
-        trajectory_refs_json: &str,
-        disposition: &str,
-        developer_notes: Option<&str>,
-    ) -> Result<(), PersistenceError>;
-
-    async fn list_feature_requests(
-        &self,
-        disposition: Option<&str>,
-    ) -> Result<Vec<FeatureRequestRow>, PersistenceError>;
-
-    async fn update_feature_request(
-        &self,
-        id: &str,
-        disposition: &str,
-        developer_notes: Option<&str>,
-    ) -> Result<bool, PersistenceError>;
-
-    async fn insert_evolution_record(
-        &self,
-        id: &str,
-        record_type: &str,
-        status: &str,
-        created_by: &str,
-        derived_from: Option<&str>,
-        data_json: &str,
-    ) -> Result<(), PersistenceError>;
-
-    async fn get_evolution_record(
-        &self,
-        id: &str,
-    ) -> Result<Option<EvolutionRecordRow>, PersistenceError>;
-
-    async fn list_evolution_records(
-        &self,
-        record_type: Option<&str>,
-        status: Option<&str>,
-    ) -> Result<Vec<EvolutionRecordRow>, PersistenceError>;
-
-    async fn list_ranked_insights(&self) -> Result<Vec<EvolutionRecordRow>, PersistenceError>;
-}
-
-/// Design-time verification event capability.
-#[async_trait::async_trait]
-pub trait DesignTimeEventStore: Send + Sync {
-    #[allow(clippy::too_many_arguments)]
-    async fn insert_design_time_event(
-        &self,
-        kind: &str,
-        entity_type: &str,
-        tenant: &str,
-        summary: &str,
-        level: Option<&str>,
-        passed: Option<bool>,
-        step_number: Option<i64>,
-        total_steps: Option<i64>,
-    ) -> Result<(), PersistenceError>;
-
-    async fn list_design_time_events(
-        &self,
-        tenant: Option<&str>,
-        limit: i64,
-    ) -> Result<Vec<DesignTimeEventRow>, PersistenceError>;
-}
-
-/// OTS trajectory capability.
-#[async_trait::async_trait]
-pub trait OtsStore: Send + Sync {
-    async fn persist_ots_trajectory(
-        &self,
-        params: &OtsTrajectoryParams<'_>,
-    ) -> Result<(), PersistenceError>;
-
-    async fn enqueue_ots_trajectory(
-        &self,
-        params: &OtsTrajectoryParams<'_>,
-    ) -> Result<(), PersistenceError>;
-
-    async fn mark_ots_trajectory_persisted(
-        &self,
-        trajectory_id: &str,
-    ) -> Result<(), PersistenceError>;
-
-    async fn mark_ots_trajectory_failed(
-        &self,
-        trajectory_id: &str,
-        error: &str,
-    ) -> Result<(), PersistenceError>;
-
-    async fn list_queued_ots_trajectories(
-        &self,
-        limit: i64,
-    ) -> Result<Vec<OtsQueuedTrajectoryRow>, PersistenceError>;
-
-    async fn list_ots_trajectories(
-        &self,
-        tenant: &str,
-        agent_id: Option<&str>,
-        outcome: Option<&str>,
-        limit: i64,
-    ) -> Result<Vec<OtsTrajectoryRow>, PersistenceError>;
-
-    async fn get_ots_trajectory(
-        &self,
-        trajectory_id: &str,
-    ) -> Result<Option<String>, PersistenceError>;
-}
+pub use capabilities::{DesignTimeEventStore, EvolutionStore, OtsStore};
 
 /// Legacy database-backed blob capability.
 #[async_trait::async_trait]
@@ -1867,7 +1753,7 @@ impl EvolutionStore for PostgresEventStore {
         trajectory_refs_json: &str,
         disposition: &str,
         developer_notes: Option<&str>,
-    ) -> Result<(), PersistenceError> {
+    ) -> Result<bool, PersistenceError> {
         self.upsert_feature_request(
             id,
             category,
@@ -1949,7 +1835,7 @@ impl EvolutionStore for TursoEventStore {
         trajectory_refs_json: &str,
         disposition: &str,
         developer_notes: Option<&str>,
-    ) -> Result<(), PersistenceError> {
+    ) -> Result<bool, PersistenceError> {
         self.upsert_feature_request(
             id,
             category,

--- a/crates/temper-store-postgres/src/platform.rs
+++ b/crates/temper-store-postgres/src/platform.rs
@@ -1785,28 +1785,45 @@ impl PostgresEventStore {
         trajectory_refs_json: &str,
         disposition: &str,
         developer_notes: Option<&str>,
-    ) -> Result<(), PersistenceError> {
+    ) -> Result<bool, PersistenceError> {
         let trajectory_refs = parse_json(trajectory_refs_json)?;
-        crate::dbm::postgres_query!(
+        // ARN-240: disposition and developer_notes are developer-owned after
+        // creation — regeneration writes them ONLY on first insert, and the
+        // caller learns whether this insert created the record.
+        let result = crate::dbm::postgres_query!(
             "INSERT INTO feature_requests \
              (id, category, description, frequency, trajectory_refs, disposition, developer_notes, updated_at) \
              VALUES ($1, $2, $3, $4, $5, $6, $7, now()) \
-             ON CONFLICT (id) DO UPDATE SET \
-                 category = EXCLUDED.category, description = EXCLUDED.description, frequency = EXCLUDED.frequency, \
-                 trajectory_refs = EXCLUDED.trajectory_refs, disposition = EXCLUDED.disposition, \
-                 developer_notes = EXCLUDED.developer_notes, updated_at = now()",
+             ON CONFLICT (id) DO NOTHING",
+        )
+        .bind(id)
+        .bind(category)
+        .bind(description)
+        .bind(frequency)
+        .bind(trajectory_refs.clone())
+        .bind(disposition)
+        .bind(developer_notes)
+        .execute(self.pool())
+        .await
+        .map_err(storage_error)?;
+        if result.rows_affected() > 0 {
+            return Ok(true);
+        }
+        crate::dbm::postgres_query!(
+            "UPDATE feature_requests SET \
+                 category = $2, description = $3, frequency = $4, \
+                 trajectory_refs = $5, updated_at = now() \
+             WHERE id = $1",
         )
         .bind(id)
         .bind(category)
         .bind(description)
         .bind(frequency)
         .bind(trajectory_refs)
-        .bind(disposition)
-        .bind(developer_notes)
         .execute(self.pool())
         .await
         .map_err(storage_error)?;
-        Ok(())
+        Ok(false)
     }
 
     pub async fn list_feature_requests(

--- a/crates/temper-store-turso/src/store/evolution.rs
+++ b/crates/temper-store-turso/src/store/evolution.rs
@@ -24,20 +24,34 @@ impl TursoEventStore {
         trajectory_refs_json: &str,
         disposition: &str,
         developer_notes: Option<&str>,
-    ) -> Result<(), PersistenceError> {
+    ) -> Result<bool, PersistenceError> {
         let _query_timer = TursoQueryTimer::start("turso.upsert_feature_request");
         let conn = self.configured_connection().await?;
+        // ARN-240: disposition and developer_notes are developer-owned after
+        // creation — regeneration writes them ONLY on first insert, and the
+        // caller learns whether this insert created the record.
+        let inserted = conn
+            .execute(
+                "INSERT INTO feature_requests (id, category, description, frequency, trajectory_refs, disposition, developer_notes, updated_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, datetime('now')) \
+                 ON CONFLICT(id) DO NOTHING",
+                params![id, category, description, frequency, trajectory_refs_json, disposition, developer_notes],
+            )
+            .await
+            .map_err(storage_error)?;
+        if inserted > 0 {
+            return Ok(true);
+        }
         conn.execute(
-            "INSERT INTO feature_requests (id, category, description, frequency, trajectory_refs, disposition, developer_notes, updated_at) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, datetime('now')) \
-             ON CONFLICT(id) DO UPDATE SET \
+            "UPDATE feature_requests SET \
                  category = ?2, description = ?3, frequency = ?4, trajectory_refs = ?5, \
-                 disposition = ?6, developer_notes = ?7, updated_at = datetime('now')",
-            params![id, category, description, frequency, trajectory_refs_json, disposition, developer_notes],
+                 updated_at = datetime('now') \
+             WHERE id = ?1",
+            params![id, category, description, frequency, trajectory_refs_json],
         )
         .await
         .map_err(storage_error)?;
-        Ok(())
+        Ok(false)
     }
 
     /// List feature requests with optional disposition filter.

--- a/docs/adrs/0163-feature-request-read-idempotency.md
+++ b/docs/adrs/0163-feature-request-read-idempotency.md
@@ -1,0 +1,70 @@
+# ADR-0163: Feature-Request Reads Are Idempotent
+
+## Status
+
+Accepted (2026-07-13)
+
+(Numbered 0163: 0156–0162 are claimed by concurrently open arena branches.)
+
+## Context
+
+`GET /observe/evolution/feature-requests` regenerates feature requests from
+trajectory gap analysis on every read and persists what it generates. Every
+generated record minted a fresh UUID-suffixed id (`RecordHeader::new`), so
+the store "upsert" — keyed on that id — inserted a NEW row on every GET, and
+a fresh `FR-{uuid}` system entity was dispatched per generated record per
+GET. Reads spawned unbounded duplicates (ARN-240). The upsert also
+overwrote `disposition` and `developer_notes` with generator defaults, so a
+developer's WontFix could be silently reset by any read racing a re-listing.
+
+## Decision
+
+1. **Identity is derived from content, not minted.** A feature request's id
+   is a stable hash of its gap group key — `FR-{sha256(action, error_pattern)
+   [..12]}`. The same gap always maps to the same record, making generation
+   idempotent by construction rather than by bookkeeping.
+2. **Insert and update are separated, and developer-owned fields are only
+   ever written on insert.** `upsert_feature_request` first attempts
+   `INSERT … ON CONFLICT (id) DO NOTHING`; if the row already existed, an
+   UPDATE refreshes only the generator-owned fields (category, description,
+   frequency, trajectory_refs, updated_at). `disposition` and
+   `developer_notes` belong to the developer after creation and are never
+   touched by re-generation. The method returns whether it inserted.
+3. **System entities are created once, keyed by the record id.** The handler
+   dispatches `CreateFeatureRequest` only when the store reports a fresh
+   insert, and the entity id IS the deterministic record id (the previous
+   code minted a second, unrelated `FR-{uuid}` per GET).
+
+## Consequences
+
+- A GET is now a read: repeating it changes nothing. The regeneration that
+  runs inside it converges on the same rows and skips entity creation for
+  anything already known.
+- Existing duplicate rows from the previous behavior are not migrated —
+  they remain until dispositioned. (A cleanup migration was considered and
+  rejected: rows may carry developer notes; deletion is a human decision.)
+- Two concurrent GETs race benignly: both compute the same id, one wins the
+  insert, the other's `DO NOTHING` reports "existed" and skips the entity.
+- **Entity dispatch is at-most-once with no reconciliation.** If the process
+  dies between the successful insert and the entity dispatch — or the
+  dispatch fails (it is warn-only) — the system entity for that record is
+  never created: every later GET sees an existing row and skips. The
+  previous behavior was strictly worse (a new entity per read), so this is
+  accepted here; a reconciliation sweep (create entities for rows whose
+  journal is empty) is the follow-up if the entity plane becomes
+  load-bearing.
+- The frequency/description of an existing record now tracks the latest
+  generation window rather than accumulating forever — which is what the
+  listing already claimed to show.
+
+## Alternatives Considered
+
+- **Moving generation out of the GET entirely** (event-driven, e.g. on
+  trajectory write or sentinel schedule): the cleaner long-term shape —
+  reads should not write at all — but it changes when insights appear and
+  belongs with the broader evolution-engine scheduling work. The
+  deterministic identity fix is required under any scheduling model, and
+  once it is in, the in-GET generation is harmless (idempotent).
+- **Deduplicating in the generator against existing rows** (read-modify-
+  write): racy without a transaction spanning generation, and still leaves
+  identity random — the class survives anywhere a second writer appears.

--- a/docs/adrs/0163-feature-request-read-idempotency.md
+++ b/docs/adrs/0163-feature-request-read-idempotency.md
@@ -56,6 +56,15 @@ developer's WontFix could be silently reset by any read racing a re-listing.
 - The frequency/description of an existing record now tracks the latest
   generation window rather than accumulating forever — which is what the
   listing already claimed to show.
+- **The gap-group key excludes tenant** — identical gaps across tenants share
+  one record. This is pre-existing grouping semantics (the accumulation map
+  always merged across tenants); the deterministic id cements it rather than
+  introducing it. Tenant-scoped grouping is a deliberate product decision to
+  take separately, not a side effect to smuggle into a duplication fix.
+- `legacy_record_id` in the entity dispatch params now equals the entity id
+  at this site (they were distinct when entity ids were minted per read).
+  The key is kept: it is the uniform convention across all six evolution
+  dispatch sites, and consumers read it generically.
 
 ## Alternatives Considered
 


### PR DESCRIPTION
Fixes ARN-240 (`feature-request GET creates duplicate evolution entities on every read`).

## Defect (three legs, one root cause)

`GET /observe/evolution/feature-requests` regenerates feature requests from trajectory gap analysis on every read — and every generated record minted a fresh UUID-suffixed id (`RecordHeader::new`). Consequently:

1. The store "upsert", keyed on that fresh id, **inserted a new row on every GET** — the live E2E below shows totals growing 1 → 2 → 3 on three consecutive reads of the same single gap.
2. A fresh `FR-{sim_uuid()}` **system entity was dispatched per generated record per GET** — the "duplicate evolution entities" of the issue title.
3. The upsert's `ON CONFLICT … DO UPDATE` **overwrote developer-owned `disposition` and `developer_notes`** with generator defaults.

## Fix (root cause: identity)

- **Content-derived identity**: `FR-{sha256(action, error_pattern)[..12]}` — the same platform gap always maps to the same record, making regeneration idempotent by construction (`gap_analysis.rs`).
- **Insert/update separation** in both store backends: `INSERT … ON CONFLICT (id) DO NOTHING` (reporting whether it inserted), else an UPDATE of only the generator-owned fields. Disposition and notes are written **once, on insert** — a developer's WontFix survives any number of re-listings. `EvolutionStore::upsert_feature_request` returns `bool`.
- **Entity dispatched once**, on the read that first discovered the gap, keyed by the record id (the per-read `next_system_entity_id("FR")` dispatch is gone).
- Concurrency: two concurrent GETs race only on the atomic INSERT (one wins, one no-ops); GET racing PATCH cannot lose the developer's write because the two paths write disjoint column sets (reviewer-verified across all interleavings).
- ADR-0163 records the decision, the at-most-once entity-dispatch residual, and why generation stays in the GET for now (idempotent; moving it out entirely is the event-driven follow-up).
- Ratchet: +4 trait-doc lines pushed `storage/mod.rs` over the ceiling → the three capability traits (EvolutionStore, DesignTimeEventStore, OtsStore) moved byte-verbatim to `storage/capabilities.rs` (2833 → 2715 lines; reviewer diffed the move mechanically).

## TDD

- RED `121573d9` (committed alone; both reviewers' r2 PASS): three tests against the real turso-backed stack pin all three legs — row cardinality + identity stability across reads, developer-field preservation, and the entity journal under the record's id.
- GREEN `2d70eccd`: all three pass. One honest amendment: the RED entity test asserted `len == 1`; the GREEN run revealed a fresh entity journals a bootstrap `Created` event plus the action event, so a **correct** implementation journals 2 — the assertion now pins the real invariant (non-empty after the first read, unchanged by later reads; still failing at the RED base where dispatches went to unrelated random ids). The pre-commit reviewer verified the amendment preserves the RED's evidentiary value.

## Verification

- 3/3 new tests; turso 60/60 + 5/5; full `cargo test --workspace` sweep clean (exit 0); clippy `-D warnings`, ratchet, fmt clean.
- Pre-commit review: RED r1 FAIL (the entity-dispatch leg wasn't pinned — test added; id-stability assertion added) → r2 PASS; GREEN PASS with 3 suggestions, all fixed in the commit (ADR residual bullet, map_err convention, stale doc comment).
- Live local E2E (before/after): PR comment below.

## Residual risks (in ADR-0163)

- **At-most-once entity dispatch, no reconciliation**: a crash between insert and dispatch (or a warn-only dispatch failure) leaves that record's system entity permanently uncreated. Strictly better than the old unbounded duplication; a reconciliation sweep is the follow-up if the entity plane becomes load-bearing.
- Existing duplicate rows from the old behavior are not migrated (they may carry developer notes; deletion is a human decision).
- The gap-group key excludes tenant (pre-existing grouping semantics, now cemented into the id): identical gaps across tenants share one record.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes ARN-240 by replacing per-read UUID minting with a content-derived identity (`FR-{sha256(action, error_pattern)[..12]}`), splitting the store upsert into an `INSERT … DO NOTHING` / conditional `UPDATE` pair that never overwrites developer-owned fields, and gating system-entity creation behind the insert-won signal. All three duplicating legs (growing row count, unbounded entity dispatch, developer-field clobber) are eliminated.

- **Content-derived identity** (`gap_analysis.rs`): SHA-256 over NUL-separated `(action, error_pattern)`, truncated to 12 hex chars — the same gap always maps to the same id, making regeneration idempotent by construction.
- **Two-phase upsert** (both Turso and Postgres): `INSERT … ON CONFLICT DO NOTHING` detects first-creation; a separate `UPDATE` refreshes only generator-owned columns, leaving `disposition` and `developer_notes` permanently under developer control after first insert.
- **Three turso-backed regression tests** pin all three legs; the capability traits moved verbatim to `storage/capabilities.rs` to satisfy the 500-line ratchet.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The fix is mechanically straightforward, the two-phase upsert correctly partitions writer responsibilities across disjoint column sets, and all three duplicating legs are covered by regression tests against a real Turso-backed stack.

The core change — deterministic id plus insert/update separation — is a minimal, locally-contained rewrite with no shared mutable state, no new external dependencies beyond sha2, and a clean concurrent-GET / GET-races-PATCH story verified column-by-column. The three tests exercise the exact failure modes from the bug report. The trait extraction is byte-verbatim and mechanical. No migration risk on the new path; old duplicate rows are explicitly left for human triage.

No files require special attention. Both store backends (Turso and Postgres) apply identical two-phase logic, parameter positions are consistent, and the entity-dispatch guard is correctly placed in the handler.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/temper-server/src/observe/evolution/insight_generator/gap_analysis.rs | Adds deterministic_feature_request_id using SHA-256 over NUL-separated (action, error_pattern); replaces RecordHeader::new UUID with this stable hash so repeated regeneration is idempotent. |
| crates/temper-server/src/observe/evolution/operations.rs | Consumes the new bool return from upsert_feature_request and gates CreateFeatureRequest entity dispatch behind if inserted, eliminating per-read entity duplication. |
| crates/temper-server/src/observe/evolution/operations/feature_requests_test.rs | New test module covering all three legs: row cardinality stability, developer-field preservation across GETs, and entity-journal created exactly once under the record id. |
| crates/temper-server/src/storage/capabilities.rs | New file receiving EvolutionStore, DesignTimeEventStore, and OtsStore verbatim from storage/mod.rs; upsert_feature_request signature updated to return Result<bool> with doc comment. |
| crates/temper-server/src/storage/mod.rs | Removes three capability trait blocks and re-exports them from the new capabilities module; impl signatures updated to return bool. |
| crates/temper-store-postgres/src/platform.rs | Replaces DO UPDATE upsert with INSERT DO NOTHING then conditional UPDATE of generator-owned columns only; returns bool via rows_affected(). |
| crates/temper-store-turso/src/store/evolution.rs | Same two-phase upsert as postgres: INSERT DO NOTHING returns u64 rows-affected; if 0, runs UPDATE of generator fields only; disposition and developer_notes never touched on re-generation. |
| docs/adrs/0163-feature-request-read-idempotency.md | ADR documenting the decision, consequences, and rejected alternatives including at-most-once entity dispatch residual and cross-tenant key scope. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Handler as handle_feature_requests
    participant Gen as gap_analysis
    participant Store as upsert_feature_request
    participant DB as Database
    participant Entity as create_system_entity_logged
    Client->>Handler: GET /observe/evolution/feature-requests
    Handler->>Gen: generate_feature_requests(trajectory_entries)
    Gen-->>Handler: "Vec FeatureRequestRecord id=FR-sha256"
    loop for each generated feature request
        Handler->>Store: upsert_feature_request(id, ...)
        Store->>DB: INSERT ON CONFLICT DO NOTHING
        alt Row inserted
            DB-->>Store: "rows_affected=1"
            Store-->>Handler: Ok(true)
            Handler->>Entity: create_system_entity_logged once
        else Row existed
            DB-->>Store: "rows_affected=0"
            Store->>DB: UPDATE generator-owned columns only
            Store-->>Handler: Ok(false)
        end
    end
    Handler->>DB: list_feature_requests
    DB-->>Handler: rows
    Handler-->>Client: JSON response
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Handler as handle_feature_requests
    participant Gen as gap_analysis
    participant Store as upsert_feature_request
    participant DB as Database
    participant Entity as create_system_entity_logged
    Client->>Handler: GET /observe/evolution/feature-requests
    Handler->>Gen: generate_feature_requests(trajectory_entries)
    Gen-->>Handler: "Vec FeatureRequestRecord id=FR-sha256"
    loop for each generated feature request
        Handler->>Store: upsert_feature_request(id, ...)
        Store->>DB: INSERT ON CONFLICT DO NOTHING
        alt Row inserted
            DB-->>Store: "rows_affected=1"
            Store-->>Handler: Ok(true)
            Handler->>Entity: create_system_entity_logged once
        else Row existed
            DB-->>Store: "rows_affected=0"
            Store->>DB: UPDATE generator-owned columns only
            Store-->>Handler: Ok(false)
        end
    end
    Handler->>DB: list_feature_requests
    DB-->>Handler: rows
    Handler-->>Client: JSON response
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["docs(adr): record the tenant-scope and l..."](https://github.com/nerdsane/temper/commit/904e9af88319a856915668388ba938d454acfb76) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44292613)</sub>

<!-- /greptile_comment -->