### PR TITLE
fix(kernel): name Cedar policies in denials, close policy/actor-directory races

### DIFF
--- a/crates/temper-authz/src/engine/engine_test.rs
+++ b/crates/temper-authz/src/engine/engine_test.rs
@@ -700,16 +700,203 @@ fn test_named_policies_produce_meaningful_ids() {
 
     // Check that the denial includes meaningful policy IDs.
     if let AuthzDecision::Deny(AuthzDenial::PolicyDenied { policy_ids }) = &decision {
-        // Should contain something like "default:decision:abc" not "policy0".
+        // Should name the source, e.g. "decision:abc#1", never "policy0".
         let has_meaningful = policy_ids
             .iter()
-            .any(|id| id.contains("default:") || id.contains("decision:"));
+            .any(|id| id.starts_with("os-app:pm#") || id.starts_with("decision:abc#"));
         assert!(
             has_meaningful,
             "policy IDs should be meaningful, got: {policy_ids:?}"
         );
     }
     // NoMatchingPermit is also acceptable since user-1 != bot-1
+}
+
+#[test]
+fn denial_names_the_cedar_file_a_statement_came_from() {
+    // ARN-286: the rendered denial must point a human at a file and at the
+    // statement inside it, not at a positional id like "policy1874".
+    let engine = AuthzEngine::empty();
+
+    engine
+        .reload_tenant_policies_named(
+            "katagami",
+            &[(
+                "katagami-commons/art_style.cedar".to_string(),
+                concat!(
+                    "permit(principal is Customer, action == Action::\"read\", resource is ArtStyle);\n",
+                    "forbid(principal is Customer, action == Action::\"update\", resource is ArtStyle);\n",
+                )
+                .to_string(),
+            )],
+        )
+        .unwrap();
+
+    let ctx = customer_context("user-1");
+    let mut attrs = HashMap::new();
+    attrs.insert("id".to_string(), serde_json::json!("as-1"));
+
+    let decision = engine.authorize_for_tenant("katagami", &ctx, "update", "ArtStyle", &attrs);
+    let AuthzDecision::Deny(denial) = decision else {
+        panic!("forbid statement should deny the update");
+    };
+
+    assert_eq!(
+        denial.to_string(),
+        "denied by policy: katagami-commons/art_style.cedar#2",
+        "the denial must name the source file and the statement within it"
+    );
+}
+
+#[test]
+fn named_policy_ids_are_stable_when_a_sibling_statement_is_added() {
+    // Every statement carries a "#n" suffix, including the only statement in a
+    // one-statement file, so adding a second statement later does not silently
+    // change what an already-reported id refers to.
+    let engine = AuthzEngine::empty();
+    engine
+        .reload_tenant_policies_named(
+            "t",
+            &[(
+                "app/only.cedar".to_string(),
+                r#"forbid(principal is Customer, action == Action::"read", resource is Doc);"#
+                    .to_string(),
+            )],
+        )
+        .unwrap();
+
+    let ctx = customer_context("user-1");
+    let mut attrs = HashMap::new();
+    attrs.insert("id".to_string(), serde_json::json!("d-1"));
+
+    let decision = engine.authorize_for_tenant("t", &ctx, "read", "Doc", &attrs);
+    let AuthzDecision::Deny(AuthzDenial::PolicyDenied { policy_ids }) = decision else {
+        panic!("expected a policy denial");
+    };
+    assert_eq!(policy_ids, vec!["app/only.cedar#1".to_string()]);
+}
+
+#[test]
+fn adding_one_policy_keeps_the_labels_of_the_others() {
+    // Approving a governance decision adds a policy. It must not flatten the
+    // tenant back to positional ids for everything else (ARN-286).
+    let engine = AuthzEngine::empty();
+    engine
+        .reload_tenant_policies_named(
+            "katagami",
+            &[(
+                "katagami-commons/art_style.cedar".to_string(),
+                concat!(
+                    "permit(principal is Customer, action == Action::\"read\", resource is ArtStyle);\n",
+                    "forbid(principal is Customer, action == Action::\"update\", resource is ArtStyle);\n",
+                )
+                .to_string(),
+            )],
+        )
+        .unwrap();
+
+    engine
+        .upsert_tenant_policy_source(
+            "katagami",
+            "katagami/generated/GD-1.cedar",
+            r#"permit(principal is Customer, action == Action::"list", resource is ArtStyle);"#,
+        )
+        .unwrap();
+
+    let ctx = customer_context("user-1");
+    let mut attrs = HashMap::new();
+    attrs.insert("id".to_string(), serde_json::json!("as-1"));
+
+    // The generated policy took effect...
+    assert!(
+        engine
+            .authorize_for_tenant("katagami", &ctx, "list", "ArtStyle", &attrs)
+            .is_allowed()
+    );
+
+    // ...and the pre-existing file still names itself in a denial.
+    let decision = engine.authorize_for_tenant("katagami", &ctx, "update", "ArtStyle", &attrs);
+    let AuthzDecision::Deny(denial) = decision else {
+        panic!("forbid statement should still deny the update");
+    };
+    assert_eq!(
+        denial.to_string(),
+        "denied by policy: katagami-commons/art_style.cedar#2"
+    );
+}
+
+#[test]
+fn adding_a_policy_to_a_blob_loaded_tenant_labels_the_blob_once() {
+    let engine = AuthzEngine::empty();
+    engine
+        .reload_tenant_policies(
+            "blobby",
+            r#"forbid(principal is Customer, action == Action::"read", resource is Doc);"#,
+        )
+        .unwrap();
+
+    engine
+        .upsert_tenant_policy_source(
+            "blobby",
+            "blobby/generated/GD-1.cedar",
+            r#"permit(principal is Customer, action == Action::"list", resource is Doc);"#,
+        )
+        .unwrap();
+
+    let labels: Vec<String> = engine
+        .tenant_policy_sources("blobby")
+        .into_iter()
+        .map(|(label, _)| label)
+        .collect();
+    assert_eq!(
+        labels,
+        vec![
+            unlabelled_source_label("blobby"),
+            "blobby/generated/GD-1.cedar".to_string()
+        ]
+    );
+
+    // The blob's statements still apply, now under a label that says where
+    // they came from.
+    let ctx = customer_context("user-1");
+    let mut attrs = HashMap::new();
+    attrs.insert("id".to_string(), serde_json::json!("d-1"));
+    let decision = engine.authorize_for_tenant("blobby", &ctx, "read", "Doc", &attrs);
+    let AuthzDecision::Deny(AuthzDenial::PolicyDenied { policy_ids }) = decision else {
+        panic!("expected the blob's forbid to still deny");
+    };
+    assert_eq!(
+        policy_ids,
+        vec![format!("{}#1", unlabelled_source_label("blobby"))]
+    );
+}
+
+#[test]
+fn labelled_sources_are_readable_back_for_rebuilds() {
+    let engine = AuthzEngine::empty();
+    let sources = vec![
+        (
+            "katagami-commons/art_style.cedar".to_string(),
+            r#"permit(principal is Customer, action == Action::"read", resource is ArtStyle);"#
+                .to_string(),
+        ),
+        (
+            "katagami-curation/review.cedar".to_string(),
+            r#"permit(principal is Customer, action == Action::"read", resource is Review);"#
+                .to_string(),
+        ),
+    ];
+    engine
+        .reload_tenant_policies_named("katagami", &sources)
+        .unwrap();
+
+    assert_eq!(engine.tenant_policy_sources("katagami"), sources);
+
+    // An unlabelled blob reload reports no sources rather than inventing one.
+    engine
+        .reload_tenant_policies("blobby", "permit(principal, action, resource);")
+        .unwrap();
+    assert!(engine.tenant_policy_sources("blobby").is_empty());
 }
 
 #[test]
@@ -754,9 +941,141 @@ fn candidate_filter_preserves_named_forbid_policy_ids() {
     };
 
     assert!(
-        policy_ids
-            .iter()
-            .any(|id| id == "default:decision:block-issue-1"),
+        policy_ids.iter().any(|id| id == "decision:block-issue-1#1"),
         "candidate filtering must preserve named policy diagnostics, got: {policy_ids:?}"
     );
+}
+
+/// Two policy applications that overlap in time must both survive.
+///
+/// The regression: `upsert_tenant_policy_source` used to read the tenant's
+/// sources under a read lock, mutate a local `Vec`, then reload under a write
+/// lock. A reads, B reads, A writes, B writes — A's policy is gone and both
+/// calls returned `Ok`. Here the first writer is parked *inside* the
+/// critical section while the second runs start to finish, so a non-atomic
+/// sequence loses one of them every run rather than occasionally.
+#[test]
+fn concurrent_policy_upserts_do_not_lose_each_other() {
+    use std::sync::Arc;
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    let engine = Arc::new(AuthzEngine::empty());
+    engine
+        .reload_tenant_policies_named(
+            "katagami",
+            &[(
+                "katagami-commons/art_style.cedar".to_string(),
+                r#"permit(principal is Customer, action == Action::"read", resource is ArtStyle);"#
+                    .to_string(),
+            )],
+        )
+        .unwrap();
+
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let slow_writer = {
+        let engine = Arc::clone(&engine);
+        std::thread::spawn(move || {
+            engine
+                .update_tenant_policy_sources("katagami", move |mut sources| {
+                    entered_tx.send(()).unwrap();
+                    // Hold the critical section open long enough for the other
+                    // writer to complete if nothing is serializing them.
+                    std::thread::sleep(Duration::from_millis(300));
+                    sources.push((
+                        "katagami/generated/GD-slow.cedar".to_string(),
+                        r#"permit(principal is Customer, action == Action::"list", resource is ArtStyle);"#
+                            .to_string(),
+                    ));
+                    sources
+                })
+                .unwrap();
+        })
+    };
+
+    entered_rx.recv().unwrap();
+    engine
+        .upsert_tenant_policy_source(
+            "katagami",
+            "katagami/generated/GD-fast.cedar",
+            r#"permit(principal is Customer, action == Action::"create", resource is ArtStyle);"#,
+        )
+        .unwrap();
+    slow_writer.join().unwrap();
+
+    let labels: Vec<String> = engine
+        .tenant_policy_sources("katagami")
+        .into_iter()
+        .map(|(label, _)| label)
+        .collect();
+    assert!(
+        labels.contains(&"katagami-commons/art_style.cedar".to_string()),
+        "the pre-existing app policy must survive both upserts, got: {labels:?}"
+    );
+    assert!(
+        labels.contains(&"katagami/generated/GD-slow.cedar".to_string()),
+        "the parked writer's policy must survive, got: {labels:?}"
+    );
+    assert!(
+        labels.contains(&"katagami/generated/GD-fast.cedar".to_string()),
+        "the concurrent writer's policy must survive, got: {labels:?}"
+    );
+
+    // Both generated policies are actually in effect, not merely recorded.
+    let ctx = customer_context("user-1");
+    let mut attrs = HashMap::new();
+    attrs.insert("id".to_string(), serde_json::json!("as-1"));
+    for action in ["read", "list", "create"] {
+        assert!(
+            engine
+                .authorize_for_tenant("katagami", &ctx, action, "ArtStyle", &attrs)
+                .is_allowed(),
+            "action '{action}' should be permitted after both upserts"
+        );
+    }
+}
+
+/// The same guarantee under real contention: every writer's policy is present
+/// once all of them have returned.
+#[test]
+fn every_racing_policy_upsert_is_retained() {
+    use std::sync::{Arc, Barrier};
+
+    const WRITERS: usize = 8;
+
+    let engine = Arc::new(AuthzEngine::empty());
+    let barrier = Arc::new(Barrier::new(WRITERS));
+    let writers: Vec<_> = (0..WRITERS)
+        .map(|i| {
+            let engine = Arc::clone(&engine);
+            let barrier = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                barrier.wait();
+                engine
+                    .upsert_tenant_policy_source(
+                        "katagami",
+                        &format!("katagami/generated/GD-{i}.cedar"),
+                        &format!(
+                            r#"permit(principal is Customer, action == Action::"read", resource == ArtStyle::"as-{i}");"#
+                        ),
+                    )
+                    .unwrap();
+            })
+        })
+        .collect();
+    for writer in writers {
+        writer.join().unwrap();
+    }
+
+    let labels: Vec<String> = engine
+        .tenant_policy_sources("katagami")
+        .into_iter()
+        .map(|(label, _)| label)
+        .collect();
+    for i in 0..WRITERS {
+        assert!(
+            labels.contains(&format!("katagami/generated/GD-{i}.cedar")),
+            "writer {i}'s policy was lost, got: {labels:?}"
+        );
+    }
 }

--- a/crates/temper-authz/src/engine/mod.rs
+++ b/crates/temper-authz/src/engine/mod.rs
@@ -10,8 +10,8 @@ use std::sync::RwLock;
 use std::time::Instant;
 
 use cedar_policy::{
-    Authorizer, Context, Decision, Entities, Entity, EntityUid, Policy, PolicyId, PolicySet,
-    Request, Response as CedarResponse,
+    Authorizer, Context, Decision, Entities, Entity, EntityUid, PolicyId, PolicySet, Request,
+    Response as CedarResponse,
 };
 
 use crate::context::{PrincipalKind, SecurityContext};
@@ -21,6 +21,7 @@ use crate::metrics::{CedarDecisionMetric, CedarPhaseOutcome};
 mod candidates;
 
 #[cfg(test)]
+#[path = "engine_test.rs"]
 mod tests;
 
 /// The result of an authorization check.
@@ -71,10 +72,103 @@ impl CompiledPolicies {
     }
 }
 
+/// A labelled chunk of Cedar policy text: `(label, cedar_text)`.
+///
+/// The label names where the text came from — `"katagami-commons/art_style.cedar"`
+/// — and becomes the prefix of every `PolicyId` parsed out of it, so a denial
+/// reads `denied by policy: katagami-commons/art_style.cedar#2` instead of
+/// `policy1874`. See [`policy_statement_id`].
+pub type PolicySource = (String, String);
+
+/// Build the `PolicyId` for the `index`-th statement (0-based) of `label`.
+///
+/// Rendered as `"{label}#{n}"` with `n` 1-based, so `#2` names the second
+/// `permit`/`forbid` statement in the file a human would open. Every statement
+/// is suffixed, including the only one in a single-statement file, so an
+/// existing id does not shift meaning when a sibling statement is added.
+fn policy_statement_id(label: &str, index: usize) -> PolicyId {
+    PolicyId::new(format!("{label}#{}", index + 1))
+}
+
+/// Label for a tenant's carried-over unlabelled policy blob.
+///
+/// Statements inside it are still positional, but the id at least says they
+/// came from the tenant blob rather than a named file. The label disappears
+/// once the apps owning those statements have been loaded from labelled
+/// sources. Every caller that carries a blob forward uses this one label, so a
+/// tenant never accumulates two differently-named copies of the same text.
+pub fn unlabelled_source_label(tenant: &str) -> String {
+    format!("{tenant}:unlabelled")
+}
+
 /// Per-tenant policy data: the compiled policies and the source text.
 struct TenantPolicies {
     policies: CompiledPolicies,
     source_text: String,
+    /// The labelled sources this policy set was built from, in load order.
+    /// Empty when the tenant was loaded from an unlabelled blob via
+    /// [`AuthzEngine::reload_tenant_policies`]. Callers that rebuild a
+    /// tenant's policy set — an os-app install, say — read this back so
+    /// provenance established by earlier loads is not flattened away.
+    sources: Vec<PolicySource>,
+}
+
+/// Compile labelled sources into a tenant's policy set.
+///
+/// Each `(label, cedar_text)` pair is parsed on its own and every statement it
+/// contains is re-keyed to `"{label}#{n}"` (`n` 1-based) — see
+/// [`AuthzEngine::reload_tenant_policies_named`] for why the labels matter.
+///
+/// Takes no locks, so a caller holding the tenant write lock across a
+/// read-modify-write can compile inside that critical section.
+fn compile_tenant_policies(policies: &[PolicySource]) -> Result<TenantPolicies, AuthzError> {
+    let mut combined_set = PolicySet::new();
+    let mut combined_text = String::new();
+
+    for (label, cedar_text) in policies {
+        // Parse each entry's Cedar text individually.
+        let entry_set: PolicySet = cedar_text
+            .parse()
+            .map_err(|e| AuthzError::PolicyParse(format!("{label}: {e}")))?;
+
+        // Re-add each statement under an id that names its source.
+        for (idx, policy) in entry_set.policies().enumerate() {
+            let named = policy.clone().new_id(policy_statement_id(label, idx));
+            combined_set
+                .add(named)
+                .map_err(|e| AuthzError::PolicyParse(format!("{label}: {e}")))?;
+        }
+
+        if !combined_text.is_empty() {
+            combined_text.push('\n');
+        }
+        combined_text.push_str(cedar_text);
+    }
+
+    merge_system_platform_policy(&mut combined_set);
+
+    Ok(TenantPolicies {
+        policies: CompiledPolicies::new(combined_set),
+        source_text: combined_text,
+        sources: policies.to_vec(),
+    })
+}
+
+/// A tenant's labelled sources, or its unlabelled blob as a single entry.
+///
+/// Takes the tenant's entry rather than the engine so it can be called with
+/// the tenant lock already held.
+fn tenant_sources_or_blob(tenant: &str, existing: Option<&TenantPolicies>) -> Vec<PolicySource> {
+    let Some(tp) = existing else {
+        return Vec::new();
+    };
+    if !tp.sources.is_empty() {
+        return tp.sources.clone();
+    }
+    if tp.source_text.trim().is_empty() {
+        return Vec::new();
+    }
+    vec![(unlabelled_source_label(tenant), tp.source_text.clone())]
 }
 
 /// The authorization engine. Holds per-tenant compiled Cedar policies and
@@ -165,74 +259,124 @@ impl AuthzEngine {
             TenantPolicies {
                 policies: CompiledPolicies::new(new_policy_set),
                 source_text: policy_text.to_string(),
+                sources: Vec::new(),
             },
         );
         Ok(())
     }
 
-    /// Hot-reload Cedar policies for a tenant from individually named policy
-    /// entries. Each `(policy_id, cedar_text)` pair is parsed individually and
-    /// assigned a meaningful `PolicyId` of the form `"{tenant}:{policy_id}"`.
+    /// Hot-reload Cedar policies for a tenant from labelled sources.
     ///
-    /// Multiple permit/forbid statements in one `cedar_text` are suffixed:
-    /// `"{tenant}:{policy_id}:0"`, `":1"`, etc.
+    /// Each `(label, cedar_text)` pair is parsed on its own and every statement
+    /// it contains is re-keyed to `"{label}#{n}"` (`n` 1-based). Labelling the
+    /// source is the whole point: Cedar names policies positionally within
+    /// whatever text it was handed, so a concatenated tenant blob yields ids
+    /// like `policy1874` that map back to nothing, and a denial diagnostic
+    /// becomes unreadable (ARN-286). With a `"{app}/{file}.cedar"` label the
+    /// same denial reads `denied by policy: katagami-commons/art_style.cedar#2`.
     ///
-    /// This enables meaningful policy IDs in denial diagnostics instead of
-    /// auto-generated names like `"policy0"`.
+    /// The labelled sources are retained so a later caller can rebuild the
+    /// tenant's set without losing provenance — see [`tenant_policy_sources`](Self::tenant_policy_sources).
     pub fn reload_tenant_policies_named(
         &self,
         tenant: &str,
-        policies: &[(String, String)], // (policy_id, cedar_text)
+        policies: &[PolicySource],
     ) -> Result<(), AuthzError> {
-        let mut combined_set = PolicySet::new();
-        let mut combined_text = String::new();
-
-        for (policy_id, cedar_text) in policies {
-            // Parse each entry's Cedar text individually.
-            let entry_set: PolicySet = cedar_text
-                .parse()
-                .map_err(|e| AuthzError::PolicyParse(format!("{policy_id}: {e}")))?;
-
-            // Re-add each policy with a meaningful PolicyId.
-            let entry_policies: Vec<Policy> = entry_set.policies().cloned().collect();
-            if entry_policies.len() == 1 {
-                let named = entry_policies
-                    .into_iter()
-                    .next()
-                    .unwrap() // ci-ok: checked len == 1
-                    .new_id(PolicyId::new(format!("{tenant}:{policy_id}")));
-                combined_set
-                    .add(named)
-                    .map_err(|e| AuthzError::PolicyParse(e.to_string()))?;
-            } else {
-                for (idx, p) in entry_policies.into_iter().enumerate() {
-                    let named = p.new_id(PolicyId::new(format!("{tenant}:{policy_id}:{idx}")));
-                    combined_set
-                        .add(named)
-                        .map_err(|e| AuthzError::PolicyParse(e.to_string()))?;
-                }
-            }
-
-            if !combined_text.is_empty() {
-                combined_text.push('\n');
-            }
-            combined_text.push_str(cedar_text);
-        }
-
-        merge_system_platform_policy(&mut combined_set);
+        let compiled = compile_tenant_policies(policies)?;
 
         let mut tenants = self
             .tenant_policies
             .write()
             .map_err(|e| AuthzError::Engine(format!("tenant policy lock poisoned: {e}")))?;
 
-        tenants.insert(
-            tenant.to_string(),
-            TenantPolicies {
-                policies: CompiledPolicies::new(combined_set),
-                source_text: combined_text,
-            },
-        );
+        tenants.insert(tenant.to_string(), compiled);
+        Ok(())
+    }
+
+    /// The labelled policy sources currently active for a tenant, in load
+    /// order.
+    ///
+    /// Empty when the tenant's policies were loaded from an unlabelled blob.
+    /// Callers rebuilding a tenant's policy set start from this so labels
+    /// contributed by earlier loads survive.
+    pub fn tenant_policy_sources(&self, tenant: &str) -> Vec<PolicySource> {
+        self.tenant_policies
+            .read()
+            .ok()
+            .and_then(|t| t.get(tenant).map(|tp| tp.sources.clone()))
+            .unwrap_or_default()
+    }
+
+    /// Rebuild a tenant's labelled policy sources under a single lock.
+    ///
+    /// `update` receives the sources currently active for the tenant — or its
+    /// unlabelled blob as one entry — and returns the set to install. Reading
+    /// the current sources, applying `update`, compiling the result and
+    /// swapping it in all happen while this call holds the tenant write lock,
+    /// so two concurrent rebuilds serialize. Splitting that into a read
+    /// followed by a separate [`reload_tenant_policies_named`](Self::reload_tenant_policies_named)
+    /// loses updates: both callers read the same pre-state, both write, and
+    /// the first caller's policies are gone while both calls returned `Ok`.
+    ///
+    /// Returns the tenant's combined policy text as installed, so a caller
+    /// mirroring that text into a cache writes what the engine actually holds
+    /// rather than what it computed before the merge.
+    ///
+    /// `update` runs with the tenant lock held, so it must not call back into
+    /// this engine — [`get_tenant_policy_text`](Self::get_tenant_policy_text),
+    /// [`tenant_policy_sources`](Self::tenant_policy_sources) or another
+    /// update would deadlock. Read anything it needs from the engine before
+    /// calling. Cedar compilation also happens under the lock, so a tenant
+    /// with a large policy set has its authorization requests briefly queued
+    /// behind a rebuild; that is the cost of the sequence being atomic.
+    ///
+    /// If the updated sources do not parse, the tenant keeps the policies it
+    /// had.
+    pub fn update_tenant_policy_sources<F>(
+        &self,
+        tenant: &str,
+        update: F,
+    ) -> Result<String, AuthzError>
+    where
+        F: FnOnce(Vec<PolicySource>) -> Vec<PolicySource>,
+    {
+        let mut tenants = self
+            .tenant_policies
+            .write()
+            .map_err(|e| AuthzError::Engine(format!("tenant policy lock poisoned: {e}")))?;
+
+        let current = tenant_sources_or_blob(tenant, tenants.get(tenant));
+        let updated = update(current);
+        // Compile before touching the map: a parse failure leaves the tenant
+        // on the policies it already had.
+        let compiled = compile_tenant_policies(&updated)?;
+        let policy_text = compiled.source_text.clone();
+        tenants.insert(tenant.to_string(), compiled);
+        Ok(policy_text)
+    }
+
+    /// Add or replace a single labelled policy source and reload the tenant.
+    ///
+    /// For paths that contribute one policy to a tenant that already has some
+    /// — generating a policy from an approved governance decision, say.
+    /// Sources already loaded keep their labels, so adding a policy does not
+    /// flatten a tenant back to positional `policy1874` ids (ARN-286). If the
+    /// new text does not parse, the tenant's existing policies stay in effect.
+    ///
+    /// Atomic: two policies upserted concurrently both survive.
+    pub fn upsert_tenant_policy_source(
+        &self,
+        tenant: &str,
+        label: &str,
+        cedar_text: &str,
+    ) -> Result<(), AuthzError> {
+        self.update_tenant_policy_sources(tenant, |mut sources| {
+            match sources.iter_mut().find(|(existing, _)| existing == label) {
+                Some(entry) => entry.1 = cedar_text.to_string(),
+                None => sources.push((label.to_string(), cedar_text.to_string())),
+            }
+            sources
+        })?;
         Ok(())
     }
 

--- a/crates/temper-authz/src/error.rs
+++ b/crates/temper-authz/src/error.rs
@@ -47,6 +47,59 @@ pub enum AuthzDenial {
     EngineError(String),
 }
 
+/// What kind of thing an [`AuthzDenial`] actually is.
+///
+/// Only [`DenialClass::Policy`] is an authorization *decision*. The other two
+/// are faults: the request never became a well-formed Cedar question, or the
+/// engine failed while answering it. Callers use this to pick an HTTP status
+/// and — critically — to decide whether the denial belongs in the human
+/// approval queue. Recording a fault as a pending decision produces a row
+/// nobody can ever approve, because no policy change can make it allow
+/// (ARN-287).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DenialClass {
+    /// Cedar evaluated the request and refused it. Reviewable by a human and
+    /// fixable by a policy change.
+    Policy,
+    /// The request could not be turned into a Cedar question — malformed
+    /// principal, action, resource, or context. The caller must fix the
+    /// request.
+    RequestFault,
+    /// The authorization engine itself failed (poisoned lock, entity store
+    /// construction failure). Nothing about the request is wrong.
+    EngineFault,
+}
+
+impl AuthzDenial {
+    /// Classify this denial as a policy decision, a request fault, or an
+    /// engine fault.
+    pub fn class(&self) -> DenialClass {
+        match self {
+            AuthzDenial::PolicyDenied { .. } | AuthzDenial::NoMatchingPermit => DenialClass::Policy,
+            AuthzDenial::InvalidPrincipal(_)
+            | AuthzDenial::InvalidAction(_)
+            | AuthzDenial::InvalidResource(_)
+            | AuthzDenial::InvalidContext(_) => DenialClass::RequestFault,
+            AuthzDenial::EngineError(_) => DenialClass::EngineFault,
+        }
+    }
+
+    /// Whether this denial is a real policy decision — the only kind that may
+    /// be recorded as a pending decision for human approval.
+    pub fn is_policy_decision(&self) -> bool {
+        self.class() == DenialClass::Policy
+    }
+
+    /// Stable machine-readable error code for API error bodies.
+    pub fn error_code(&self) -> &'static str {
+        match self.class() {
+            DenialClass::Policy => "AuthorizationDenied",
+            DenialClass::RequestFault => "InvalidAuthorizationRequest",
+            DenialClass::EngineFault => "AuthorizationEngineError",
+        }
+    }
+}
+
 impl std::fmt::Display for AuthzDenial {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -148,6 +201,45 @@ mod tests {
             AuthzDenial::EngineError("crash".into()).to_string(),
             "authorization engine error: crash"
         );
+    }
+
+    #[test]
+    fn policy_outcomes_are_decisions() {
+        for denial in [
+            AuthzDenial::PolicyDenied {
+                policy_ids: vec!["katagami-commons/art_style.cedar#2".into()],
+            },
+            AuthzDenial::NoMatchingPermit,
+        ] {
+            assert_eq!(denial.class(), DenialClass::Policy, "{denial}");
+            assert!(denial.is_policy_decision(), "{denial}");
+            assert_eq!(denial.error_code(), "AuthorizationDenied");
+        }
+    }
+
+    #[test]
+    fn malformed_requests_are_faults_not_decisions() {
+        for denial in [
+            AuthzDenial::InvalidPrincipal("bad".into()),
+            AuthzDenial::InvalidAction("bad".into()),
+            AuthzDenial::InvalidResource("unexpected token `fl`".into()),
+            AuthzDenial::InvalidContext("bad".into()),
+        ] {
+            assert_eq!(denial.class(), DenialClass::RequestFault, "{denial}");
+            assert!(
+                !denial.is_policy_decision(),
+                "{denial} must never reach the approval queue"
+            );
+            assert_eq!(denial.error_code(), "InvalidAuthorizationRequest");
+        }
+    }
+
+    #[test]
+    fn engine_failures_are_faults_not_decisions() {
+        let denial = AuthzDenial::EngineError("policy lock poisoned".into());
+        assert_eq!(denial.class(), DenialClass::EngineFault);
+        assert!(!denial.is_policy_decision());
+        assert_eq!(denial.error_code(), "AuthorizationEngineError");
     }
 
     #[test]

--- a/crates/temper-authz/src/lib.rs
+++ b/crates/temper-authz/src/lib.rs
@@ -11,8 +11,8 @@ mod metrics;
 mod policy_gen;
 
 pub use context::{Principal, PrincipalKind, SecurityContext};
-pub use engine::{AuthzDecision, AuthzEngine};
-pub use error::{AuthzDenial, AuthzError};
+pub use engine::{AuthzDecision, AuthzEngine, PolicySource, unlabelled_source_label};
+pub use error::{AuthzDenial, AuthzError, DenialClass};
 pub use metrics::init_metrics;
 pub use policy_gen::{
     ActionScope, DurationScope, PolicyScopeMatrix, PrincipalScope, ResourceScope,

--- a/crates/temper-odata/src/path.rs
+++ b/crates/temper-odata/src/path.rs
@@ -334,15 +334,38 @@ fn parse_function_params(args_str: &str) -> Result<Vec<(String, String)>, ODataE
     Ok(params)
 }
 
