### PR TITLE
fix: read a harness tool call as tooling, not as an undeclared action

### DIFF
--- a/crates/temper-server/src/api/trajectory_analysis_test.rs
+++ b/crates/temper-server/src/api/trajectory_analysis_test.rs
@@ -313,6 +313,10 @@ async fn conformance_check_folds_in_a_stored_ots_trajectory() {
     .await;
 
     // The agent decided on an action the kernel never recorded a row for.
+    // `Delete` is a platform verb the Order spec does not declare: a name the
+    // kernel can place as an action, so the decision reads as a claim about one
+    // rather than as the agent using its own tooling (see
+    // `crate::conformance::decisions`).
     let data = serde_json::json!({
         "trajectory_id": "traj-1",
         "version": "0.1.0",
@@ -332,7 +336,7 @@ async fn conformance_check_folds_in_a_stored_ots_trajectory() {
             "decisions": [{
                 "decision_id": "decision-1",
                 "decision_type": "tool_selection",
-                "choice": {"action": "Frobnicate"},
+                "choice": {"action": "Delete"},
                 "consequence": {"success": false}
             }]
         }]
@@ -368,8 +372,8 @@ async fn conformance_check_folds_in_a_stored_ots_trajectory() {
     let body = json_body(response).await;
     let violations = body["report"]["violations"].as_array().expect("violations");
     assert_eq!(violations.len(), 1);
-    assert_eq!(violations[0]["kind"], "unknown_action");
-    assert_eq!(violations[0]["action"], "Frobnicate");
+    assert_eq!(violations[0]["kind"], "forbidden_action");
+    assert_eq!(violations[0]["action"], "Delete");
     assert_eq!(
         violations[0]["index"],
         serde_json::json!(1),

--- a/crates/temper-server/src/conformance/conformance_test.rs
+++ b/crates/temper-server/src/conformance/conformance_test.rs
@@ -1134,6 +1134,83 @@ fn a_caller_supplied_audit_row_cannot_make_a_harness_tool_look_governed() {
 }
 
 #[test]
+fn an_authorization_denial_row_cannot_widen_the_vocabulary() {
+    // `POST /api/authorize` reaches `record_authz_denial` with a caller-chosen
+    // action name, resource type and `X-Temper-Ctx-SessionId`, and the row it
+    // writes leaves `spec_governed` unset — so a filter that only rejects
+    // `spec_governed = false` lets it through.
+    //
+    // The attack it would open: one unauthenticated call naming action `Bash`
+    // against somebody else's session puts `Bash` in that session's vocabulary,
+    // and every `Bash` in their clean run reports as a violation of a spec they
+    // followed. A verdict anyone can flip is not a verdict.
+    let rows = vec![
+        row("AddItem", Some("Draft"), Some("Draft")),
+        TursoTrajectoryRow {
+            entity_type: "Widget".to_string(),
+            source: Some("Authz".to_string()),
+            spec_governed: None,
+            success: false,
+            authz_denied: Some(true),
+            to_status: None,
+            ..row("Bash", None, None)
+        },
+    ];
+    let ots = ots_with_decisions(&["Bash"]);
+
+    let report = check(&order_automaton(), &rows, Some(&ots));
+
+    assert!(
+        report.passed,
+        "an authorization denial names what a caller asked about, not what the \
+         kernel dispatched: {:?}",
+        report.violations
+    );
+    assert_eq!(report.stats.ots_decisions_skipped_as_unrecognized_name, 1);
+}
+
+#[test]
+fn a_platform_bookkeeping_row_does_not_widen_the_vocabulary() {
+    // Kernel-written, so the names are not a caller's — but they are already in
+    // KERNEL_PLATFORM_ACTIONS, so admitting the source adds nothing and would
+    // reopen the marker case. Narrow on purpose.
+    let rows = vec![
+        row("AddItem", Some("Draft"), Some("Draft")),
+        TursoTrajectoryRow {
+            source: Some("Platform".to_string()),
+            ..row("Bash", Some("Draft"), Some("Draft"))
+        },
+    ];
+    let ots = ots_with_decisions(&["Bash"]);
+
+    let report = check(&order_automaton(), &rows, Some(&ots));
+
+    assert!(report.passed, "{:?}", report.violations);
+    assert_eq!(report.stats.ots_decisions_skipped_as_unrecognized_name, 1);
+    assert_eq!(report.stats.platform_rows_skipped, 1);
+}
+
+#[test]
+fn a_harness_tool_named_after_a_platform_verb_is_reported() {
+    // The one place the tie-break runs toward reporting, pinned so it stays a
+    // decision rather than a surprise. A harness tool called `Delete` is
+    // indistinguishable from an agent reaching for the platform's `Delete`, and
+    // the checker reports it — the module doc says why.
+    let rows = vec![row("AddItem", Some("Draft"), Some("Draft"))];
+    let ots = ots_with_decisions(&["Delete"]);
+
+    let report = check(&order_automaton(), &rows, Some(&ots));
+
+    let violation = only_violation(&report);
+    assert_eq!(violation.kind, ViolationKind::ForbiddenAction);
+    assert_eq!(violation.action, "Delete");
+    assert_eq!(
+        report.stats.ots_decisions_skipped_as_unrecognized_name, 0,
+        "a platform verb is placeable, so it is judged rather than counted"
+    );
+}
+
+#[test]
 fn a_capture_loss_marker_does_not_widen_the_vocabulary() {
     // The marker's action name is the capture path's own. Reading it as an
     // action would make a decision named `CaptureLost` judgeable, and the

--- a/crates/temper-server/src/conformance/conformance_test.rs
+++ b/crates/temper-server/src/conformance/conformance_test.rs
@@ -501,20 +501,25 @@ fn decisions_never_substitute_for_the_rows_a_run_did_not_leave() {
 fn a_run_with_no_actor_rows_still_fails_on_a_disagreeing_decision() {
     // The other half of the rule: decisions still *fail* a run. Only the path
     // to Pass is closed to them.
-    let ots = ots_with_decisions(&["Frobnicate"]);
+    //
+    // `Delete` rather than an invented name: the platform defines it, so the
+    // kernel can place it as an action and read the decision as a claim about
+    // one. A name nothing in this deployment defines cannot be told apart from
+    // a harness tool — see `conformance::decisions` for the rule.
+    let ots = ots_with_decisions(&["Delete"]);
 
     let report = check(&order_automaton(), &[], Some(&ots));
 
     assert_eq!(report.verdict, Verdict::Fail);
-    assert_eq!(only_violation(&report).kind, ViolationKind::UnknownAction);
+    assert_eq!(only_violation(&report).kind, ViolationKind::ForbiddenAction);
 }
 
 #[test]
 fn ots_decisions_the_kernel_never_recorded_are_checked_after_the_rows() {
     let rows = vec![row("AddItem", Some("Draft"), Some("Draft"))];
-    // `AddItem` already has a row and must not be double-counted; `Frobnicate`
-    // never reached the kernel at all.
-    let ots = ots_with_decisions(&["AddItem", "Frobnicate"]);
+    // `AddItem` already has a row and must not be double-counted; `Delete` is a
+    // platform verb the Order spec never declares and no row accounts for.
+    let ots = ots_with_decisions(&["AddItem", "Delete"]);
 
     let report = check(&order_automaton(), &rows, Some(&ots));
 
@@ -523,8 +528,8 @@ fn ots_decisions_the_kernel_never_recorded_are_checked_after_the_rows() {
         violation.index, 1,
         "OTS decisions are indexed after the kernel rows"
     );
-    assert_eq!(violation.kind, ViolationKind::UnknownAction);
-    assert_eq!(violation.action, "Frobnicate");
+    assert_eq!(violation.kind, ViolationKind::ForbiddenAction);
+    assert_eq!(violation.action, "Delete");
     assert!(violation.detail.contains("never recorded a row"));
     assert_eq!(report.stats.ots_decisions_checked, 1);
     assert_eq!(report.stats.stream_length, 2);
@@ -974,4 +979,173 @@ fn an_undeclared_action_that_moved_the_entity_is_reported_once() {
     let violation = only_violation(&report);
     assert_eq!(violation.index, 1);
     assert_eq!(violation.kind, ViolationKind::UnknownAction);
+}
+
+/// The tools a Claude Code trajectory records one decision apiece for. Every
+/// one of these has the shape of an action name, which is why they were being
+/// judged as governed-action claims.
+const HARNESS_TOOLS: &[&str] = &[
+    "Bash",
+    "Read",
+    "Write",
+    "Edit",
+    "Agent",
+    "ToolSearch",
+    "SendMessage",
+    "mcp__linear__list_issues",
+];
+
+#[test]
+fn harness_tool_decisions_are_counted_rather_than_reported() {
+    // The regression this fixture exists for: a clean Claude Code run against
+    // a conforming session returned `fail` with one `unknown_action` per tool
+    // call — 81 of them in the run that found this — each saying the agent
+    // "decided on `Bash`, which the kernel never recorded a row for".
+    let rows = vec![
+        row("AddItem", Some("Draft"), Some("Draft")),
+        row("SubmitOrder", Some("Draft"), Some("Submitted")),
+    ];
+    let ots = ots_with_decisions(HARNESS_TOOLS);
+
+    let report = check(&order_automaton(), &rows, Some(&ots));
+
+    assert!(
+        report.passed,
+        "the agent's own tools are not this actor's alphabet: {:?}",
+        report.violations
+    );
+    assert_eq!(
+        report.stats.ots_decisions_skipped_as_unrecognized_name,
+        HARNESS_TOOLS.len()
+    );
+    assert_eq!(report.stats.ots_decisions_checked, 0);
+    assert_eq!(
+        report.stats.ots_decisions_skipped_as_harness_tool, 0,
+        "a bare tool name is not the MCP envelope shape, and the two counts say \
+         different things"
+    );
+}
+
+#[test]
+fn harness_tools_mixed_with_governed_actions_leave_the_governed_ones_judged() {
+    // The realistic stream: tool calls interleaved with the actor's own
+    // actions. Skipping the tools must not skip anything else.
+    let rows = vec![row("AddItem", Some("Draft"), Some("Draft"))];
+    let mut stream: Vec<&str> = vec!["Bash", "AddItem", "Read"];
+    // Declared, and no row accounts for it: judged, and raises nothing.
+    stream.push("CancelOrder");
+    // A platform verb the Order spec does not declare: still reported.
+    stream.extend(["Edit", "Delete"]);
+    let ots = ots_with_decisions(&stream);
+
+    let report = check(&order_automaton(), &rows, Some(&ots));
+
+    let violation = only_violation(&report);
+    assert_eq!(violation.kind, ViolationKind::ForbiddenAction);
+    assert_eq!(violation.action, "Delete");
+    assert_eq!(
+        report.stats.ots_decisions_skipped_as_unrecognized_name, 3,
+        "Bash, Read and Edit"
+    );
+    assert_eq!(
+        report.stats.ots_decisions_checked, 2,
+        "CancelOrder and Delete; AddItem has a row and is not re-judged"
+    );
+}
+
+#[test]
+fn an_undeclared_action_reached_through_the_harness_is_still_reported() {
+    // The check that must survive the fix. The envelope's own action list says
+    // these were governed calls, so an undeclared one is a violation however
+    // many tool calls surround it.
+    let rows = vec![row("AddItem", Some("Draft"), Some("Draft"))];
+    let mut ots = mcp_execute_trajectory(
+        "temper.action('default', 'Order', 'Frobnicate', {})",
+        &["Frobnicate"],
+    );
+    let now = "2026-01-01T00:00:00Z"
+        .parse::<chrono::DateTime<chrono::Utc>>()
+        .expect("timestamp parses");
+    let mut noise = OTSTurn::new(2, now);
+    for tool in HARNESS_TOOLS {
+        noise = noise.with_decision(OTSDecision::new(
+            DecisionType::ToolSelection,
+            OTSChoice::new(*tool),
+            OTSConsequence::success(),
+        ));
+    }
+    ots = ots.with_turn(noise);
+
+    let report = check(&order_automaton(), &rows, Some(&ots));
+
+    let violation = only_violation(&report);
+    assert_eq!(violation.kind, ViolationKind::UnknownAction);
+    assert_eq!(violation.action, "Frobnicate");
+    assert_eq!(report.stats.ots_decisions_checked, 1);
+}
+
+#[test]
+fn an_action_the_session_dispatched_on_another_entity_stays_judgeable() {
+    // `PayInvoice` is not in the Order alphabet and not a platform verb, but
+    // the kernel dispatched it in this session, so it is an action name in this
+    // deployment rather than a tool name — and a decision claiming it against
+    // Order is still the fault it always was.
+    let rows = vec![
+        row("AddItem", Some("Draft"), Some("Draft")),
+        TursoTrajectoryRow {
+            entity_type: "Invoice".to_string(),
+            ..row("PayInvoice", Some("Due"), Some("Paid"))
+        },
+    ];
+    let ots = ots_with_decisions(&["Bash", "PayInvoice"]);
+
+    let report = check(&order_automaton(), &rows, Some(&ots));
+
+    let violation = only_violation(&report);
+    assert_eq!(violation.kind, ViolationKind::UnknownAction);
+    assert_eq!(violation.action, "PayInvoice");
+    assert_eq!(report.stats.ots_decisions_skipped_as_unrecognized_name, 1);
+}
+
+#[test]
+fn a_caller_supplied_audit_row_cannot_make_a_harness_tool_look_governed() {
+    // The injection the vocabulary has to refuse. `POST /api/audit` takes a
+    // caller-chosen session and action name; if those names counted as
+    // governed, writing one record called `Bash` into somebody else's session
+    // would turn every `Bash` in their run into a violation of their spec.
+    let rows = vec![
+        row("AddItem", Some("Draft"), Some("Draft")),
+        TursoTrajectoryRow {
+            spec_governed: Some(false),
+            ..row("Bash", Some("Draft"), Some("Draft"))
+        },
+    ];
+    let ots = ots_with_decisions(&["Bash"]);
+
+    let report = check(&order_automaton(), &rows, Some(&ots));
+
+    assert!(
+        report.passed,
+        "a caller does not get to decide what counts as an action: {:?}",
+        report.violations
+    );
+    assert_eq!(report.stats.ots_decisions_skipped_as_unrecognized_name, 1);
+    assert_eq!(report.stats.non_governed_rows_skipped, 1);
+}
+
+#[test]
+fn a_capture_loss_marker_does_not_widen_the_vocabulary() {
+    // The marker's action name is the capture path's own. Reading it as an
+    // action would make a decision named `CaptureLost` judgeable, and the
+    // marker is not an action at all.
+    let rows = vec![
+        row("AddItem", Some("Draft"), Some("Draft")),
+        capture_loss_marker_row(),
+    ];
+    let ots = ots_with_decisions(&[CAPTURE_LOSS_ACTION]);
+
+    let report = check(&order_automaton(), &rows, Some(&ots));
+
+    assert!(report.violations.is_empty(), "{:?}", report.violations);
+    assert_eq!(report.stats.ots_decisions_skipped_as_unrecognized_name, 1);
 }

--- a/crates/temper-server/src/conformance/decisions.rs
+++ b/crates/temper-server/src/conformance/decisions.rs
@@ -168,22 +168,25 @@ impl<'a> ActionVocabulary<'a> {
     }
 }
 
-/// Whether this row records the kernel dispatching an action, which is the only
-/// thing that proves a name is an action at all.
+/// Whether this row records the kernel dispatching an action on an entity,
+/// which is the closest thing to proof that a name is an action at all.
 ///
-/// Written as an allowlist of one source, because the question is whether the
-/// KERNEL chose this name, and only the entity dispatch path
-/// ([`TrajectorySource::Entity`](crate::state::TrajectorySource)) answers yes.
-/// The other two both carry names a caller can choose:
+/// Written as an allowlist of one source
+/// ([`TrajectorySource::Entity`](crate::state::TrajectorySource)), because that
+/// is the only path on which the kernel routed the name to an actor. The other
+/// two both carry names a caller can choose:
 ///
 /// - `Authz` rows come from `authz::helpers::record_authz_denial`, which
 ///   `POST /api/authorize` reaches with a caller-supplied action name, resource
 ///   type and `X-Temper-Ctx-SessionId`. They are written with `spec_governed`
 ///   unset, so testing that flag alone lets them through.
-/// - `Platform` rows are kernel bookkeeping. Their names are the kernel's, but
-///   they are already in [`KERNEL_PLATFORM_ACTIONS`], so admitting them adds
-///   nothing — and it is what would let a capture-loss marker's `CaptureLost`
-///   into the vocabulary.
+/// - `Platform` rows are kernel bookkeeping, so their names are the kernel's
+///   own and admitting them would be safe. They are left out because the ones
+///   that matter to an actor are already in [`KERNEL_PLATFORM_ACTIONS`], while
+///   admitting the source is what would let a capture-loss marker's
+///   `CaptureLost` in. The cost is exact and small: a decision naming a
+///   platform-source action that the list does not carry — `policy_saved`,
+///   `repl_execution` — is counted rather than judged.
 ///
 /// `spec_governed = false` is then checked on top: `POST /api/audit` and
 /// `POST /api/evolution/trajectories/unmet` write caller-named rows and mark
@@ -195,6 +198,28 @@ impl<'a> ActionVocabulary<'a> {
 /// followed. A row that cannot be placed here simply does not widen the
 /// vocabulary, which is the safe direction — it can only cause a decision to be
 /// counted rather than judged.
+///
+/// # What this does NOT shut out
+///
+/// Two things, both stated so nobody reads this filter as closing the class.
+///
+/// `Entity` is where the kernel routed the name, not always where it invented
+/// one: a Cedar-permitted dispatch of an action no spec declares is refused
+/// inside the actor and still recorded here, so a caller who is allowed to
+/// dispatch at all can put a name of their choosing into the vocabulary.
+///
+/// More important, the same unauthenticated `POST /api/authorize` still reaches
+/// the ROW walk. Point its `resource_type` at the entity type under check
+/// instead of some other one and the denial row is judged as this actor's
+/// execution ([`row_disposition`](super::walk::row_disposition) diverts only
+/// `Platform` and `spec_governed = false`), so its caller-chosen name is
+/// reported as `unknown_action` directly — no vocabulary involved. That is
+/// older than this module and is not repaired here, because denial rows are
+/// deliberately judged (it is how `denied_then_retried` sees a denial) and
+/// changing that is a decision about denial-row provenance, not about how a
+/// decision is classified. Closing it properly means either binding the session
+/// on that endpoint to an authenticated principal or teaching the walk that an
+/// `Authz` row records a question rather than an act.
 fn names_a_kernel_dispatch(row: &TursoTrajectoryRow) -> bool {
     row.source.as_deref() == Some(ENTITY_DISPATCH_SOURCE)
         && row.spec_governed != Some(false)

--- a/crates/temper-server/src/conformance/decisions.rs
+++ b/crates/temper-server/src/conformance/decisions.rs
@@ -85,6 +85,11 @@ const TRAJECTORY_ACTIONS_KEY: &str = "trajectory_actions";
 /// Field naming the action inside one entry of that list.
 const NESTED_ACTION_KEY: &str = "action";
 
+/// `source` on a row the kernel wrote while dispatching an action on an entity
+/// (`TrajectorySource::Entity`). The serialized form, because that is what
+/// reaches the checker on a stored row.
+const ENTITY_DISPATCH_SOURCE: &str = "Entity";
+
 /// What a decision names.
 pub(super) enum DecisionActions<'a> {
     /// A thought rather than a callable: nothing was invoked.
@@ -111,12 +116,29 @@ pub(super) enum DecisionActions<'a> {
 ///   spec does not declare it that is a
 ///   [`ForbiddenAction`](super::ViolationKind::ForbiddenAction) — the more
 ///   consequential of the two undeclared kinds, and it stays reported;
-/// - every action name the kernel dispatched in this session, on any entity. A
-///   name the kernel wrote a governed row for is a real action name in this
-///   deployment whoever it belonged to, so a decision naming it is claiming a
-///   governed action. Rows on other entities widen the vocabulary but never
-///   excuse a decision: [`check_decisions`](super::check_decisions) still
-///   reports a name this actor's spec does not declare.
+/// - every action name the kernel dispatched on an entity in this session, on
+///   any entity type (see [`names_a_kernel_dispatch`], which is narrower than
+///   "appears on a row"). A name the kernel dispatched is a real action name in
+///   this deployment whoever it belonged to, so a decision naming it is
+///   claiming a governed action. Rows on other entities widen the vocabulary
+///   but never excuse a decision:
+///   [`check_decisions`](super::check_decisions) still reports a name this
+///   actor's spec does not declare.
+///
+/// # The collision this resolves against the harness
+///
+/// A harness tool whose name is also a platform verb — a filesystem tool called
+/// `Delete`, an HTTP tool called `Put` or `Patch` — is placeable, so it is
+/// judged, and against an actor that does not declare it that is a
+/// `forbidden_action`. Nothing in the record separates the two readings, so one
+/// of them has to be chosen, and this is the deliberate choice: the platform's
+/// own write verbs are the most consequential names an agent can claim, and a
+/// false report on one of them is preferable to silence on an agent reaching
+/// for `Delete` or `SubmitSpec`. The tie-break runs the other way everywhere
+/// else — an unplaceable name is counted, not condemned. Pinned by
+/// `a_harness_tool_named_after_a_platform_verb_is_reported`.
+///
+/// # The agent's own account is not a source
 ///
 /// The trajectory's own tool inventory (`context.entities` of type `tool`) is
 /// deliberately not a source. A transcript converter builds it from the same
@@ -146,18 +168,36 @@ impl<'a> ActionVocabulary<'a> {
     }
 }
 
-/// Whether this row's action name was chosen by the kernel rather than by a
-/// caller.
+/// Whether this row records the kernel dispatching an action, which is the only
+/// thing that proves a name is an action at all.
 ///
-/// Only kernel-chosen names may widen the vocabulary. `POST /api/audit` and
-/// `POST /api/evolution/trajectories/unmet` write rows with a caller-supplied
-/// session, entity type and action name, and mark them `spec_governed = false`;
-/// a capture-loss marker's action is the capture path's own. Reading either
-/// would let a caller decide what counts as a governed action in somebody
-/// else's session — one audit record named `Bash` would turn every `Bash`
-/// decision in that session into a violation.
+/// Written as an allowlist of one source, because the question is whether the
+/// KERNEL chose this name, and only the entity dispatch path
+/// ([`TrajectorySource::Entity`](crate::state::TrajectorySource)) answers yes.
+/// The other two both carry names a caller can choose:
+///
+/// - `Authz` rows come from `authz::helpers::record_authz_denial`, which
+///   `POST /api/authorize` reaches with a caller-supplied action name, resource
+///   type and `X-Temper-Ctx-SessionId`. They are written with `spec_governed`
+///   unset, so testing that flag alone lets them through.
+/// - `Platform` rows are kernel bookkeeping. Their names are the kernel's, but
+///   they are already in [`KERNEL_PLATFORM_ACTIONS`], so admitting them adds
+///   nothing — and it is what would let a capture-loss marker's `CaptureLost`
+///   into the vocabulary.
+///
+/// `spec_governed = false` is then checked on top: `POST /api/audit` and
+/// `POST /api/evolution/trajectories/unmet` write caller-named rows and mark
+/// them, and nothing says such a row cannot claim `Entity` as its source.
+///
+/// The failure this shuts out: one `POST /api/authorize` naming action `Bash`
+/// against somebody else's session id puts `Bash` in that session's vocabulary,
+/// and every `Bash` in their run then reports as a violation of a spec they
+/// followed. A row that cannot be placed here simply does not widen the
+/// vocabulary, which is the safe direction — it can only cause a decision to be
+/// counted rather than judged.
 fn names_a_kernel_dispatch(row: &TursoTrajectoryRow) -> bool {
-    row.spec_governed != Some(false)
+    row.source.as_deref() == Some(ENTITY_DISPATCH_SOURCE)
+        && row.spec_governed != Some(false)
         && !(row.entity_type == CAPTURE_LOSS_ENTITY_TYPE && row.action == CAPTURE_LOSS_ACTION)
 }
 

--- a/crates/temper-server/src/conformance/decisions.rs
+++ b/crates/temper-server/src/conformance/decisions.rs
@@ -1,7 +1,7 @@
 //! What one OTS decision contributes to the action walk.
 //!
-//! A decision's `choice.action` is not always an action name. Three shapes
-//! reach the checker:
+//! A decision's `choice.action` is not always an action name. Four shapes reach
+//! the checker:
 //!
 //! - a thought — a reasoning step or a response formulation, whose `action` is
 //!   free-form prose ([`temper_ots::models::DecisionType::is_invocation`]);
@@ -10,13 +10,73 @@
 //!   call as one decision whose `choice.action` is `"execute: <the submitted
 //!   code>"` (`temper_mcp::runtime::record_execute_turn`), with the governed
 //!   actions the code calls listed under `choice.arguments.trajectory_actions`;
+//! - a **harness tool** — `Bash`, `Read`, `mcp__linear__list_issues`. A
+//!   transcript-derived trajectory writes one decision per tool call with the
+//!   tool's own name as `choice.action`, so most decisions in an agent-harness
+//!   run are these;
 //! - an action name, which is what the checker can judge.
 //!
-//! Reading the first two as action names reports attempts the agent never made:
-//! every MCP-produced decision would surface as one `unknown_action` violation
-//! naming a hundred characters of Python.
+//! Reading the first three as action names reports attempts the agent never
+//! made: one violation naming a hundred characters of Python per MCP turn, and
+//! one per harness tool call for every `Bash` and `Read` in the run.
+//!
+//! # Which decisions claim a governed action
+//!
+//! The rule, spelled out, because the two cases it separates are not separable
+//! by inspection:
+//!
+//! **A decision is judged as a governed-action claim only when something
+//! positively identifies it as one.** Two things can:
+//!
+//! 1. the names listed under `choice.arguments.trajectory_actions`. That key
+//!    means "the governed actions this code called", so every name in it is a
+//!    claim about a governed action whether or not the kernel recognises it —
+//!    an envelope naming `Frobnicate` is exactly the fault to report;
+//! 2. a `choice.action` that this deployment's action vocabulary contains (see
+//!    [`ActionVocabulary`]) — a name the actor spec declares, a name the
+//!    platform defines, or a name the kernel dispatched somewhere in this
+//!    session.
+//!
+//! Everything else names something the kernel has no reason to believe is a
+//! governed action, and is read as the agent's own tooling: skipped from the
+//! walk and counted, never reported.
+//!
+//! # What this cannot tell apart, and what that costs
+//!
+//! A bare `Bash` and a bare `Frobnicate` are the same token from the same
+//! producer path. Nothing in the record distinguishes a harness tool from an
+//! action name the kernel has never seen — a transcript converter writes both
+//! as `choice.action = <the tool the model called>` with the tool's arguments
+//! beside it. So the checker cannot have both "no false violations for harness
+//! tools" and "every unplaceable name reported", and this is the conservative
+//! half: a name it cannot place is counted, not condemned.
+//!
+//! What that gives up is narrow, and it is not the governance check. Every
+//! action that actually reached the platform leaves a kernel row, and rows are
+//! judged in full — an undeclared action, an illegal source state, a move after
+//! a terminal state are all caught there, from evidence this rule never
+//! touches. What is given up is one candour signal: an agent that *reports*
+//! reaching for an action which never reached the platform, whose name no spec
+//! in the walk declares and which nothing in the session dispatched, is counted
+//! as harness use rather than reported. The attempt failed before the kernel
+//! saw it; what is lost is the record that it was made.
+//!
+//! The way to narrow that gap is to add positive identification, never to widen
+//! what counts as a name: reading a governed target out of a decision's
+//! arguments (as katagami's `scripts/trajectory/conformance_check.py` does
+//! offline), or giving [`ActionVocabulary`] the tenant's other registered specs
+//! so a name belonging to another actor becomes placeable. Both are additive —
+//! they can only move decisions from "skipped" to "judged" — which is why the
+//! vocabulary is one type with one constructor rather than a test scattered
+//! through the walk.
+
+use std::collections::BTreeSet;
 
 use temper_ots::models::OTSDecision;
+use temper_store_turso::TursoTrajectoryRow;
+
+use super::spec_view::SpecView;
+use super::{CAPTURE_LOSS_ACTION, CAPTURE_LOSS_ENTITY_TYPE, KERNEL_PLATFORM_ACTIONS};
 
 /// Key under `choice.arguments` where a harness envelope lists the governed
 /// actions the submitted code calls.
@@ -29,29 +89,101 @@ const NESTED_ACTION_KEY: &str = "action";
 pub(super) enum DecisionActions<'a> {
     /// A thought rather than a callable: nothing was invoked.
     Thinking,
-    /// A harness tool, naming no governed action the checker can judge.
-    HarnessTool,
+    /// A harness envelope — a `choice.action` that is not even shaped like an
+    /// action name — which reached no governed action.
+    HarnessEnvelope,
+    /// A name shaped like an action name but outside this deployment's action
+    /// vocabulary, so the kernel cannot read it as a governed action: the
+    /// agent's own tooling, as far as the record shows.
+    UnrecognizedName,
     /// Governed action names the agent decided on, in the order given.
     Actions(Vec<&'a str>),
 }
 
+/// The action names this deployment is known to define.
+///
+/// Three sources, all of them the kernel's own knowledge rather than the
+/// agent's account of itself:
+///
+/// - the actor spec's declared alphabet;
+/// - [`KERNEL_PLATFORM_ACTIONS`], the verbs the platform defines for every
+///   actor. A decision naming one claims a platform verb, and if this actor's
+///   spec does not declare it that is a
+///   [`ForbiddenAction`](super::ViolationKind::ForbiddenAction) — the more
+///   consequential of the two undeclared kinds, and it stays reported;
+/// - every action name the kernel dispatched in this session, on any entity. A
+///   name the kernel wrote a governed row for is a real action name in this
+///   deployment whoever it belonged to, so a decision naming it is claiming a
+///   governed action. Rows on other entities widen the vocabulary but never
+///   excuse a decision: [`check_decisions`](super::check_decisions) still
+///   reports a name this actor's spec does not declare.
+///
+/// The trajectory's own tool inventory (`context.entities` of type `tool`) is
+/// deliberately not a source. A transcript converter builds it from the same
+/// `choice.action` values as the decisions themselves, so it carries no
+/// information the decisions do not already have — and taking the agent's word
+/// for which of its decisions were "just tools" would let a trajectory relabel
+/// its way out of the check.
+pub(super) struct ActionVocabulary<'a> {
+    names: BTreeSet<&'a str>,
+}
+
+impl<'a> ActionVocabulary<'a> {
+    pub(super) fn new(spec: &SpecView<'a>, kernel_rows: &'a [TursoTrajectoryRow]) -> Self {
+        let mut names: BTreeSet<&str> = spec.declared.keys().copied().collect();
+        names.extend(KERNEL_PLATFORM_ACTIONS.iter().copied());
+        names.extend(
+            kernel_rows
+                .iter()
+                .filter(|row| names_a_kernel_dispatch(row))
+                .map(|row| row.action.as_str()),
+        );
+        Self { names }
+    }
+
+    fn contains(&self, action: &str) -> bool {
+        self.names.contains(action)
+    }
+}
+
+/// Whether this row's action name was chosen by the kernel rather than by a
+/// caller.
+///
+/// Only kernel-chosen names may widen the vocabulary. `POST /api/audit` and
+/// `POST /api/evolution/trajectories/unmet` write rows with a caller-supplied
+/// session, entity type and action name, and mark them `spec_governed = false`;
+/// a capture-loss marker's action is the capture path's own. Reading either
+/// would let a caller decide what counts as a governed action in somebody
+/// else's session — one audit record named `Bash` would turn every `Bash`
+/// decision in that session into a violation.
+fn names_a_kernel_dispatch(row: &TursoTrajectoryRow) -> bool {
+    row.spec_governed != Some(false)
+        && !(row.entity_type == CAPTURE_LOSS_ENTITY_TYPE && row.action == CAPTURE_LOSS_ACTION)
+}
+
 /// Read the governed actions one decision names.
-pub(super) fn decision_actions(decision: &OTSDecision) -> DecisionActions<'_> {
+pub(super) fn decision_actions<'a>(
+    decision: &'a OTSDecision,
+    vocabulary: &ActionVocabulary<'_>,
+) -> DecisionActions<'a> {
     if !decision.decision_type.is_invocation() {
         return DecisionActions::Thinking;
     }
     let action = decision.choice.action.as_str();
-    if is_action_name(action) {
+    if vocabulary.contains(action) {
         return DecisionActions::Actions(vec![action]);
     }
-    // The envelope itself names no governed action, but the actions the code
-    // inside it calls are recorded alongside it and are exactly what the
+    // Not a name this deployment defines. It may still be an envelope around
+    // governed calls: those are recorded alongside it and are exactly what the
     // checker is looking for.
     let nested = nested_actions(decision);
-    if nested.is_empty() {
-        DecisionActions::HarnessTool
+    if !nested.is_empty() {
+        return DecisionActions::Actions(nested);
+    }
+    if is_action_name(action) {
+        DecisionActions::UnrecognizedName
     } else {
-        DecisionActions::Actions(nested)
+        DecisionActions::HarnessEnvelope
     }
 }
 
@@ -75,10 +207,14 @@ fn nested_actions(decision: &OTSDecision) -> Vec<&str> {
 
 /// Whether `action` has the shape of a declared action name.
 ///
-/// An `[[action]]` name in an IOA spec is a bare token. A `choice.action`
-/// carrying anything else — whitespace, a colon, a newline of Python — is a
-/// harness envelope around something that is not an action name, whatever the
-/// harness that produced it.
+/// An `[[action]]` name in an IOA spec is a bare token, so a `choice.action`
+/// carrying anything else — whitespace, a colon, a newline of Python — is an
+/// envelope around something that is not an action name, whatever the harness
+/// that produced it.
+///
+/// This is a test of what a name *cannot* be, never of what it is: `Bash`
+/// passes it, which is how every harness tool call came to be reported as a
+/// violation. Only [`ActionVocabulary`] decides that a name is an action.
 fn is_action_name(action: &str) -> bool {
     !action.is_empty()
         && action
@@ -91,39 +227,95 @@ mod tests {
     use super::*;
     use serde_json::json;
     use temper_ots::models::{DecisionType, OTSChoice, OTSConsequence};
+    use temper_spec::automaton::{Automaton, parse_automaton};
+
+    const ORDER_IOA: &str = include_str!("../../../../test-fixtures/specs/order.ioa.toml");
+
+    fn order_automaton() -> Automaton {
+        parse_automaton(ORDER_IOA).expect("order fixture parses")
+    }
 
     fn decision(decision_type: DecisionType, choice: OTSChoice) -> OTSDecision {
         OTSDecision::new(decision_type, choice, OTSConsequence::success())
     }
 
-    fn actions(decision: &OTSDecision) -> Vec<&str> {
-        match decision_actions(decision) {
+    /// Classify against the spec's own alphabet plus the platform's, with no
+    /// session rows. The row-sourced half of the vocabulary is exercised
+    /// end-to-end in [`super::super::conformance_test`], where a report is what
+    /// the assertions are about.
+    fn classify<'a>(automaton: &'a Automaton, decision: &'a OTSDecision) -> DecisionActions<'a> {
+        let spec = SpecView::new(automaton);
+        let vocabulary = ActionVocabulary::new(&spec, &[]);
+        decision_actions(decision, &vocabulary)
+    }
+
+    fn actions<'a>(automaton: &'a Automaton, decision: &'a OTSDecision) -> Vec<&'a str> {
+        match classify(automaton, decision) {
             DecisionActions::Actions(actions) => actions,
             DecisionActions::Thinking => panic!("expected actions, got a thought"),
-            DecisionActions::HarnessTool => panic!("expected actions, got a harness tool"),
+            DecisionActions::HarnessEnvelope => panic!("expected actions, got a harness envelope"),
+            DecisionActions::UnrecognizedName => {
+                panic!("expected actions, got an unplaceable name")
+            }
         }
     }
 
     #[test]
-    fn a_bare_action_name_is_the_action() {
+    fn a_declared_action_name_is_the_action() {
+        let automaton = order_automaton();
         let decision = decision(DecisionType::ToolSelection, OTSChoice::new("ConfirmOrder"));
-        assert_eq!(actions(&decision), vec!["ConfirmOrder"]);
+        assert_eq!(actions(&automaton, &decision), vec!["ConfirmOrder"]);
+    }
+
+    #[test]
+    fn a_platform_verb_is_a_name_the_kernel_can_place() {
+        // Not declared by `Order`, but defined by the platform: the claim is
+        // judgeable, and judging it is what makes it a `forbidden_action`.
+        let automaton = order_automaton();
+        let decision = decision(DecisionType::ToolSelection, OTSChoice::new("Delete"));
+        assert_eq!(actions(&automaton, &decision), vec!["Delete"]);
+    }
+
+    #[test]
+    fn a_harness_tool_name_is_not_an_action() {
+        let automaton = order_automaton();
+        for tool in [
+            "Bash",
+            "Read",
+            "Write",
+            "Edit",
+            "Agent",
+            "ToolSearch",
+            "SendMessage",
+            "mcp__linear__list_issues",
+        ] {
+            let decision = decision(DecisionType::ToolSelection, OTSChoice::new(tool));
+            assert!(
+                matches!(
+                    classify(&automaton, &decision),
+                    DecisionActions::UnrecognizedName
+                ),
+                "`{tool}` is the harness's tool, not an action this deployment defines"
+            );
+        }
     }
 
     #[test]
     fn a_thought_names_nothing() {
+        let automaton = order_automaton();
         let decision = decision(
             DecisionType::ReasoningStep,
             OTSChoice::new("compare shipping options"),
         );
         assert!(matches!(
-            decision_actions(&decision),
+            classify(&automaton, &decision),
             DecisionActions::Thinking
         ));
     }
 
     #[test]
     fn an_execute_envelope_yields_the_actions_the_code_called() {
+        let automaton = order_automaton();
         let decision = decision(
             DecisionType::ToolSelection,
             OTSChoice::new("execute: temper.action('default', 'Order', 'ConfirmOrder', {})")
@@ -134,23 +326,47 @@ mod tests {
                     ],
                 })),
         );
-        assert_eq!(actions(&decision), vec!["ConfirmOrder", "ShipOrder"]);
+        assert_eq!(
+            actions(&automaton, &decision),
+            vec!["ConfirmOrder", "ShipOrder"]
+        );
     }
 
     #[test]
-    fn an_execute_envelope_that_called_nothing_governed_is_a_harness_tool() {
+    fn an_envelope_names_its_governed_actions_even_when_the_kernel_cannot_place_them() {
+        // The envelope's own key says these were governed calls, so an
+        // undeclared one is reported rather than passed over as tooling. This
+        // is the positive identification a bare name does not have.
+        let automaton = order_automaton();
+        let decision = decision(
+            DecisionType::ToolSelection,
+            OTSChoice::new("execute: temper.action('default', 'Order', 'Frobnicate', {})")
+                .with_arguments(json!({
+                    "trajectory_actions": [{ "action": "Frobnicate", "params": {} }],
+                })),
+        );
+        assert_eq!(actions(&automaton, &decision), vec!["Frobnicate"]);
+    }
+
+    #[test]
+    fn an_execute_envelope_that_called_nothing_governed_is_a_harness_envelope() {
+        let automaton = order_automaton();
         let decision = decision(
             DecisionType::ToolSelection,
             OTSChoice::new("execute: print('hello')"),
         );
         assert!(
-            matches!(decision_actions(&decision), DecisionActions::HarnessTool),
+            matches!(
+                classify(&automaton, &decision),
+                DecisionActions::HarnessEnvelope
+            ),
             "a code envelope names no governed action, so it must not be judged as one"
         );
     }
 
     #[test]
-    fn a_nested_list_of_non_names_is_a_harness_tool() {
+    fn a_nested_list_of_non_names_is_a_harness_envelope() {
+        let automaton = order_automaton();
         let decision = decision(
             DecisionType::ToolSelection,
             OTSChoice::new("execute: temper.action(...)").with_arguments(json!({
@@ -158,8 +374,8 @@ mod tests {
             })),
         );
         assert!(matches!(
-            decision_actions(&decision),
-            DecisionActions::HarnessTool
+            classify(&automaton, &decision),
+            DecisionActions::HarnessEnvelope
         ));
     }
 }

--- a/crates/temper-server/src/conformance/mod.rs
+++ b/crates/temper-server/src/conformance/mod.rs
@@ -53,6 +53,12 @@
 //! decision either. Decisions carry no observed state, so only the action-set
 //! checks apply to them.
 //!
+//! Most decisions in a run driven by an agent harness name that harness's own
+//! tools rather than anything this kernel governs. [`decisions`] holds the rule
+//! that separates the two and the one blind spot it leaves; the counts are
+//! [`ConformanceStats::ots_decisions_skipped_as_harness_tool`] and
+//! [`ConformanceStats::ots_decisions_skipped_as_unrecognized_name`].
+//!
 //! # Verdict, and why `passed` is not just "no violations"
 //!
 //! A report that saw nothing found no violations, and so did a report that
@@ -70,7 +76,10 @@
 //!
 //! - [`ViolationKind::UnknownAction`] — the action name appears in no
 //!   `[[action]]` of the spec and is not a name the kernel itself emits. No
-//!   spec defines it anywhere.
+//!   spec defines it anywhere. From a kernel row this is unconditional: the
+//!   platform dispatched the name, so it was an action. From an OTS decision it
+//!   requires that the name be placeable as an action at all — see
+//!   [`decisions`].
 //! - [`ViolationKind::ForbiddenAction`] — the action is one the platform
 //!   defines (see [`KERNEL_PLATFORM_ACTIONS`]) but this actor's spec does not
 //!   declare, recorded against the actor from the entity dispatch path. The
@@ -118,7 +127,7 @@ use temper_ots::models::OTSTrajectory;
 use temper_spec::automaton::Automaton;
 use temper_store_turso::TursoTrajectoryRow;
 
-use decisions::{DecisionActions, decision_actions};
+use decisions::{ActionVocabulary, DecisionActions, decision_actions};
 use report::{EvidenceContext, evidence_gaps};
 use spec_view::SpecView;
 use walk::{RowDisposition, Walk, check_row, row_disposition, undeclared_detail};
@@ -257,9 +266,13 @@ fn check_decisions(
         .filter(|row| row_disposition(spec, row) == RowDisposition::ActorExecution)
         .map(|row| row.action.as_str())
         .collect();
+    // Built from every row in the session, not just this actor's: the question
+    // it answers is "is this name an action in this deployment at all", which a
+    // row on another entity settles just as well.
+    let vocabulary = ActionVocabulary::new(spec, kernel_rows);
     let mut index = kernel_rows.len();
     for decision in trajectory.turns.iter().flat_map(|turn| &turn.decisions) {
-        let actions = match decision_actions(decision) {
+        let actions = match decision_actions(decision, &vocabulary) {
             // A reasoning step or a response formulation names a thought, not
             // a callable; reporting it as an action invents an attempt the
             // agent never made.
@@ -270,8 +283,16 @@ fn check_decisions(
             // The agent invoked its harness, not this actor. The governed
             // actions it reached through that call, if any, are recorded
             // alongside it and are judged as `Actions` instead.
-            DecisionActions::HarnessTool => {
+            DecisionActions::HarnessEnvelope => {
                 stats.ots_decisions_skipped_as_harness_tool += 1;
+                continue;
+            }
+            // A name no action vocabulary the kernel knows contains. Read as
+            // the agent's own tooling, which is what it is in every run driven
+            // by an agent harness; see [`decisions`] for why the alternative
+            // reading cannot be told apart from this one, and what that costs.
+            DecisionActions::UnrecognizedName => {
+                stats.ots_decisions_skipped_as_unrecognized_name += 1;
                 continue;
             }
             DecisionActions::Actions(actions) => actions,

--- a/crates/temper-server/src/conformance/report.rs
+++ b/crates/temper-server/src/conformance/report.rs
@@ -127,6 +127,20 @@ pub struct ConformanceStats {
     /// rather than a governed action, and carry no governed action inside
     /// them (see [`decisions`](super::decisions)).
     pub ots_decisions_skipped_as_harness_tool: usize,
+    /// OTS decisions passed over because their name is in no action vocabulary
+    /// the kernel knows: not declared by this actor's spec, not defined by the
+    /// platform, and not dispatched anywhere in this session. In a run driven
+    /// by an agent harness this is the harness's own tooling — `Bash`, `Read`,
+    /// an MCP tool — and it is normally the largest count in this struct.
+    ///
+    /// It is also the checker's blind spot, which is why it is counted rather
+    /// than folded into the line above: an action name the kernel has never
+    /// seen is indistinguishable from a tool name, so a decision claiming an
+    /// action that never reached the platform lands here instead of in
+    /// [`Self::violations_by_kind`]. Actions that *did* reach the platform are
+    /// unaffected — they have rows, and rows are judged in full. See
+    /// [`decisions`](super::decisions) for the rule and its limits.
+    pub ots_decisions_skipped_as_unrecognized_name: usize,
     /// Entities observed reaching a terminal state.
     pub terminal_entities: usize,
     /// Violation count per kind, keyed by [`ViolationKind::as_str`].

--- a/crates/temper-server/src/conformance/walk.rs
+++ b/crates/temper-server/src/conformance/walk.rs
@@ -385,6 +385,7 @@ impl Walk {
             ots_decisions_checked: 0,
             ots_decisions_skipped_as_thinking: 0,
             ots_decisions_skipped_as_harness_tool: 0,
+            ots_decisions_skipped_as_unrecognized_name: 0,
             terminal_entities: self.terminal_at.len(),
             violations_by_kind: BTreeMap::new(),
         }


### PR DESCRIPTION
## The bug

A conformance check of a **clean** Claude Code run returned `fail` with one `unknown_action` violation per harness tool call — 81 in the run that found it — each reporting that the agent "decided on `Bash`, which the kernel never recorded a row for; no `[[action]]` in the `CuratorAgent` spec defines this name". The rows were clean, `evidence_complete` was true, the spec was pinned. The verdict was noise, and layer 1 could not return `pass` for any harness-driven run however conformant.

`is_action_name` accepted any bare `[A-Za-z0-9_.-]+` token, so `Bash`, `Read`, `Write`, `Edit`, `Agent`, `ToolSearch`, `SendMessage` and every `mcp__*` tool classified as a claim about a governed action. The existing `HarnessTool` escape only fired for the Temper MCP envelope, whose `choice.action` carries a colon and a line of Python.

## The rule

A decision is judged as a governed-action claim only when something **positively identifies** it as one. Two things can:

1. **The names under `choice.arguments.trajectory_actions`.** That key means "the governed actions this code called", so every name in it is judged whether or not the kernel recognises it — an envelope naming `Frobnicate` is exactly the fault to report.
2. **A `choice.action` the new `ActionVocabulary` contains** — a name the actor spec declares, a name the platform defines (`KERNEL_PLATFORM_ACTIONS`), or a name the kernel dispatched somewhere in this session, on any entity.

Everything else is the agent's own tooling: skipped from the action walk, counted, never reported.

Only rows the kernel wrote while dispatching on an entity (`TrajectorySource::Entity`) may widen the vocabulary, and caller-named rows on that source (`spec_governed = false`, from `POST /api/audit` and the unmet-trajectory endpoint) plus capture-loss markers are excluded on top. Otherwise one record named `Bash` written into somebody else's session turns every `Bash` in their run into a violation of a spec they followed. See the review round below — the first version of this filter did not check the source, and that hole was real.

## What is not weakened

Kernel rows are untouched. An undeclared action, an illegal source state, a move after a terminal state, a denied-then-retried action — all still caught from the platform's own record, which is where the governance check lives.

On the decision side specifically, these survive and have tests: a platform verb the actor does not declare (`forbidden_action`), an action the session dispatched on another entity, and every name inside an MCP `execute` envelope.

**Blast radius, precisely:** every decision the old rule judged and the new rule skips is one it can no longer report. The only shape where the new rule judges something the old one did not is a bare, action-shaped `choice.action` that *also* carries a `trajectory_actions` list — the old rule took the bare name and ignored the list. No current producer emits that shape.

## What this cannot do, and what that costs

A bare `Bash` and a bare `Frobnicate` are the same token from the same producer path. Nothing in the record distinguishes a harness tool from an action name the kernel has never seen — a transcript converter writes both as `choice.action = <the tool the model called>`. So the checker cannot have both "no false violations for harness tools" and "every unplaceable name reported". This is the conservative half, and the module doc says so.

What is given up is one candour signal: an agent that *reports* reaching for an action which never reached the platform, whose name no spec in the walk declares and which nothing in the session dispatched, is counted rather than reported. The attempt failed before the kernel saw it; what is lost is the record that it was made — not any action that occurred.

Two existing tests encoded that lost case with an invented name; both are rewritten to use a name the kernel can place (`Delete`), so "decisions still fail a run" stays pinned.

The way to narrow the gap is to add positive identification, never to widen what counts as a name: reading a governed target out of a decision's arguments (as katagami's offline `conformance_check.py` already does), or giving `ActionVocabulary` the tenant's other registered specs. Both are additive — they can only move decisions from skipped to judged — which is why the vocabulary is one type with one constructor.

## Stats

`ots_decisions_skipped_as_harness_tool` keeps its exact meaning: an envelope whose name is not even shaped like an action name. The new `ots_decisions_skipped_as_unrecognized_name` counts the new class, so the two skip reasons stay distinguishable and the checker's blind spot is visible in every report rather than folded into a line that reads as certainty.

## Tests

`cargo test -p temper-server --lib --features observe` — **786 pass, 0 fail**, 63 of them conformance.

New coverage: the Bash/Read/Write/Edit/Agent/ToolSearch/SendMessage/`mcp__*` regression fixture; harness tools interleaved with real declared actions; an undeclared action reached through the harness still reported; an action the session dispatched on another entity still judgeable; the caller-supplied audit row that must not widen the vocabulary; the capture-loss marker that must not either.

**Mutation-tested.** Restoring the pre-fix rule (bare token wins) fails 7 of the new tests, including the regression fixture — so they pin the behaviour rather than merely accompanying it.

## Live verification

A local kernel with the katagami-curation app loaded, driving a real `CuratorAgent` through `ReceiveBrief → BeginDrafting → RecordDraft → SelfReview`, then posting a 13-decision Claude Code trajectory (12 harness tools + one declared action) for the same session and calling `POST /api/conformance/check`:

```
verdict: pass | passed: True | evidence_complete: True | spec_resolution: pinned
violations: []
  actor_rows                                 = 4
  ots_decisions_checked                      = 0
  ots_decisions_skipped_as_harness_tool      = 0
  ots_decisions_skipped_as_unrecognized_name = 12
```

A second live run confirms the check was not blunted — a `Delete` decision the spec never declares is still reported:

```
kind: forbidden_action, action: Delete
detail: agent decided on `Delete`, which the kernel never recorded a row for;
        the platform defines this action, but the `CuratorAgent` spec does not declare it
```

## Relationship to katagami PR #204

#204 is the producer-side half of the same symptom: the converter writes harness calls as `"<harness> tool: <name>"` envelopes. It states it does not depend on this change, and the two compose correctly. With #204, those decisions carry a colon and land in `ots_decisions_skipped_as_harness_tool` — exactly what its evidence table expects; without it they land in the new counter. All five source fragments #204 pins in `kernel_decision_contract.json` (`TRAJECTORY_ACTIONS_KEY`, `NESTED_ACTION_KEY`, the `is_action_name` signature, and its two character predicates) survive this refactor verbatim, so its kernel contract test still passes.

**Known remaining defect, neither PR's scope:** a genuine cross-entity governed call (`Workspaces('x')/Temper.ResolvePath` from a curator run) still reads as `unknown_action` against `CuratorAgent`, because the decision path attributes every named action to the actor's own entity while the row path does not. #204 now records the entity set each call drove, so the kernel could read it and skip entries belonging to another actor — a follow-up that depends on #204 landing first.

---

## Review round (three fresh-context adversarial reviews, findings closed)

**A vocabulary-injection hole, found and fixed (commit 2).** The first commit's filter accepted any row not marked `spec_governed = false`. `record_authz_denial` writes rows with that flag UNSET, and the unauthenticated `POST /api/authorize` reaches it with a caller-supplied action name, resource type and `X-Temper-Ctx-SessionId`. So one call naming action `Bash` against somebody else's session put `Bash` in that session's vocabulary and turned every `Bash` in their clean run into a violation — the exact regression this branch removes, reintroduced against a targeted session.

The filter is now an allowlist of one source, `TrajectorySource::Entity`, with the `spec_governed` test kept on top (nothing stops a caller-named audit row claiming `Entity`). Two new tests, both mutation-checked: reverting to the flag-only filter fails them.

**Two claims corrected, one residual named (commit 3).** `Entity` is where the kernel *routed* a name, not always where it chose one — a Cedar-permitted dispatch of an undeclared action is refused inside the actor and still recorded there. And "every Platform name is already in `KERNEL_PLATFORM_ACTIONS`" was false (`policy_saved`, `repl_execution`).

**Residual, deliberately not fixed here and documented beside the filter:** the same unauthenticated `POST /api/authorize` still reaches the ROW walk. Aim its `resource_type` at the entity type under check and the denial row is judged as the actor's own execution, so its caller-chosen name reports as `unknown_action` directly, with no vocabulary involved. That is older than this module and untouched by these commits. It is not repaired here because denial rows are judged on purpose — it is how `denied_then_retried` sees a denial — so changing it is a decision about denial-row provenance, not about how a decision is classified. The two ways to close it (bind that endpoint's session to an authenticated principal, or teach the walk that an `Authz` row records a question rather than an act) are written down in `decisions.rs` so the next reader inherits the choice rather than the impression that the class is handled. **Worth its own issue.**

Final state: 786 tests pass in `cargo test -p temper-server --lib --features observe`, 63 of them conformance. The push ran the repo's pre-push gates — rustfmt, `cargo clippy --workspace -- -D warnings`, the readability ratchet, and `cargo test --workspace` across 99 test binaries — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SF1Xhjcg7zG38WjmfC239C

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR distinguishes harness tool calls from governed-action decisions by introducing a deployment-aware action vocabulary and a separate counter for unrecognized names.

- Builds the vocabulary from the checked actor specification, platform actions, and qualifying entity-dispatch rows.
- Skips and counts unrecognized harness names while preserving checks for declared, platform, row-established, and nested trajectory actions.
- Adds regression coverage for harness tools, cross-entity actions, caller-supplied rows, authorization denials, and capture-loss markers.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with one non-blocking classification inconsistency for a valid but currently unproduced decision shape.

The harness-tool regression is addressed with narrow vocabulary sources and broad tests, but recognized outer actions bypass nested `trajectory_actions` despite the module’s contract that all nested governed-action claims are judged.

**Files Needing Attention:** crates/temper-server/src/conformance/decisions.rs
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/temper-server/src/conformance/decisions.rs | Introduces `ActionVocabulary` and the new decision-classification rules; recognized outer actions currently suppress nested governed-action claims. |
| crates/temper-server/src/conformance/mod.rs | Wires the vocabulary into decision checking and records the new skip category without changing kernel-row validation. |
| crates/temper-server/src/conformance/report.rs | Adds a serialized statistic documenting decisions skipped because their names are outside the known action vocabulary. |
| crates/temper-server/src/conformance/conformance_test.rs | Adds extensive regression coverage for harness calls, nested actions, vocabulary sources, and caller-influenced rows. |
| crates/temper-server/src/conformance/walk.rs | Initializes the new conformance statistic when converting row-walk state into a report. |
| crates/temper-server/src/api/trajectory_analysis_test.rs | Updates API-level expectations to use a platform-defined forbidden action rather than an unplaceable invented name. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    D[OTS invocation decision] --> T{Invocation type?}
    T -->|Thought| ST[Count as thinking]
    T -->|Callable| V{Outer action in vocabulary?}
    V -->|Yes| O[Judge outer action]
    V -->|No| N{trajectory_actions present?}
    N -->|Yes| G[Judge nested governed actions]
    N -->|No| S{Outer token action-shaped?}
    S -->|Yes| U[Count as unrecognized name]
    S -->|No| H[Count as harness envelope]
    O --> C[Compare against actor spec and recorded rows]
    G --> C
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Acrates%2Ftemper-server%2Fsrc%2Fconformance%2Fdecisions.rs%3A213-215%0A**Nested%20action%20claims%20are%20bypassed**%0A%0AWhen%20a%20decision%20has%20a%20vocabulary-recognized%20outer%20action%20and%20also%20carries%20%60trajectory_actions%60%2C%20this%20early%20return%20ignores%20every%20nested%20governed-action%20claim.%20An%20undeclared%20nested%20action%20is%20therefore%20omitted%20from%20the%20report%2C%20contrary%20to%20the%20documented%20contract%20that%20every%20%60trajectory_actions%60%20entry%20is%20judged.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=nerdsane%2Ftemper&pr=419&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22claude%2Fharness-tool-classification%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fharness-tool-classification%22.%0A%0A%23%23%23%20Issue%201%0Acrates%2Ftemper-server%2Fsrc%2Fconformance%2Fdecisions.rs%3A213-215%0A**Nested%20action%20claims%20are%20bypassed**%0A%0AWhen%20a%20decision%20has%20a%20vocabulary-recognized%20outer%20action%20and%20also%20carries%20%60trajectory_actions%60%2C%20this%20early%20return%20ignores%20every%20nested%20governed-action%20claim.%20An%20undeclared%20nested%20action%20is%20therefore%20omitted%20from%20the%20report%2C%20contrary%20to%20the%20documented%20contract%20that%20every%20%60trajectory_actions%60%20entry%20is%20judged.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=nerdsane%2Ftemper&pr=419&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Acrates%2Ftemper-server%2Fsrc%2Fconformance%2Fdecisions.rs%3A213-215%0A**Nested%20action%20claims%20are%20bypassed**%0A%0AWhen%20a%20decision%20has%20a%20vocabulary-recognized%20outer%20action%20and%20also%20carries%20%60trajectory_actions%60%2C%20this%20early%20return%20ignores%20every%20nested%20governed-action%20claim.%20An%20undeclared%20nested%20action%20is%20therefore%20omitted%20from%20the%20report%2C%20contrary%20to%20the%20documented%20contract%20that%20every%20%60trajectory_actions%60%20entry%20is%20judged.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=419&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
crates/temper-server/src/conformance/decisions.rs:213-215
**Nested action claims are bypassed**

When a decision has a vocabulary-recognized outer action and also carries `trajectory_actions`, this early return ignores every nested governed-action claim. An undeclared nested action is therefore omitted from the report, contrary to the documented contract that every `trajectory_actions` entry is judged.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: only an entity dispatch may widen t..."](https://github.com/nerdsane/temper/commit/efd92587ce3056a0b3d2ae84be8b6e1a5a00b6f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52768757)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->