### PR TITLE
fix(http_endpoint): git pack modules get a fuel floor, not a fixed ceiling

### DIFF
--- a/crates/temper-server/src/http_endpoint.rs
+++ b/crates/temper-server/src/http_endpoint.rs
@@ -28,11 +28,13 @@ use tokio::sync::RwLock;
 
 const ACTOR_ASK_TIMEOUT: Duration = Duration::from_millis(500);
 
-/// Fuel floor for git pack-transfer modules (upload-pack / receive-pack).
-/// Their instruction count scales with repo size, so these bulk-streaming
-/// modules are bounded by timeout and memory rather than a fixed instruction
-/// budget. 10T is ~100x the previous 100B manual override — effectively
-/// unbounded for any realistic pack while remaining a runaway safety bound.
+/// Fuel floor for the git upload-pack (clone/fetch) module. Pack emission's
+/// instruction count scales with the server's own repo size, so this
+/// bulk-streaming module is bounded by timeout and memory rather than a fixed
+/// instruction budget. 10T is ~100x the previous 100B manual override —
+/// effectively unbounded for any realistic pack while remaining a runaway
+/// safety bound. Not applied to receive-pack, whose input is client-controlled
+/// (see route_from_entity_fields).
 const GIT_PACK_FUEL_FLOOR: u64 = 10_000_000_000_000;
 
 /// One row of the table. Derived from an `HttpEndpoint` entity.
@@ -352,18 +354,23 @@ pub fn route_from_entity_fields(id: &str, fields: &serde_json::Value) -> Option<
     let git_pack_defaults =
         integration_module == "git_receive_pack" || integration_module == "git_upload_pack";
     let configured_fuel = obj.get("MaxFuel").and_then(|v| v.as_u64());
-    let max_fuel = if git_pack_defaults {
-        // Pack emission (upload-pack) and ingest (receive-pack) are bulk
-        // byte-streaming: their instruction count scales with repo size, so
-        // ANY fixed fuel ceiling silently truncates clones/pushes once a repo
-        // outgrows it — the recurring ARN-57/278/284 failure class (raise to
-        // 20B, then 100B, then it exhausts again). These are trusted internal
-        // modules bounded by timeout and memory, not instruction count.
-        // Enforce a floor so large-repo transfers don't fuel-exhaust; the
-        // endpoint's stored MaxFuel can only raise it further, never lower it.
+    let max_fuel = if integration_module == "git_upload_pack" {
+        // upload-pack (clone/fetch) is pure server-side pack EMISSION: the work
+        // is bounded by the server's own repo size, not by any client input.
+        // Its instruction count scales with repo size, so a fixed fuel ceiling
+        // silently truncates clones once a repo outgrows it — the recurring
+        // ARN-57/278/284 class (raised 20B -> 100B, then paw-agent exhausted
+        // 100B). Bounded instead by timeout and memory. Enforce a floor the
+        // stored MaxFuel can only raise further, never lower.
+        //
+        // Deliberately NOT applied to receive-pack (ingest): its input is a
+        // CLIENT-controlled pack and its endpoint runs unauthenticated ahead
+        // of the Cedar-gated IngestPack, so its tight fuel bound is what caps
+        // unauthenticated attacker-controlled work (PR #417 review finding).
         Some(configured_fuel.unwrap_or(0).max(GIT_PACK_FUEL_FLOOR))
     } else {
-        configured_fuel
+        // receive-pack keeps its existing 20B default when unset.
+        configured_fuel.or_else(|| git_pack_defaults.then_some(20_000_000_000))
     };
     let max_memory = obj
         .get("MaxMemory")
@@ -680,6 +687,18 @@ mod tests {
         });
         let r = route_from_entity_fields("he-other", &other).unwrap();
         assert_eq!(r.max_fuel, Some(5_000_000));