+/// String delimiters recognised around a key literal.
+///
+/// OData spells string keys with single quotes (`'abc'`). Clients that borrow
+/// JSON habits emit double quotes (`"abc"`) instead, so both are recognised —
+/// see [`parse_key_literal`] for why the delimiter must never survive parsing.
+const KEY_DELIMITERS: [char; 2] = ['\'', '"'];
+
+fn is_key_delimiter(ch: char) -> bool {
+    KEY_DELIMITERS.contains(&ch)
+}
+
+/// Track whether the scanner is inside a quoted literal.
+///
+/// Only the delimiter that opened the literal closes it, so a double quote
+/// inside `'it"s'` is ordinary text rather than a state change.
+fn step_quote_state(open: Option<char>, ch: char) -> Option<char> {
+    match open {
+        Some(delim) if ch == delim => None,
+        Some(delim) => Some(delim),
+        None if is_key_delimiter(ch) => Some(ch),
+        None => None,
+    }
+}
+
 /// Check if a key expression is a composite key (has `=` outside quotes).
 fn is_composite_key(s: &str) -> bool {
-    let mut in_quotes = false;
+    let mut open: Option<char> = None;
     for ch in s.chars() {
-        match ch {
-            '\'' => in_quotes = !in_quotes,
-            '=' if !in_quotes => return true,
-            _ => {}
+        if ch == '=' && open.is_none() {
+            return true;
         }
+        open = step_quote_state(open, ch);
     }
     false
 }
@@ -351,24 +374,18 @@ fn is_composite_key(s: &str) -> bool {
 fn split_composite_key(s: &str) -> Result<Vec<String>, ODataError> {
     let mut parts = Vec::new();
     let mut current = String::new();
-    let mut in_quotes = false;
+    let mut open: Option<char> = None;
 
     for ch in s.chars() {
-        match ch {
-            '\'' => {
-                in_quotes = !in_quotes;
-                current.push(ch);
-            }
-            ',' if !in_quotes => {
-                parts.push(std::mem::take(&mut current));
-            }
-            _ => {
-                current.push(ch);
-            }
+        if ch == ',' && open.is_none() {
+            parts.push(std::mem::take(&mut current));
+            continue;
         }
+        open = step_quote_state(open, ch);
+        current.push(ch);
     }
 
-    if in_quotes {
+    if open.is_some() {
         return Err(ODataError::InvalidPath {
             message: "unmatched quote in key value".into(),
         });
@@ -381,43 +398,52 @@ fn split_composite_key(s: &str) -> Result<Vec<String>, ODataError> {
     Ok(parts)
 }
 
-/// Parse an OData key literal, unquoting single-quoted strings.
+/// Parse an OData key literal, stripping the string delimiters.
 ///
-/// Per OData v4 (ABNF `string` rule), a single quote inside a quoted
-/// literal is escaped by doubling it: `'abc''123'` denotes the value
-/// `abc'123`. A bare (un-doubled) quote inside the literal, trailing
-/// text after the closing quote, and an unterminated literal are all
-/// parse errors. Unquoted literals (integers, GUIDs) are returned
-/// unchanged but must not contain quote characters.
+/// Per OData v4 (ABNF `string` rule), a single quote inside a quoted literal
+/// is escaped by doubling it: `'abc''123'` denotes the value `abc'123`. The
+/// same rule is applied to double-quoted literals (`"abc"`), which OData does
+/// not define but clients do send.
+///
+/// The delimiter must never survive into the returned value: the key becomes
+/// the entity id, and an id that still carries its quotes fails Cedar's
+/// `Type::"id"` UID parsing, turning an ordinary policy question into a 403
+/// that no policy change can fix (ARN-287).
+///
+/// A bare (un-doubled) quote inside the literal, trailing text after the
+/// closing quote, and an unterminated literal are all parse errors. Unquoted
+/// literals (integers, GUIDs) are returned unchanged but must not contain
+/// quote characters.
 fn parse_key_literal(s: &str) -> Result<String, ODataError> {
-    let Some(interior) = s.strip_prefix('\'') else {
+    let Some(delimiter) = s.chars().next().filter(|ch| is_key_delimiter(*ch)) else {
         // Unquoted literal (integer, GUID, …) — quotes are not allowed.
-        if s.contains('\'') {
+        if s.contains(KEY_DELIMITERS) {
             return Err(ODataError::InvalidPath {
-                message: format!("unquoted key literal '{s}' contains a single quote"),
+                message: format!("unquoted key literal '{s}' contains a quote"),
             });
         }
         return Ok(s.to_string());
     };
 
+    let interior = &s[delimiter.len_utf8()..];
     let mut value = String::with_capacity(interior.len());
     let mut chars = interior.chars().peekable();
     while let Some(ch) = chars.next() {
-        if ch != '\'' {
+        if ch != delimiter {
             value.push(ch);
             continue;
         }
-        // Doubled quote — an escaped literal quote.
-        if chars.peek() == Some(&'\'') {
+        // Doubled delimiter — an escaped literal quote.
+        if chars.peek() == Some(&delimiter) {
             chars.next();
-            value.push('\'');
+            value.push(delimiter);
             continue;
         }
-        // Lone quote — closes the literal; it must be the final character.
+        // Lone delimiter — closes the literal; it must be the final character.
         if chars.next().is_some() {
             return Err(ODataError::InvalidPath {
                 message: format!(
-                    "invalid key literal {s}: quotes inside a key must be escaped as ''"
+                    "invalid key literal {s}: a {delimiter} inside a key must be escaped by doubling it"
                 ),
             });
         }
@@ -714,6 +740,74 @@ mod tests {
     #[test]
     fn parse_entity_key_unquoted_with_quote_rejected() {
         assert!(parse_path("/Orders(abc'def)").is_err());
+    }
+
+    #[test]
+    fn parse_entity_key_double_quoted_matches_single_quoted() {
+        // ARN-287: a double-quoted key must yield the same entity id as the
+        // OData-spelled single-quoted one — the delimiter never reaches Cedar.
+        assert_eq!(
+            parse_path("/Files(\"fl-019efde0-3fa5\")").unwrap(),
+            parse_path("/Files('fl-019efde0-3fa5')").unwrap()
+        );
+        assert_eq!(
+            parse_path("/Files(\"fl-019efde0-3fa5\")").unwrap(),
+            ODataPath::Entity("Files".into(), KeyValue::Single("fl-019efde0-3fa5".into()))
+        );
+    }
+
+    #[test]
+    fn parse_entity_key_double_quoted_with_escaped_quote() {
+        assert_eq!(
+            parse_path("/Orders(\"abc\"\"123\")").unwrap(),
+            ODataPath::Entity("Orders".into(), KeyValue::Single("abc\"123".into()))
+        );
+    }
+
+    #[test]
+    fn parse_entity_key_single_quoted_keeps_interior_double_quotes() {
+        // Only the outermost delimiter is stripped; a double quote inside a
+        // single-quoted literal is ordinary key text.
+        assert_eq!(
+            parse_path("/Orders('a\"b')").unwrap(),
+            ODataPath::Entity("Orders".into(), KeyValue::Single("a\"b".into()))
+        );
+    }
+
+    #[test]
+    fn parse_entity_key_unquoted_with_double_quote_rejected() {
+        assert!(parse_path("/Orders(abc\"def)").is_err());
+    }
+
+    #[test]
+    fn parse_entity_key_double_quoted_unterminated_rejected() {
+        assert!(parse_path("/Orders(\"abc)").is_err());
+    }
+
+    #[test]
+    fn parse_composite_key_double_quoted_values() {
+        assert_eq!(
+            parse_path("/OrderItems(OrderId=\"a,b\",LineNo=1)").unwrap(),
+            ODataPath::Entity(
+                "OrderItems".into(),
+                KeyValue::Composite(vec![
+                    ("OrderId".into(), "a,b".into()),
+                    ("LineNo".into(), "1".into()),
+                ])
+            )
+        );
+    }
+
+    #[test]
+    fn parse_bound_function_double_quoted_argument() {
+        assert_eq!(
+            parse_path("/Refs/Temper.Nearest(decl=\"taste\",k=10)").unwrap(),
+            ODataPath::BoundFunction {
+                parent: Box::new(ODataPath::EntitySet("Refs".into())),
+                function: "Temper.Nearest".into(),
+                params: vec![("decl".into(), "taste".into()), ("k".into(), "10".into()),],
+            }
+        );
     }
 
     #[test]

--- a/crates/temper-platform/src/hooks.rs
+++ b/crates/temper-platform/src/hooks.rs
@@ -224,26 +224,27 @@ fn handle_generate_cedar_policy(
         "GenerateCedarPolicy hook: generated policy, validating and loading"
     );
 
-    // Validate and reload the per-tenant policy set.
-    {
+    // Validate and reload the per-tenant policy set. The generated policy is
+    // its own labelled source: appending it to the tenant blob and reloading
+    // raw would rename every statement in the tenant positionally, so
+    // approving one decision would erase the file provenance of every other
+    // policy (ARN-286).
+    if let Err(e) = state.server.authz.upsert_tenant_policy_source(
+        tenant,
+        &generate_cedar::generated_policy_label(tenant, entity_id),
+        &generated_policy,
+    ) {
+        tracing::error!(error = %e, "GenerateCedarPolicy: failed to reload policies");
+        return Err(format!("Failed to reload policies: {e}"));
+    }
+
+    // Mirror the engine's authoritative text into the cache only once the
+    // reload succeeded, so a policy the engine rejected never lands in it.
+    if let Some(tenant_text) = state.server.authz.get_tenant_policy_text(tenant) {
         let Ok(mut policies) = state.server.tenant_policies.write() else {
             return Err("tenant_policies lock poisoned".to_string());
         };
-        let entry = policies.entry(tenant.to_string()).or_default();
-        if !entry.is_empty() {
-            entry.push('\n');
-        }
-        entry.push_str(&generated_policy);
-
-        let tenant_text = entry.clone();
-        if let Err(e) = state
-            .server
-            .authz
-            .reload_tenant_policies(tenant, &tenant_text)
-        {
-            tracing::error!(error = %e, "GenerateCedarPolicy: failed to reload policies");
-            return Err(format!("Failed to reload policies: {e}"));
-        }
+        policies.insert(tenant.to_string(), tenant_text);
     }
 
     tracing::info!(

--- a/crates/temper-platform/src/hooks/generate_cedar.rs
+++ b/crates/temper-platform/src/hooks/generate_cedar.rs
@@ -1,5 +1,13 @@
 use temper_server::ServerState;
 
+/// Label for a policy generated from an approved governance decision.
+///
+/// Named after the decision that produced it, so a denial or an allow that
+/// cites it points straight back at the approval it came from (ARN-286).
+pub(crate) fn generated_policy_label(tenant: &str, entity_id: &str) -> String {
+    format!("{tenant}/generated/{entity_id}.cedar")
+}
+
 /// Generate Cedar policy from entity state fields.
 ///
 /// Reads agent_id, action_name, resource_type, resource_id, scope, tenant,
@@ -88,21 +96,26 @@ pub(super) fn handle_generate_cedar_from_fields(
         "GenerateCedarPolicy hook: generated policy, validating and loading"
     );
 
-    {
+    // Load the generated policy as its own labelled source. Appending it to
+    // the tenant blob and reloading raw would rename every statement in the
+    // tenant positionally, so approving one decision would erase the file
+    // provenance of every other policy (ARN-286).
+    if let Err(e) = server.authz.upsert_tenant_policy_source(
+        tenant,
+        &generated_policy_label(tenant, entity_id),
+        &generated_policy,
+    ) {
+        tracing::error!(error = %e, "GenerateCedarPolicy: failed to reload policies");
+        return Err(format!("Failed to reload policies: {e}"));
+    }
+
+    // Mirror the engine's authoritative text into the cache only once the
+    // reload succeeded, so a policy the engine rejected never lands in it.
+    if let Some(tenant_text) = server.authz.get_tenant_policy_text(tenant) {
         let Ok(mut policies) = server.tenant_policies.write() else {
             return Err("tenant_policies lock poisoned".to_string());
         };
-        let entry = policies.entry(tenant.to_string()).or_default();
-        if !entry.is_empty() {
-            entry.push('\n');
-        }
-        entry.push_str(&generated_policy);
-
-        let tenant_text = entry.clone();
-        if let Err(e) = server.authz.reload_tenant_policies(tenant, &tenant_text) {
-            tracing::error!(error = %e, "GenerateCedarPolicy: failed to reload policies");
-            return Err(format!("Failed to reload policies: {e}"));
-        }
+        policies.insert(tenant.to_string(), tenant_text);
     }
 
     tracing::info!(

--- a/crates/temper-platform/src/os_apps/mod.rs
+++ b/crates/temper-platform/src/os_apps/mod.rs
@@ -12,6 +12,7 @@ use std::time::Instant;
 
 use chrono::{DateTime, NaiveDateTime, Utc};
 use serde::Serialize;
+use temper_authz::{PolicySource, unlabelled_source_label};
 use temper_runtime::tenant::TenantId;
 use temper_server::state::WasmModuleSource;
 use temper_spec::automaton;
@@ -79,19 +80,105 @@ fn cached_or_active_tenant_policy_text(state: &PlatformState, tenant: &str) -> S
         .unwrap_or_default()
 }
 
-fn merge_bundle_policies(existing: &str, cedar_policies: &[String]) -> String {
-    let mut policy_text = existing.trim_end().to_string();
-    for policy in cedar_policies {
-        let policy = policy.trim();
-        if policy.is_empty() || policy_text.contains(policy) {
-            continue;
-        }
-        if !policy_text.is_empty() {
-            policy_text.push('\n');
-        }
-        policy_text.push_str(policy);
+/// Label for one Cedar file in an app bundle: `"{app}/{path under policies/}"`.
+///
+/// This is what a denial diagnostic shows — `katagami-commons/art_style.cedar#2`
+/// — so it must name a file a human can actually open (ARN-286). The path
+/// below `policies/` is kept rather than just the file name so
+/// `policies/commons/x.cedar` and `policies/x.cedar` stay distinct.
+fn bundle_policy_label(app_name: &str, relative_path: &str) -> String {
+    let path = relative_path.trim_start_matches('/');
+    let path = path.strip_prefix("policies/").unwrap_or(path);
+    format!("{app_name}/{path}")
+}
+
+/// Build the tenant's labelled Cedar policy sources after installing `app_name`.
+///
+/// Starts from the labelled sources already active for the tenant, so apps
+/// installed earlier keep their provenance, then upserts one entry per policy
+/// file in this bundle. Loading these labelled — rather than as one
+/// concatenated tenant blob — is what turns `denied by policy: policy1874`
+/// into `denied by policy: katagami-commons/art_style.cedar#2`.
+///
+/// A tenant whose policies were last loaded as an unlabelled blob keeps that
+/// blob as a single leading entry, minus any text this bundle is about to
+/// re-contribute under a proper label — without that subtraction, reinstalling
+/// an app would leave a second, unlabelled copy of its statements behind.
+fn merge_bundle_policy_sources(
+    existing_sources: Vec<PolicySource>,
+    existing_text: &str,
+    tenant: &str,
+    app_name: &str,
+    bundle_sources: &[CedarPolicySource],
+) -> Vec<PolicySource> {
+    let incoming: Vec<(String, &str)> = bundle_sources
+        .iter()
+        .map(|source| {
+            (
+                bundle_policy_label(app_name, &source.relative_path),
+                source.text.trim(),
+            )
+        })
+        .filter(|(_, text)| !text.is_empty())
+        .collect();
+
+    let mut sources = existing_sources;
+    if sources.is_empty() {
+        let labelled_texts: Vec<&str> = incoming.iter().map(|(_, text)| *text).collect();
+        sources.extend(carry_unlabelled_blob(
+            tenant,
+            existing_text,
+            &labelled_texts,
+        ));
     }
-    policy_text
+
+    for (label, text) in incoming {
+        match sources.iter_mut().find(|(existing, _)| *existing == label) {
+            Some(entry) => entry.1 = text.to_string(),
+            None => sources.push((label, text.to_string())),
+        }
+    }
+    sources
+}
+
+/// Carry an unlabelled policy blob forward as one source, minus any text that
+/// is also arriving under a proper label.
+///
+/// Two loaders can hold the same statements: the tenant's aggregate blob and
+/// the per-file rows written beside it. Without the subtraction both copies
+/// load, so a denial cites the unlabelled blob alongside the file — and the
+/// tenant carries twice the policies it needs. Matching on exact text is the
+/// same rule the blob merge has always used to decide a policy is already
+/// present.
+///
+/// Returns `None` when nothing is left to carry.
+pub(crate) fn carry_unlabelled_blob(
+    tenant: &str,
+    blob: &str,
+    labelled_texts: &[&str],
+) -> Option<PolicySource> {
+    let mut remaining = blob.trim().to_string();
+    for text in labelled_texts {
+        let text = text.trim();
+        if !text.is_empty() && remaining.contains(text) {
+            remaining = remaining.replace(text, "");
+        }
+    }
+    let remaining = remaining.trim();
+    if remaining.is_empty() {
+        return None;
+    }
+    Some((unlabelled_source_label(tenant), remaining.to_string()))
+}
+
+/// Flatten labelled sources into the single blob that durable storage and the
+/// in-memory text cache still speak in.
+fn combined_policy_text(sources: &[PolicySource]) -> String {
+    sources
+        .iter()
+        .map(|(_, text)| text.as_str())
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 // ── Agent / Skill / Seed Data types ─────────────────────────────────
@@ -1135,6 +1222,17 @@ pub(super) async fn install_os_app_with_plan(
         );
     }
 
+    // Steps 1-3 rebuild tenant-wide state — the merged CSDL and the Cedar
+    // policy set — by reading what the tenant already has, merging this bundle
+    // into it, and writing the result back, with durable writes and
+    // verification in between. Two installs into the same tenant running
+    // concurrently would read the same pre-state and the later write would
+    // drop the other app's policies while both installs reported success. This
+    // guard makes that sequence one at a time per tenant. It is released
+    // before Step 5 onward, which dispatches entity actions that can re-enter
+    // this installer through the Genesis bound-action hook.
+    let install_guard = state.install_locks.lock(tenant).await;
+
     // Classify each bundle spec as added / updated / skipped, and compute the
     // merged CSDL only when the reconcile plan needs spec work.
     let (mut added, mut updated, mut skipped, merged_csdl) = if plan.specs {
@@ -1186,13 +1284,31 @@ pub(super) async fn install_os_app_with_plan(
     updated.sort();
     skipped.sort();
 
-    // Build the full Cedar policy text for this tenant (existing + new).
-    let combined_policy = if plan.policies && !bundle.cedar_policies.is_empty() {
-        let existing = cached_or_active_tenant_policy_text(state, tenant);
-        Some(merge_bundle_policies(&existing, &bundle.cedar_policies))
+    // Build this tenant's Cedar policy sources (existing + this bundle's
+    // files), each still labelled with the file it came from so denials can
+    // name it. The flattened text is what durable storage speaks in.
+    //
+    // The tenant's unlabelled blob is read once here and reused when Step 3
+    // re-runs this merge inside the authz engine's lock: reading it again from
+    // there would re-enter the engine while it holds that lock.
+    let existing_policy_text = if plan.policies && !bundle.cedar_policy_sources.is_empty() {
+        Some(cached_or_active_tenant_policy_text(state, tenant))
     } else {
         None
     };
+    let policy_sources = existing_policy_text.as_deref().map(|existing_text| {
+        merge_bundle_policy_sources(
+            state.server.authz.tenant_policy_sources(tenant),
+            existing_text,
+            tenant,
+            app_name,
+            &bundle.cedar_policy_sources,
+        )
+    });
+    let combined_policy = policy_sources
+        .as_deref()
+        .map(combined_policy_text)
+        .filter(|text| !text.trim().is_empty());
 
     // ── Step 1: Persist to Turso FIRST (if available). ──────────────
     // If any write fails, bail before touching in-memory state.
@@ -1368,22 +1484,49 @@ pub(super) async fn install_os_app_with_plan(
     }
 
     // ── Step 3: Load Cedar policies into memory. ────────────────────
-    if let Some(ref policy_text) = combined_policy {
-        if let Err(e) = state
+    // Loaded per source file, so a denial names the file and statement that
+    // produced it rather than a positional `policy1874` (ARN-286).
+    // A failed reload is FATAL to the install, like every other step in this
+    // function. Warn-and-continue would return success while the tenant silently
+    // kept its previous policy set — a published policy change that never took
+    // effect, visible only as one warn line. Reachable via a Cedar parse error in
+    // any published `.cedar`, or a duplicate label in `sources` (which aborts the
+    // whole reload). Authorization state must never fail open.
+    //
+    // The bundle is merged into whatever the tenant holds *now*, inside the
+    // engine's tenant lock, rather than replacing its policy set with the
+    // snapshot read at the top of this function. A policy generated from an
+    // approved governance decision lands through that same engine while an
+    // install is running; replacing from the snapshot would silently drop it.
+    if combined_policy.is_some()
+        && let Some(existing_text) = existing_policy_text.as_deref()
+    {
+        let installed_text = state
             .server
             .authz
-            .reload_tenant_policies(tenant, policy_text)
-        {
-            tracing::warn!(
-                tenant,
-                error = %e,
-                "Failed to reload tenant Cedar policies after os-app install"
-            );
-        } else {
-            let mut policies = state.server.tenant_policies.write().unwrap(); // ci-ok: infallible lock
-            policies.insert(tenant.to_string(), policy_text.clone());
-        }
+            .update_tenant_policy_sources(tenant, |existing_sources| {
+                merge_bundle_policy_sources(
+                    existing_sources,
+                    existing_text,
+                    tenant,
+                    app_name,
+                    &bundle.cedar_policy_sources,
+                )
+            })
+            .map_err(|e| {
+                format!("Failed to reload tenant Cedar policies after os-app install: {e}")
+            })?;
+        // Mirror what the engine actually installed, not what was computed
+        // before the merge.
+        let mut policies = state.server.tenant_policies.write().unwrap(); // ci-ok: infallible lock
+        policies.insert(tenant.to_string(), installed_text);
     }
+
+    // Everything tenant-wide has been rebuilt and published. The remaining
+    // steps write per-module and per-entity rows, and Step 5 onward dispatches
+    // actions that can re-enter this installer via the Genesis bound-action
+    // hook — which would deadlock on a held guard.
+    drop(install_guard);
 
     // ── Step 4: Persist/register WASM modules, warming only eager modules. ──
     //

--- a/crates/temper-platform/src/os_apps/mod_test.rs
+++ b/crates/temper-platform/src/os_apps/mod_test.rs
@@ -16,6 +16,165 @@ use temper_spec::csdl::parse_csdl;
 use temper_store_turso::TursoSpecVerificationUpdate;
 use temper_verify::cascade::VerificationCascade;
 
+fn cedar_source(path: &str, text: &str) -> CedarPolicySource {
+    CedarPolicySource {
+        relative_path: path.to_string(),
+        text: text.to_string(),
+    }
+}
+
+#[test]
+fn bundle_policy_label_names_the_file_under_policies() {
+    assert_eq!(
+        bundle_policy_label("katagami-commons", "policies/art_style.cedar"),
+        "katagami-commons/art_style.cedar"
+    );
+    // Nested files keep their sub-path so two same-named files stay distinct.
+    assert_eq!(
+        bundle_policy_label("katagami-commons", "policies/commons/art_style.cedar"),
+        "katagami-commons/commons/art_style.cedar"
+    );
+}
+
+#[test]
+fn bundle_sources_are_labelled_per_file() {
+    let sources = merge_bundle_policy_sources(
+        Vec::new(),
+        "",
+        "katagami",
+        "katagami-commons",
+        &[
+            cedar_source(
+                "policies/art_style.cedar",
+                "permit(principal, action, resource);",
+            ),
+            cedar_source(
+                "policies/palette.cedar",
+                "forbid(principal, action, resource);",
+            ),
+        ],
+    );
+
+    assert_eq!(
+        sources,
+        vec![
+            (
+                "katagami-commons/art_style.cedar".to_string(),
+                "permit(principal, action, resource);".to_string()
+            ),
+            (
+                "katagami-commons/palette.cedar".to_string(),
+                "forbid(principal, action, resource);".to_string()
+            ),
+        ]
+    );
+    assert_eq!(
+        combined_policy_text(&sources),
+        "permit(principal, action, resource);\nforbid(principal, action, resource);"
+    );
+}
+
+#[test]
+fn installing_a_second_app_keeps_the_first_apps_labels() {
+    let commons = merge_bundle_policy_sources(
+        Vec::new(),
+        "",
+        "katagami",
+        "katagami-commons",
+        &[cedar_source(
+            "policies/art_style.cedar",
+            "permit(principal, action, resource);",
+        )],
+    );
+
+    let both = merge_bundle_policy_sources(
+        commons,
+        "",
+        "katagami",
+        "katagami-curation",
+        &[cedar_source(
+            "policies/review.cedar",
+            "forbid(principal, action, resource);",
+        )],
+    );
+
+    let labels: Vec<&str> = both.iter().map(|(label, _)| label.as_str()).collect();
+    assert_eq!(
+        labels,
+        vec![
+            "katagami-commons/art_style.cedar",
+            "katagami-curation/review.cedar"
+        ],
+        "an app install must not flatten the labels of apps installed before it"
+    );
+}
+
+#[test]
+fn reinstalling_an_app_replaces_its_entry_rather_than_appending() {
+    let first = merge_bundle_policy_sources(
+        Vec::new(),
+        "",
+        "katagami",
+        "katagami-commons",
+        &[cedar_source(
+            "policies/art_style.cedar",
+            r#"permit(principal, action == Action::"read", resource);"#,
+        )],
+    );
+
+    let second = merge_bundle_policy_sources(
+        first,
+        "",
+        "katagami",
+        "katagami-commons",
+        &[cedar_source(
+            "policies/art_style.cedar",
+            r#"permit(principal, action == Action::"update", resource);"#,
+        )],
+    );
+
+    assert_eq!(
+        second,
+        vec![(
+            "katagami-commons/art_style.cedar".to_string(),
+            r#"permit(principal, action == Action::"update", resource);"#.to_string()
+        )],
+        "a changed policy file must supersede its previous text, not stack on it"
+    );
+}
+
+#[test]
+fn unlabelled_tenant_blob_is_carried_forward_without_duplicating_bundle_text() {
+    let bundle_text = r#"permit(principal, action == Action::"read", resource);"#;
+    let other_text = r#"permit(principal, action == Action::"list", resource);"#;
+    let blob = format!("{other_text}\n{bundle_text}");
+
+    let sources = merge_bundle_policy_sources(
+        Vec::new(),
+        &blob,
+        "katagami",
+        "katagami-commons",
+        &[cedar_source("policies/art_style.cedar", bundle_text)],
+    );
+
+    assert_eq!(
+        sources,
+        vec![
+            (unlabelled_source_label("katagami"), other_text.to_string()),
+            (
+                "katagami-commons/art_style.cedar".to_string(),
+                bundle_text.to_string()
+            ),
+        ],
+        "text the bundle re-contributes under a label must be removed from the blob"
+    );
+    assert_eq!(
+        combined_policy_text(&sources).matches(bundle_text).count(),
+        1,
+        "the bundle's statements must appear exactly once"
+    );
+}
+
 #[test]
 fn test_pm_specs_parse() {
     let bundle = get_os_app("project-management").expect("PM app not found");
@@ -1372,11 +1531,17 @@ async fn test_install_os_app_persists_granular_policy_rows() {
         .expect("load granular policies");
     assert!(
         rows.iter().any(|row| {
-            row.policy_id == "project-management-issue"
+            row.policy_id == "project-management/issue.cedar"
                 && row.enabled
                 && row.cedar_text.contains("resource is Issue")
         }),
         "project-management install should persist policies/issue.cedar as a granular row: {rows:?}"
+    );
+    assert!(
+        !rows
+            .iter()
+            .any(|row| row.policy_id == "project-management-issue"),
+        "the pre-ARN-286 slug row must not survive alongside the labelled one: {rows:?}"
     );
 
     let turso_ref = state.server.platform_turso_store().unwrap();
@@ -1831,13 +1996,15 @@ mode = "commons"
         source_paths,
         vec!["policies/base.cedar", "policies/commons/guardrail.cedar"]
     );
+    // The row id is the label a denial reports, so it names a file a human can
+    // open: "katagami-commons/art_style.cedar#2" (ARN-286).
     assert_eq!(
         os_app_policy_row_id("katagami-commons", "policies/palette_system.cedar"),
-        "katagami-commons-palette_system"
+        "katagami-commons/palette_system.cedar"
     );
     assert_eq!(
         os_app_policy_row_id("katagami-commons", "policies/commons/guardrail.cedar"),
-        "katagami-commons-commons-guardrail"
+        "katagami-commons/commons/guardrail.cedar"
     );
     assert!(
         bundle
@@ -3418,6 +3585,246 @@ async fn test_local_stream_uploads_create_real_file_version_lineage() {
     );
     assert_eq!(previous.state.counters.get("version_number"), Some(&1));
 
+    let _ = fs::remove_file(&db_path);
+    let _ = fs::remove_file(format!("{db_path}-wal"));
+    let _ = fs::remove_file(format!("{db_path}-shm"));
+}
+
+/// Write a minimal policies-only app bundle into `app_root`.
+fn write_policy_only_app(app_root: &std::path::Path, app_name: &str, cedar_text: &str) {
+    let app_dir = app_root.join(app_name);
+    fs::create_dir_all(app_dir.join("policies")).unwrap();
+    fs::write(
+        app_dir.join("app.toml"),
+        format!(
+            "name = \"{app_name}\"\ndescription = \"Concurrent install policy test app\"\nversion = \"0.1.0\"\n"
+        ),
+    )
+    .unwrap();
+    fs::write(
+        app_dir.join("APP.md"),
+        format!("# {app_name}\n\nConcurrent install policy test app.\n"),
+    )
+    .unwrap();
+    fs::write(app_dir.join("policies").join("access.cedar"), cedar_text).unwrap();
+}
+
+/// Two apps installed into the same tenant at the same time must both end up
+/// with their policies active.
+///
+/// The regression: the install path read the tenant's policy sources, ran its
+/// durable writes and verification, then wrote a rebuilt set back — a
+/// read-modify-write spanning many awaits with nothing serializing it. Both
+/// installs read the same pre-state and the second write dropped the first
+/// app's policies, while both installs returned `Ok`.
+///
+/// This asserts the end state. Whether two spawned installs actually overlap
+/// is up to the scheduler, so the guarantee itself — that the second install
+/// waits for the first — is pinned deterministically by
+/// [`test_install_waits_for_the_tenant_install_lock`].
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_concurrent_installs_into_one_tenant_keep_both_policy_sets() {
+    use std::sync::Arc;
+    use temper_store_turso::TursoEventStore;
+    use tokio::sync::Barrier;
+
+    let app_root = std::env::temp_dir().join(format!(
+        "temper-os-apps-concurrent-policies-{}",
+        uuid::Uuid::new_v4()
+    ));
+    write_policy_only_app(
+        &app_root,
+        "concurrent-policy-app-a",
+        r#"permit(principal is Customer, action == Action::"ReadAlpha", resource is Alpha);"#,
+    );
+    write_policy_only_app(
+        &app_root,
+        "concurrent-policy-app-b",
+        r#"permit(principal is Customer, action == Action::"ReadBeta", resource is Beta);"#,
+    );
+    add_os_apps_dir(app_root.clone());
+
+    let db_path = format!(
+        "/tmp/temper-concurrent-install-policies-{}.db",
+        uuid::Uuid::new_v4()
+    );
+    let db_url = format!("file:{db_path}");
+    let turso = TursoEventStore::new(&db_url, None).await.unwrap();
+    let mut state = PlatformState::new(None);
+    state
+        .server
+        .set_storage_stack(temper_server::StorageStack::from_turso(turso));
+    let tenant = format!("test-concurrent-install-{}", uuid::Uuid::new_v4());
+
+    // Start both installs at the same instant so their reads of the tenant's
+    // policy state overlap.
+    let barrier = Arc::new(Barrier::new(2));
+    let installs: Vec<_> = ["concurrent-policy-app-a", "concurrent-policy-app-b"]
+        .into_iter()
+        .map(|app_name| {
+            let state = state.clone();
+            let tenant = tenant.clone();
+            let barrier = Arc::clone(&barrier);
+            tokio::spawn(async move {
+                barrier.wait().await;
+                install_os_app(&state, &tenant, app_name).await
+            })
+        })
+        .collect();
+    for install in installs {
+        install
+            .await
+            .expect("install task should not panic")
+            .expect("concurrent install should succeed");
+    }
+
+    let labels: Vec<String> = state
+        .server
+        .authz
+        .tenant_policy_sources(&tenant)
+        .into_iter()
+        .map(|(label, _)| label)
+        .collect();
+    assert!(
+        labels.contains(&"concurrent-policy-app-a/access.cedar".to_string()),
+        "app A's policy file must stay loaded, got: {labels:?}"
+    );
+    assert!(
+        labels.contains(&"concurrent-policy-app-b/access.cedar".to_string()),
+        "app B's policy file must stay loaded, got: {labels:?}"
+    );
+
+    // Both apps' policies are in effect, not merely recorded.
+    let customer_ctx = SecurityContext::from_headers(&[
+        ("X-Temper-Principal-Id".to_string(), "cust-1".to_string()),
+        (
+            "X-Temper-Principal-Kind".to_string(),
+            "customer".to_string(),
+        ),
+    ]);
+    let mut attrs = HashMap::new();
+    attrs.insert("id".to_string(), serde_json::json!("res-1"));
+    for (action, resource_type) in [("ReadAlpha", "Alpha"), ("ReadBeta", "Beta")] {
+        assert!(
+            state
+                .server
+                .authz
+                .authorize_for_tenant(&tenant, &customer_ctx, action, resource_type, &attrs)
+                .is_allowed(),
+            "'{action}' on '{resource_type}' should be permitted after both installs"
+        );
+    }
+
+    // The text cache mirrors the merged set, so a later install that starts
+    // from it does not resurrect a half-tenant.
+    let cached_text = state
+        .server
+        .tenant_policies
+        .read()
+        .unwrap()
+        .get(&tenant)
+        .cloned()
+        .expect("tenant policy text cache should hold the merged text");
+    assert!(cached_text.contains("ReadAlpha"), "cached: {cached_text}");
+    assert!(cached_text.contains("ReadBeta"), "cached: {cached_text}");
+
+    let _ = fs::remove_dir_all(&app_root);
+    let _ = fs::remove_file(&db_path);
+    let _ = fs::remove_file(format!("{db_path}-wal"));
+    let _ = fs::remove_file(format!("{db_path}-shm"));
+}
+
+/// An install must not touch a tenant's policy set while another holder of
+/// that tenant's install lock is inside the critical section.
+///
+/// This is the deterministic half of the regression above. The install path
+/// rebuilds tenant-wide state by reading what the tenant has, running its
+/// durable writes and verification, and writing the result back; without a
+/// per-tenant lock that sequence interleaves and one app's policies are lost
+/// with both installs reporting success. Here the lock is held by the test, so
+/// an install that does not wait for it publishes its policies during the
+/// window below and fails the assertion — no scheduling luck involved.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_install_waits_for_the_tenant_install_lock() {
+    use temper_store_turso::TursoEventStore;
+
+    let app_root = std::env::temp_dir().join(format!(
+        "temper-os-apps-install-lock-{}",
+        uuid::Uuid::new_v4()
+    ));
+    write_policy_only_app(
+        &app_root,
+        "install-lock-app-a",
+        r#"permit(principal is Customer, action == Action::"ReadAlpha", resource is Alpha);"#,
+    );
+    write_policy_only_app(
+        &app_root,
+        "install-lock-app-b",
+        r#"permit(principal is Customer, action == Action::"ReadBeta", resource is Beta);"#,
+    );
+    add_os_apps_dir(app_root.clone());
+
+    let db_path = format!("/tmp/temper-install-lock-{}.db", uuid::Uuid::new_v4());
+    let db_url = format!("file:{db_path}");
+    let turso = TursoEventStore::new(&db_url, None).await.unwrap();
+    let mut state = PlatformState::new(None);
+    state
+        .server
+        .set_storage_stack(temper_server::StorageStack::from_turso(turso));
+    let tenant = format!("test-install-lock-{}", uuid::Uuid::new_v4());
+
+    install_os_app(&state, &tenant, "install-lock-app-a")
+        .await
+        .expect("first install should succeed");
+
+    let policy_labels = |state: &PlatformState, tenant: &str| -> Vec<String> {
+        state
+            .server
+            .authz
+            .tenant_policy_sources(tenant)
+            .into_iter()
+            .map(|(label, _)| label)
+            .collect()
+    };
+
+    let guard = state.install_locks.lock(&tenant).await;
+    let second_install = tokio::spawn({
+        let state = state.clone();
+        let tenant = tenant.clone();
+        async move { install_os_app(&state, &tenant, "install-lock-app-b").await }
+    });
+
+    // Comfortably longer than an install of these bundles takes when nothing
+    // blocks it — the two installs in the test above complete in well under a
+    // second including their assertions.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    assert!(
+        !second_install.is_finished(),
+        "an install must wait for the tenant install lock"
+    );
+    let labels = policy_labels(&state, &tenant);
+    assert!(
+        !labels.contains(&"install-lock-app-b/access.cedar".to_string()),
+        "the blocked install must not have rebuilt the tenant policy set, got: {labels:?}"
+    );
+
+    drop(guard);
+    second_install
+        .await
+        .expect("install task should not panic")
+        .expect("install should succeed once the lock is released");
+
+    let labels = policy_labels(&state, &tenant);
+    assert!(
+        labels.contains(&"install-lock-app-a/access.cedar".to_string()),
+        "the first app's policy must survive the second install, got: {labels:?}"
+    );
+    assert!(
+        labels.contains(&"install-lock-app-b/access.cedar".to_string()),
+        "the second app's policy must be loaded, got: {labels:?}"
+    );
+
+    let _ = fs::remove_dir_all(&app_root);
     let _ = fs::remove_file(&db_path);
     let _ = fs::remove_file(format!("{db_path}-wal"));
     let _ = fs::remove_file(format!("{db_path}-shm"));

--- a/crates/temper-platform/src/os_apps/policy_rows.rs
+++ b/crates/temper-platform/src/os_apps/policy_rows.rs
@@ -1,7 +1,22 @@
-use super::AppBundle;
+use super::{AppBundle, bundle_policy_label};
 use crate::state::PlatformState;
 
+/// Durable `policies` row id for one Cedar file in an app bundle.
+///
+/// This is the same string the Cedar engine labels the file's statements with,
+/// so a denial recovered from durable storage after a restart still reads
+/// `katagami-commons/art_style.cedar#2` (ARN-286). Keeping the two in sync is
+/// the point — a row id that differs from the load label would give the same
+/// policy two different names depending on which path loaded it.
 pub(crate) fn os_app_policy_row_id(app_name: &str, relative_path: &str) -> String {
+    bundle_policy_label(app_name, relative_path)
+}
+
+/// The pre-ARN-286 row id: a dash-slugged `{app}-{path}` with the `.cedar`
+/// suffix dropped. Rows written under it are deleted once the same policy has
+/// been re-saved under [`os_app_policy_row_id`], so a tenant does not end up
+/// loading both copies.
+fn legacy_os_app_policy_row_id(app_name: &str, relative_path: &str) -> String {
     let source = relative_path
         .trim_start_matches('/')
         .strip_prefix("policies/")
@@ -53,6 +68,26 @@ pub(super) async fn persist_bundle_policy_rows(
                     "Failed to persist OS app Cedar policy row '{policy_id}' for '{app_name}': {error}"
                 )
             })?;
+
+        // Drop the row this policy used to live under, now that it has been
+        // re-saved under its label. Leaving it would load the same statements
+        // twice, once unnamed.
+        // Fatal, not warn-only: a surviving legacy row is loaded again on the
+        // next recovery, so the OLD generation of these statements comes back
+        // alongside the new one. With Cedar's forbid-overrides-permit that can
+        // reactivate a forbid the operator believes they deleted — stale
+        // authorization restored by a restart, with no signal at install time.
+        let legacy_id = legacy_os_app_policy_row_id(app_name, &source.relative_path);
+        if legacy_id != policy_id {
+            policy_store
+                .delete_policy(tenant, &legacy_id)
+                .await
+                .map_err(|error| {
+                    format!(
+                        "Failed to remove superseded OS app Cedar policy row '{legacy_id}' for '{app_name}': {error}"
+                    )
+                })?;
+        }
     }
     Ok(())
 }

--- a/crates/temper-platform/src/recovery.rs
+++ b/crates/temper-platform/src/recovery.rs
@@ -9,6 +9,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
+use temper_authz::PolicySource;
 use temper_runtime::tenant::TenantId;
 use temper_server::platform_store::PlatformStore;
 use temper_server::registry::VerificationStatus;
@@ -99,38 +100,46 @@ pub async fn recover_cedar_policies(state: &PlatformState, ps: &dyn PlatformStor
     for tenant in tenants {
         let entries = granular_entries.remove(&tenant).unwrap_or_default();
         let has_primary_granular = entries.iter().any(|(policy_id, _)| policy_id == "primary");
-        let mut policy_text = String::new();
-        let mut entry_count = 0usize;
+        let mut sources: Vec<PolicySource> = Vec::new();
 
         // `primary` is the durable aggregate policy row for newer installs. If
         // it exists, prefer it over the legacy blob to avoid loading the same
         // multi-megabyte generated policy twice.
         if !has_primary_granular {
             if let Some(legacy_text) = legacy_entries.get(&tenant) {
-                append_cedar_policy_text(&mut policy_text, legacy_text);
-                entry_count += 1;
+                // The aggregate blob written at install time repeats what the
+                // per-file rows already hold. Carry only what the labelled
+                // rows do not cover, so a denial cites the file rather than
+                // both the file and an unlabelled copy of it.
+                let labelled_texts: Vec<&str> =
+                    entries.iter().map(|(_, text)| text.as_str()).collect();
+                sources.extend(os_apps::carry_unlabelled_blob(
+                    &tenant,
+                    legacy_text,
+                    &labelled_texts,
+                ));
             }
         } else if legacy_entries.contains_key(&tenant) {
             skipped_legacy_count += 1;
         }
 
-        for (_, cedar_text) in entries {
-            append_cedar_policy_text(&mut policy_text, &cedar_text);
-            entry_count += 1;
-        }
+        // Each durable row keeps its own label, so a denial after a restart
+        // still names the file the statement came from rather than its
+        // position in a concatenated blob (ARN-286). This costs one shallow
+        // policy clone per statement at boot — a large `primary` row makes
+        // that tens of thousands of clones — which is the price of denial
+        // diagnostics that survive a restart.
+        sources.extend(entries);
 
-        if policy_text.trim().is_empty() {
+        let entry_count = sources.len();
+        if sources.iter().all(|(_, text)| text.trim().is_empty()) {
             continue;
         }
 
-        // Use the raw policy reload path here instead of per-row PolicyId
-        // rewriting. Production primary policies can contain tens of thousands
-        // of generated statements; raw reload matches the pre-existing startup
-        // path and avoids deep Cedar policy cloning during restart recovery.
         if let Err(e) = state
             .server
             .authz
-            .reload_tenant_policies(&tenant, &policy_text)
+            .reload_tenant_policies_named(&tenant, &sources)
         {
             tracing::warn!(tenant, error = %e, "Skipping invalid Cedar policies for tenant");
             continue;
@@ -154,13 +163,6 @@ pub async fn recover_cedar_policies(state: &PlatformState, ps: &dyn PlatformStor
             "Restored Cedar policies from durable storage."
         );
     }
-}
-
-fn append_cedar_policy_text(target: &mut String, cedar_text: &str) {
-    if !target.is_empty() {
-        target.push('\n');
-    }
-    target.push_str(cedar_text);
 }
 
 /// Restore previously installed OS apps from the platform store.
@@ -338,131 +340,5 @@ fn tenant_has_ready_app_specs(state: &PlatformState, tenant: &str, app_name: &st
 }
 
 #[cfg(test)]
-mod tests {
-    use std::collections::HashMap;
-
-    use temper_authz::SecurityContext;
-    use temper_store_turso::TursoEventStore;
-
-    use super::*;
-
-    fn sqlite_test_url(test_name: &str) -> String {
-        let mut path = std::env::temp_dir();
-        path.push(format!(
-            "temper-recovery-{test_name}-{}.db",
-            uuid::Uuid::new_v4()
-        ));
-        format!("file:{}", path.display())
-    }
-
-    #[tokio::test]
-    async fn recover_cedar_policies_activates_granular_policy_rows() {
-        let store = TursoEventStore::new(&sqlite_test_url("granular-policies"), None)
-            .await
-            .expect("create test store");
-        let policy = r#"
-permit(
-  principal is Agent,
-  action == Action::"http_call",
-  resource is HttpEndpoint
-) when {
-  context.module == "build_session_message"
-};
-"#;
-        store
-            .save_policy("default", "katagami-curation-wasm", policy, "test")
-            .await
-            .expect("save granular policy");
-
-        let state = PlatformState::new(None);
-        recover_cedar_policies(&state, &store).await;
-
-        let mut resource_attrs = HashMap::new();
-        resource_attrs.insert(
-            "id".to_string(),
-            serde_json::json!("__trigger__:Submit:build_session_message"),
-        );
-        resource_attrs.insert(
-            "module".to_string(),
-            serde_json::json!("build_session_message"),
-        );
-
-        let decision = state.server.authz.authorize_for_tenant(
-            "default",
-            &SecurityContext::from_resolved_identity("wasm-module", "wasm_module", None),
-            "http_call",
-            "HttpEndpoint",
-            &resource_attrs,
-        );
-
-        assert!(
-            decision.is_allowed(),
-            "granular policy rows should be active after recovery, got {decision:?}"
-        );
-        assert!(
-            state
-                .server
-                .authz
-                .get_tenant_policy_text("default")
-                .expect("tenant policy text")
-                .contains("build_session_message")
-        );
-    }
-
-    #[tokio::test]
-    async fn recover_cedar_policies_prefers_primary_row_over_legacy_blob() {
-        let store = TursoEventStore::new(&sqlite_test_url("primary-policy-recovery"), None)
-            .await
-            .expect("create test store");
-        store
-            .upsert_tenant_policy(
-                "default",
-                r#"permit(principal, action == Action::"legacy_only", resource);"#,
-            )
-            .await
-            .expect("save legacy policy");
-        store
-            .save_policy(
-                "default",
-                "primary",
-                r#"permit(principal, action == Action::"read", resource);"#,
-                "test",
-            )
-            .await
-            .expect("save primary policy");
-        store
-            .save_policy(
-                "default",
-                "katagami-curation-wasm",
-                r#"
-permit(
-  principal is Agent,
-  action == Action::"http_call",
-  resource is HttpEndpoint
-) when {
-  context.module == "build_session_message"
-};
-"#,
-                "test",
-            )
-            .await
-            .expect("save granular policy");
-
-        let state = PlatformState::new(None);
-        recover_cedar_policies(&state, &store).await;
-
-        let tenant_text = state
-            .server
-            .authz
-            .get_tenant_policy_text("default")
-            .expect("tenant policy text");
-        assert!(
-            tenant_text.contains("build_session_message"),
-            "granular app policy should be appended to primary policy"
-        );
-        assert!(
-            !tenant_text.contains("legacy_only"),
-            "legacy blob should be skipped when durable primary policy row exists"
-        );
-    }
-}
+#[path = "recovery_test.rs"]
+mod tests;

--- a/crates/temper-platform/src/recovery_test.rs
+++ b/crates/temper-platform/src/recovery_test.rs
@@ -1,0 +1,238 @@
+use std::collections::HashMap;
+
+use temper_authz::SecurityContext;
+use temper_store_turso::TursoEventStore;
+
+use super::*;
+
+fn sqlite_test_url(test_name: &str) -> String {
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "temper-recovery-{test_name}-{}.db",
+        uuid::Uuid::new_v4()
+    ));
+    format!("file:{}", path.display())
+}
+
+#[tokio::test]
+async fn recover_cedar_policies_activates_granular_policy_rows() {
+    let store = TursoEventStore::new(&sqlite_test_url("granular-policies"), None)
+        .await
+        .expect("create test store");
+    let policy = r#"
+permit(
+  principal is Agent,
+  action == Action::"http_call",
+  resource is HttpEndpoint
+) when {
+  context.module == "build_session_message"
+};
+"#;
+    store
+        .save_policy("default", "katagami-curation-wasm", policy, "test")
+        .await
+        .expect("save granular policy");
+
+    let state = PlatformState::new(None);
+    recover_cedar_policies(&state, &store).await;
+
+    let mut resource_attrs = HashMap::new();
+    resource_attrs.insert(
+        "id".to_string(),
+        serde_json::json!("__trigger__:Submit:build_session_message"),
+    );
+    resource_attrs.insert(
+        "module".to_string(),
+        serde_json::json!("build_session_message"),
+    );
+
+    let decision = state.server.authz.authorize_for_tenant(
+        "default",
+        &SecurityContext::from_resolved_identity("wasm-module", "wasm_module", None),
+        "http_call",
+        "HttpEndpoint",
+        &resource_attrs,
+    );
+
+    assert!(
+        decision.is_allowed(),
+        "granular policy rows should be active after recovery, got {decision:?}"
+    );
+    assert!(
+        state
+            .server
+            .authz
+            .get_tenant_policy_text("default")
+            .expect("tenant policy text")
+            .contains("build_session_message")
+    );
+}
+
+#[tokio::test]
+async fn recover_cedar_policies_prefers_primary_row_over_legacy_blob() {
+    let store = TursoEventStore::new(&sqlite_test_url("primary-policy-recovery"), None)
+        .await
+        .expect("create test store");
+    store
+        .upsert_tenant_policy(
+            "default",
+            r#"permit(principal, action == Action::"legacy_only", resource);"#,
+        )
+        .await
+        .expect("save legacy policy");
+    store
+        .save_policy(
+            "default",
+            "primary",
+            r#"permit(principal, action == Action::"read", resource);"#,
+            "test",
+        )
+        .await
+        .expect("save primary policy");
+    store
+        .save_policy(
+            "default",
+            "katagami-curation-wasm",
+            r#"
+permit(
+  principal is Agent,
+  action == Action::"http_call",
+  resource is HttpEndpoint
+) when {
+  context.module == "build_session_message"
+};
+"#,
+            "test",
+        )
+        .await
+        .expect("save granular policy");
+
+    let state = PlatformState::new(None);
+    recover_cedar_policies(&state, &store).await;
+
+    let tenant_text = state
+        .server
+        .authz
+        .get_tenant_policy_text("default")
+        .expect("tenant policy text");
+    assert!(
+        tenant_text.contains("build_session_message"),
+        "granular app policy should be appended to primary policy"
+    );
+    assert!(
+        !tenant_text.contains("legacy_only"),
+        "legacy blob should be skipped when durable primary policy row exists"
+    );
+}
+
+#[tokio::test]
+async fn recovered_denial_names_the_source_file() {
+    // ARN-286: a restart must not flatten policy provenance. After
+    // recovery a denial still has to name the file and statement, so an
+    // operator reading the decision log can open the policy that caused it.
+    let store = TursoEventStore::new(&sqlite_test_url("named-denial"), None)
+        .await
+        .expect("create test store");
+    store
+        .save_policy(
+            "katagami",
+            "katagami-commons/art_style.cedar",
+            concat!(
+                "permit(principal is Customer, action == Action::\"read\", resource is ArtStyle);\n",
+                "forbid(principal is Customer, action == Action::\"update\", resource is ArtStyle);\n",
+            ),
+            "test",
+        )
+        .await
+        .expect("save granular policy");
+
+    let state = PlatformState::new(None);
+    recover_cedar_policies(&state, &store).await;
+
+    let mut resource_attrs = HashMap::new();
+    resource_attrs.insert("id".to_string(), serde_json::json!("as-1"));
+
+    let mut ctx = SecurityContext::from_headers(&[]);
+    ctx.principal.kind = temper_authz::PrincipalKind::Customer;
+    ctx.principal.id = "user-1".to_string();
+
+    let decision = state.server.authz.authorize_for_tenant(
+        "katagami",
+        &ctx,
+        "update",
+        "ArtStyle",
+        &resource_attrs,
+    );
+
+    let temper_authz::AuthzDecision::Deny(denial) = decision else {
+        panic!("forbid statement should deny the update, got {decision:?}");
+    };
+    assert_eq!(
+        denial.to_string(),
+        "denied by policy: katagami-commons/art_style.cedar#2"
+    );
+}
+
+#[tokio::test]
+async fn legacy_blob_does_not_duplicate_what_granular_rows_already_carry() {
+    // Installs write both an aggregate tenant blob and per-file rows. Left
+    // alone, recovery loads the app's statements twice — and a denial then
+    // cites an unlabelled copy alongside the file it came from.
+    let store = TursoEventStore::new(&sqlite_test_url("blob-dedup"), None)
+        .await
+        .expect("create test store");
+    let app_policy =
+        r#"forbid(principal is Customer, action == Action::"update", resource is ArtStyle);"#;
+    let other_policy =
+        r#"permit(principal is Customer, action == Action::"read", resource is ArtStyle);"#;
+
+    store
+        .upsert_tenant_policy("katagami", &format!("{other_policy}\n{app_policy}"))
+        .await
+        .expect("save legacy blob");
+    store
+        .save_policy(
+            "katagami",
+            "katagami-commons/art_style.cedar",
+            app_policy,
+            "test",
+        )
+        .await
+        .expect("save granular policy");
+
+    let state = PlatformState::new(None);
+    recover_cedar_policies(&state, &store).await;
+
+    let tenant_text = state
+        .server
+        .authz
+        .get_tenant_policy_text("katagami")
+        .expect("tenant policy text");
+    assert_eq!(
+        tenant_text.matches(app_policy).count(),
+        1,
+        "the app's statement must be loaded exactly once: {tenant_text}"
+    );
+    assert!(
+        tenant_text.contains(other_policy),
+        "statements only the blob carries must survive: {tenant_text}"
+    );
+
+    let mut resource_attrs = HashMap::new();
+    resource_attrs.insert("id".to_string(), serde_json::json!("as-1"));
+    let decision = state.server.authz.authorize_for_tenant(
+        "katagami",
+        &SecurityContext::from_headers(&[]),
+        "update",
+        "ArtStyle",
+        &resource_attrs,
+    );
+    let temper_authz::AuthzDecision::Deny(denial) = decision else {
+        panic!("forbid statement should deny the update, got {decision:?}");
+    };
+    assert_eq!(
+        denial.to_string(),
+        "denied by policy: katagami-commons/art_style.cedar#1",
+        "the denial must cite the file, not an unlabelled duplicate"
+    );
+}

--- a/crates/temper-platform/src/state.rs
+++ b/crates/temper-platform/src/state.rs
@@ -3,7 +3,8 @@
 //! [`PlatformState`] extends `ServerState` with the broadcast channel
 //! for internal event propagation and the Claude API key.
 
-use std::sync::{Arc, RwLock};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, RwLock};
 
 use tokio::sync::broadcast;
 
@@ -15,6 +16,40 @@ use temper_server::identity::IdentityResolver;
 
 use crate::protocol::PlatformEvent;
 use crate::spec_store::SpecStore;
+
+/// Per-tenant serialization for app installs.
+///
+/// An install rebuilds tenant-wide state — the merged CSDL and the Cedar
+/// policy set — by reading what the tenant has, merging the bundle into it and
+/// writing the result back, with durable writes and verification in between.
+/// Two installs into the same tenant running concurrently would each read the
+/// same pre-state and the second write would drop the first app's policies,
+/// with both installs reporting success. Holding this lock across the
+/// read-modify-write makes the sequence one at a time per tenant; installs
+/// into different tenants stay parallel.
+#[derive(Default)]
+pub struct TenantInstallLocks {
+    locks: Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
+}
+
+impl TenantInstallLocks {
+    /// Wait for exclusive rights to mutate `tenant`'s installed surface.
+    ///
+    /// The guard is owned, so a caller can hold it across awaits and release
+    /// it early with `drop`. Never hold it across a step that dispatches
+    /// entity actions — a bound-action hook can re-enter the installer for
+    /// the same tenant, and this mutex is not reentrant.
+    pub async fn lock(&self, tenant: &str) -> tokio::sync::OwnedMutexGuard<()> {
+        let tenant_lock = {
+            let mut locks = self
+                .locks
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            locks.entry(tenant.to_string()).or_default().clone()
+        };
+        tenant_lock.lock_owned().await
+    }
+}
 
 /// Shared state for the Temper hosting platform.
 ///
@@ -37,6 +72,8 @@ pub struct PlatformState {
     pub spec_store: Arc<RwLock<SpecStore>>,
     /// Agent identity resolver — maps bearer tokens to verified identities.
     pub identity_resolver: Arc<IdentityResolver>,
+    /// Serializes the install read-modify-write per tenant.
+    pub install_locks: Arc<TenantInstallLocks>,
 }
 
 /// Default broadcast channel capacity.
@@ -91,6 +128,7 @@ impl PlatformState {
             api_token: None,
             spec_store,
             identity_resolver: Arc::new(IdentityResolver::new()),
+            install_locks: Arc::new(TenantInstallLocks::default()),
         };
         state.server.bound_action_hook = Some(Arc::new(
             crate::genesis_install::GenesisInstallHook::new(state.clone()),
@@ -127,6 +165,7 @@ impl PlatformState {
             api_token: None,
             spec_store,
             identity_resolver: Arc::new(IdentityResolver::new()),
+            install_locks: Arc::new(TenantInstallLocks::default()),
         };
         state.server.bound_action_hook = Some(Arc::new(
             crate::genesis_install::GenesisInstallHook::new(state.clone()),

--- a/crates/temper-runtime/src/actor/cell.rs
+++ b/crates/temper-runtime/src/actor/cell.rs
@@ -1,11 +1,27 @@
+use std::sync::Arc;
+
 use tracing::{error, info, warn};
 
 use super::actor_ref::{ActorId, ActorRef, Envelope, SystemSignal};
 use super::context::ActorContext;
-use super::errors::ActorError;
-use super::traits::Actor;
+use super::errors::{ActorError, InitFailureKind};
+use super::traits::{Actor, Message};
 use crate::mailbox::{self, DEFAULT_MAILBOX_CAPACITY, MailboxReceiver};
 use crate::supervision::SupervisionStrategy;
+
+/// Notified exactly once when a cell permanently gives up on initialization.
+///
+/// Spawning an actor usually means recording it somewhere — a registry, an
+/// index — before `pre_start` has had a chance to run. That bookkeeping has to
+/// be undone when the actor never starts, and the cell is the only place that
+/// knows it has stopped trying: it fires after the supervision strategy is
+/// exhausted, whether or not anyone is waiting for a reply, and *before* the
+/// waiting callers are answered, so a caller that sees an init failure can rely
+/// on the retraction having already happened.
+///
+/// The observer runs on the actor's own task. It must not block for long and
+/// must not send to the actor it describes.
+pub type InitFailureObserver = Arc<dyn Fn(&ActorId, &ActorError) + Send + Sync>;
 
 /// The ActorCell is the runtime container for an actor instance.
 /// It owns the actor, its state, its mailbox receiver, and drives the message loop.
@@ -14,6 +30,7 @@ pub struct ActorCell<A: Actor> {
     actor: A,
     id: ActorId,
     mailbox_capacity: usize,
+    on_init_failure: Option<InitFailureObserver>,
 }
 
 impl<A: Actor> ActorCell<A> {
@@ -23,12 +40,19 @@ impl<A: Actor> ActorCell<A> {
             actor,
             id,
             mailbox_capacity: DEFAULT_MAILBOX_CAPACITY,
+            on_init_failure: None,
         }
     }
 
     /// Set custom mailbox capacity (TigerStyle: explicit budgets).
     pub fn with_mailbox_capacity(mut self, capacity: usize) -> Self {
         self.mailbox_capacity = capacity;
+        self
+    }
+
+    /// Observe a permanent initialization failure — see [`InitFailureObserver`].
+    pub fn with_init_failure_observer(mut self, observer: InitFailureObserver) -> Self {
+        self.on_init_failure = Some(observer);
         self
     }
 
@@ -54,6 +78,7 @@ impl<A: Actor> ActorCell<A> {
     async fn run(self, mut rx: MailboxReceiver<A::Msg>) {
         let actor = self.actor;
         let id = self.id;
+        let on_init_failure = self.on_init_failure;
         let strategy = actor.supervision_strategy();
 
         let mut restart_count: u32 = 0;
@@ -78,7 +103,28 @@ impl<A: Actor> ActorCell<A> {
                         tokio::time::sleep(backoff).await; // determinism-ok: production actor cell, backoff between restarts
                         continue;
                     } else {
-                        error!(actor = %id, "actor permanently failed during init");
+                        // The cell is giving up. Tell the observer first: the
+                        // spawner's bookkeeping has to be retracted even when
+                        // the mailbox is empty (nobody ever asked, or the only
+                        // caller walked away), and a caller that is about to be
+                        // handed this failure must find the retraction already
+                        // done rather than race it.
+                        if let Some(observer) = on_init_failure.as_ref() {
+                            observer(&id, &e);
+                        }
+                        // Everything already queued is owed an answer: dropping
+                        // the reply channels turns every waiting `ask` into a
+                        // bare `Stopped` ("actor stopped") and throws the real
+                        // cause away, which is how an init failure became an
+                        // unexplained 500.
+                        let (asks, tells) = fail_pending(&mut rx, &e);
+                        error!(
+                            actor = %id,
+                            error = %e,
+                            failed_asks = asks,
+                            dropped_tells = tells,
+                            "actor permanently failed during init"
+                        );
                         return;
                     }
                 }
@@ -156,38 +202,49 @@ fn should_restart(strategy: &SupervisionStrategy, current_restarts: u32) -> bool
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::time::Duration;
+/// Close the mailbox and answer everything still queued with the init failure
+/// that killed the actor.
+///
+/// Returns `(asks_failed, tells_dropped)`. Closing first means a sender racing
+/// this shutdown gets `SendFailed` instead of queueing behind us forever.
+fn fail_pending<M: Message>(rx: &mut MailboxReceiver<M>, cause: &ActorError) -> (usize, usize) {
+    rx.close();
 
-    #[test]
-    fn stop_strategy_never_restarts() {
-        let strategy = SupervisionStrategy::Stop;
-        assert!(!should_restart(&strategy, 0));
-        assert!(!should_restart(&strategy, 1));
-        assert!(!should_restart(&strategy, 100));
+    let mut asks = 0usize;
+    let mut tells = 0usize;
+    while let Some(envelope) = rx.try_recv() {
+        match envelope {
+            Envelope::Ask { reply, .. } => {
+                // One error per waiting caller: ActorError is not Clone
+                // (anyhow::Error is not), so re-derive it from the cause.
+                let _ = reply.send(Err(init_failure_for(cause)));
+                asks += 1;
+            }
+            Envelope::Tell(_) | Envelope::Signal(_) => tells += 1,
+        }
     }
+    (asks, tells)
+}
 
-    #[test]
-    fn restart_strategy_respects_max_retries() {
-        let strategy = SupervisionStrategy::Restart {
-            max_retries: 3,
-            backoff_base: Duration::from_millis(100),
-        };
-        assert!(should_restart(&strategy, 0));
-        assert!(should_restart(&strategy, 1));
-        assert!(should_restart(&strategy, 2));
-        assert!(!should_restart(&strategy, 3));
-        assert!(!should_restart(&strategy, 4));
-    }
-
-    #[test]
-    fn restart_strategy_zero_retries_never_restarts() {
-        let strategy = SupervisionStrategy::Restart {
-            max_retries: 0,
-            backoff_base: Duration::from_millis(100),
-        };
-        assert!(!should_restart(&strategy, 0));
+/// Restate a `pre_start` error as the init failure the caller should see.
+///
+/// An actor that classified its own failure (see [`ActorError::init_failed`])
+/// keeps that classification; anything else is preserved verbatim as the cause
+/// and inherits the transience the error already declares.
+fn init_failure_for(cause: &ActorError) -> ActorError {
+    match cause {
+        ActorError::InitFailed { cause, kind } => ActorError::init_failed(cause.clone(), *kind),
+        other => ActorError::init_failed(
+            other.to_string(),
+            if other.is_transient() {
+                InitFailureKind::TransientDependency
+            } else {
+                InitFailureKind::Defect
+            },
+        ),
     }
 }
+
+#[cfg(test)]
+#[path = "cell_test.rs"]
+mod tests;

--- a/crates/temper-runtime/src/actor/cell_test.rs
+++ b/crates/temper-runtime/src/actor/cell_test.rs
@@ -1,0 +1,349 @@
+use super::*;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use crate::actor::context::ActorContext;
+use crate::actor::traits::{Actor, Message};
+
+/// What an init-failure observer recorded: the actor name and the kind it saw.
+/// Named because the inline type trips `clippy::type_complexity`, which CI
+/// promotes to an error with `-D warnings`.
+type ObservedInitFailures = Arc<std::sync::Mutex<Vec<(String, Option<InitFailureKind>)>>>;
+
+#[derive(Debug)]
+struct Ping;
+impl Message for Ping {}
+
+/// An actor whose `pre_start` always fails with the supplied error.
+struct NeverStarts {
+    cause: Box<dyn Fn() -> ActorError + Send + Sync>,
+    strategy: SupervisionStrategy,
+    attempts: Arc<AtomicUsize>,
+}
+
+impl Actor for NeverStarts {
+    type Msg = Ping;
+    type State = ();
+
+    fn supervision_strategy(&self) -> SupervisionStrategy {
+        self.strategy.clone()
+    }
+
+    async fn pre_start(&self, _ctx: &mut ActorContext<Self>) -> Result<(), ActorError> {
+        self.attempts.fetch_add(1, Ordering::SeqCst);
+        Err((self.cause)())
+    }
+
+    async fn handle(
+        &self,
+        _msg: Ping,
+        _state: &mut (),
+        _ctx: &mut ActorContext<Self>,
+    ) -> Result<(), ActorError> {
+        Ok(())
+    }
+
+    async fn post_stop(&self, _state: (), _ctx: &mut ActorContext<Self>) {}
+}
+
+fn never_starts(
+    cause: impl Fn() -> ActorError + Send + Sync + 'static,
+) -> (NeverStarts, Arc<AtomicUsize>) {
+    let attempts = Arc::new(AtomicUsize::new(0));
+    (
+        NeverStarts {
+            cause: Box::new(cause),
+            strategy: SupervisionStrategy::Stop,
+            attempts: attempts.clone(),
+        },
+        attempts,
+    )
+}
+
+#[tokio::test]
+async fn pending_ask_gets_the_init_cause_not_stopped() {
+    let (actor, _) = never_starts(|| {
+        ActorError::init_failed(
+            "duplicate declared key 'ws_path' for File: held by fl-019efda8",
+            InitFailureKind::Constraint,
+        )
+    });
+    let actor_ref = ActorCell::new(actor, ActorId::new("file", "test/file-1")).spawn();
+
+    let err = actor_ref
+        .ask::<()>(Ping, Duration::from_secs(5))
+        .await
+        .expect_err("pre_start failed, so the ask cannot succeed");
+
+    match err {
+        ActorError::InitFailed { cause, kind } => {
+            assert_eq!(kind, InitFailureKind::Constraint);
+            assert!(
+                cause.contains("ws_path") && cause.contains("fl-019efda8"),
+                "the underlying cause must reach the caller, got: {cause}"
+            );
+        }
+        other => panic!("expected InitFailed carrying the cause, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn every_queued_ask_is_answered() {
+    // Several callers pile onto one cold entity; all of them must be told
+    // why, not just the one at the head of the mailbox. `join!` polls every
+    // ask once before any of them can await, so all four are enqueued
+    // before the cell runs — no timing race.
+    let (actor, _) = never_starts(|| {
+        ActorError::init_failed("store unavailable", InitFailureKind::TransientDependency)
+    });
+    let actor_ref = ActorCell::new(actor, ActorId::new("file", "test/file-2")).spawn();
+
+    let budget = Duration::from_secs(5);
+    let (a, b, c, d) = tokio::join!(
+        actor_ref.ask::<()>(Ping, budget),
+        actor_ref.ask::<()>(Ping, budget),
+        actor_ref.ask::<()>(Ping, budget),
+        actor_ref.ask::<()>(Ping, budget),
+    );
+
+    for result in [a, b, c, d] {
+        let err = result.expect_err("pre_start failed, so the ask cannot succeed");
+        assert!(
+            err.is_transient(),
+            "a transient dependency failure must stay transient, got {err:?}"
+        );
+        assert_eq!(
+            err.init_failure_kind(),
+            Some(InitFailureKind::TransientDependency)
+        );
+    }
+}
+
+#[tokio::test]
+async fn unclassified_pre_start_failure_is_reported_as_a_defect() {
+    let (actor, attempts) = never_starts(|| ActorError::custom("table lock poisoned"));
+    let actor_ref = ActorCell::new(actor, ActorId::new("file", "test/file-3")).spawn();
+
+    let err = actor_ref
+        .ask::<()>(Ping, Duration::from_secs(5))
+        .await
+        .expect_err("pre_start failed, so the ask cannot succeed");
+
+    assert_eq!(err.init_failure_kind(), Some(InitFailureKind::Defect));
+    assert!(err.is_permanent());
+    assert!(err.to_string().contains("table lock poisoned"));
+    assert_eq!(attempts.load(Ordering::SeqCst), 1, "Stop strategy: one try");
+}
+
+#[tokio::test]
+async fn init_failure_is_reported_after_restarts_are_exhausted() {
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let actor = NeverStarts {
+        cause: Box::new(|| {
+            ActorError::init_failed("store unavailable", InitFailureKind::TransientDependency)
+        }),
+        strategy: SupervisionStrategy::Restart {
+            max_retries: 2,
+            backoff_base: Duration::from_millis(1),
+        },
+        attempts: attempts.clone(),
+    };
+    let actor_ref = ActorCell::new(actor, ActorId::new("file", "test/file-4")).spawn();
+
+    let err = actor_ref
+        .ask::<()>(Ping, Duration::from_secs(5))
+        .await
+        .expect_err("pre_start failed on every attempt");
+
+    assert_eq!(
+        err.init_failure_kind(),
+        Some(InitFailureKind::TransientDependency)
+    );
+    // 1 initial + 2 restarts, all inside the caller's ask.
+    assert_eq!(attempts.load(Ordering::SeqCst), 3);
+}
+
+#[tokio::test]
+async fn mailbox_is_closed_so_later_senders_fail_fast() {
+    let (actor, _) = never_starts(|| ActorError::init_failed("nope", InitFailureKind::Defect));
+    let actor_ref = ActorCell::new(actor, ActorId::new("file", "test/file-5")).spawn();
+
+    let _ = actor_ref.ask::<()>(Ping, Duration::from_secs(5)).await;
+
+    // The cell is gone; a send must be refused immediately rather than
+    // queueing into a mailbox nobody reads.
+    assert_eq!(actor_ref.tell(Ping), Err(ActorError::SendFailed));
+}
+
+/// The regression that matters most: an init failure nobody is waiting for.
+/// The spawner recorded this actor before it started, so the retraction
+/// cannot be conditional on a caller turning up to receive the error.
+#[tokio::test]
+async fn observer_fires_when_no_caller_ever_asks() {
+    let seen: ObservedInitFailures = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let recorder = seen.clone();
+    let (actor, _) = never_starts(|| {
+        ActorError::init_failed("store unavailable", InitFailureKind::TransientDependency)
+    });
+    let _actor_ref = ActorCell::new(actor, ActorId::new("file", "test/file-6"))
+        .with_init_failure_observer(Arc::new(move |id: &ActorId, err: &ActorError| {
+            recorder
+                .lock()
+                .unwrap()
+                .push((id.path.clone(), err.init_failure_kind()));
+        }))
+        .spawn();
+
+    // No ask, no tell — just wait for the cell to give up on its own.
+    for _ in 0..500 {
+        if !seen.lock().unwrap().is_empty() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    let seen = seen.lock().unwrap();
+    assert_eq!(
+        seen.len(),
+        1,
+        "an unwatched init failure must still be reported exactly once, got {seen:?}"
+    );
+    assert_eq!(seen[0].0, "test/file-6");
+    assert_eq!(
+        seen[0].1,
+        Some(InitFailureKind::TransientDependency),
+        "the observer needs the classification to decide what to retract"
+    );
+}
+
+#[tokio::test]
+async fn observer_runs_before_any_caller_is_answered() {
+    let retracted = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let flag = retracted.clone();
+    let (actor, _) = never_starts(|| {
+        ActorError::init_failed("duplicate declared key 'path'", InitFailureKind::Constraint)
+    });
+    let actor_ref = ActorCell::new(actor, ActorId::new("file", "test/file-7"))
+        .with_init_failure_observer(Arc::new(move |_: &ActorId, _: &ActorError| {
+            flag.store(true, Ordering::SeqCst);
+        }))
+        .spawn();
+
+    let err = actor_ref
+        .ask::<()>(Ping, Duration::from_secs(5))
+        .await
+        .expect_err("pre_start failed, so the ask cannot succeed");
+
+    assert_eq!(err.init_failure_kind(), Some(InitFailureKind::Constraint));
+    assert!(
+        retracted.load(Ordering::SeqCst),
+        "a caller handed an init failure must find the spawn already retracted, \
+         or it races the cleanup it depends on"
+    );
+}
+
+#[tokio::test]
+async fn observer_fires_once_after_restarts_are_exhausted() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let counter = calls.clone();
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let actor = NeverStarts {
+        cause: Box::new(|| {
+            ActorError::init_failed("store unavailable", InitFailureKind::TransientDependency)
+        }),
+        strategy: SupervisionStrategy::Restart {
+            max_retries: 2,
+            backoff_base: Duration::from_millis(1),
+        },
+        attempts: attempts.clone(),
+    };
+    let actor_ref = ActorCell::new(actor, ActorId::new("file", "test/file-8"))
+        .with_init_failure_observer(Arc::new(move |_: &ActorId, _: &ActorError| {
+            counter.fetch_add(1, Ordering::SeqCst);
+        }))
+        .spawn();
+
+    let _ = actor_ref.ask::<()>(Ping, Duration::from_secs(5)).await;
+
+    assert_eq!(attempts.load(Ordering::SeqCst), 3, "1 initial + 2 restarts");
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "a cell that is still retrying has not given up — retracting mid-retry \
+         would un-register an actor that may yet start"
+    );
+}
+
+#[tokio::test]
+async fn observer_is_silent_when_init_succeeds() {
+    struct Healthy;
+    impl Actor for Healthy {
+        type Msg = Ping;
+        type State = ();
+        async fn pre_start(&self, _ctx: &mut ActorContext<Self>) -> Result<(), ActorError> {
+            Ok(())
+        }
+        async fn handle(
+            &self,
+            _msg: Ping,
+            _state: &mut (),
+            ctx: &mut ActorContext<Self>,
+        ) -> Result<(), ActorError> {
+            ctx.reply(());
+            Ok(())
+        }
+        async fn post_stop(&self, _state: (), _ctx: &mut ActorContext<Self>) {}
+    }
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let counter = calls.clone();
+    let actor_ref = ActorCell::new(Healthy, ActorId::new("file", "test/file-9"))
+        .with_init_failure_observer(Arc::new(move |_: &ActorId, _: &ActorError| {
+            counter.fetch_add(1, Ordering::SeqCst);
+        }))
+        .spawn();
+
+    actor_ref
+        .ask::<()>(Ping, Duration::from_secs(5))
+        .await
+        .expect("a healthy actor answers");
+    actor_ref.stop().expect("stop is accepted");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        0,
+        "an actor that started and then stopped did not fail to initialize"
+    );
+}
+
+#[test]
+fn stop_strategy_never_restarts() {
+    let strategy = SupervisionStrategy::Stop;
+    assert!(!should_restart(&strategy, 0));
+    assert!(!should_restart(&strategy, 1));
+    assert!(!should_restart(&strategy, 100));
+}
+
+#[test]
+fn restart_strategy_respects_max_retries() {
+    let strategy = SupervisionStrategy::Restart {
+        max_retries: 3,
+        backoff_base: Duration::from_millis(100),
+    };
+    assert!(should_restart(&strategy, 0));
+    assert!(should_restart(&strategy, 1));
+    assert!(should_restart(&strategy, 2));
+    assert!(!should_restart(&strategy, 3));
+    assert!(!should_restart(&strategy, 4));
+}
+
+#[test]
+fn restart_strategy_zero_retries_never_restarts() {
+    let strategy = SupervisionStrategy::Restart {
+        max_retries: 0,
+        backoff_base: Duration::from_millis(100),
+    };
+    assert!(!should_restart(&strategy, 0));
+}

--- a/crates/temper-runtime/src/actor/errors.rs
+++ b/crates/temper-runtime/src/actor/errors.rs
@@ -1,5 +1,37 @@
 use thiserror::Error;
 
+/// Why an actor could not initialize, from the caller's point of view.
+///
+/// `pre_start` failures are not interchangeable: a constraint rejection is the
+/// caller's input being wrong, a store blip is the platform being briefly
+/// unavailable, and anything else is a defect. Callers (HTTP mapping, dispatch
+/// retry) need to tell them apart without parsing an error string, so the
+/// classification travels with the error instead of being re-derived.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InitFailureKind {
+    /// A uniqueness / integrity constraint rejected the actor's bootstrap
+    /// write. The same request will be rejected the same way forever — the
+    /// caller must change its input. Maps to HTTP 409.
+    Constraint,
+    /// A dependency the actor needs to initialize (event store, network)
+    /// failed in a way that may clear on its own. Maps to HTTP 503.
+    TransientDependency,
+    /// Anything else — a defect in the actor or its configuration. Retrying
+    /// does not help. Maps to HTTP 500.
+    Defect,
+}
+
+impl InitFailureKind {
+    /// Stable label for metrics and logs.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Constraint => "constraint",
+            Self::TransientDependency => "transient_dependency",
+            Self::Defect => "defect",
+        }
+    }
+}
+
 /// Errors that can occur during actor lifecycle and message handling.
 #[derive(Error, Debug)]
 pub enum ActorError {
@@ -18,8 +50,22 @@ pub enum ActorError {
     #[error("actor panicked: {0}")]
     Panicked(String),
 
-    #[error("actor init failed: {0}")]
-    InitFailed(String),
+    /// The actor could not initialize: `pre_start` returned an error and the
+    /// supervision strategy gave up.
+    ///
+    /// Distinct from [`ActorError::Stopped`], which means "you asked an actor
+    /// that had already finished". Conflating the two hides the cause: an
+    /// `ask` whose reply channel is dropped by a dying cell reads as
+    /// `Stopped`, which tells the caller nothing about *why* and cannot be
+    /// classified. This variant carries the underlying cause verbatim and the
+    /// classification the caller needs.
+    #[error("actor init failed ({}): {cause}", kind.as_str())]
+    InitFailed {
+        /// The underlying failure, formatted at the point it happened.
+        cause: String,
+        /// How the caller should treat it.
+        kind: InitFailureKind,
+    },
 
     #[error("max restart attempts exceeded ({0})")]
     MaxRestartsExceeded(u32),
@@ -34,16 +80,40 @@ impl ActorError {
         Self::Custom(anyhow::anyhow!("{}", msg.into()))
     }
 
+    /// Create an init failure carrying its cause and classification.
+    pub fn init_failed(cause: impl Into<String>, kind: InitFailureKind) -> Self {
+        Self::InitFailed {
+            cause: cause.into(),
+            kind,
+        }
+    }
+
+    /// The init-failure classification, if this is an init failure.
+    pub fn init_failure_kind(&self) -> Option<InitFailureKind> {
+        match self {
+            Self::InitFailed { kind, .. } => Some(*kind),
+            _ => None,
+        }
+    }
+
     /// Returns `true` if retrying the operation may succeed because the cause
-    /// is timing or capacity related rather than logic.
+    /// is timing, capacity, or dependency related rather than logic.
     ///
     /// Transient variants:
     /// - `AskTimeout` — the actor did not reply within the per-attempt budget.
     /// - `MailboxFull` — the actor's bounded mailbox refused the message.
+    /// - `InitFailed` with [`InitFailureKind::TransientDependency`] — the
+    ///   actor could not start because a dependency was briefly unavailable.
+    ///   Before this existed every init failure was permanent, so a store blip
+    ///   during spawn was reported as a hard error and never retried.
     ///
     /// See ADR-0048 (Dispatch-layer retry and error taxonomy).
     pub fn is_transient(&self) -> bool {
-        matches!(self, Self::AskTimeout(_) | Self::MailboxFull)
+        match self {
+            Self::AskTimeout(_) | Self::MailboxFull => true,
+            Self::InitFailed { kind, .. } => *kind == InitFailureKind::TransientDependency,
+            _ => false,
+        }
     }
 
     /// Returns `true` if the error reflects a terminal condition and retries
@@ -85,8 +155,16 @@ mod tests {
             "actor panicked: boom"
         );
         assert_eq!(
-            ActorError::InitFailed("init error".to_string()).to_string(),
-            "actor init failed: init error"
+            ActorError::init_failed("init error", InitFailureKind::Defect).to_string(),
+            "actor init failed (defect): init error"
+        );
+        assert_eq!(
+            ActorError::init_failed(
+                "duplicate declared key 'ws_path' for File: held by fl-1",
+                InitFailureKind::Constraint
+            )
+            .to_string(),
+            "actor init failed (constraint): duplicate declared key 'ws_path' for File: held by fl-1"
         );
         assert_eq!(
             ActorError::MaxRestartsExceeded(3).to_string(),
@@ -116,12 +194,17 @@ mod tests {
         // Transient variants — retrying may succeed.
         assert!(ActorError::AskTimeout(Duration::from_secs(5)).is_transient());
         assert!(ActorError::MailboxFull.is_transient());
+        assert!(
+            ActorError::init_failed("store down", InitFailureKind::TransientDependency)
+                .is_transient()
+        );
 
         // Permanent variants — retrying is pointless.
         assert!(ActorError::Stopped.is_permanent());
         assert!(ActorError::SendFailed.is_permanent());
         assert!(ActorError::Panicked("x".into()).is_permanent());
-        assert!(ActorError::InitFailed("x".into()).is_permanent());
+        assert!(ActorError::init_failed("x", InitFailureKind::Defect).is_permanent());
+        assert!(ActorError::init_failed("dup key", InitFailureKind::Constraint).is_permanent());
         assert!(ActorError::MaxRestartsExceeded(3).is_permanent());
         assert!(ActorError::custom("boom").is_permanent());
     }
@@ -135,7 +218,9 @@ mod tests {
             ActorError::SendFailed,
             ActorError::AskTimeout(Duration::from_millis(1)),
             ActorError::Panicked("p".into()),
-            ActorError::InitFailed("i".into()),
+            ActorError::init_failed("i", InitFailureKind::Defect),
+            ActorError::init_failed("i", InitFailureKind::Constraint),
+            ActorError::init_failed("i", InitFailureKind::TransientDependency),
             ActorError::MaxRestartsExceeded(1),
             ActorError::custom("c"),
         ];
@@ -146,5 +231,39 @@ mod tests {
                 "variant {err:?} is both (or neither) transient and permanent"
             );
         }
+    }
+
+    #[test]
+    fn init_failure_is_distinct_from_stopped() {
+        // The bug this taxonomy fixes: an ask against an actor that died in
+        // pre_start used to be indistinguishable from an ask against an actor
+        // that had already finished its work.
+        let stopped = ActorError::Stopped;
+        let init = ActorError::init_failed("boom", InitFailureKind::Constraint);
+        assert_ne!(stopped, init);
+        assert_eq!(stopped.init_failure_kind(), None);
+        assert_eq!(init.init_failure_kind(), Some(InitFailureKind::Constraint));
+    }
+
+    #[test]
+    fn init_failure_preserves_the_underlying_cause() {
+        let err = ActorError::init_failed(
+            "duplicate declared key 'ws_path' for File: held by fl-019efda8",
+            InitFailureKind::Constraint,
+        );
+        // The operator-facing cause must survive to the caller verbatim —
+        // that is the whole point of the variant.
+        assert!(err.to_string().contains("ws_path"));
+        assert!(err.to_string().contains("fl-019efda8"));
+    }
+
+    #[test]
+    fn init_failure_kind_labels_are_stable() {
+        assert_eq!(InitFailureKind::Constraint.as_str(), "constraint");
+        assert_eq!(
+            InitFailureKind::TransientDependency.as_str(),
+            "transient_dependency"
+        );
+        assert_eq!(InitFailureKind::Defect.as_str(), "defect");
     }
 }

--- a/crates/temper-runtime/src/actor/mod.rs
+++ b/crates/temper-runtime/src/actor/mod.rs
@@ -5,7 +5,7 @@ pub(crate) mod errors;
 pub(crate) mod traits;
 
 pub use actor_ref::{ActorId, ActorRef, SystemSignal};
-pub use cell::ActorCell;
+pub use cell::{ActorCell, InitFailureObserver};
 pub use context::ActorContext;
-pub use errors::ActorError;
+pub use errors::{ActorError, InitFailureKind};
 pub use traits::{Actor, Message};

--- a/crates/temper-runtime/src/mailbox/mod.rs
+++ b/crates/temper-runtime/src/mailbox/mod.rs
@@ -85,6 +85,23 @@ impl<M: Message> MailboxReceiver<M> {
     pub async fn recv(&mut self) -> Option<Envelope<M>> {
         self.inner.recv().await
     }
+
+    /// Take the next already-queued message without waiting. Returns `None`
+    /// when the mailbox is momentarily empty *or* closed — used by the actor
+    /// cell to drain queued work when it is about to give up, so pending asks
+    /// get an answer instead of a dropped reply channel.
+    pub fn try_recv(&mut self) -> Option<Envelope<M>> {
+        self.inner.try_recv().ok()
+    }
+
+    /// Refuse further sends while leaving queued messages receivable.
+    ///
+    /// The cell closes the mailbox before draining so a sender racing the
+    /// shutdown gets a deterministic `SendFailed` rather than queueing into a
+    /// mailbox nobody will ever read.
+    pub fn close(&mut self) {
+        self.inner.close();
+    }
 }
 
 impl<M: Message> Clone for MailboxSender<M> {

--- a/crates/temper-runtime/src/persistence/mod.rs
+++ b/crates/temper-runtime/src/persistence/mod.rs
@@ -503,12 +503,117 @@ pub enum PersistenceError {
     #[error("serialization error: {0}")]
     Serialization(String),
 
+    /// A declared-key uniqueness constraint rejected the append (ADR-0153):
+    /// a *different* entity of the same type already holds this key value.
+    ///
+    /// Kept separate from [`PersistenceError::Storage`] because it is a
+    /// constraint decision, not a backend fault: the caller sent a conflicting
+    /// value and retrying the same write can never succeed. Callers map it to
+    /// a conflict (HTTP 409) and surface `key_name` + `holder_id` so the writer
+    /// can see which key collided and who holds it.
+    #[error("duplicate declared key '{key_name}' for {entity_type}: held by {holder_id}")]
+    DeclaredKeyConflict {
+        /// Entity type the declared key belongs to.
+        entity_type: String,
+        /// Declared key name (as written in the spec).
+        key_name: String,
+        /// Entity id that currently holds the key value.
+        holder_id: String,
+    },
+
     /// Underlying storage backend returned an error.
     #[error("storage error: {0}")]
     Storage(String),
 }
 
+impl PersistenceError {
+    /// Returns `true` if retrying the identical write may succeed.
+    ///
+    /// - `Storage` — the backend failed for a reason it did not name
+    ///   (connection reset, statement timeout, deadlock); a retry may land.
+    /// - `ConcurrencyViolation` — another writer won the race; a retry
+    ///   re-reads the sequence and may land.
+    /// - `DeclaredKeyConflict` / `Serialization` — terminal. The same input
+    ///   fails the same way every time, so a retry only adds load.
+    pub fn is_transient(&self) -> bool {
+        matches!(self, Self::Storage(_) | Self::ConcurrencyViolation { .. })
+    }
+
+    /// Returns `true` if the error is terminal for this write. Every variant is
+    /// exactly one of transient or permanent, never both.
+    pub fn is_permanent(&self) -> bool {
+        !self.is_transient()
+    }
+}
+
 /// Convert backend-specific errors into [`PersistenceError::Storage`].
 pub fn storage_error(err: impl std::fmt::Display) -> PersistenceError {
     PersistenceError::Storage(err.to_string())
+}
+
+#[cfg(test)]
+mod persistence_error_tests {
+    use super::PersistenceError;
+
+    #[test]
+    fn declared_key_conflict_names_the_key_and_the_holder() {
+        let err = PersistenceError::DeclaredKeyConflict {
+            entity_type: "File".to_string(),
+            key_name: "ws_path".to_string(),
+            holder_id: "fl-019efda8".to_string(),
+        };
+        // Callers surface this text straight to the writer, so it must stay
+        // self-explanatory.
+        assert_eq!(
+            err.to_string(),
+            "duplicate declared key 'ws_path' for File: held by fl-019efda8"
+        );
+    }
+
+    #[test]
+    fn a_constraint_rejection_is_not_a_backend_fault() {
+        // The distinction the outage turned on: a rejected write is terminal
+        // and must not be retried; an unexplained backend error may clear.
+        let conflict = PersistenceError::DeclaredKeyConflict {
+            entity_type: "File".to_string(),
+            key_name: "ws_path".to_string(),
+            holder_id: "fl-1".to_string(),
+        };
+        assert!(conflict.is_permanent());
+        assert!(!conflict.is_transient());
+
+        assert!(PersistenceError::Storage("connection reset".into()).is_transient());
+        assert!(
+            PersistenceError::ConcurrencyViolation {
+                expected: 1,
+                actual: 2
+            }
+            .is_transient()
+        );
+        assert!(PersistenceError::Serialization("bad json".into()).is_permanent());
+    }
+
+    #[test]
+    fn transient_and_permanent_are_mutually_exclusive() {
+        let all = [
+            PersistenceError::ConcurrencyViolation {
+                expected: 0,
+                actual: 1,
+            },
+            PersistenceError::Serialization("s".into()),
+            PersistenceError::DeclaredKeyConflict {
+                entity_type: "T".into(),
+                key_name: "k".into(),
+                holder_id: "h".into(),
+            },
+            PersistenceError::Storage("s".into()),
+        ];
+        for err in all {
+            assert_ne!(
+                err.is_transient(),
+                err.is_permanent(),
+                "{err} is both (or neither) transient and permanent"
+            );
+        }
+    }
 }

--- a/crates/temper-runtime/src/system/mod.rs
+++ b/crates/temper-runtime/src/system/mod.rs
@@ -1,5 +1,5 @@
 use crate::actor::actor_ref::{ActorId, ActorRef};
-use crate::actor::cell::ActorCell;
+use crate::actor::cell::{ActorCell, InitFailureObserver};
 use crate::actor::traits::Actor;
 
 /// The ActorSystem is the top-level container for all actors.
@@ -20,11 +20,38 @@ impl ActorSystem {
     /// Spawn a new top-level actor in this system.
     /// Returns an ActorRef for communicating with the actor.
     pub fn spawn<A: Actor>(&self, actor: A, name: impl Into<String>) -> ActorRef<A::Msg> {
+        self.spawn_cell(actor, name, None)
+    }
+
+    /// Spawn an actor whose permanent initialization failure must be observed.
+    ///
+    /// For spawners that record the actor somewhere before it starts: the
+    /// observer is how that record gets retracted when `pre_start` never
+    /// succeeds, including when no caller is waiting to be told. See
+    /// [`InitFailureObserver`].
+    pub fn spawn_observing_init_failure<A: Actor>(
+        &self,
+        actor: A,
+        name: impl Into<String>,
+        on_init_failure: InitFailureObserver,
+    ) -> ActorRef<A::Msg> {
+        self.spawn_cell(actor, name, Some(on_init_failure))
+    }
+
+    fn spawn_cell<A: Actor>(
+        &self,
+        actor: A,
+        name: impl Into<String>,
+        on_init_failure: Option<InitFailureObserver>,
+    ) -> ActorRef<A::Msg> {
         let actor_name = name.into();
         let path = format!("/{}/{}", self.name, actor_name);
         let id = ActorId::new(&actor_name, &path);
 
-        let cell = ActorCell::new(actor, id);
+        let mut cell = ActorCell::new(actor, id);
+        if let Some(observer) = on_init_failure {
+            cell = cell.with_init_failure_observer(observer);
+        }
         cell.spawn()
     }
 

--- a/crates/temper-server/src/api/authorize.rs
+++ b/crates/temper-server/src/api/authorize.rs
@@ -9,7 +9,9 @@ use axum::response::IntoResponse;
 use temper_runtime::scheduler::sim_now;
 use tracing::instrument;
 
-use crate::authz::{DenialInput, record_authz_denial, security_context_from_headers};
+use crate::authz::{
+    DenialInput, denial_status, record_denial_if_policy, security_context_from_headers,
+};
 use crate::odata::extract_tenant;
 use crate::state::{ServerState, TrajectoryEntry, TrajectorySource};
 
@@ -58,8 +60,9 @@ pub(crate) async fn handle_authorize(
         Err(denial) => {
             let reason = denial.to_string();
 
-            let pd = record_authz_denial(
+            let pd = record_denial_if_policy(
                 &state,
+                &denial,
                 DenialInput {
                     tenant: tenant.as_str(),
                     security_ctx: &security_ctx,
@@ -78,6 +81,23 @@ pub(crate) async fn handle_authorize(
                 },
             )
             .await;
+
+            // A policy denial is an answer: 200 with `allowed: false` and a
+            // decision the human can approve. A request or engine fault is not
+            // an answer at all, so it surfaces as an error status instead of
+            // being reported as a decision nobody made (ARN-287).
+            let Some(pd) = pd else {
+                return (
+                    denial_status(&denial),
+                    axum::Json(serde_json::json!({
+                        "error": {
+                            "code": denial.error_code(),
+                            "message": reason,
+                        }
+                    })),
+                )
+                    .into_response();
+            };
 
             (
                 StatusCode::OK,

--- a/crates/temper-server/src/api/mod.rs
+++ b/crates/temper-server/src/api/mod.rs
@@ -23,7 +23,9 @@ use axum::response::IntoResponse;
 use axum::routing::{get, patch, post, put};
 use temper_authz::PrincipalKind;
 
-use crate::authz::{DenialInput, record_authz_denial, security_context_from_headers};
+use crate::authz::{
+    DenialInput, denial_status, record_denial_if_policy, security_context_from_headers,
+};
 use crate::state::ServerState;
 
 /// Build the management API router (mounted at /api).
@@ -208,8 +210,9 @@ pub(crate) async fn require_policy_auth(
         tenant,
     ) {
         let reason = denial.to_string();
-        let pd = record_authz_denial(
+        let pd = record_denial_if_policy(
             state,
+            &denial,
             DenialInput {
                 tenant,
                 security_ctx: &security_ctx,
@@ -225,13 +228,17 @@ pub(crate) async fn require_policy_auth(
             },
         )
         .await;
+        let message = match pd {
+            Some(pd) => format!("{reason} Decision {}", pd.id),
+            None => reason,
+        };
         return Some(
             (
-                StatusCode::FORBIDDEN,
+                denial_status(&denial),
                 axum::Json(serde_json::json!({
                     "error": {
-                        "code": "AuthorizationDenied",
-                        "message": format!("{reason} Decision {}", pd.id),
+                        "code": denial.error_code(),
+                        "message": message,
                     }
                 })),
             )

--- a/crates/temper-server/src/authz/helpers.rs
+++ b/crates/temper-server/src/authz/helpers.rs
@@ -7,12 +7,68 @@
 use std::collections::BTreeMap;
 
 use axum::http::{HeaderMap, StatusCode};
-use temper_authz::SecurityContext;
+use temper_authz::{AuthzDenial, DenialClass, SecurityContext};
 use temper_runtime::scheduler::{sim_now, sim_uuid};
 use temper_runtime::tenant::TenantId;
 
 use crate::request_context::{AgentContext, intent_from_headers};
 use crate::state::{PendingDecision, TrajectoryEntry, TrajectorySource};
+
+/// HTTP status for an authorization denial, by what the denial actually is.
+///
+/// A policy decision is a 403: the request was understood and refused, and a
+/// policy change can make it succeed. A request fault is a 400: the caller
+/// sent something that never became a valid Cedar question, so retrying or
+/// widening policy cannot help. An engine fault is a 500: the request was
+/// fine, we failed (ARN-287).
+pub(crate) fn denial_status(denial: &AuthzDenial) -> StatusCode {
+    match denial.class() {
+        DenialClass::Policy => StatusCode::FORBIDDEN,
+        DenialClass::RequestFault => StatusCode::BAD_REQUEST,
+        DenialClass::EngineFault => StatusCode::INTERNAL_SERVER_ERROR,
+    }
+}
+
+/// Record an authorization denial for human review — but only when it is a
+/// policy decision.
+///
+/// Request and engine faults are dropped from the approval queue on purpose:
+/// "invalid resource: unexpected token `fl`" is not something a human can
+/// approve, and recording it buries the decisions that are (ARN-287). Faults
+/// are logged instead, at the severity their class deserves.
+///
+/// Returns `None` when nothing was recorded.
+pub(crate) async fn record_denial_if_policy(
+    state: &crate::state::ServerState,
+    denial: &AuthzDenial,
+    input: DenialInput<'_>,
+) -> Option<PendingDecision> {
+    match denial.class() {
+        DenialClass::Policy => Some(record_authz_denial(state, input).await),
+        DenialClass::RequestFault => {
+            tracing::warn!(
+                reason = %denial,
+                tenant = input.tenant,
+                action = input.action,
+                resource_type = input.resource_type,
+                resource_id = input.resource_id,
+                "malformed authorization request; not recorded as a pending decision"
+            );
+            None
+        }
+        DenialClass::EngineFault => {
+            tracing::error!(
+                reason = %denial,
+                tenant = input.tenant,
+                action = input.action,
+                resource_type = input.resource_type,
+                resource_id = input.resource_id,
+                "authorization engine failure; not recorded as a pending decision"
+            );
+            None
+        }
+    }
+}
 
 /// Extract `X-Temper-*` headers from an axum `HeaderMap` into `(key, value)` pairs
 /// suitable for `SecurityContext::from_headers`.
@@ -48,8 +104,9 @@ pub(crate) fn security_context_from_headers(
 /// Check Cedar authorization for observe endpoints.
 ///
 /// Admin and System principals bypass the check. Other principals must have the
-/// specified `action` on `resource_type`. Returns `Ok(())` if authorized or
-/// `Err(StatusCode::FORBIDDEN)` if denied.
+/// specified `action` on `resource_type`. Returns `Ok(())` if authorized, or
+/// the status matching the denial's class — 403 for a policy denial, 400 for a
+/// malformed request, 500 for an engine failure.
 pub(crate) fn require_observe_auth(
     state: &crate::state::ServerState,
     headers: &HeaderMap,
@@ -75,7 +132,7 @@ pub(crate) fn require_observe_auth(
         tenant,
     ) {
         tracing::warn!(reason = %denial, action, resource_type, "unauthorized observe access");
-        return Err(axum::http::StatusCode::FORBIDDEN);
+        return Err(denial_status(&denial));
     }
     Ok(())
 }
@@ -241,6 +298,10 @@ pub(crate) struct GovernedMutationAuth<'a> {
 /// `PendingDecision` records. Non-agent or sessionless denials stay ordinary
 /// `403 Forbidden` responses so passive/admin surfaces do not generate noisy
 /// approval work.
+///
+/// Only policy denials become decisions. Request and engine faults return
+/// their own status (400/500) with no `decision_id`, because there is nothing
+/// to approve — see [`record_denial_if_policy`].
 #[allow(unused)] // Staged for governed management endpoints after the latency package lands.
 pub(crate) async fn require_governed_mutation_auth(
     state: &crate::state::ServerState,
@@ -282,8 +343,9 @@ pub(crate) async fn require_governed_mutation_auth(
     {
         let resource_attrs_json =
             serde_json::to_value(&input.resource_attrs).unwrap_or_else(|_| serde_json::json!({}));
-        let pd = record_authz_denial(
+        let pd = record_denial_if_policy(
             state,
+            &denial,
             DenialInput {
                 tenant: input.tenant,
                 security_ctx: &security_ctx,
@@ -299,13 +361,27 @@ pub(crate) async fn require_governed_mutation_auth(
             },
         )
         .await;
+        if let Some(pd) = pd {
+            return Some((
+                StatusCode::FORBIDDEN,
+                serde_json::json!({
+                    "decision_id": pd.id,
+                    "error": {
+                        "code": "AuthorizationDenied",
+                        "message": format!("{reason} Decision {}", pd.id),
+                    }
+                })
+                .to_string(),
+            ));
+        }
+        // Fault, not a decision: there is no `decision_id` to hand back and
+        // nothing for a human to approve.
         return Some((
-            StatusCode::FORBIDDEN,
+            denial_status(&denial),
             serde_json::json!({
-                "decision_id": pd.id,
                 "error": {
-                    "code": "AuthorizationDenied",
-                    "message": format!("{reason} Decision {}", pd.id),
+                    "code": denial.error_code(),
+                    "message": reason,
                 }
             })
             .to_string(),
@@ -319,7 +395,7 @@ pub(crate) async fn require_governed_mutation_auth(
         resource_id = input.resource_id,
         "unauthorized non-resumable governed mutation"
     );
-    Some((StatusCode::FORBIDDEN, reason))
+    Some((denial_status(&denial), reason))
 }
 
 /// Record result of an authorization denial.
@@ -329,6 +405,11 @@ pub(crate) async fn require_governed_mutation_auth(
 ///
 /// Returns the `PendingDecision` so callers can include the decision ID in
 /// their HTTP response.
+///
+/// Call this only for denials a human could actually act on. Callers holding
+/// an [`AuthzDenial`] should go through [`record_denial_if_policy`], which
+/// enforces that; a request or engine fault recorded here becomes an approval
+/// queue row that can never be approved (ARN-287).
 pub(crate) async fn record_authz_denial(
     state: &crate::state::ServerState,
     input: DenialInput<'_>,
@@ -484,6 +565,114 @@ mod tests {
     use axum::http::{HeaderMap, HeaderName, HeaderValue};
     use serde_json::Value;
     use temper_authz::PrincipalKind;
+    use temper_runtime::ActorSystem;
+    use temper_spec::csdl::parse_csdl;
+
+    fn test_state() -> crate::state::ServerState {
+        let csdl_xml = include_str!("../../../../test-fixtures/specs/model.csdl.xml");
+        let csdl = parse_csdl(csdl_xml).expect("CSDL should parse");
+        crate::state::ServerState::new(
+            ActorSystem::new("authz-denial-taxonomy-test"),
+            csdl,
+            csdl_xml.to_string(),
+        )
+    }
+
+    fn denial_input<'a>(security_ctx: &'a SecurityContext, reason: &'a str) -> DenialInput<'a> {
+        DenialInput {
+            tenant: "t",
+            security_ctx,
+            agent_id_override: None,
+            action: "update",
+            resource_type: "File",
+            resource_id: "fl-1",
+            resource_attrs: serde_json::json!({}),
+            reason,
+            module_name: None,
+            from_status: None,
+            intent: None,
+        }
+    }
+
+    #[test]
+    fn policy_denials_are_403_faults_are_400_and_500() {
+        assert_eq!(
+            denial_status(&AuthzDenial::NoMatchingPermit),
+            StatusCode::FORBIDDEN
+        );
+        assert_eq!(
+            denial_status(&AuthzDenial::PolicyDenied {
+                policy_ids: vec!["katagami-commons/art_style.cedar#2".into()],
+            }),
+            StatusCode::FORBIDDEN
+        );
+        for fault in [
+            AuthzDenial::InvalidPrincipal("bad".into()),
+            AuthzDenial::InvalidAction("bad".into()),
+            AuthzDenial::InvalidResource("unexpected token `fl`".into()),
+            AuthzDenial::InvalidContext("bad".into()),
+        ] {
+            assert_eq!(
+                denial_status(&fault),
+                StatusCode::BAD_REQUEST,
+                "{fault} is the caller's mistake, not a refusal"
+            );
+        }
+        assert_eq!(
+            denial_status(&AuthzDenial::EngineError("poisoned".into())),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+    }
+
+    #[tokio::test]
+    async fn request_and_engine_faults_are_not_recorded_as_decisions() {
+        // ARN-287: an "invalid resource" is not something a human can approve.
+        // Recording it fills the approval queue with rows nobody can action.
+        let state = test_state();
+        let ctx = SecurityContext::from_headers(&[]);
+        let mut decisions = state.pending_decision_tx.subscribe();
+
+        for fault in [
+            AuthzDenial::InvalidResource("unexpected token `fl`".into()),
+            AuthzDenial::InvalidPrincipal("bad".into()),
+            AuthzDenial::InvalidAction("bad".into()),
+            AuthzDenial::InvalidContext("bad".into()),
+            AuthzDenial::EngineError("policy lock poisoned".into()),
+        ] {
+            let reason = fault.to_string();
+            let recorded =
+                record_denial_if_policy(&state, &fault, denial_input(&ctx, &reason)).await;
+            assert!(
+                recorded.is_none(),
+                "{fault} must not become a pending decision"
+            );
+        }
+
+        assert!(
+            decisions.try_recv().is_err(),
+            "no pending decision should have been broadcast for a fault"
+        );
+    }
+
+    #[tokio::test]
+    async fn policy_denials_are_still_recorded_as_decisions() {
+        let state = test_state();
+        let ctx = SecurityContext::from_headers(&[]);
+        let mut decisions = state.pending_decision_tx.subscribe();
+
+        let denial = AuthzDenial::PolicyDenied {
+            policy_ids: vec!["katagami-commons/art_style.cedar#2".into()],
+        };
+        let reason = denial.to_string();
+        let recorded = record_denial_if_policy(&state, &denial, denial_input(&ctx, &reason)).await;
+
+        let recorded = recorded.expect("a policy denial is a decision a human can approve");
+        assert_eq!(recorded.action, "update");
+        let broadcast = decisions
+            .try_recv()
+            .expect("the decision should reach the Observe UI");
+        assert_eq!(broadcast.id, recorded.id);
+    }
 
     #[test]
     fn extract_temper_headers_filters_correctly() {

--- a/crates/temper-server/src/authz/mod.rs
+++ b/crates/temper-server/src/authz/mod.rs
@@ -6,9 +6,9 @@ pub mod wasm_gate;
 
 #[allow(unused_imports)] // Used by observe/ handlers via crate::authz::observe_tenant_scope
 pub(crate) use helpers::{
-    DenialInput, GovernedMutationAuth, observe_tenant_scope, record_authz_denial,
-    require_governed_mutation_auth, require_observe_auth, require_trajectory_content_auth,
-    security_context_from_headers,
+    DenialInput, GovernedMutationAuth, denial_status, observe_tenant_scope, record_authz_denial,
+    record_denial_if_policy, require_governed_mutation_auth, require_observe_auth,
+    require_trajectory_content_auth, security_context_from_headers,
 };
 pub use policy_persistence::{load_and_activate_tenant_policies, persist_and_activate_policy};
 pub use wasm_gate::{CedarWasmAuthzGate, PermissiveWasmAuthzGate};

--- a/crates/temper-server/src/authz/policy_persistence.rs
+++ b/crates/temper-server/src/authz/policy_persistence.rs
@@ -133,16 +133,17 @@ pub async fn load_and_activate_tenant_policies(state: &ServerState, tenant: &str
         return;
     }
 
-    // Build named policy entries for per-policy PolicyId assignment.
+    // Build named policy entries for per-policy PolicyId assignment. A row's
+    // `policy_id` is the label, so os-app rows carry their source file.
     let enabled_count = rows.iter().filter(|r| r.enabled).count();
-    let named_policies: Vec<(String, String)> = rows
+    let named_policies: Vec<temper_authz::PolicySource> = rows
         .iter()
         .filter(|r| r.enabled)
         .map(|r| (r.policy_id.clone(), r.cedar_text.clone()))
         .collect();
 
     // Load into the per-tenant Cedar engine with meaningful PolicyIds
-    // (e.g., "default:os-app:project-management:2" instead of "policy0").
+    // (e.g. "katagami-commons/art_style.cedar#2" instead of "policy1874").
     if let Err(e) = state
         .authz
         .reload_tenant_policies_named(tenant, &named_policies)

--- a/crates/temper-server/src/entity_actor/actor.rs
+++ b/crates/temper-server/src/entity_actor/actor.rs
@@ -27,7 +27,7 @@ use std::time::Instant;
 
 use temper_jit::table::{Effect, TransitionTable};
 use temper_observe::wide_event;
-use temper_runtime::actor::{Actor, ActorContext, ActorError};
+use temper_runtime::actor::{Actor, ActorContext, ActorError, InitFailureKind};
 use temper_runtime::persistence::{
     COMPOSITE_EVENT_TYPE, EventMetadata, PersistenceEnvelope, PersistenceError,
 };
@@ -44,6 +44,23 @@ use super::types::{
     EntityEvent, EntityMsg, EntityResponse, EntityState, MAX_EVENTS_SINCE_SNAPSHOT,
     MAX_ITEMS_PER_ENTITY,
 };
+
+/// Restate a persistence failure that happened during `pre_start` as a
+/// classified actor init failure.
+///
+/// The classification is what lets the HTTP layer answer honestly: a declared-key
+/// rejection is the caller's input (409), a store fault may clear on its own
+/// (503), and anything else is ours (500). Deriving it here — where the typed
+/// `PersistenceError` still exists — keeps every layer above from re-deriving it
+/// by matching on message text.
+pub(crate) fn init_failure_from_persistence(context: String, err: &PersistenceError) -> ActorError {
+    let kind = match err {
+        PersistenceError::DeclaredKeyConflict { .. } => InitFailureKind::Constraint,
+        other if other.is_transient() => InitFailureKind::TransientDependency,
+        _ => InitFailureKind::Defect,
+    };
+    ActorError::init_failed(format!("{context}: {err}"), kind)
+}
 
 fn event_budget_workspace_id(state: &EntityState) -> String {
     if state.entity_type == "Workspace" {
@@ -548,13 +565,19 @@ impl EntityActor {
         match store.read_events(persistence_id, from_sequence).await {
             Ok(envelopes) => {
                 if envelopes.len() > MAX_EVENTS_SINCE_SNAPSHOT {
-                    return Err(ActorError::custom(format!(
-                        "snapshot tail replay budget exceeded for {}:{} ({} > {} events since snapshot)",
-                        state.entity_type,
-                        state.entity_id,
-                        envelopes.len(),
-                        MAX_EVENTS_SINCE_SNAPSHOT
-                    )));
+                    // A blown replay budget means snapshotting fell behind —
+                    // retrying replays the same oversized tail, so it is ours
+                    // to fix, not the caller's to retry.
+                    return Err(ActorError::init_failed(
+                        format!(
+                            "snapshot tail replay budget exceeded for {}:{} ({} > {} events since snapshot)",
+                            state.entity_type,
+                            state.entity_id,
+                            envelopes.len(),
+                            MAX_EVENTS_SINCE_SNAPSHOT
+                        ),
+                        InitFailureKind::Defect,
+                    ));
                 }
                 for env in &envelopes {
                     if env.event_type == COMPOSITE_EVENT_TYPE {
@@ -711,10 +734,13 @@ impl EntityActor {
             }
             Err(e) => {
                 if strict_journal_read {
-                    return Err(ActorError::custom(format!(
-                        "failed to read events for replay of {}:{}: {e}",
-                        state.entity_type, state.entity_id
-                    )));
+                    return Err(init_failure_from_persistence(
+                        format!(
+                            "failed to read events for replay of {}:{}",
+                            state.entity_type, state.entity_id
+                        ),
+                        &e,
+                    ));
                 }
                 tracing::error!(
                     entity = %state.entity_id, error = %e,
@@ -815,10 +841,13 @@ impl Actor for EntityActor {
                 self.persist_event(store, backend, &self.persistence_id(), &mut state, &created)
                     .await
                     .map_err(|e| {
-                        ActorError::custom(format!(
-                            "failed to persist bootstrap Created event for {}:{}: {}",
-                            self.entity_type, self.entity_id, e
-                        ))
+                        init_failure_from_persistence(
+                            format!(
+                                "failed to persist bootstrap Created event for {}:{}",
+                                self.entity_type, self.entity_id
+                            ),
+                            &e,
+                        )
                     })?;
             }
             state.push_event_bounded(created);

--- a/crates/temper-server/src/observe/evolution/records_detail.rs
+++ b/crates/temper-server/src/observe/evolution/records_detail.rs
@@ -97,7 +97,7 @@ pub(crate) async fn handle_decide(
         )
     {
         tracing::warn!(reason = %denial, "unauthorized decide attempt");
-        return Err(StatusCode::FORBIDDEN);
+        return Err(crate::authz::denial_status(&denial));
     }
 
     // Verify the target record exists.

--- a/crates/temper-server/src/observe/metrics.rs
+++ b/crates/temper-server/src/observe/metrics.rs
@@ -204,6 +204,24 @@ pub(crate) async fn handle_metrics(
             .load(std::sync::atomic::Ordering::Relaxed)
     ));
 
+    // -- temper_entity_spawn_failure_total --
+    // Creates that failed before the entity existed. They emit no transition
+    // and no trajectory row, so this is the only signal that separates a
+    // healthy entity type from one where every create is failing.
+    lines.push(
+        "# HELP temper_entity_spawn_failure_total Entity creates that failed before the entity existed, by entity type and reason.".to_string(),
+    );
+    lines.push("# TYPE temper_entity_spawn_failure_total counter".to_string());
+    if let Ok(map) = state.metrics.entity_spawn_failures.read() {
+        for (key, count) in map.iter() {
+            if let Some((entity_type, reason)) = key.split_once(':') {
+                lines.push(format!(
+                    "temper_entity_spawn_failure_total{{entity_type=\"{entity_type}\",reason=\"{reason}\"}} {count}"
+                ));
+            }
+        }
+    }
+
     lines.push(String::new()); // trailing newline
     let body = lines.join("\n");
 

--- a/crates/temper-server/src/observe/mod_test.rs
+++ b/crates/temper-server/src/observe/mod_test.rs
@@ -1555,6 +1555,59 @@ async fn test_metrics_returns_prometheus_format() {
     );
 }
 
+/// A create that dies before the entity exists emits no transition and no
+/// trajectory row, so `/observe/trajectories` reported a fully broken entity
+/// type at ~100% success straight through an outage. This counter is the only
+/// place that shows up, so it has to reach the exposition.
+#[tokio::test]
+async fn test_metrics_exposes_entity_spawn_failures_per_type() {
+    let state = test_state_with_registry();
+    state
+        .metrics
+        .record_entity_spawn_failure("File", "declared_key_conflict");
+    state
+        .metrics
+        .record_entity_spawn_failure("File", "declared_key_conflict");
+    state
+        .metrics
+        .record_entity_spawn_failure("Workspace", "transient_dependency");
+
+    let app = Router::new()
+        .nest("/observe", build_observe_router())
+        .nest("/api", crate::api::build_api_router())
+        .with_state(state);
+
+    let response = app
+        .oneshot(
+            Request::get("/observe/metrics")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let text = std::str::from_utf8(&body).unwrap();
+
+    assert!(
+        text.contains("# TYPE temper_entity_spawn_failure_total counter"),
+        "the counter must be declared for scrapers, got:\n{text}"
+    );
+    assert!(
+        text.contains(
+            "temper_entity_spawn_failure_total{entity_type=\"File\",reason=\"declared_key_conflict\"} 2"
+        ),
+        "per-type, per-reason counts must be exposed, got:\n{text}"
+    );
+    assert!(
+        text.contains(
+            "temper_entity_spawn_failure_total{entity_type=\"Workspace\",reason=\"transient_dependency\"} 1"
+        ),
+        "one degraded type must be distinguishable from another, got:\n{text}"
+    );
+}
+
 // -- Trajectory endpoint tests --
 
 #[tokio::test]

--- a/crates/temper-server/src/observe/specs/load_inline.rs
+++ b/crates/temper-server/src/observe/specs/load_inline.rs
@@ -71,6 +71,24 @@ pub(crate) async fn handle_load_inline(
     );
     if let Err(denial) = authz_result {
         let reason = denial.to_string();
+
+        // A malformed request or an engine failure is not a governance event:
+        // there is no decision for a human to approve and no policy gap to
+        // analyse, so it must not open an O/A record chain or land in the
+        // approval queue (ARN-287).
+        if !denial.is_policy_decision() {
+            return Err((
+                crate::authz::denial_status(&denial),
+                serde_json::json!({
+                    "error": {
+                        "code": denial.error_code(),
+                        "message": reason,
+                    }
+                })
+                .to_string(),
+            ));
+        }
+
         // Record denials and use the first decision ID as the primary chain anchor.
         // Record a single denial per authz check. The resource_id must match
         // what Cedar evaluated: SpecRegistry::"<tenant>".

--- a/crates/temper-server/src/odata/authz.rs
+++ b/crates/temper-server/src/odata/authz.rs
@@ -2,12 +2,14 @@
 
 use std::collections::BTreeMap;
 
-use axum::http::{HeaderMap, StatusCode};
+use axum::http::HeaderMap;
 use axum::response::{IntoResponse, Response};
 use temper_authz::SecurityContext;
 use temper_runtime::tenant::TenantId;
 
-use crate::authz::{DenialInput, record_authz_denial, security_context_from_headers};
+use crate::authz::{
+    DenialInput, denial_status, record_denial_if_policy, security_context_from_headers,
+};
 use crate::identity::ResolvedIdentity;
 use crate::request_context::AgentContext;
 use crate::response::odata_error;
@@ -113,8 +115,8 @@ pub(crate) fn authorize_read(
         .map_err(|denial| {
             Box::new(
                 odata_error(
-                    StatusCode::FORBIDDEN,
-                    "AuthorizationDenied",
+                    denial_status(&denial),
+                    denial.error_code(),
                     &denial.to_string(),
                 )
                 .into_response(),
@@ -148,8 +150,9 @@ pub(super) async fn authorize_mutation(
     };
 
     let reason = denial.to_string();
-    let decision = record_authz_denial(
+    let decision = record_denial_if_policy(
         state,
+        &denial,
         DenialInput {
             tenant: tenant.as_str(),
             security_ctx,
@@ -169,10 +172,9 @@ pub(super) async fn authorize_mutation(
     )
     .await;
 
-    Err(odata_error(
-        StatusCode::FORBIDDEN,
-        "AuthorizationDenied",
-        &format!("{reason} (decision: {})", decision.id),
-    )
-    .into_response())
+    let message = match decision {
+        Some(pd) => format!("{reason} (decision: {})", pd.id),
+        None => reason,
+    };
+    Err(odata_error(denial_status(&denial), denial.error_code(), &message).into_response())
 }

--- a/crates/temper-server/src/odata/bindings.rs
+++ b/crates/temper-server/src/odata/bindings.rs
@@ -8,13 +8,15 @@ use temper_runtime::scheduler::sim_now;
 use temper_runtime::tenant::TenantId;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
-use temper_authz::SecurityContext;
+use temper_authz::{DenialClass, SecurityContext};
 
 use super::account_verification::enforce_commons_account_verified_for_action;
 use super::common::run_write_prechecks;
 use super::rate_limit::{enforce_commons_write_rate_limit, owner_id_from_action};
 use super::response::annotate_entity;
-use crate::authz::{DenialInput, record_authz_denial, security_context_from_headers};
+use crate::authz::{
+    DenialInput, denial_status, record_denial_if_policy, security_context_from_headers,
+};
 use crate::blobs::hydrate_blob_refs_for_tenant;
 use crate::identity::ResolvedIdentity;
 use crate::request_context::AgentContext;
@@ -194,8 +196,9 @@ pub(super) async fn dispatch_bound_action(
     );
     if let Err(denial) = authz_result {
         let reason = denial.to_string();
-        let pd = record_authz_denial(
+        let pd = record_denial_if_policy(
             state,
+            &denial,
             DenialInput {
                 tenant: tenant.as_str(),
                 security_ctx: &security_ctx,
@@ -215,13 +218,11 @@ pub(super) async fn dispatch_bound_action(
         http_span.set_status(Status::error(reason.clone()));
         let end_time: std::time::SystemTime = sim_now().into();
         http_span.end_with_timestamp(end_time);
-        let reason_with_id = format!("{reason} (decision: {})", pd.id);
-        return odata_error(
-            StatusCode::FORBIDDEN,
-            "AuthorizationDenied",
-            &reason_with_id,
-        )
-        .into_response();
+        let message = match pd {
+            Some(pd) => format!("{reason} (decision: {})", pd.id),
+            None => reason,
+        };
+        return odata_error(denial_status(&denial), denial.error_code(), &message).into_response();
     }
 
     let current_fields = current_state.state.fields.clone();
@@ -362,10 +363,23 @@ pub(super) async fn dispatch_bound_action(
             http_span.set_attribute(OtelKeyValue::new("http.status_code", 404i64));
             odata_error(StatusCode::NOT_FOUND, "EntityTypeNotGoverned", &reason).into_response()
         }
-        Err(DispatchError::AuthzDenied(reason)) => {
+        Err(DispatchError::AuthzDenied { class, reason }) => {
+            let (status, code) = match class {
+                DenialClass::Policy => (StatusCode::FORBIDDEN, "AuthorizationDenied"),
+                DenialClass::RequestFault => {
+                    (StatusCode::BAD_REQUEST, "InvalidAuthorizationRequest")
+                }
+                DenialClass::EngineFault => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "AuthorizationEngineError",
+                ),
+            };
             http_span.set_status(Status::error(reason.clone()));
-            http_span.set_attribute(OtelKeyValue::new("http.status_code", 403i64));
-            odata_error(StatusCode::FORBIDDEN, "AuthorizationDenied", &reason).into_response()
+            http_span.set_attribute(OtelKeyValue::new(
+                "http.status_code",
+                i64::from(status.as_u16()),
+            ));
+            odata_error(status, code, &reason).into_response()
         }
         Err(DispatchError::QuotaExceeded(reason)) => {
             http_span.set_status(Status::error(reason.clone()));

--- a/crates/temper-server/src/odata/common.rs
+++ b/crates/temper-server/src/odata/common.rs
@@ -41,6 +41,13 @@ pub(crate) fn extract_tenant(
     Ok(TenantId::default())
 }
 
+/// Flatten a parsed OData key into the entity id used downstream.
+///
+/// The key arrives already unquoted from [`temper_odata::path`], which strips
+/// the string delimiters for both `'…'` and the `"…"` spelling some clients
+/// send. That matters here: this id is what Cedar builds `Type::"id"` from, so
+/// a surviving delimiter breaks UID parsing and turns every request into a 403
+/// no policy change can fix (ARN-287).
 pub(super) fn extract_key(key: &KeyValue) -> String {
     match key {
         KeyValue::Single(k) => k.clone(),
@@ -269,5 +276,92 @@ pub(super) fn check_has_stream_or_400(
             &format!("Entity type '{entity_type}' does not support $value (HasStream=false)"),
         )
         .into_response())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use temper_authz::{AuthzDenial, AuthzEngine, SecurityContext};
+    use temper_odata::path::{ODataPath, parse_path};
+
+    use super::extract_key;
+
+    const FILE_ID: &str = "fl-019efde0-3fa5-7000-8000-000000000001";
+
+    fn key_from_url(path: &str) -> String {
+        match parse_path(path).expect("path should parse") {
+            ODataPath::Entity(_, key) => extract_key(&key),
+            other => panic!("expected an entity path, got {other:?}"),
+        }
+    }
+
+    fn engine_permitting_update_of(id: &str) -> AuthzEngine {
+        let engine = AuthzEngine::empty();
+        engine
+            .reload_tenant_policies_named(
+                "t",
+                &[(
+                    "app/files.cedar".to_string(),
+                    format!(
+                        r#"permit(principal, action == Action::"update", resource == File::"{id}");"#
+                    ),
+                )],
+            )
+            .expect("policy should parse");
+        engine
+    }
+
+    fn id_attrs(id: &str) -> HashMap<String, serde_json::Value> {
+        HashMap::from([("id".to_string(), serde_json::Value::String(id.to_string()))])
+    }
+
+    /// ARN-287: production saw 20x ('File','update') denials reading
+    /// "invalid resource: unexpected token `fl`", with the resource id still
+    /// wearing its double quotes. Both URL spellings of a key must reach Cedar
+    /// as the same UID.
+    #[test]
+    fn quoted_key_authorizes_against_the_same_uid_as_an_unquoted_one() {
+        let single_quoted = key_from_url(&format!("/Files('{FILE_ID}')"));
+        let double_quoted = key_from_url(&format!("/Files(\"{FILE_ID}\")"));
+
+        assert_eq!(single_quoted, FILE_ID);
+        assert_eq!(double_quoted, single_quoted);
+
+        let engine = engine_permitting_update_of(FILE_ID);
+        let ctx = SecurityContext::from_headers(&[]);
+        for key in [single_quoted.as_str(), double_quoted.as_str()] {
+            let decision = engine.authorize_for_tenant("t", &ctx, "update", "File", &id_attrs(key));
+            assert!(
+                decision.is_allowed(),
+                "key spelled as {key:?} should authorize, got {decision:?}"
+            );
+        }
+    }
+
+    /// The failure the fix removes: an id that still carries its delimiter
+    /// cannot even be turned into a Cedar UID, so no policy can permit it.
+    #[test]
+    fn an_id_that_kept_its_delimiter_cannot_build_a_cedar_uid() {
+        let engine = engine_permitting_update_of(FILE_ID);
+        let ctx = SecurityContext::from_headers(&[]);
+
+        let decision = engine.authorize_for_tenant(
+            "t",
+            &ctx,
+            "update",
+            "File",
+            &id_attrs(&format!("\"{FILE_ID}\"")),
+        );
+
+        assert!(
+            matches!(decision.denial(), Some(AuthzDenial::InvalidResource(_))),
+            "a quoted id must fail UID construction, got {decision:?}"
+        );
+        assert!(
+            !decision.denial().expect("denial").is_policy_decision(),
+            "and it is a request fault, not something a human can approve"
+        );
     }
 }

--- a/crates/temper-server/src/odata/read.rs
+++ b/crates/temper-server/src/odata/read.rs
@@ -74,9 +74,9 @@ async fn resolve_parent_entity(
                 security_ctx,
             )
             .await
-            .map_err(|_| {
+            .map_err(|response| {
                 (
-                    StatusCode::FORBIDDEN,
+                    response.status(),
                     format!("Read access denied for parent entity '{parent_type}'"),
                 )
             })?;
@@ -93,9 +93,9 @@ async fn resolve_parent_entity(
                 security_ctx,
             )
             .await
-            .map_err(|_| {
+            .map_err(|response| {
                 (
-                    StatusCode::FORBIDDEN,
+                    response.status(),
                     format!("Read access denied for navigation property '{property}'"),
                 )
             })?;

--- a/crates/temper-server/src/odata/write.rs
+++ b/crates/temper-server/src/odata/write.rs
@@ -32,10 +32,48 @@ use crate::blobs::hydrate_blob_refs_for_tenant;
 use crate::identity::ResolvedIdentity;
 use crate::request_context::{AgentContext, extract_agent_context, remote_parent_context};
 use crate::response::{ODataResponse, odata_error};
-use crate::state::ServerState;
 use crate::state::trajectory::{TrajectoryEntry, TrajectorySource};
+use crate::state::{EntityCreateError, ServerState};
 
 type ODataWriteError = Box<axum::response::Response>;
+
+/// Seconds a client should wait before retrying a create that failed on a
+/// dependency. Matches the conservative default used for transient dispatch
+/// exhaustion in `bindings.rs`.
+const CREATE_RETRY_AFTER_SECS: &str = "1";
+
+/// Turn a failed create into the status the caller can act on.
+///
+/// Every create failure used to leave as `500 CreateError` with the cause
+/// flattened into a sentence, so a caller could not tell a key collision it
+/// must fix from a store blip it should wait out — and retried the
+/// unretryable hundreds of times. The classification comes from the typed
+/// error, never from inspecting the message.
+fn create_error_response(err: &EntityCreateError) -> axum::response::Response {
+    match err {
+        // The write is rejected by a uniqueness constraint. The detail is the
+        // store's own message, which names the declared key and the entity id
+        // holding it — the two things a caller needs to resolve the collision.
+        EntityCreateError::DeclaredKeyConflict { detail } => {
+            odata_error(StatusCode::CONFLICT, "DeclaredKeyConflict", detail).into_response()
+        }
+        // A dependency was briefly unavailable: say so, and say when to come
+        // back, so clients and proxies back off instead of hammering.
+        EntityCreateError::TransientDependency { detail } => {
+            let mut response =
+                odata_error(StatusCode::SERVICE_UNAVAILABLE, "CreateUnavailable", detail)
+                    .into_response();
+            response.headers_mut().insert(
+                axum::http::header::RETRY_AFTER,
+                axum::http::HeaderValue::from_static(CREATE_RETRY_AFTER_SECS),
+            );
+            response
+        }
+        EntityCreateError::Internal { detail } => {
+            odata_error(StatusCode::INTERNAL_SERVER_ERROR, "CreateError", detail).into_response()
+        }
+    }
+}
 
 fn parse_odata_path_or_400(path: &str) -> Result<ODataPath, ODataWriteError> {
     parse_path(&format!("/{path}")).map_err(|e| {
@@ -514,10 +552,7 @@ pub async fn handle_odata_post(
                     .into_response();
                 }
                 Ok(None) => {}
-                Err(e) => {
-                    return odata_error(StatusCode::INTERNAL_SERVER_ERROR, "CreateError", &e)
-                        .into_response();
-                }
+                Err(e) => return create_error_response(&e),
             }
 
             match state
@@ -542,8 +577,7 @@ pub async fn handle_odata_post(
                     }
                     .into_response()
                 }
-                Err(e) => odata_error(StatusCode::INTERNAL_SERVER_ERROR, "CreateError", &e)
-                    .into_response(),
+                Err(e) => create_error_response(&e),
             }
         }
 
@@ -1201,5 +1235,53 @@ fn entity_type_prefix(entity_type: &str) -> &'static str {
         "Monitor" => "mn-",
         "AlertCycle" => "ac-",
         _ => "en-",
+    }
+}
+
+#[cfg(test)]
+mod create_error_response_tests {
+    use super::*;
+
+    fn detail_of(response: &axum::response::Response) -> StatusCode {
+        response.status()
+    }
+
+    #[test]
+    fn a_key_collision_is_a_conflict_not_a_server_error() {
+        let response = create_error_response(&EntityCreateError::DeclaredKeyConflict {
+            detail: "duplicate declared key 'ws_path' for File: held by fl-019efda8".to_string(),
+        });
+        assert_eq!(detail_of(&response), StatusCode::CONFLICT);
+        assert!(
+            response
+                .headers()
+                .get(axum::http::header::RETRY_AFTER)
+                .is_none(),
+            "there is nothing to wait for — the same request collides forever"
+        );
+    }
+
+    #[test]
+    fn a_dependency_outage_is_unavailable_with_a_retry_hint() {
+        let response = create_error_response(&EntityCreateError::TransientDependency {
+            detail: "storage error: connection reset".to_string(),
+        });
+        assert_eq!(detail_of(&response), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            response
+                .headers()
+                .get(axum::http::header::RETRY_AFTER)
+                .and_then(|v| v.to_str().ok()),
+            Some("1"),
+            "a retryable failure must say when to come back"
+        );
+    }
+
+    #[test]
+    fn an_unclassified_failure_is_still_a_server_error() {
+        let response = create_error_response(&EntityCreateError::Internal {
+            detail: "no transition table".to_string(),
+        });
+        assert_eq!(detail_of(&response), StatusCode::INTERNAL_SERVER_ERROR);
     }
 }

--- a/crates/temper-server/src/runtime_metrics.rs
+++ b/crates/temper-server/src/runtime_metrics.rs
@@ -5,7 +5,7 @@
 //! sampler live in `state::runtime_metrics` via `spawn_runtime_metrics_loop`.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::sync::OnceLock;
+use std::sync::{OnceLock, RwLock};
 use std::time::Duration;
 
 use opentelemetry::metrics::{Counter, Gauge, Histogram};
@@ -35,6 +35,7 @@ struct RuntimeMetrics {
     dispatch_ask_latency_ms: Histogram<f64>,
     dispatch_ask_outcome_total: Counter<u64>,
     dispatch_ask_error_total: Counter<u64>,
+    entity_spawn_failure_total: Counter<u64>,
     // --- ADR-0049: state-entry timeouts -----------------------------------
     state_timeout_fired_total: Counter<u64>,
     state_timeout_cancelled_total: Counter<u64>,
@@ -178,6 +179,15 @@ fn metrics() -> &'static RuntimeMetrics {
                 .with_description(
                     "ADR-0048: ActorError kind breakdown (ask_timeout, mailbox_full, \
                      stopped, send_failed, panicked, init_failed, max_restarts_exceeded).",
+                )
+                .build(),
+            entity_spawn_failure_total: meter
+                .u64_counter("temper_entity_spawn_failure_total")
+                .with_description(
+                    "Entity creates that failed before the entity existed, by tenant, \
+                     entity_type and reason (declared_key_conflict, transient_dependency, \
+                     internal). These writes produce no trajectory row, so without this \
+                     counter a fully broken entity type still reads as healthy.",
                 )
                 .build(),
             state_timeout_fired_total: meter
@@ -422,11 +432,28 @@ fn metrics() -> &'static RuntimeMetrics {
 
 /// Record actor and entity counts from the current server state snapshot.
 pub fn record_server_state_metrics(state: &ServerState) {
-    if let Ok(registry) = state.actor_registry.read() {
+    record_actor_directory_metrics(&state.actor_registry, &state.entity_index);
+}
+
+/// Record the same actor and entity gauges straight from the maps that back
+/// them.
+///
+/// Split out of [`record_server_state_metrics`] for the failed-spawn retraction,
+/// which runs inside the failed actor's own task (see
+/// `state::entity_ops::ActorDirectory`) and holds those maps directly with no
+/// `ServerState` to borrow — but moves these gauges just as much as any other
+/// registry edit.
+pub fn record_actor_directory_metrics(
+    actor_registry: &RwLock<
+        BTreeMap<String, temper_runtime::actor::ActorRef<crate::entity_actor::EntityMsg>>,
+    >,
+    entity_index: &RwLock<BTreeMap<String, BTreeSet<String>>>,
+) {
+    if let Ok(registry) = actor_registry.read() {
         record_active_actor_count(registry.len());
         record_actor_mailbox_metrics(&registry);
     }
-    if let Ok(index) = state.entity_index.read() {
+    if let Ok(index) = entity_index.read() {
         record_active_entity_counts(&index);
     }
 }
@@ -643,6 +670,22 @@ pub fn record_dispatch_error(
             KeyValue::new("entity_type", entity_type.to_string()),
             KeyValue::new("action", action.to_string()),
             KeyValue::new("error_kind", error_kind),
+        ],
+    );
+}
+
+/// Record an entity create that failed before the entity existed.
+///
+/// `reason` is one of `declared_key_conflict`, `transient_dependency`,
+/// `internal`. Counted per entity type so one degraded type is visible even
+/// while every other type is healthy.
+pub fn record_entity_spawn_failure(tenant: &str, entity_type: &str, reason: &'static str) {
+    metrics().entity_spawn_failure_total.add(
+        1,
+        &[
+            KeyValue::new("tenant", tenant.to_string()),
+            KeyValue::new("entity_type", entity_type.to_string()),
+            KeyValue::new("reason", reason),
         ],
     );
 }

--- a/crates/temper-server/src/state/dispatch/actions.rs
+++ b/crates/temper-server/src/state/dispatch/actions.rs
@@ -580,7 +580,19 @@ impl crate::state::ServerState {
                     temper_runtime::actor::ActorError::Stopped => "stopped",
                     temper_runtime::actor::ActorError::SendFailed => "send_failed",
                     temper_runtime::actor::ActorError::Panicked(_) => "panicked",
-                    temper_runtime::actor::ActorError::InitFailed(_) => "init_failed",
+                    // Split by classification: a dispatch that fails because the
+                    // actor could not initialize needs the reason in the metric,
+                    // not one lump "init_failed" that hides whether it was the
+                    // caller's key, a store blip, or a defect.
+                    temper_runtime::actor::ActorError::InitFailed { kind, .. } => match kind {
+                        temper_runtime::actor::InitFailureKind::Constraint => {
+                            "init_failed_constraint"
+                        }
+                        temper_runtime::actor::InitFailureKind::TransientDependency => {
+                            "init_failed_transient_dependency"
+                        }
+                        temper_runtime::actor::InitFailureKind::Defect => "init_failed_defect",
+                    },
                     temper_runtime::actor::ActorError::MaxRestartsExceeded(_) => {
                         "max_restarts_exceeded"
                     }

--- a/crates/temper-server/src/state/dispatch/composite.rs
+++ b/crates/temper-server/src/state/dispatch/composite.rs
@@ -628,9 +628,12 @@ impl crate::state::ServerState {
                     tenant.as_str(),
                 )
                 .map_err(|denial| {
-                    DispatchError::AuthzDenied(format!(
-                        "composite {entity_type}.{action} sub-write {idx} denied for {sub_entity_type}.{sub_action}: {denial}"
-                    ))
+                    DispatchError::AuthzDenied {
+                        class: denial.class(),
+                        reason: format!(
+                            "composite {entity_type}.{action} sub-write {idx} denied for {sub_entity_type}.{sub_action}: {denial}"
+                        ),
+                    }
                 })?;
             }
 

--- a/crates/temper-server/src/state/dispatch/composite/helpers.rs
+++ b/crates/temper-server/src/state/dispatch/composite/helpers.rs
@@ -362,6 +362,11 @@ pub(super) fn composite_batch_persistence_error(error: PersistenceError) -> Disp
         PersistenceError::ConcurrencyViolation { .. } => {
             DispatchError::Conflict(format!("composite batch persistence conflict: {error}"))
         }
+        // A declared key already held by another entity is a conflict the
+        // caller must resolve, not an internal fault to page on.
+        PersistenceError::DeclaredKeyConflict { .. } => {
+            DispatchError::Conflict(format!("composite batch persistence conflict: {error}"))
+        }
         PersistenceError::Serialization(_) | PersistenceError::Storage(_) => {
             DispatchError::Internal(format!("composite batch persistence failed: {error}"))
         }
@@ -371,7 +376,10 @@ pub(super) fn composite_batch_persistence_error(error: PersistenceError) -> Disp
 pub(super) fn composite_storage_cap_error(error: CommonsStorageCapError) -> DispatchError {
     match error {
         CommonsStorageCapError::Exceeded(_) => DispatchError::QuotaExceeded(error.to_string()),
-        CommonsStorageCapError::OwnerSuspended(_) => DispatchError::AuthzDenied(error.to_string()),
+        CommonsStorageCapError::OwnerSuspended(_) => DispatchError::AuthzDenied {
+            class: temper_authz::DenialClass::Policy,
+            reason: error.to_string(),
+        },
         CommonsStorageCapError::MissingAttribution(_) | CommonsStorageCapError::Internal(_) => {
             DispatchError::Internal(error.to_string())
         }
@@ -384,9 +392,10 @@ pub(super) fn composite_account_verification_error(
     match error {
         CommonsAccountVerificationError::Required(_)
         | CommonsAccountVerificationError::MissingOwner(_)
-        | CommonsAccountVerificationError::OwnerSuspended(_) => {
-            DispatchError::AuthzDenied(error.to_string())
-        }
+        | CommonsAccountVerificationError::OwnerSuspended(_) => DispatchError::AuthzDenied {
+            class: temper_authz::DenialClass::Policy,
+            reason: error.to_string(),
+        },
         CommonsAccountVerificationError::Internal(_) => DispatchError::Internal(error.to_string()),
     }
 }

--- a/crates/temper-server/src/state/dispatch/dispatch_mod_test.rs
+++ b/crates/temper-server/src/state/dispatch/dispatch_mod_test.rs
@@ -1,0 +1,64 @@
+use super::*;
+use temper_runtime::ActorSystem;
+use temper_spec::csdl::parse_csdl;
+
+fn test_state() -> crate::state::ServerState {
+    let csdl_xml = include_str!("../../../../../test-fixtures/specs/model.csdl.xml");
+    let csdl = parse_csdl(csdl_xml).expect("CSDL should parse");
+    crate::state::ServerState::new(
+        ActorSystem::new("dispatch-wasm-authz-test"),
+        csdl,
+        csdl_xml.to_string(),
+    )
+}
+
+#[test]
+fn wasm_authz_gate_evaluates_cedar_when_policy_set_is_empty() {
+    let state = test_state();
+    state
+        .authz
+        .reload_policies("")
+        .expect("empty policy set should parse");
+
+    let gate = state.wasm_authz_gate();
+    let decision = gate.authorize_http_call(
+        "api.example.com",
+        "GET",
+        "https://api.example.com/v1/ping",
+        &WasmAuthzContext::test_fixture(),
+    );
+
+    assert_eq!(
+        decision,
+        WasmAuthzDecision::Deny("no matching permit policy".to_string())
+    );
+}
+
+#[test]
+fn wasm_authz_gate_allows_when_cedar_policy_matches() {
+    let state = test_state();
+    state
+        .authz
+        .reload_policies(
+            r#"
+            permit(
+                principal is Agent,
+                action == Action::"http_call",
+                resource is HttpEndpoint
+            ) when {
+                context.module == "stripe_charge"
+            };
+            "#,
+        )
+        .expect("policy should parse");
+
+    let gate = state.wasm_authz_gate();
+    let decision = gate.authorize_http_call(
+        "api.stripe.com",
+        "POST",
+        "https://api.stripe.com/v1/charges",
+        &WasmAuthzContext::test_fixture(),
+    );
+
+    assert_eq!(decision, WasmAuthzDecision::Allow);
+}

--- a/crates/temper-server/src/state/dispatch/mod.rs
+++ b/crates/temper-server/src/state/dispatch/mod.rs
@@ -98,10 +98,17 @@ pub enum DispatchError {
     #[allow(dead_code)] // Reserved for structured error handling migration
     WasmFailed(String),
 
-    /// An authorization check denied the action.
-    #[error("authorization denied: {0}")]
-    #[allow(dead_code)] // Reserved for structured error handling migration
-    AuthzDenied(String),
+    /// An authorization check refused the action.
+    ///
+    /// `class` preserves *why* it was refused: a Cedar policy decision, a
+    /// request the engine could not evaluate, or an engine failure. Without
+    /// it the HTTP boundary reports an engine crash as "denied by policy",
+    /// which sends the caller chasing a policy that does not exist (ARN-287).
+    #[error("authorization denied: {reason}")]
+    AuthzDenied {
+        class: temper_authz::DenialClass,
+        reason: String,
+    },
 
     /// A tenant or owner quota denied the action before dispatch.
     #[error("quota exceeded: {0}")]
@@ -160,11 +167,13 @@ mod dispatch_error_tests {
 
     #[test]
     fn permanent_actor_errors_map_to_permanent_dispatch_variant() {
+        use temper_runtime::actor::InitFailureKind;
         for err in [
             ActorError::Stopped,
             ActorError::SendFailed,
             ActorError::Panicked("boom".into()),
-            ActorError::InitFailed("init".into()),
+            ActorError::init_failed("init", InitFailureKind::Defect),
+            ActorError::init_failed("dup key", InitFailureKind::Constraint),
             ActorError::MaxRestartsExceeded(4),
             ActorError::custom("misc"),
         ] {
@@ -173,6 +182,20 @@ mod dispatch_error_tests {
                 DispatchError::Permanent { .. } => {}
                 other => panic!("expected Permanent for {label}, got {other:?}"),
             }
+        }
+    }
+
+    #[test]
+    fn an_init_failure_on_a_dependency_maps_to_transient() {
+        // A store blip during spawn is retryable; before the taxonomy split
+        // every init failure was permanent and this dispatch was given up on.
+        let err = ActorError::init_failed(
+            "store unavailable",
+            temper_runtime::actor::InitFailureKind::TransientDependency,
+        );
+        match DispatchError::from_actor_error(err, 2) {
+            DispatchError::Transient { attempts, .. } => assert_eq!(attempts, 2),
+            other => panic!("expected Transient, got {other:?}"),
         }
     }
 }
@@ -423,69 +446,5 @@ impl crate::state::ServerState {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use temper_runtime::ActorSystem;
-    use temper_spec::csdl::parse_csdl;
-
-    fn test_state() -> crate::state::ServerState {
-        let csdl_xml = include_str!("../../../../../test-fixtures/specs/model.csdl.xml");
-        let csdl = parse_csdl(csdl_xml).expect("CSDL should parse");
-        crate::state::ServerState::new(
-            ActorSystem::new("dispatch-wasm-authz-test"),
-            csdl,
-            csdl_xml.to_string(),
-        )
-    }
-
-    #[test]
-    fn wasm_authz_gate_evaluates_cedar_when_policy_set_is_empty() {
-        let state = test_state();
-        state
-            .authz
-            .reload_policies("")
-            .expect("empty policy set should parse");
-
-        let gate = state.wasm_authz_gate();
-        let decision = gate.authorize_http_call(
-            "api.example.com",
-            "GET",
-            "https://api.example.com/v1/ping",
-            &WasmAuthzContext::test_fixture(),
-        );
-
-        assert_eq!(
-            decision,
-            WasmAuthzDecision::Deny("no matching permit policy".to_string())
-        );
-    }
-
-    #[test]
-    fn wasm_authz_gate_allows_when_cedar_policy_matches() {
-        let state = test_state();
-        state
-            .authz
-            .reload_policies(
-                r#"
-                permit(
-                    principal is Agent,
-                    action == Action::"http_call",
-                    resource is HttpEndpoint
-                ) when {
-                    context.module == "stripe_charge"
-                };
-                "#,
-            )
-            .expect("policy should parse");
-
-        let gate = state.wasm_authz_gate();
-        let decision = gate.authorize_http_call(
-            "api.stripe.com",
-            "POST",
-            "https://api.stripe.com/v1/charges",
-            &WasmAuthzContext::test_fixture(),
-        );
-
-        assert_eq!(decision, WasmAuthzDecision::Allow);
-    }
-}
+#[path = "dispatch_mod_test.rs"]
+mod tests;

--- a/crates/temper-server/src/state/dispatch/retry.rs
+++ b/crates/temper-server/src/state/dispatch/retry.rs
@@ -179,7 +179,7 @@ where
             }
             Err(err) if err.is_permanent() => {
                 return AskResult {
-                    result: Err(err),
+                    result: Err(most_diagnostic(last_err, err)),
                     attempts: attempt + 1,
                     elapsed: start.elapsed(),
                     retried_after_transient: saw_transient,
@@ -199,6 +199,24 @@ where
         attempts: max_attempts,
         elapsed: start.elapsed(),
         retried_after_transient: saw_transient,
+    }
+}
+
+/// Pick the error worth reporting when an attempt fails after an earlier one.
+///
+/// An actor that dies in `pre_start` drains its mailbox, answers the in-flight
+/// ask with the real cause, and closes. The *next* attempt therefore cannot even
+/// enqueue and comes back `SendFailed` — "send failed: actor not running", which
+/// is true and useless. Keeping the init failure preserves the only error that
+/// explains the outage.
+fn most_diagnostic(previous: Option<ActorError>, current: ActorError) -> ActorError {
+    match previous {
+        Some(prev @ ActorError::InitFailed { .. })
+            if matches!(current, ActorError::SendFailed | ActorError::Stopped) =>
+        {
+            prev
+        }
+        _ => current,
     }
 }
 
@@ -327,6 +345,49 @@ mod tests {
         // layer depends on.
         let effective = p.max_attempts.max(1);
         assert_eq!(effective, 1);
+    }
+
+    #[test]
+    fn send_failed_after_an_init_failure_keeps_the_init_cause() {
+        // The dead-cell sequence: attempt 0 gets the classified init failure,
+        // attempt 1 cannot enqueue because the cell closed its mailbox.
+        let init = ActorError::init_failed(
+            "duplicate declared key 'ws_path' for File: held by fl-019efda8",
+            temper_runtime::actor::InitFailureKind::Constraint,
+        );
+        let kept = most_diagnostic(Some(init), ActorError::SendFailed);
+        assert!(
+            kept.to_string().contains("ws_path"),
+            "the init cause must survive the follow-up SendFailed, got: {kept}"
+        );
+        assert_eq!(
+            kept.init_failure_kind(),
+            Some(temper_runtime::actor::InitFailureKind::Constraint)
+        );
+    }
+
+    #[test]
+    fn a_real_permanent_error_is_not_masked_by_an_earlier_transient() {
+        // Only SendFailed / Stopped are treated as the echo of a dead cell.
+        // Anything else is the truth of this attempt and must win.
+        let earlier = ActorError::init_failed(
+            "store unavailable",
+            temper_runtime::actor::InitFailureKind::TransientDependency,
+        );
+        let now = ActorError::Panicked("handler exploded".into());
+        let kept = most_diagnostic(Some(earlier), now);
+        assert!(matches!(kept, ActorError::Panicked(_)));
+
+        // No prior error at all — the current one is reported unchanged.
+        let kept = most_diagnostic(None, ActorError::SendFailed);
+        assert_eq!(kept, ActorError::SendFailed);
+
+        // A prior AskTimeout is not an init failure and must not be resurrected.
+        let kept = most_diagnostic(
+            Some(ActorError::AskTimeout(Duration::from_secs(5))),
+            ActorError::SendFailed,
+        );
+        assert_eq!(kept, ActorError::SendFailed);
     }
 
     #[test]

--- a/crates/temper-server/src/state/entity_ops.rs
+++ b/crates/temper-server/src/state/entity_ops.rs
@@ -121,6 +121,96 @@ fn record_projection_update_error(
     );
 }
 
+/// Why an entity could not be created.
+///
+/// The create path used to return a bare `String`, so every failure — a key
+/// collision, a store outage, a missing spec — reached the HTTP layer as one
+/// undifferentiated message and left as `500 CreateError`. A caller could not
+/// tell "change your request" from "try again in a second", which is how a
+/// single declared-key collision turned into hundreds of identical retries.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EntityCreateError {
+    /// A declared-key uniqueness constraint rejected the write: another entity
+    /// of the same type already holds this key value (ADR-0153). Terminal —
+    /// the same body collides with the same holder every time.
+    DeclaredKeyConflict {
+        /// The store's own rejection, which names the key and its holder.
+        detail: String,
+    },
+    /// A dependency needed to create the entity was briefly unavailable.
+    /// Worth retrying after a short pause.
+    TransientDependency {
+        /// The underlying failure, verbatim.
+        detail: String,
+    },
+    /// Anything else. Retrying does not help.
+    Internal {
+        /// The underlying failure, verbatim.
+        detail: String,
+    },
+}
+
+impl EntityCreateError {
+    /// Classify an actor failure surfaced by an `ask`.
+    ///
+    /// The classification rides on the error (see `InitFailureKind`); nothing
+    /// here inspects message text to decide what kind of failure it was.
+    pub(crate) fn from_actor_error(err: &temper_runtime::actor::ActorError) -> Self {
+        use temper_runtime::actor::InitFailureKind;
+        let detail = err.to_string();
+        match err.init_failure_kind() {
+            Some(InitFailureKind::Constraint) => Self::DeclaredKeyConflict { detail },
+            Some(InitFailureKind::TransientDependency) => Self::TransientDependency { detail },
+            Some(InitFailureKind::Defect) => Self::Internal { detail },
+            None if err.is_transient() => Self::TransientDependency { detail },
+            None => Self::Internal { detail },
+        }
+    }
+
+    /// Classify a persistence failure raised on the data-only create fast path,
+    /// which writes without an actor.
+    pub(crate) fn from_persistence_error(context: &str, err: &PersistenceError) -> Self {
+        match err {
+            PersistenceError::DeclaredKeyConflict { .. } => Self::DeclaredKeyConflict {
+                detail: err.to_string(),
+            },
+            other if other.is_transient() => Self::TransientDependency {
+                detail: format!("{context}: {other}"),
+            },
+            other => Self::Internal {
+                detail: format!("{context}: {other}"),
+            },
+        }
+    }
+
+    /// Stable label for metrics and logs.
+    pub(crate) fn metric_label(&self) -> &'static str {
+        match self {
+            Self::DeclaredKeyConflict { .. } => "declared_key_conflict",
+            Self::TransientDependency { .. } => "transient_dependency",
+            Self::Internal { .. } => "internal",
+        }
+    }
+}
+
+impl std::fmt::Display for EntityCreateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DeclaredKeyConflict { detail }
+            | Self::TransientDependency { detail }
+            | Self::Internal { detail } => write!(f, "{detail}"),
+        }
+    }
+}
+
+impl std::error::Error for EntityCreateError {}
+
+impl From<EntityCreateError> for String {
+    fn from(err: EntityCreateError) -> Self {
+        err.to_string()
+    }
+}
+
 /// Error returned when the verification gate blocks an operation.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct VerificationGateError {
@@ -152,6 +242,224 @@ pub struct FailedLevelInfo {
 pub(crate) struct AuthzResourceSnapshot {
     pub(crate) current_state: EntityResponse,
     pub(crate) resource_attrs: BTreeMap<String, serde_json::Value>,
+}
+
+/// Where a registration also listed the entity for collection queries:
+/// the `{tenant}:{entity_type}` index key and the id inside it.
+#[derive(Clone, Copy)]
+pub(crate) struct IndexedAs<'a> {
+    index_key: &'a str,
+    entity_id: &'a str,
+}
+
+/// The in-memory bookkeeping that one entity spawn creates, and the only place
+/// allowed to create or destroy it.
+///
+/// Three maps have to agree about every live actor: the actor registry a
+/// request asks through, the entity index collection queries read, and the
+/// access stamps passivation reads. Every registration and every removal
+/// publishes its edits to all three inside a **single critical section held on
+/// the actor-registry write lock** — the lock every reader already takes first
+/// (`get_or_spawn_tenant_actor_with_fields`, `passivate_idle_actors`,
+/// `observe::entities`). Two properties follow, and they are the point of this
+/// type:
+///
+/// - no caller can observe an entity that is half-registered or half-removed
+///   (registry entry gone while the index still lists it, or the reverse);
+/// - a removal aimed at one incarnation cannot straddle a concurrent respawn
+///   and delete the replacement's index entry or access stamp — the identity
+///   check and the edits it guards are inside the same section.
+///
+/// It holds `Arc` clones rather than a `ServerState` reference because the
+/// failed-init retraction runs inside the dead actor's own task, where there is
+/// no `ServerState` to borrow.
+#[derive(Clone)]
+pub(crate) struct ActorDirectory {
+    actor_registry: Arc<RwLock<BTreeMap<String, ActorRef<EntityMsg>>>>,
+    entity_index: Arc<RwLock<BTreeMap<String, std::collections::BTreeSet<String>>>>,
+    last_accessed: Arc<RwLock<BTreeMap<String, chrono::DateTime<chrono::Utc>>>>,
+}
+
+impl ActorDirectory {
+    pub(crate) fn of(state: &ServerState) -> Self {
+        Self {
+            actor_registry: state.actor_registry.clone(),
+            entity_index: state.entity_index.clone(),
+            last_accessed: state.last_accessed.clone(),
+        }
+    }
+
+    /// Register `spawn()`'s actor for `key` unless one is already registered.
+    ///
+    /// Returns the live actor and whether this call is the one that spawned it.
+    /// The spawn happens under the lock, so the actor cannot fail and retract
+    /// itself before the registration it is meant to undo is visible.
+    fn get_or_register(
+        &self,
+        key: &str,
+        indexed_as: IndexedAs<'_>,
+        spawn: impl FnOnce() -> ActorRef<EntityMsg>,
+    ) -> (ActorRef<EntityMsg>, bool) {
+        let mut registry = self.write_registry();
+        if let Some(existing) = registry.get(key) {
+            let existing = existing.clone();
+            self.stamp_access(key);
+            return (existing, false);
+        }
+        let actor_ref = spawn();
+        registry.insert(key.to_string(), actor_ref.clone());
+        // Nested in the same order as every removal (registry → access stamp →
+        // index) so the two never form a cycle, even though the registry lock
+        // they both hold already makes them mutually exclusive.
+        self.stamp_access(key);
+        self.write_index()
+            .entry(indexed_as.index_key.to_string())
+            .or_default()
+            .insert(indexed_as.entity_id.to_string());
+        (actor_ref, true)
+    }
+
+    /// Remove the registration of one specific incarnation.
+    ///
+    /// A replacement spawned in the meantime carries a different `ActorId`, so
+    /// the identity check makes this call either take that exact incarnation
+    /// down whole or touch nothing at all.
+    ///
+    /// `unlist` additionally drops the entity-index entry. Pass it only when the
+    /// entity provably does not exist; an actor that merely died (a failed
+    /// hydration, an idle passivation) says nothing about whether the entity is
+    /// there, and un-listing on that basis hides real data from collection
+    /// queries.
+    ///
+    /// Returns whether anything was removed.
+    fn unregister(
+        &self,
+        key: &str,
+        incarnation: &temper_runtime::actor::ActorId,
+        unlist: Option<IndexedAs<'_>>,
+    ) -> bool {
+        let mut registry = self.write_registry();
+        match registry.get(key) {
+            Some(current) if current.id().uid == incarnation.uid => {}
+            _ => return false,
+        }
+        self.evict_locked(&mut registry, key, unlist);
+        true
+    }
+
+    /// Remove whatever is registered for `key`, returning it so the caller can
+    /// stop it once the lock is released.
+    ///
+    /// The delete path's counterpart to [`Self::unregister`]: no identity check
+    /// (a delete evicts whichever incarnation is serving the entity) but the
+    /// same single critical section, so a delete is no more observable
+    /// half-applied than a retraction is.
+    fn unregister_any(&self, key: &str, unlist: IndexedAs<'_>) -> Option<ActorRef<EntityMsg>> {
+        let mut registry = self.write_registry();
+        self.evict_locked(&mut registry, key, Some(unlist))
+    }
+
+    /// The removal itself. Takes the guard by `&mut` so the type system carries
+    /// the proof that the whole eviction runs under the registry write lock.
+    fn evict_locked(
+        &self,
+        registry: &mut BTreeMap<String, ActorRef<EntityMsg>>,
+        key: &str,
+        unlist: Option<IndexedAs<'_>>,
+    ) -> Option<ActorRef<EntityMsg>> {
+        let removed = registry.remove(key);
+        self.write_last_accessed().remove(key);
+        if let Some(IndexedAs {
+            index_key,
+            entity_id,
+        }) = unlist
+        {
+            let mut index = self.write_index();
+            if let Some(ids) = index.get_mut(index_key) {
+                ids.remove(entity_id);
+                if ids.is_empty() {
+                    index.remove(index_key);
+                }
+            }
+        }
+        removed
+    }
+
+    /// Retract the spawn bookkeeping for an actor that permanently failed to
+    /// initialize. Wired as the cell's `InitFailureObserver`, so it runs once
+    /// per dead incarnation whether or not a caller is there to be told.
+    fn retract_failed_init(
+        &self,
+        tenant: &TenantId,
+        entity_type: &str,
+        entity_id: &str,
+        failed: &temper_runtime::actor::ActorId,
+        err: &temper_runtime::actor::ActorError,
+    ) {
+        let Some(kind) = err.init_failure_kind() else {
+            return;
+        };
+        // A constraint rejection can only come from the bootstrap append, which
+        // the actor performs solely when the entity has no events at all — so
+        // the entity provably does not exist and must not be listed. Every other
+        // init failure may belong to an entity that *does* exist and merely
+        // failed to hydrate (an oversized replay tail, a store blip); un-listing
+        // those would hide real data, so only the dead actor is retracted.
+        let entity_provably_absent = kind == temper_runtime::actor::InitFailureKind::Constraint;
+        let key = format!("{tenant}:{entity_type}:{entity_id}");
+        let index_key = format!("{tenant}:{entity_type}");
+        let unlist = entity_provably_absent.then_some(IndexedAs {
+            index_key: &index_key,
+            entity_id,
+        });
+        if !self.unregister(&key, failed, unlist) {
+            return;
+        }
+        tracing::warn!(
+            tenant = %tenant,
+            entity_type = %entity_type,
+            entity_id = %entity_id,
+            failure = kind.as_str(),
+            unlisted = entity_provably_absent,
+            error = %err,
+            "retracted the spawn of an actor that never initialized"
+        );
+        runtime_metrics::record_actor_directory_metrics(&self.actor_registry, &self.entity_index);
+    }
+
+    fn stamp_access(&self, key: &str) {
+        self.write_last_accessed()
+            .insert(key.to_string(), sim_now());
+    }
+
+    // A panic elsewhere must not strand entity bookkeeping: recovering the
+    // guard keeps registration and removal working against a poisoned lock,
+    // where bailing out would leave exactly the corpse this type exists to
+    // prevent. The maps hold no invariant a panicking writer could have broken
+    // mid-update — every edit here is a single map operation.
+    fn write_registry(
+        &self,
+    ) -> std::sync::RwLockWriteGuard<'_, BTreeMap<String, ActorRef<EntityMsg>>> {
+        self.actor_registry
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn write_index(
+        &self,
+    ) -> std::sync::RwLockWriteGuard<'_, BTreeMap<String, std::collections::BTreeSet<String>>> {
+        self.entity_index
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn write_last_accessed(
+        &self,
+    ) -> std::sync::RwLockWriteGuard<'_, BTreeMap<String, chrono::DateTime<chrono::Utc>>> {
+        self.last_accessed
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
 }
 
 impl ServerState {
@@ -744,58 +1052,74 @@ impl ServerState {
                 .with_blob_store(tenant_blob_store),
         };
 
-        // Slow-path: atomically re-check and spawn under write lock.
-        // This prevents duplicate actors when concurrent requests race to create
-        // the same (tenant, entity_type, entity_id) key.
-        let actor_ref = {
-            let mut registry = self.actor_registry.write().unwrap();
-            if let Some(existing) = registry.get(&key) {
-                return Some(existing.clone());
-            }
-            let actor_ref = self.actor_system.spawn(actor, &key);
-            registry.insert(key.clone(), actor_ref.clone());
-            actor_ref
+        // Slow-path: atomically re-check, spawn, and publish the bookkeeping
+        // under one write lock. This prevents duplicate actors when concurrent
+        // requests race to create the same (tenant, entity_type, entity_id)
+        // key, and keeps the registry entry, the entity-index membership and
+        // the access stamp indivisible — a retraction cannot land between them.
+        let directory = ActorDirectory::of(self);
+        let index_key = format!("{tenant}:{entity_type}");
+        let on_init_failure: temper_runtime::actor::InitFailureObserver = {
+            // The cell calls this when it permanently gives up on `pre_start`,
+            // from its own task, before answering anyone — so the retraction
+            // happens even when no caller is waiting (an abandoned request, an
+            // actor spawned by a read that timed out) and is already done by
+            // the time a caller is handed the failure.
+            let directory = directory.clone();
+            let tenant = tenant.clone();
+            let entity_type = entity_type.to_string();
+            let entity_id = entity_id.to_string();
+            Arc::new(move |failed: &temper_runtime::actor::ActorId, err: &_| {
+                directory.retract_failed_init(&tenant, &entity_type, &entity_id, failed, err);
+            })
         };
 
-        // Track in entity index for collection queries
-        {
-            let index_key = format!("{tenant}:{entity_type}");
-            let mut index = self.entity_index.write().unwrap();
-            index
-                .entry(index_key)
-                .or_default()
-                .insert(entity_id.to_string());
+        // The actor's own name is the registry key; `spawn` takes it by value,
+        // so this clone replaces the allocation `spawn` would make anyway.
+        let actor_name = key.clone();
+        let indexed_as = IndexedAs {
+            index_key: &index_key,
+            entity_id,
+        };
+        let (actor_ref, spawned) = directory.get_or_register(&key, indexed_as, move || {
+            self.actor_system
+                .spawn_observing_init_failure(actor, actor_name, on_init_failure)
+        });
+        if spawned {
+            runtime_metrics::record_server_state_metrics(self);
         }
-        self.touch_actor_access(&key);
-        runtime_metrics::record_server_state_metrics(self);
 
         Some(actor_ref)
+    }
+
+    /// Count a create that failed before the entity existed, and hand the error
+    /// back unchanged.
+    ///
+    /// A create that dies before its first event writes no trajectory row, so
+    /// the per-entity-type success rate on `/observe/trajectories` stayed near
+    /// 100% straight through an outage in which every create failed. This is
+    /// the counter that makes a degraded entity type visible; it is exported
+    /// both to OTLP and to `/observe/metrics`.
+    fn record_create_failure(
+        &self,
+        tenant: &TenantId,
+        entity_type: &str,
+        error: EntityCreateError,
+    ) -> EntityCreateError {
+        runtime_metrics::record_entity_spawn_failure(
+            tenant.as_str(),
+            entity_type,
+            error.metric_label(),
+        );
+        self.metrics
+            .record_entity_spawn_failure(entity_type, error.metric_label());
+        error
     }
 
     /// Remove an entity from the index and actor registry.
     #[instrument(skip_all, fields(otel.name = "entity.remove_entity", tenant = %tenant, entity_type, entity_id))]
     pub fn remove_entity(&self, tenant: &TenantId, entity_type: &str, entity_id: &str) {
-        let actor_key = format!("{tenant}:{entity_type}:{entity_id}");
-
-        // Remove from actor registry
-        {
-            let mut registry = self.actor_registry.write().unwrap();
-            registry.remove(&actor_key);
-        }
-        {
-            let mut last_accessed = self.last_accessed.write().unwrap();
-            last_accessed.remove(&actor_key);
-        }
-
-        // Remove from entity index
-        {
-            let index_key = format!("{tenant}:{entity_type}");
-            let mut index = self.entity_index.write().unwrap();
-            if let Some(ids) = index.get_mut(&index_key) {
-                ids.remove(entity_id);
-            }
-        }
-        runtime_metrics::record_server_state_metrics(self);
+        self.evict_entity(tenant, entity_type, entity_id, false);
     }
 
     /// Stop and evict an entity actor plus its in-memory indexes.
@@ -810,21 +1134,28 @@ impl ServerState {
         entity_type: &str,
         entity_id: &str,
     ) {
-        let actor_key = format!("{tenant}:{entity_type}:{entity_id}");
+        self.evict_entity(tenant, entity_type, entity_id, true);
+    }
 
-        if let Ok(mut registry) = self.actor_registry.write()
-            && let Some(actor_ref) = registry.remove(&actor_key)
-        {
+    /// Drop the registry entry, the entity-index membership and the access
+    /// stamp together, optionally stopping the actor that was registered.
+    ///
+    /// One critical section for all three maps, the same one every other
+    /// mutation of them uses — see [`ActorDirectory`]. The actor is stopped
+    /// after the lock is released; `stop` is a mailbox send, and holding the
+    /// registry across it would pin the lock behind a channel.
+    fn evict_entity(&self, tenant: &TenantId, entity_type: &str, entity_id: &str, stop: bool) {
+        let actor_key = format!("{tenant}:{entity_type}:{entity_id}");
+        let index_key = format!("{tenant}:{entity_type}");
+        let removed = ActorDirectory::of(self).unregister_any(
+            &actor_key,
+            IndexedAs {
+                index_key: &index_key,
+                entity_id,
+            },
+        );
+        if stop && let Some(actor_ref) = removed {
             let _ = actor_ref.stop();
-        }
-        if let Ok(mut last_accessed) = self.last_accessed.write() {
-            last_accessed.remove(&actor_key);
-        }
-        if let Ok(mut index) = self.entity_index.write() {
-            let index_key = format!("{tenant}:{entity_type}");
-            if let Some(ids) = index.get_mut(&index_key) {
-                ids.remove(entity_id);
-            }
         }
         runtime_metrics::record_server_state_metrics(self);
     }
@@ -968,22 +1299,48 @@ impl ServerState {
         entity_type: &str,
         entity_id: &str,
         initial_fields: serde_json::Value,
-    ) -> Result<EntityResponse, String> {
+    ) -> Result<EntityResponse, EntityCreateError> {
         let actor_ref = self
             .get_or_spawn_tenant_actor_with_fields(tenant, entity_type, entity_id, initial_fields)
-            .ok_or_else(|| {
-                format!("No transition table for tenant '{tenant}', entity type '{entity_type}'")
+            .ok_or_else(|| EntityCreateError::Internal {
+                detail: format!(
+                    "No transition table for tenant '{tenant}', entity type '{entity_type}'"
+                ),
             })?;
 
         let policy = self.dispatch_retry_policy();
-        let response = retry::ask_with_backoff::<_, EntityResponse, _>(
+        let response = match retry::ask_with_backoff::<_, EntityResponse, _>(
             &actor_ref,
             || EntityMsg::GetState,
             &policy,
         )
         .await
         .result
-        .map_err(|e| format!("Actor query failed: {e}"))?;
+        {
+            Ok(response) => response,
+            Err(err) => {
+                // An actor that could not initialize left nothing durable. Its
+                // registry entry and index id are already retracted by the time
+                // this error arrives — the cell does that before answering
+                // anyone — so the retry respawns instead of asking a dead
+                // mailbox. All that is left here is to count the failure per
+                // entity type and report the classified cause.
+                let create_error = self.record_create_failure(
+                    tenant,
+                    entity_type,
+                    EntityCreateError::from_actor_error(&err),
+                );
+                tracing::error!(
+                    tenant = %tenant,
+                    entity_type = %entity_type,
+                    entity_id = %entity_id,
+                    failure = create_error.metric_label(),
+                    error = %create_error,
+                    "entity create failed before the entity existed"
+                );
+                return Err(create_error);
+            }
+        };
 
         // Broadcast entity creation event for SSE subscribers
         let seq = self.next_entity_event_sequence(tenant.as_str(), entity_type, entity_id);
@@ -1054,7 +1411,14 @@ impl ServerState {
                     entity_id = %entity_id,
                     "failed to update query projection during create"
                 );
-                return Err(format!("query projection write failed during create: {e}"));
+                return Err(self.record_create_failure(
+                    tenant,
+                    entity_type,
+                    EntityCreateError::from_persistence_error(
+                        "query projection write failed during create",
+                        &e,
+                    ),
+                ));
             }
             record_projection_update_success(
                 tenant,
@@ -1081,7 +1445,7 @@ impl ServerState {
         entity_type: &str,
         entity_id: &str,
         initial_fields: serde_json::Value,
-    ) -> Result<Option<EntityResponse>, String> {
+    ) -> Result<Option<EntityResponse>, EntityCreateError> {
         if !initial_fields.is_object() {
             return Ok(None);
         }
@@ -1150,8 +1514,9 @@ impl ServerState {
             params: initial_fields,
             idempotency_key: None,
         };
-        let payload = serde_json::to_value(&created)
-            .map_err(|e| format!("failed to serialize Created event: {e}"))?;
+        let payload = serde_json::to_value(&created).map_err(|e| EntityCreateError::Internal {
+            detail: format!("failed to serialize Created event: {e}"),
+        })?;
         let envelope = PersistenceEnvelope {
             sequence_nr: 1,
             event_type: created.action.clone(),
@@ -1231,8 +1596,15 @@ impl ServerState {
                         entity_id = %entity_id,
                         "failed to update query projection during native data-only create fast path"
                     );
-                    return Err(format!(
-                        "native data-only create failed for {entity_type}:{entity_id}: {e}"
+                    return Err(self.record_create_failure(
+                        tenant,
+                        entity_type,
+                        EntityCreateError::from_persistence_error(
+                            &format!(
+                                "native data-only create failed for {entity_type}:{entity_id}"
+                            ),
+                            &e,
+                        ),
                     ));
                 }
             }
@@ -1254,8 +1626,15 @@ impl ServerState {
                     return Ok(None);
                 }
                 Err(e) => {
-                    return Err(format!(
-                        "failed to persist data-only Created event for {entity_type}:{entity_id}: {e}"
+                    return Err(self.record_create_failure(
+                        tenant,
+                        entity_type,
+                        EntityCreateError::from_persistence_error(
+                            &format!(
+                                "failed to persist data-only Created event for {entity_type}:{entity_id}"
+                            ),
+                            &e,
+                        ),
                     ));
                 }
             }
@@ -1290,8 +1669,13 @@ impl ServerState {
                     entity_id = %entity_id,
                     "failed to update query projection during data-only create fast path"
                 );
-                return Err(format!(
-                    "query projection write failed during data-only create: {e}"
+                return Err(self.record_create_failure(
+                    tenant,
+                    entity_type,
+                    EntityCreateError::from_persistence_error(
+                        "query projection write failed during data-only create",
+                        &e,
+                    ),
                 ));
             }
             record_projection_update_success(
@@ -1695,25 +2079,17 @@ impl ServerState {
 
             let _ = actor_ref.stop();
 
-            let removed = {
-                let Ok(mut registry) = self.actor_registry.write() else {
-                    continue;
-                };
-                if registry
-                    .get(&actor_key)
-                    .is_some_and(|current| current.id().uid == actor_ref.id().uid)
-                {
-                    registry.remove(&actor_key);
-                    true
-                } else {
-                    false
-                }
-            };
+            // Registry entry and access stamp go together: a respawn that lands
+            // between them would keep its registry entry but lose its stamp,
+            // and an actor with no stamp is never a passivation candidate
+            // again. The identity check inside covers both.
+            //
+            // The entity index is deliberately left alone — passivation says
+            // the actor is idle, not that the entity is gone, and the index is
+            // what lets the next access lazy-spawn it.
+            let removed = ActorDirectory::of(self).unregister(&actor_key, actor_ref.id(), None);
 
             if removed {
-                if let Ok(mut last_accessed) = self.last_accessed.write() {
-                    last_accessed.remove(&actor_key);
-                }
                 // Evict the state cache entry so stale status doesn't linger.
                 if let Ok(mut cache) = self.entity_state_cache.lock() {
                     cache.pop(&actor_key);
@@ -1860,3 +2236,345 @@ impl ServerState {
 
 use temper_authz::{AuthzDecision, AuthzDenial, SecurityContext};
 use temper_runtime::actor::ActorRef;
+
+#[cfg(test)]
+mod actor_directory_tests {
+    use std::collections::BTreeMap;
+    use std::sync::{Arc, RwLock};
+    use std::time::{Duration, Instant};
+
+    use temper_jit::table::TransitionTable;
+    use temper_runtime::ActorSystem;
+    use temper_runtime::actor::ActorRef;
+
+    use super::{ActorDirectory, IndexedAs};
+    use crate::entity_actor::{EntityActor, EntityMsg};
+
+    const DOC_IOA: &str = include_str!("../../../../test-fixtures/specs/keyed_doc.ioa.toml");
+
+    fn directory() -> ActorDirectory {
+        ActorDirectory {
+            actor_registry: Arc::new(RwLock::new(BTreeMap::new())),
+            entity_index: Arc::new(RwLock::new(BTreeMap::new())),
+            last_accessed: Arc::new(RwLock::new(BTreeMap::new())),
+        }
+    }
+
+    /// A healthy actor, so the directory is exercised without an init failure
+    /// racing the assertions.
+    fn spawn_doc(system: &ActorSystem, entity_id: &str) -> ActorRef<EntityMsg> {
+        let table = Arc::new(RwLock::new(TransitionTable::from_ioa_source(DOC_IOA)));
+        system.spawn(
+            EntityActor::new("Doc", entity_id, table, serde_json::json!({})).with_tenant("default"),
+            format!("default:Doc:{entity_id}"),
+        )
+    }
+
+    fn indexed_as<'a>(index_key: &'a str, entity_id: &'a str) -> IndexedAs<'a> {
+        IndexedAs {
+            index_key,
+            entity_id,
+        }
+    }
+
+    /// Registration publishes the registry entry, the index membership and the
+    /// access stamp together.
+    #[tokio::test]
+    async fn registration_publishes_all_three_maps() {
+        let system = ActorSystem::new("directory-register");
+        let directory = directory();
+        let key = "default:Doc:doc-1";
+
+        let (_actor, spawned) =
+            directory.get_or_register(key, indexed_as("default:Doc", "doc-1"), || {
+                spawn_doc(&system, "doc-1")
+            });
+
+        assert!(spawned, "an empty directory spawns");
+        assert!(directory.actor_registry.read().unwrap().contains_key(key));
+        assert!(
+            directory.entity_index.read().unwrap()["default:Doc"].contains("doc-1"),
+            "a registered actor's entity must be listed for collection queries"
+        );
+        assert!(directory.last_accessed.read().unwrap().contains_key(key));
+
+        // A second call finds the incumbent and does not spawn again.
+        let (_again, spawned_again) =
+            directory.get_or_register(key, indexed_as("default:Doc", "doc-1"), || {
+                panic!("must not spawn a second incarnation for a registered key")
+            });
+        assert!(!spawned_again);
+    }
+
+    /// The whole retraction — identity check, registry removal, un-listing,
+    /// access stamp — is one critical section on the registry write lock.
+    ///
+    /// Proof by obstruction: hold the entity index, then start a retraction
+    /// that has to un-list. If it still holds the registry while it waits for
+    /// the index, the registry write lock is unavailable to anyone else; if it
+    /// released the registry first (removing the actor, then reaching for the
+    /// index), the registry is free — and a concurrent caller could see the
+    /// actor gone while the entity is still listed, or respawn and have its
+    /// fresh index entry deleted by the tail of this cleanup.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn retraction_holds_the_registry_lock_across_the_whole_cleanup() {
+        let system = ActorSystem::new("directory-retract");
+        let directory = directory();
+        let key = "default:Doc:doc-2";
+
+        let (actor, _) = directory.get_or_register(key, indexed_as("default:Doc", "doc-2"), || {
+            spawn_doc(&system, "doc-2")
+        });
+        let incarnation = actor.id().clone();
+
+        let index_held = directory.entity_index.write().unwrap();
+
+        let retractor = {
+            let directory = directory.clone();
+            std::thread::spawn(move || {
+                directory.unregister(
+                    "default:Doc:doc-2",
+                    &incarnation,
+                    Some(indexed_as("default:Doc", "doc-2")),
+                )
+            })
+        };
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut registry_stayed_locked = false;
+        while Instant::now() < deadline {
+            if directory.actor_registry.try_write().is_err() {
+                registry_stayed_locked = true;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+
+        assert!(
+            registry_stayed_locked,
+            "the retraction reached the entity index without holding the actor \
+             registry — the window where an entity is deregistered but still \
+             listed is observable, and a respawn can slip into it"
+        );
+
+        drop(index_held);
+        assert!(retractor.join().expect("the retraction thread finished"));
+        assert!(!directory.actor_registry.read().unwrap().contains_key(key));
+        assert!(
+            !directory
+                .entity_index
+                .read()
+                .unwrap()
+                .contains_key("default:Doc"),
+            "the last id of a type leaves no empty index bucket behind"
+        );
+        assert!(!directory.last_accessed.read().unwrap().contains_key(key));
+    }
+
+    /// The identity check guards every edit, not just the registry removal: a
+    /// retraction aimed at a dead incarnation must leave a live successor's
+    /// index entry and access stamp completely alone.
+    #[tokio::test]
+    async fn a_stale_retraction_cannot_touch_the_successor() {
+        let system = ActorSystem::new("directory-stale");
+        let directory = directory();
+        let key = "default:Doc:doc-3";
+
+        let (dead, _) = directory.get_or_register(key, indexed_as("default:Doc", "doc-3"), || {
+            spawn_doc(&system, "doc-3")
+        });
+        let dead_incarnation = dead.id().clone();
+
+        // The first incarnation goes away and a fresh one takes the key.
+        assert!(directory.unregister(key, &dead_incarnation, None));
+        let (successor, spawned) =
+            directory.get_or_register(key, indexed_as("default:Doc", "doc-3"), || {
+                spawn_doc(&system, "doc-3")
+            });
+        assert!(spawned, "the key was free, so this is a new incarnation");
+        assert_ne!(successor.id().uid, dead_incarnation.uid);
+
+        // The dead incarnation's cleanup arrives late.
+        assert!(!directory.unregister(
+            key,
+            &dead_incarnation,
+            Some(indexed_as("default:Doc", "doc-3"))
+        ));
+
+        assert!(
+            directory.actor_registry.read().unwrap().contains_key(key),
+            "the successor must still be registered"
+        );
+        assert!(
+            directory.entity_index.read().unwrap()["default:Doc"].contains("doc-3"),
+            "the successor's entity must still be listed — un-listing it would \
+             hide a live entity from every collection query"
+        );
+        assert!(
+            directory.last_accessed.read().unwrap().contains_key(key),
+            "an actor with no access stamp is never passivated again"
+        );
+    }
+
+    /// An unconditional eviction (the delete path) drops all three together and
+    /// hands back the actor so the caller can stop it outside the lock.
+    #[tokio::test]
+    async fn eviction_drops_all_three_maps_and_returns_the_actor() {
+        let system = ActorSystem::new("directory-evict");
+        let directory = directory();
+        let key = "default:Doc:doc-4";
+
+        let (actor, _) = directory.get_or_register(key, indexed_as("default:Doc", "doc-4"), || {
+            spawn_doc(&system, "doc-4")
+        });
+
+        let removed = directory
+            .unregister_any(key, indexed_as("default:Doc", "doc-4"))
+            .expect("the registered actor comes back so the caller can stop it");
+        assert_eq!(removed.id().uid, actor.id().uid);
+
+        assert!(directory.actor_registry.read().unwrap().is_empty());
+        assert!(
+            directory.entity_index.read().unwrap().is_empty(),
+            "the deleted entity must not stay listed"
+        );
+        assert!(directory.last_accessed.read().unwrap().is_empty());
+
+        assert!(
+            directory
+                .unregister_any(key, indexed_as("default:Doc", "doc-4"))
+                .is_none(),
+            "a second delete finds nothing and says so"
+        );
+    }
+}
+
+#[cfg(test)]
+mod entity_create_error_tests {
+    use super::EntityCreateError;
+    use temper_runtime::actor::{ActorError, InitFailureKind};
+    use temper_runtime::persistence::PersistenceError;
+
+    #[test]
+    fn a_constraint_init_failure_becomes_a_conflict() {
+        let err = ActorError::init_failed(
+            "failed to persist bootstrap Created event for File:fl-2: \
+             duplicate declared key 'ws_path' for File: held by fl-1",
+            InitFailureKind::Constraint,
+        );
+        match EntityCreateError::from_actor_error(&err) {
+            EntityCreateError::DeclaredKeyConflict { detail } => {
+                // The key and the holder are what the caller needs to act; they
+                // must survive from the store to the response.
+                assert!(detail.contains("ws_path"), "lost the key name: {detail}");
+                assert!(detail.contains("fl-1"), "lost the holder id: {detail}");
+            }
+            other => panic!("expected a conflict, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_dependency_init_failure_becomes_retryable() {
+        let err =
+            ActorError::init_failed("storage error: reset", InitFailureKind::TransientDependency);
+        assert!(matches!(
+            EntityCreateError::from_actor_error(&err),
+            EntityCreateError::TransientDependency { .. }
+        ));
+    }
+
+    #[test]
+    fn an_actor_error_that_is_not_an_init_failure_is_classified_by_transience() {
+        // A dropped or timed-out ask is not an init failure, but a timeout is
+        // still worth retrying and must not be reported as a hard error.
+        assert!(matches!(
+            EntityCreateError::from_actor_error(&ActorError::AskTimeout(
+                std::time::Duration::from_secs(5)
+            )),
+            EntityCreateError::TransientDependency { .. }
+        ));
+        assert!(matches!(
+            EntityCreateError::from_actor_error(&ActorError::MailboxFull),
+            EntityCreateError::TransientDependency { .. }
+        ));
+        assert!(matches!(
+            EntityCreateError::from_actor_error(&ActorError::Stopped),
+            EntityCreateError::Internal { .. }
+        ));
+        assert!(matches!(
+            EntityCreateError::from_actor_error(&ActorError::init_failed(
+                "budget exceeded",
+                InitFailureKind::Defect
+            )),
+            EntityCreateError::Internal { .. }
+        ));
+    }
+
+    #[test]
+    fn the_data_only_path_classifies_the_same_way() {
+        // The fast path writes without an actor, so it classifies the typed
+        // persistence error directly — same three outcomes, same wire contract.
+        let conflict = PersistenceError::DeclaredKeyConflict {
+            entity_type: "File".to_string(),
+            key_name: "ws_path".to_string(),
+            holder_id: "fl-1".to_string(),
+        };
+        match EntityCreateError::from_persistence_error("create failed", &conflict) {
+            EntityCreateError::DeclaredKeyConflict { detail } => {
+                assert!(detail.contains("ws_path") && detail.contains("fl-1"));
+            }
+            other => panic!("expected a conflict, got {other:?}"),
+        }
+
+        assert!(matches!(
+            EntityCreateError::from_persistence_error(
+                "create failed",
+                &PersistenceError::Storage("connection reset".into())
+            ),
+            EntityCreateError::TransientDependency { .. }
+        ));
+        assert!(matches!(
+            EntityCreateError::from_persistence_error(
+                "create failed",
+                &PersistenceError::Serialization("bad json".into())
+            ),
+            EntityCreateError::Internal { .. }
+        ));
+    }
+
+    #[test]
+    fn metric_labels_are_stable() {
+        // Dashboards and monitors key off these strings.
+        assert_eq!(
+            EntityCreateError::DeclaredKeyConflict {
+                detail: String::new()
+            }
+            .metric_label(),
+            "declared_key_conflict"
+        );
+        assert_eq!(
+            EntityCreateError::TransientDependency {
+                detail: String::new()
+            }
+            .metric_label(),
+            "transient_dependency"
+        );
+        assert_eq!(
+            EntityCreateError::Internal {
+                detail: String::new()
+            }
+            .metric_label(),
+            "internal"
+        );
+    }
+
+    #[test]
+    fn display_keeps_the_cause_intact_for_string_callers() {
+        // Callers that still take a String must not lose the reason.
+        let err = EntityCreateError::TransientDependency {
+            detail: "storage error: connection reset".to_string(),
+        };
+        assert_eq!(String::from(err.clone()), "storage error: connection reset");
+        assert_eq!(err.to_string(), "storage error: connection reset");
+    }
+}

--- a/crates/temper-server/src/state/metrics.rs
+++ b/crates/temper-server/src/state/metrics.rs
@@ -41,6 +41,13 @@ pub struct MetricsCollector {
     pub cross_invariant_eval_duration_ms_bucket: RwLock<BTreeMap<String, u64>>,
     /// Enforcement bypass count.
     pub cross_invariant_bypass_total: AtomicU64,
+    /// Entity creates that failed before the entity existed:
+    /// key = "entity_type:reason".
+    ///
+    /// A create that dies before its first event produces no transition and no
+    /// trajectory row, so it is invisible in every success-rate view. This is
+    /// the only place a fully broken entity type shows up.
+    pub entity_spawn_failures: RwLock<BTreeMap<String, u64>>,
 }
 
 impl Default for MetricsCollector {
@@ -61,6 +68,19 @@ impl MetricsCollector {
             relation_integrity_violations: RwLock::new(BTreeMap::new()),
             cross_invariant_eval_duration_ms_bucket: RwLock::new(BTreeMap::new()),
             cross_invariant_bypass_total: AtomicU64::new(0),
+            entity_spawn_failures: RwLock::new(BTreeMap::new()),
+        }
+    }
+
+    /// Record an entity create that failed before the entity existed.
+    ///
+    /// `reason` is a stable label — `declared_key_conflict`,
+    /// `transient_dependency`, or `internal`.
+    pub fn record_entity_spawn_failure(&self, entity_type: &str, reason: &str) {
+        let key = format!("{entity_type}:{reason}");
+        if let Ok(mut map) = self.entity_spawn_failures.write() {
+            *map.entry(key).or_insert(0) += 1;
+            evict_least_incremented(&mut map);
         }
     }
 
@@ -131,5 +151,32 @@ impl MetricsCollector {
     pub fn record_cross_bypass(&self) {
         self.cross_invariant_bypass_total
             .fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MetricsCollector;
+
+    #[test]
+    fn spawn_failures_are_counted_per_type_and_reason() {
+        let metrics = MetricsCollector::new();
+        metrics.record_entity_spawn_failure("File", "declared_key_conflict");
+        metrics.record_entity_spawn_failure("File", "declared_key_conflict");
+        metrics.record_entity_spawn_failure("File", "transient_dependency");
+        metrics.record_entity_spawn_failure("Workspace", "internal");
+
+        let map = metrics.entity_spawn_failures.read().unwrap();
+        assert_eq!(map.get("File:declared_key_conflict"), Some(&2));
+        // A degraded dependency must not be lumped in with a caller error,
+        // and one broken type must not hide behind a healthy one.
+        assert_eq!(map.get("File:transient_dependency"), Some(&1));
+        assert_eq!(map.get("Workspace:internal"), Some(&1));
+    }
+
+    #[test]
+    fn an_untouched_collector_reports_nothing() {
+        let metrics = MetricsCollector::new();
+        assert!(metrics.entity_spawn_failures.read().unwrap().is_empty());
     }
 }

--- a/crates/temper-server/src/state/mod.rs
+++ b/crates/temper-server/src/state/mod.rs
@@ -27,7 +27,7 @@ pub mod wasm_invocation_log;
 
 pub use admission::{AdmissionController, AdmissionOutcome, AdmissionPermit};
 pub use dispatch::{DispatchCommand, DispatchError, DispatchExtOptions, StateTimeoutTracker};
-pub use entity_ops::{FailedLevelInfo, VerificationGateError};
+pub use entity_ops::{EntityCreateError, FailedLevelInfo, VerificationGateError};
 pub use file_reads::{IndexedFileStreamRead, TextFileReadResult, TextFileVersionReadResult};
 pub(crate) use file_writes::FileStreamContentError;
 pub use metrics::MetricsCollector;

--- a/crates/temper-server/tests/entity_init_failure.rs
+++ b/crates/temper-server/tests/entity_init_failure.rs
@@ -1,0 +1,594 @@
+//! An entity create that dies inside `pre_start` must be diagnosable.
+//!
+//! Reproduces the production chain that turned a single declared-key collision
+//! into a 25-minute outage: `POST /tdata/<set>` spawns a fresh `EntityActor`,
+//! `pre_start` co-commits the bootstrap `Created` event, the declared-key
+//! uniqueness check rejects it, the cell burns its restarts and returns —
+//! dropping every waiting reply channel. The caller saw
+//! `500 {"code":"CreateError","message":"Actor query failed: actor stopped"}`
+//! and retried ~240 times because nothing told it the truth.
+//!
+//! What must hold now:
+//! 1. the waiting `ask` gets the *cause*, classified, not a bare "actor stopped";
+//! 2. the HTTP layer answers 409 naming the key and its holder, never a 500
+//!    with the cause discarded;
+//! 3. the failed spawn is retracted, so the retry re-derives the same honest
+//!    answer instead of "send failed: actor not running";
+//! 4. the failure is counted per entity type and visible on `/observe/metrics`,
+//!    which a create that dies before its first event never reached.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use temper_jit::table::TransitionTable;
+use temper_runtime::ActorSystem;
+use temper_runtime::actor::InitFailureKind;
+use temper_runtime::persistence::{EntityKeyRow, EventMetadata, EventStore, PersistenceEnvelope};
+use temper_runtime::scheduler::{install_deterministic_context, sim_now, sim_uuid};
+use temper_runtime::tenant::TenantId;
+use temper_server::registry::{
+    EntityLevelSummary, EntityVerificationResult, SpecRegistry, VerificationStatus,
+};
+use temper_server::request_context::AgentContext;
+use temper_server::state::EntityCreateError;
+use temper_server::storage::{BackendLabel, BoxedEventStore, StorageStack};
+use temper_server::{EntityActor, EntityMsg, ServerState, build_router};
+use temper_spec::csdl::parse_csdl;
+use temper_store_sim::{SimEventStore, SimFaultConfig};
+use tower::ServiceExt;
+
+const DOC_IOA: &str = include_str!("../../../test-fixtures/specs/keyed_doc.ioa.toml");
+
+const DOC_CSDL_XML: &str = r#"<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="Temper.EntityInitFailureTest" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="Doc">
+        <Key><PropertyRef Name="Id"/></Key>
+        <Property Name="Id" Type="Edm.String" Nullable="false"/>
+        <Property Name="Status" Type="Edm.String"/>
+        <Property Name="WorkspaceId" Type="Edm.String"/>
+        <Property Name="Path" Type="Edm.String"/>
+      </EntityType>
+      <EntityContainer Name="Container">
+        <EntitySet Name="Docs" EntityType="Temper.EntityInitFailureTest.Doc"/>
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>"#;
+
+fn doc_table() -> Arc<RwLock<TransitionTable>> {
+    Arc::new(RwLock::new(TransitionTable::from_ioa_source(DOC_IOA)))
+}
+
+fn test_envelope() -> PersistenceEnvelope {
+    PersistenceEnvelope {
+        sequence_nr: 1,
+        event_type: "Created".to_string(),
+        payload: serde_json::json!({ "action": "Created" }),
+        metadata: EventMetadata {
+            event_id: sim_uuid(),
+            causation_id: sim_uuid(),
+            correlation_id: sim_uuid(),
+            timestamp: sim_now(),
+            actor_id: "default:Doc:holder".to_string(),
+        },
+    }
+}
+
+/// Give `key_name` to `holder_id` so the next writer collides with it.
+async fn claim_key(store: &SimEventStore, holder_id: &str, key_hash: &str) {
+    store
+        .append_with_keys(
+            &format!("default:Doc:{holder_id}"),
+            0,
+            &[test_envelope()],
+            &[EntityKeyRow {
+                key_name: "path".to_string(),
+                key_hash: key_hash.to_string(),
+            }],
+        )
+        .await
+        .expect("the first writer claims the key");
+}
+
+/// A store whose every append fails — the shape of a backend outage, as
+/// opposed to a write the backend deliberately rejected.
+fn store_that_always_fails_writes(seed: u64) -> SimEventStore {
+    SimEventStore::new(
+        seed,
+        SimFaultConfig {
+            write_failure_prob: 1.0,
+            ..SimFaultConfig::none()
+        },
+    )
+}
+
+fn doc_key_hash(workspace: &str, path: &str) -> String {
+    let mut fields = serde_json::Map::new();
+    fields.insert("WorkspaceId".to_string(), serde_json::json!(workspace));
+    fields.insert("Path".to_string(), serde_json::json!(path));
+    temper_server::key_index::canonical_key_hash(
+        "path",
+        &["WorkspaceId".to_string(), "Path".to_string()],
+        &fields,
+    )
+    .expect("both key properties are present")
+}
+
+/// The actor boundary: a `pre_start` that cannot persist its bootstrap event
+/// must answer the waiting caller with the classified cause.
+#[tokio::test]
+async fn ask_against_a_failed_init_carries_the_cause() {
+    let (_guard, _clock, _id) = install_deterministic_context(7);
+    let store = SimEventStore::no_faults(7);
+    claim_key(&store, "doc-holder", &doc_key_hash("ws1", "/a.md")).await;
+    let boxed: BoxedEventStore = BoxedEventStore::new(store);
+
+    let system = ActorSystem::new("init-failure");
+    let actor = EntityActor::with_persistence(
+        "Doc",
+        "doc-colliding",
+        doc_table(),
+        serde_json::json!({ "WorkspaceId": "ws1", "Path": "/a.md" }),
+        boxed,
+        BackendLabel::Sim,
+    )
+    .with_tenant("default");
+    let actor_ref = system.spawn(actor, "doc-colliding");
+
+    let err = actor_ref
+        .ask::<temper_server::EntityResponse>(EntityMsg::GetState, Duration::from_secs(10))
+        .await
+        .expect_err("the bootstrap append is rejected, so init cannot succeed");
+
+    assert_eq!(
+        err.init_failure_kind(),
+        Some(InitFailureKind::Constraint),
+        "a declared-key rejection is a constraint failure, got: {err}"
+    );
+    assert!(
+        err.is_permanent(),
+        "retrying the same colliding key can never succeed, got: {err}"
+    );
+    let message = err.to_string();
+    assert!(
+        message.contains("duplicate declared key 'path'") && message.contains("doc-holder"),
+        "the caller must be told which key collided and who holds it, got: {message}"
+    );
+    assert!(
+        !message.contains("actor stopped"),
+        "the cause must not degrade to 'actor stopped', got: {message}"
+    );
+}
+
+/// A `pre_start` failure that is *not* the caller's fault stays retryable, so
+/// the dispatch layer and the HTTP layer can back off instead of giving up.
+#[tokio::test]
+async fn a_dependency_failure_during_init_stays_transient() {
+    let (_guard, _clock, _id) = install_deterministic_context(11);
+    let store = store_that_always_fails_writes(11);
+    let boxed: BoxedEventStore = BoxedEventStore::new(store);
+
+    let system = ActorSystem::new("init-transient");
+    let actor = EntityActor::with_persistence(
+        "Doc",
+        "doc-unlucky",
+        doc_table(),
+        serde_json::json!({ "WorkspaceId": "ws1", "Path": "/b.md" }),
+        boxed,
+        BackendLabel::Sim,
+    )
+    .with_tenant("default");
+    let actor_ref = system.spawn(actor, "doc-unlucky");
+
+    let err = actor_ref
+        .ask::<temper_server::EntityResponse>(EntityMsg::GetState, Duration::from_secs(10))
+        .await
+        .expect_err("every append fails, so init cannot succeed");
+
+    assert_eq!(
+        err.init_failure_kind(),
+        Some(InitFailureKind::TransientDependency),
+        "a store fault is not the caller's fault, got: {err}"
+    );
+    assert!(
+        err.is_transient(),
+        "a store fault must be retryable so ADR-0048 retry applies, got: {err}"
+    );
+}
+
+fn build_doc_state(name: &str, store: SimEventStore) -> ServerState {
+    let csdl = parse_csdl(DOC_CSDL_XML).expect("Doc CSDL parses");
+    let mut registry = SpecRegistry::new();
+    registry.register_tenant(
+        "default",
+        csdl,
+        DOC_CSDL_XML.to_string(),
+        &[("Doc", DOC_IOA)],
+    );
+    let mut state = ServerState::from_registry(ActorSystem::new(name), registry);
+    state.set_storage_stack(StorageStack::from_sim(store, None));
+    {
+        let mut registry = state.registry.write().unwrap();
+        registry.set_verification_status(
+            &TenantId::default(),
+            "Doc",
+            VerificationStatus::Completed(EntityVerificationResult {
+                all_passed: true,
+                levels: vec![EntityLevelSummary {
+                    level: "L0".to_string(),
+                    passed: true,
+                    summary: "test fixture verified".to_string(),
+                    details: None,
+                }],
+                verified_at: "2026-08-06T00:00:00Z".to_string(),
+            }),
+        );
+    }
+    state
+}
+
+/// The server boundary: a create that collides on a declared key is reported as
+/// a conflict, and the failed spawn leaves no corpse behind — the identical
+/// retry gets the identical answer, not "send failed: actor not running".
+#[tokio::test]
+async fn colliding_create_is_a_conflict_and_stays_one_on_retry() {
+    let (_guard, _clock, _id) = install_deterministic_context(13);
+    let store = SimEventStore::no_faults(13);
+    claim_key(&store, "doc-holder", &doc_key_hash("ws1", "/a.md")).await;
+    let state = build_doc_state("init-failure-conflict", store);
+    let tenant = TenantId::default();
+    let fields = serde_json::json!({ "WorkspaceId": "ws1", "Path": "/a.md" });
+
+    for attempt in 1..=3 {
+        let err = state
+            .get_or_create_tenant_entity(&tenant, "Doc", "doc-colliding", fields.clone())
+            .await
+            .expect_err("attempt {attempt}: the declared key is already held");
+        match &err {
+            EntityCreateError::DeclaredKeyConflict { detail } => {
+                assert!(
+                    detail.contains("duplicate declared key 'path'")
+                        && detail.contains("doc-holder"),
+                    "attempt {attempt}: the conflict must name the key and its holder, got: {detail}"
+                );
+            }
+            other => panic!(
+                "attempt {attempt}: expected a declared-key conflict, got {other:?} ({other})"
+            ),
+        }
+    }
+
+    // Nothing exists, so nothing may be listed: the optimistic index entry
+    // written at spawn time must have been retracted with the actor.
+    let index = state.entity_index.read().unwrap();
+    let listed = index
+        .get("default:Doc")
+        .map(|ids| ids.contains("doc-colliding"))
+        .unwrap_or(false);
+    assert!(
+        !listed,
+        "an entity that never persisted must not appear in the entity index"
+    );
+    drop(index);
+
+    let registry = state.actor_registry.read().unwrap();
+    assert!(
+        !registry.contains_key("default:Doc:doc-colliding"),
+        "a dead actor must not stay in the registry for the next request to ask"
+    );
+}
+
+/// The wire contract: 409 with the key and the holder, not 500 with the cause
+/// flattened into a sentence.
+#[tokio::test]
+async fn post_returns_409_naming_the_key_and_the_holder() {
+    let (_guard, _clock, _id) = install_deterministic_context(17);
+    let store = SimEventStore::no_faults(17);
+    claim_key(&store, "doc-holder", &doc_key_hash("ws1", "/a.md")).await;
+    let state = build_doc_state("init-failure-http", store);
+
+    let router = build_router(state.clone());
+    let response = router
+        .oneshot(
+            Request::post("/tdata/Docs")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    r#"{"Id":"doc-colliding","WorkspaceId":"ws1","Path":"/a.md"}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), 1_000_000)
+        .await
+        .unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
+
+    assert_eq!(
+        status,
+        StatusCode::CONFLICT,
+        "a declared-key collision is the caller's to fix, got {status} with body {body}"
+    );
+    assert_eq!(body["error"]["code"], "DeclaredKeyConflict");
+    let message = body["error"]["message"].as_str().unwrap_or_default();
+    assert!(
+        message.contains("duplicate declared key 'path'") && message.contains("doc-holder"),
+        "the 409 must name the key and its holder, got: {message}"
+    );
+
+    // The failure is now visible per entity type — a create that dies before
+    // its first event writes no trajectory row, so this counter is the only
+    // place a fully broken entity type shows up. (The `/observe/metrics`
+    // exposition of the same counter is covered in `observe::mod_test`, which
+    // runs under the `observe` feature.)
+    assert_eq!(
+        spawn_failures(&state, "Doc", "declared_key_conflict"),
+        1,
+        "the failed create must be counted for its entity type"
+    );
+}
+
+/// A store outage during create answers 503 with `Retry-After`, so a client
+/// backs off instead of retrying in a tight loop.
+#[tokio::test]
+async fn post_returns_503_with_retry_after_when_the_store_is_down() {
+    let (_guard, _clock, _id) = install_deterministic_context(19);
+    let state = build_doc_state(
+        "init-failure-unavailable",
+        store_that_always_fails_writes(19),
+    );
+
+    let router = build_router(state.clone());
+    let response = router
+        .oneshot(
+            Request::post("/tdata/Docs")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    r#"{"Id":"doc-unlucky","WorkspaceId":"ws1","Path":"/b.md"}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "a store fault is ours, and it may clear — say so"
+    );
+    assert_eq!(
+        response
+            .headers()
+            .get(axum::http::header::RETRY_AFTER)
+            .and_then(|v| v.to_str().ok()),
+        Some("1"),
+        "a retryable failure must tell the caller when to come back"
+    );
+
+    assert_eq!(
+        spawn_failures(&state, "Doc", "transient_dependency"),
+        1,
+        "a dependency outage must be counted apart from a caller error"
+    );
+    assert_eq!(
+        spawn_failures(&state, "Doc", "declared_key_conflict"),
+        0,
+        "a store outage must not be filed as the caller's mistake"
+    );
+
+    // The dead actor is retracted so the retry respawns instead of asking a
+    // corpse — but the entity is NOT un-listed. A store fault says nothing
+    // about whether the entity exists, and un-listing on that basis would hide
+    // a real entity that merely failed to hydrate.
+    let registry = state.actor_registry.read().unwrap();
+    assert!(
+        !registry.contains_key("default:Doc:doc-unlucky"),
+        "a dead actor must not be left for the next request"
+    );
+    drop(registry);
+    let index = state.entity_index.read().unwrap();
+    assert!(
+        index
+            .get("default:Doc")
+            .map(|ids| ids.contains("doc-unlucky"))
+            .unwrap_or(false),
+        "an unproven absence must not un-list the entity"
+    );
+}
+
+/// Nobody is waiting. The request that would have received the failure was
+/// abandoned, or never asked at all — spawning is the first thing a read does,
+/// and the caller can be gone before `pre_start` even finishes. A retraction
+/// that only fires when someone receives the error leaves this corpse behind
+/// forever, and every later request for the entity asks its dead mailbox.
+#[tokio::test]
+async fn an_init_failure_nobody_waits_for_is_still_retracted() {
+    let (_guard, _clock, _id) = install_deterministic_context(23);
+    let store = SimEventStore::no_faults(23);
+    claim_key(&store, "doc-holder", &doc_key_hash("ws1", "/a.md")).await;
+    let state = build_doc_state("init-failure-unwatched", store);
+    let tenant = TenantId::default();
+
+    // Spawn and walk away: no ask, no dispatch, no HTTP request.
+    let actor_ref = state
+        .get_or_spawn_tenant_actor_with_fields(
+            &tenant,
+            "Doc",
+            "doc-colliding",
+            serde_json::json!({ "WorkspaceId": "ws1", "Path": "/a.md" }),
+        )
+        .expect("the Doc entity type has a transition table");
+    assert!(
+        registered(&state, "default:Doc:doc-colliding"),
+        "the spawn is registered optimistically — that is what has to be undone"
+    );
+    drop(actor_ref);
+
+    await_true("the unwatched failed spawn was never retracted", || {
+        !registered(&state, "default:Doc:doc-colliding")
+    })
+    .await;
+    assert!(
+        !listed(&state, "default:Doc", "doc-colliding"),
+        "a constraint failure proves the entity does not exist, so it must not \
+         stay listed either — whether or not anyone was waiting to be told"
+    );
+}
+
+/// The invariant is not the create path's alone. A PATCH against a cold entity
+/// spawns it too, so an update can be the request that discovers a broken init
+/// — and must leave no corpse for the next one to ask.
+#[tokio::test]
+async fn a_field_update_that_breaks_init_leaves_no_corpse() {
+    let (_guard, _clock, _id) = install_deterministic_context(29);
+    let state = build_doc_state("init-failure-patch", store_that_always_fails_writes(29));
+    let tenant = TenantId::default();
+
+    let err = state
+        .update_tenant_entity_fields(
+            &tenant,
+            "Doc",
+            "doc-patched",
+            serde_json::json!({ "Status": "Draft" }),
+            false,
+        )
+        .await
+        .expect_err("every append fails, so the actor never starts");
+    assert!(
+        err.contains("Actor update failed"),
+        "the update must report the actor failure, got: {err}"
+    );
+
+    assert!(
+        !registered(&state, "default:Doc:doc-patched"),
+        "a dead actor must not be left for the next PATCH to ask"
+    );
+    assert!(
+        listed(&state, "default:Doc", "doc-patched"),
+        "a store fault proves nothing about existence, so the entity stays listed"
+    );
+}
+
+/// Same for DELETE: it spawns the entity to tombstone it, and a spawn that dies
+/// in `pre_start` must not survive the request that provoked it.
+#[tokio::test]
+async fn a_delete_that_breaks_init_leaves_no_corpse() {
+    let (_guard, _clock, _id) = install_deterministic_context(31);
+    let state = build_doc_state("init-failure-delete", store_that_always_fails_writes(31));
+    let tenant = TenantId::default();
+
+    let err = state
+        .delete_tenant_entity(&tenant, "Doc", "doc-deleted")
+        .await
+        .expect_err("every append fails, so the actor never starts");
+    assert!(
+        err.contains("Actor delete failed"),
+        "the delete must report the actor failure, got: {err}"
+    );
+
+    assert!(
+        listed(&state, "default:Doc", "doc-deleted"),
+        "the entity was listed by the spawn this test depends on"
+    );
+    assert!(
+        !registered(&state, "default:Doc:doc-deleted"),
+        "a dead actor must not be left for the next DELETE to ask"
+    );
+}
+
+/// A dispatched action takes the same path — the generic mutation verb, not
+/// just the named create.
+#[tokio::test]
+async fn a_dispatched_action_that_breaks_init_leaves_no_corpse() {
+    let (_guard, _clock, _id) = install_deterministic_context(37);
+    let state = build_doc_state("init-failure-dispatch", store_that_always_fails_writes(37));
+    let tenant = TenantId::default();
+
+    let outcome = state
+        .dispatch_tenant_action(
+            &tenant,
+            "Doc",
+            "doc-dispatched",
+            "Create",
+            serde_json::json!({ "WorkspaceId": "ws1", "Path": "/c.md" }),
+            &AgentContext::default(),
+        )
+        .await;
+    assert!(
+        outcome.is_err(),
+        "every append fails, so the action cannot be applied"
+    );
+
+    // Only a spawn lists the entity, so this also proves the dispatch got past
+    // its governance gates and really did reach the actor.
+    assert!(
+        listed(&state, "default:Doc", "doc-dispatched"),
+        "the dispatch must have spawned the entity for this test to mean anything"
+    );
+    assert!(
+        !registered(&state, "default:Doc:doc-dispatched"),
+        "a dead actor must not be left for the next dispatch to ask"
+    );
+}
+
+fn registered(state: &ServerState, actor_key: &str) -> bool {
+    state.actor_registry.read().unwrap().contains_key(actor_key)
+}
+
+fn listed(state: &ServerState, index_key: &str, entity_id: &str) -> bool {
+    state
+        .entity_index
+        .read()
+        .unwrap()
+        .get(index_key)
+        .is_some_and(|ids| ids.contains(entity_id))
+}
+
+/// Wait for a condition the failed actor's own task brings about. Bounded, so a
+/// regression fails the suite instead of hanging it.
+async fn await_true(what_failed: &str, cond: impl Fn() -> bool) {
+    for _ in 0..600 {
+        if cond() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("{what_failed} (waited 6s)");
+}
+
+/// How many creates of `entity_type` failed for `reason`, as `/observe/metrics`
+/// would report it.
+fn spawn_failures(state: &ServerState, entity_type: &str, reason: &str) -> u64 {
+    state
+        .metrics
+        .entity_spawn_failures
+        .read()
+        .unwrap()
+        .get(&format!("{entity_type}:{reason}"))
+        .copied()
+        .unwrap_or(0)
+}
+
+/// Guard against a silently reintroduced `BTreeMap` import churn: the fixture
+/// spec must actually declare the key this suite depends on.
+#[test]
+fn fixture_declares_the_key_under_test() {
+    let table = TransitionTable::from_ioa_source(DOC_IOA);
+    let declared: BTreeMap<&str, Vec<String>> = table
+        .keys
+        .iter()
+        .map(|k| (k.name.as_str(), k.properties.clone()))
+        .collect();
+    assert_eq!(
+        declared.get("path"),
+        Some(&vec!["WorkspaceId".to_string(), "Path".to_string()]),
+        "the suite reproduces a collision on the declared (WorkspaceId, Path) key"
+    );
+}

--- a/crates/temper-store-postgres/src/store.rs
+++ b/crates/temper-store-postgres/src/store.rs
@@ -157,10 +157,11 @@ impl EventStore for PostgresEventStore {
             if let Some((existing,)) = holder
                 && existing != entity_id
             {
-                return Err(PersistenceError::Storage(format!(
-                    "duplicate declared key '{}' for {entity_type}: held by {existing}",
-                    key.key_name
-                )));
+                return Err(PersistenceError::DeclaredKeyConflict {
+                    entity_type: entity_type.to_string(),
+                    key_name: key.key_name.clone(),
+                    holder_id: existing,
+                });
             }
         }
 

--- a/crates/temper-store-sim/src/lib.rs
+++ b/crates/temper-store-sim/src/lib.rs
@@ -466,10 +466,11 @@ impl EventStore for SimEventStore {
                     row.key_hash.clone(),
                 )) && existing.as_str() != entity_id
                 {
-                    return Err(PersistenceError::Storage(format!(
-                        "duplicate declared key '{}' for {entity_type}: held by {existing}",
-                        row.key_name
-                    )));
+                    return Err(PersistenceError::DeclaredKeyConflict {
+                        entity_type: entity_type.to_string(),
+                        key_name: row.key_name.clone(),
+                        holder_id: existing.clone(),
+                    });
                 }
             }
         }


### PR DESCRIPTION
Found while diagnosing why a contributor agent could not learn *why* it had been denied — it burned ~76 minutes and ~$8 hunting introspection endpoints that do not exist (ARN-286).

## Denials name their source file

A denial read `denied by policy: policy1874, policy1875` — positional ids that map to nothing, so neither an agent nor a human can tell **which rule fired**.

Policies loaded from an app bundle now carry the label `{app}/{path under policies/}`, so the same denial reads `katagami-commons/art_style.cedar#2`. The durable `policies` row id is that same string, so a denial recovered after a restart still names the file rather than reverting to a position.

The pre-ARN-286 row id is deleted once the policy has been re-saved under its label — **fatally, not warn-only**. A surviving legacy row is loaded again on the next recovery, bringing the OLD generation of those statements back alongside the new one; with Cedar's forbid-overrides-permit that silently reactivates a forbid the operator believes they deleted. Stale authorization restored by a restart, with no signal at install time, is not something to log and continue past.

## Policy reload was read-then-write

Reading a tenant's sources, compiling them, and swapping them in were three separate steps. Two concurrent rebuilds both read the same pre-state, both wrote, and the first caller's policies were gone — **with both calls returning `Ok`**. `update_tenant_policy_sources` now performs the whole read-modify-write while holding the tenant write lock, and the os-app installer mirrors what the engine actually installed rather than what it computed before the merge.

## Policy load failures no longer fail open

A failed reload after an os-app install was logged and swallowed, leaving the tenant running on whatever policy set happened to be live. It is now fatal to the install.

## Three maps had to agree about every live actor

The actor registry, the entity index, and the last-accessed stamps were mutated independently, so a failure on a cleanup path could remove an actor from one and leave it in the others. Rather than patch the four sites that leaked, the invariant moved into one guarded directory that owns all three and takes the registry write lock first — the lock everything else already takes first.

## Also in here

- Restored a committed `// TEMP probe: lock acquisition removed` that had disabled per-tenant install serialization on this branch.
- Extracted the inline `#[cfg(test)]` modules from `cell.rs`, `recovery.rs`, and `dispatch/mod.rs` into `*_test.rs` siblings, and renamed `engine/tests.rs` to `engine_test.rs`. This is what the readability ratchet is asking for — production files shrink, tests are excluded by design. **The ratchet is now better than baseline: `PROD_FILES_GT500` 83 vs 84.**

## Verification

- `cargo build --workspace` clean.
- `cargo clippy --workspace --all-targets -- -D warnings` clean (the CI gate — an earlier run without `-D warnings` hid a `type_complexity` error).
- Full suite green through the pre-push hook, including the Docker-backed testcontainers integration tests.
- Live e2e: booted `temper serve` against `katagami-commons/specs`, created an `ArtStyle` as an `agent_type=contributor` principal, attempted `SubmitForReview` — correctly denied.

**One honest gap.** That live denial read `primary#5, primary#4`, not `katagami-commons/art_style.cedar#2`. The labelling is on the **os-app install path**, which is what production uses and which is covered by tests asserting the exact string (including after a reload). `temper serve --app` takes a different path that flattens the policies into one blob before they reach the engine. So this is fixed and tested for the production path, but **not demonstrated end-to-end against a running server** — that needs a Genesis-backed install. Filed as ARN-314 with the code path and a verification recipe. I am not claiming the live run proves the headline fix; it does not.

Unrelated flakes that gate this repo's pre-push hook are filed as ARN-323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR gives Cedar statements stable source-file labels, serializes tenant policy rebuilds, makes policy activation failures fatal, and centralizes actor registry/index/access bookkeeping. It also improves authorization error classification, entity-initialization failure propagation, OData key parsing, metrics, recovery, and associated tests.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until legacy policy cleanup verifies ownership or otherwise avoids deleting colliding policy IDs.

A valid app installation can derive the same lossy legacy key as another durable policy and delete that row, potentially removing an authorization forbid or permit during recovery.

**Files Needing Attention:** crates/temper-platform/src/os_apps/policy_rows.rs
</details>

<details open><summary><h3>Security Review</h3></summary>

App-policy migration cleanup derives a lossy legacy ID and deletes that row without validating ownership, allowing an installation to remove an unrelated durable Cedar policy after an ID collision.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/temper-platform/src/os_apps/policy_rows.rs | Persists source-labelled policy rows and removes legacy rows, but the lossy legacy-ID deletion can remove an unrelated policy. |
| crates/temper-authz/src/engine/mod.rs | Adds stable statement labels and serializes tenant policy source read-modify-write operations under the tenant-policy lock. |
| crates/temper-platform/src/os_apps/mod.rs | Serializes tenant installations, activates merged policy sources, and mirrors the engine’s actual installed text. |
| crates/temper-server/src/state/entity_ops.rs | Centralizes actor registry, entity-index, and access-stamp mutations while retracting failed actor initialization safely. |
| crates/temper-runtime/src/actor/cell.rs | Propagates classified initialization failures to pending requests and observers after restart supervision is exhausted. |
| crates/temper-odata/src/path.rs | Expands key and parameter literal parsing, including double-quoted forms and escaped quote handling. |
| crates/temper-platform/src/recovery.rs | Recovers granular labelled Cedar sources alongside compatible legacy policy state. |
| crates/temper-server/src/authz/helpers.rs | Separates policy decisions from malformed-request and engine faults for API and approval-queue handling. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Installer
    participant PolicyStore
    participant AuthzEngine
    participant Recovery
    Installer->>PolicyStore: Save app/path.cedar
    Installer->>PolicyStore: Delete derived legacy slug
    Note over PolicyStore: Lossy slug may identify another policy
    Installer->>AuthzEngine: Atomically merge labelled sources
    Recovery->>PolicyStore: Load durable policy rows
    PolicyStore-->>Recovery: Remaining rows
    Recovery->>AuthzEngine: Activate recovered labelled policies
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Acrates%2Ftemper-platform%2Fsrc%2Fos_apps%2Fpolicy_rows.rs%3A80-83%0A**Legacy%20cleanup%20deletes%20colliding%20policies**%0A%0AWhen%20two%20policy%20sources%20share%20the%20same%20lossy%20legacy%20slug%2C%20this%20cleanup%20deletes%20the%20row%20by%20tenant%20and%20derived%20ID%20without%20validating%20its%20source%20or%20owner%2C%20causing%20an%20unrelated%20durable%20permit%20or%20forbid%20to%20disappear%20after%20recovery.%0A%0A**How%20this%20was%20verified%3A**%20Both%20dots%20and%20path%20separators%20collapse%20to%20%60-%60%2C%20while%20deletion%20uses%20only%20the%20resulting%20tenant-scoped%20policy%20ID.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=nerdsane%2Ftemper&pr=418&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22claude%2Ftemper-error-taxonomy%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Ftemper-error-taxonomy%22.%0A%0A%23%23%23%20Issue%201%0Acrates%2Ftemper-platform%2Fsrc%2Fos_apps%2Fpolicy_rows.rs%3A80-83%0A**Legacy%20cleanup%20deletes%20colliding%20policies**%0A%0AWhen%20two%20policy%20sources%20share%20the%20same%20lossy%20legacy%20slug%2C%20this%20cleanup%20deletes%20the%20row%20by%20tenant%20and%20derived%20ID%20without%20validating%20its%20source%20or%20owner%2C%20causing%20an%20unrelated%20durable%20permit%20or%20forbid%20to%20disappear%20after%20recovery.%0A%0A**How%20this%20was%20verified%3A**%20Both%20dots%20and%20path%20separators%20collapse%20to%20%60-%60%2C%20while%20deletion%20uses%20only%20the%20resulting%20tenant-scoped%20policy%20ID.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=nerdsane%2Ftemper&pr=418&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Acrates%2Ftemper-platform%2Fsrc%2Fos_apps%2Fpolicy_rows.rs%3A80-83%0A**Legacy%20cleanup%20deletes%20colliding%20policies**%0A%0AWhen%20two%20policy%20sources%20share%20the%20same%20lossy%20legacy%20slug%2C%20this%20cleanup%20deletes%20the%20row%20by%20tenant%20and%20derived%20ID%20without%20validating%20its%20source%20or%20owner%2C%20causing%20an%20unrelated%20durable%20permit%20or%20forbid%20to%20disappear%20after%20recovery.%0A%0A**How%20this%20was%20verified%3A**%20Both%20dots%20and%20path%20separators%20collapse%20to%20%60-%60%2C%20while%20deletion%20uses%20only%20the%20resulting%20tenant-scoped%20policy%20ID.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=418&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
crates/temper-platform/src/os_apps/policy_rows.rs:80-83
**Legacy cleanup deletes colliding policies**

When two policy sources share the same lossy legacy slug, this cleanup deletes the row by tenant and derived ID without validating its source or owner, causing an unrelated durable permit or forbid to disappear after recovery.

**How this was verified:** Both dots and path separators collapse to `-`, while deletion uses only the resulting tenant-scoped policy ID.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(kernel): name Cedar policies in deni..."](https://github.com/nerdsane/temper/commit/57c82f052843a36291abbe3bbac9cf593d12d39d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52738695)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [temper-authz: Cedar-Based Authorization for Agents](https://app.greptile.com/arni-labs/-/custom-context/knowledge-base/nerdsane/temper/-/docs/temper-authz.md)
- Knowledge Base — [Temper Runtime and Actor Runtime](https://app.greptile.com/arni-labs/-/custom-context/knowledge-base/nerdsane/temper/-/docs/temper-runtime.md)
- Knowledge Base — [temper-server](https://app.greptile.com/arni-labs/-/custom-context/knowledge-base/nerdsane/temper/-/docs/temper-server.md)
- Knowledge Base — [Temper storage backends](https://app.greptile.com/arni-labs/-/custom-context/knowledge-base/nerdsane/temper/-/docs/temper-storage.md)
</details>

<!-- /greptile_comment -->