+
+        // receive-pack (client-controlled ingest input) is NOT floored: a
+        // stored value below the floor is kept, and an unset value defaults to
+        // 20B — its tight bound caps unauthenticated attacker-controlled work.
+        let recv = serde_json::json!({
+            "PathPrefix": "/{owner}/{repo}.git/git-receive-pack",
+            "Methods": "POST",
+            "IntegrationModule": "git_receive_pack",
+            "MaxFuel": 20_000_000_000u64,
+        });
+        let r = route_from_entity_fields("he-recv2", &recv).unwrap();
+        assert_eq!(r.max_fuel, Some(20_000_000_000));
     }
 
     #[tokio::test]
@@ -696,7 +715,9 @@ mod tests {
             "ActionBridgeResponse": "git-receive-pack",
         });
         let r = route_from_entity_fields("he-receive", &fields).unwrap();
-        assert_eq!(r.max_fuel, Some(GIT_PACK_FUEL_FLOOR));
+        // receive-pack (client-controlled ingest input) keeps its tight 20B
+        // default — the fuel floor applies only to upload-pack.
+        assert_eq!(r.max_fuel, Some(20_000_000_000));
         assert_eq!(r.max_memory, Some(512 * 1024 * 1024));
         assert_eq!(r.max_response_bytes, Some(128 * 1024 * 1024));
         let bridge = r.action_bridge.unwrap();

--- a/crates/temper-server/src/http_endpoint.rs
+++ b/crates/temper-server/src/http_endpoint.rs
@@ -28,6 +28,13 @@ use tokio::sync::RwLock;
 
 const ACTOR_ASK_TIMEOUT: Duration = Duration::from_millis(500);
 
+/// Fuel floor for git pack-transfer modules (upload-pack / receive-pack).
+/// Their instruction count scales with repo size, so these bulk-streaming
+/// modules are bounded by timeout and memory rather than a fixed instruction
+/// budget. 10T is ~100x the previous 100B manual override — effectively
+/// unbounded for any realistic pack while remaining a runaway safety bound.
+const GIT_PACK_FUEL_FLOOR: u64 = 10_000_000_000_000;
+
 /// One row of the table. Derived from an `HttpEndpoint` entity.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HttpEndpointRoute {
@@ -344,10 +351,20 @@ pub fn route_from_entity_fields(id: &str, fields: &serde_json::Value) -> Option<
         .unwrap_or(60);
     let git_pack_defaults =
         integration_module == "git_receive_pack" || integration_module == "git_upload_pack";
-    let max_fuel = obj
-        .get("MaxFuel")
-        .and_then(|v| v.as_u64())
-        .or_else(|| git_pack_defaults.then_some(20_000_000_000));
+    let configured_fuel = obj.get("MaxFuel").and_then(|v| v.as_u64());
+    let max_fuel = if git_pack_defaults {
+        // Pack emission (upload-pack) and ingest (receive-pack) are bulk
+        // byte-streaming: their instruction count scales with repo size, so
+        // ANY fixed fuel ceiling silently truncates clones/pushes once a repo
+        // outgrows it — the recurring ARN-57/278/284 failure class (raise to
+        // 20B, then 100B, then it exhausts again). These are trusted internal
+        // modules bounded by timeout and memory, not instruction count.
+        // Enforce a floor so large-repo transfers don't fuel-exhaust; the
+        // endpoint's stored MaxFuel can only raise it further, never lower it.
+        Some(configured_fuel.unwrap_or(0).max(GIT_PACK_FUEL_FLOOR))
+    } else {
+        configured_fuel
+    };
     let max_memory = obj
         .get("MaxMemory")
         .and_then(|v| v.as_u64())
@@ -634,10 +651,35 @@ mod tests {
         assert_eq!(r.integration_module, "git_upload_pack");
         assert!(r.requires_auth);
         assert_eq!(r.timeout_secs, 120);
-        assert_eq!(r.max_fuel, Some(20_000_000_000));
+        // Git pack modules are floor-raised: a stored 20B (below the floor)
+        // becomes the 10T git-pack floor so large transfers do not exhaust.
+        assert_eq!(r.max_fuel, Some(GIT_PACK_FUEL_FLOOR));
         assert_eq!(r.max_memory, Some(536_870_912));
         assert_eq!(r.max_response_bytes, Some(134_217_728));
         assert!(r.action_bridge.is_none());
+    }
+
+    #[tokio::test]
+    async fn git_pack_fuel_floor_can_be_raised_but_not_lowered() {
+        // A stored value above the floor is preserved (floor only raises).
+        let high = serde_json::json!({
+            "PathPrefix": "/{owner}/{repo}.git/git-upload-pack",
+            "Methods": "POST",
+            "IntegrationModule": "git_upload_pack",
+            "MaxFuel": 50_000_000_000_000u64,
+        });
+        let r = route_from_entity_fields("he-high", &high).unwrap();
+        assert_eq!(r.max_fuel, Some(50_000_000_000_000));
+
+        // A non-git module's explicit fuel is untouched by the floor.
+        let other = serde_json::json!({
+            "PathPrefix": "/api/thing",
+            "Methods": "POST",
+            "IntegrationModule": "some_other_module",
+            "MaxFuel": 5_000_000u64,
+        });
+        let r = route_from_entity_fields("he-other", &other).unwrap();
+        assert_eq!(r.max_fuel, Some(5_000_000));
     }
 
     #[tokio::test]
@@ -654,7 +696,7 @@ mod tests {
             "ActionBridgeResponse": "git-receive-pack",
         });
         let r = route_from_entity_fields("he-receive", &fields).unwrap();
-        assert_eq!(r.max_fuel, Some(20_000_000_000));
+        assert_eq!(r.max_fuel, Some(GIT_PACK_FUEL_FLOOR));
         assert_eq!(r.max_memory, Some(512 * 1024 * 1024));
         assert_eq!(r.max_response_bytes, Some(128 * 1024 * 1024));
         let bridge = r.action_bridge.unwrap();


### PR DESCRIPTION
## Problem

`git_upload_pack` / `git_receive_pack` run as WASM integrations with a fixed `MaxFuel`. Pack emission and ingest are **bulk byte-streaming** — instruction count scales with repo size — so any fixed fuel ceiling silently truncates clones/pushes once a repo outgrows it. This is the recurring **ARN-57 / ARN-278 / ARN-284** class: the budget was raised 20B → 100B, and `temperpaw/paw-agent` now exhausts even 100B on clone:

```
git-upload-pack ... fuel exhausted -- module exceeded instruction budget
```

(confirmed in production Genesis logs; clone dies with `invalid index-pack output / early EOF`). The persisted endpoint entity can't be PATCHed without admin scope, and a redeploy won't reset it — so raising it per-repo isn't a durable fix.

## Fix

git pack modules are trusted internal modules bounded by **timeout (300s)** and **memory (512MB)**, not instruction count. Give them `GIT_PACK_FUEL_FLOOR = 10T` that the stored `MaxFuel` can only **raise**, never lower. ~100x the last override — effectively unbounded for any realistic pack, still a runaway safety bound. Non-git endpoints are unaffected.

## Tests

- Existing git-module fuel assertions updated to the floor.
- Added: a stored value above the floor is preserved; a non-git module's explicit fuel is untouched.
- `cargo test -p temper-server --lib http_endpoint` → 21 passed.

Deploy: merge → bump the genesis submodule temper pin → redeploy genesis → verify paw-agent clone succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vw8tCkfnUW8p149yUNfSEE

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR revises the git pack fuel fix so only `git_upload_pack` receives a 10T minimum fuel budget, while preserving the tighter limit for client-controlled `git_receive_pack`.
- Applies the fuel floor only to clone/fetch pack emission.
- Preserves configured upload-pack budgets above the floor.
- Keeps receive-pack and non-git endpoint fuel behavior unchanged.
- Adds regression coverage for lower, higher, and unaffected configured budgets.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the previously identified receive-pack resource-boundary issue is addressed and no blocking failure remains.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/temper-server/src/http_endpoint.rs | Separates upload-pack and receive-pack fuel handling, resolving the prior concern by retaining receive-pack’s bounded 20B budget while floor-raising upload-pack. |

</details>

<sub>Reviews (2): Last reviewed commit: ["review(#417): scope the fuel floor to up..."](https://github.com/nerdsane/temper/commit/97ea7418a0ba48a657932d809f264f5c446cb983) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52674351)</sub>

<!-- /greptile_comment -->