### PR TITLE
fix(sandbox,server): isolate REPL host operations from the server process (ARN-166)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,6 +274,10 @@ jobs:
         run: |
           cargo test -p temper-server --features observe --test spec_validate_endpoint
           cargo test -p temper-server --features observe --lib observe::
+          # api::repl tests (incl. server_repl_config_never_allows_host_ops,
+          # the ARN-166 host-op isolation guard) compile only under `observe`;
+          # run them explicitly so coverage never depends on feature unification.
+          cargo test -p temper-server --features observe --lib api::repl::
 
   # ─────────────────────────────────────────────────────
   # Gate 3b: DST/platform coverage (matrixed)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6648,6 +6648,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/crates/temper-mcp/src/runtime.rs
+++ b/crates/temper-mcp/src/runtime.rs
@@ -428,6 +428,10 @@ impl RuntimeContext {
                             binary_path: None,
                             api_key: api_key.as_deref(),
                             internal_credential_issuer: None,
+                            // Local stdio MCP: the host process is the
+                            // developer's own machine, so upload_wasm/compile_wasm
+                            // are legitimate developer ops (ARN-166).
+                            allow_host_ops: true,
                         };
                         temper_sandbox::dispatch::dispatch_temper_method(
                             &ctx,

--- a/crates/temper-sandbox/Cargo.toml
+++ b/crates/temper-sandbox/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["time", "process", "fs"] }
 reqwest = { workspace = true }
+tracing = { workspace = true }
 uuid = { workspace = true }
 sha2 = { workspace = true }
 

--- a/crates/temper-sandbox/src/dispatch.rs
+++ b/crates/temper-sandbox/src/dispatch.rs
@@ -35,6 +35,15 @@ pub struct DispatchContext<'a> {
     pub api_key: Option<&'a str>,
     /// Per-request credential issuer for trusted server-side loopback calls.
     pub internal_credential_issuer: Option<&'a InternalRequestCredentialIssuer>,
+    /// Whether this context may perform host-process operations — local
+    /// filesystem reads and spawning `cargo` (`upload_wasm`, `compile_wasm`).
+    ///
+    /// True only for a runner whose host process is the developer's own machine
+    /// (the local stdio MCP server). The server-hosted REPL sets this false: its
+    /// host process is the Temper server, so those ops read the server's
+    /// filesystem and run code as the server user — a host-compromise vector
+    /// (ARN-166: arbitrary file read + RCE), not a developer op.
+    pub allow_host_ops: bool,
 }
 
 impl<'a> DispatchContext<'a> {
@@ -81,6 +90,17 @@ pub async fn dispatch_temper_method(
             dispatch_governance(ctx, method, args).await
         }
         // --- WASM ---
+        // Host ops (local file read, `cargo build`) are rejected before they
+        // touch the filesystem unless this context is host-trusted. The
+        // server-hosted REPL is not: running these in the server process is a
+        // host-compromise vector (ARN-166: arbitrary file read + RCE as the
+        // server user).
+        "upload_wasm" | "compile_wasm" if !ctx.allow_host_ops => Err(format!(
+            "temper.{method}() is not available in this context. Host operations \
+             (local file read, cargo build) run only on the developer's own \
+             machine via the local MCP server, never inside the Temper server \
+             process."
+        )),
         "upload_wasm" | "compile_wasm" => dispatch_wasm(ctx, method, args).await,
         // --- Evolution / Observe ---
         "get_trajectories" | "get_insights" | "get_evolution_records" | "check_sentinel" => {
@@ -726,4 +746,92 @@ fn resolve_sdk_path(binary_path: Option<&std::path::Path>) -> Result<String, Str
         "cannot find temper-wasm-sdk crate. Ensure you are running from the temper workspace."
             .to_string(),
     )
+}
+
+#[cfg(test)]
+mod host_op_gate_tests {
+    use super::*;
+
+    /// Build a dispatch context with a given host-op capability. `base_url`
+    /// points at a port nothing listens on, so any accidental loopback call
+    /// fails fast rather than reaching a real server.
+    fn ctx(client: &reqwest::Client, allow_host_ops: bool) -> DispatchContext<'_> {
+        DispatchContext {
+            http: client,
+            base_url: "http://127.0.0.1:1",
+            tenant: "default",
+            agent_id: None,
+            session_id: None,
+            entity_set_resolver: None,
+            binary_path: None,
+            api_key: None,
+            internal_credential_issuer: None,
+            allow_host_ops,
+        }
+    }
+
+    fn str_args(values: &[&str]) -> Vec<MontyObject> {
+        values
+            .iter()
+            .map(|v| MontyObject::String((*v).to_string()))
+            .collect()
+    }
+
+    /// Without host trust, `upload_wasm` is rejected before the filesystem is
+    /// touched. The path (`/etc/hosts`) exists and is readable: if the gate
+    /// failed to fire, dispatch would read it and then fail on the loopback
+    /// POST — a different error. The "not available in this context" message
+    /// proves the read never happened (ARN-166).
+    #[tokio::test]
+    async fn upload_wasm_rejected_without_host_ops() {
+        let client = reqwest::Client::new();
+        let args = str_args(&["mod", "/etc/hosts"]);
+        let err = dispatch_temper_method(&ctx(&client, false), "upload_wasm", &args, &[])
+            .await
+            .expect_err("upload_wasm must be rejected without host ops");
+        assert!(
+            err.contains("not available in this context"),
+            "expected host-op rejection, got: {err}"
+        );
+        assert!(
+            !err.contains("failed to read"),
+            "gate must fire before any filesystem read, got: {err}"
+        );
+    }
+
+    /// `compile_wasm` is gated the same way and must be rejected before it
+    /// spawns `rustup`/`cargo`.
+    #[tokio::test]
+    async fn compile_wasm_rejected_without_host_ops() {
+        let client = reqwest::Client::new();
+        let args = str_args(&["mod", "pub fn main() {}"]);
+        let err = dispatch_temper_method(&ctx(&client, false), "compile_wasm", &args, &[])
+            .await
+            .expect_err("compile_wasm must be rejected without host ops");
+        assert!(
+            err.contains("not available in this context"),
+            "expected host-op rejection, got: {err}"
+        );
+    }
+
+    /// With host ops allowed (the local stdio MCP context), the gate does not
+    /// fire: dispatch proceeds into `upload_wasm` and fails at the filesystem
+    /// read of a nonexistent path — proving the capability flag, not a hardcoded
+    /// block, governs the two host methods.
+    #[tokio::test]
+    async fn upload_wasm_allowed_with_host_ops_reaches_filesystem() {
+        let client = reqwest::Client::new();
+        let args = str_args(&["mod", "/nonexistent/temper-arn166-does-not-exist"]);
+        let err = dispatch_temper_method(&ctx(&client, true), "upload_wasm", &args, &[])
+            .await
+            .expect_err("read of a nonexistent path must fail");
+        assert!(
+            err.contains("failed to read"),
+            "gate must allow the read attempt when host ops are permitted, got: {err}"
+        );
+        assert!(
+            !err.contains("not available in this context"),
+            "host-trusted context must not reject host ops, got: {err}"
+        );
+    }
 }

--- a/crates/temper-sandbox/src/dispatch.rs
+++ b/crates/temper-sandbox/src/dispatch.rs
@@ -95,12 +95,26 @@ pub async fn dispatch_temper_method(
         // server-hosted REPL is not: running these in the server process is a
         // host-compromise vector (ARN-166: arbitrary file read + RCE as the
         // server user).
-        "upload_wasm" | "compile_wasm" if !ctx.allow_host_ops => Err(format!(
-            "temper.{method}() is not available in this context. Host operations \
-             (local file read, cargo build) run only on the developer's own \
-             machine via the local MCP server, never inside the Temper server \
-             process."
-        )),
+        "upload_wasm" | "compile_wasm" if !ctx.allow_host_ops => {
+            // Surface the denial to the operator channel. The Monty runtime
+            // collapses a dispatch error into a `null` program result, so the
+            // HTTP caller sees no error field (a separate observability gap);
+            // this warn makes the refusal visible in logs/Datadog so a denied
+            // host op is not indistinguishable from a no-op (ARN-166).
+            tracing::warn!(
+                target: "temper.repl.host_op",
+                method = method,
+                tenant = ctx.tenant,
+                agent_id = ctx.agent_id.unwrap_or("-"),
+                "denied host operation in a non-host-trusted REPL context"
+            );
+            Err(format!(
+                "temper.{method}() is not available in this context. Host operations \
+                 (local file read, cargo build) run only on the developer's own \
+                 machine via the local MCP server, never inside the Temper server \
+                 process."
+            ))
+        }
         "upload_wasm" | "compile_wasm" => dispatch_wasm(ctx, method, args).await,
         // --- Evolution / Observe ---
         "get_trajectories" | "get_insights" | "get_evolution_records" | "check_sentinel" => {
@@ -812,6 +826,13 @@ mod host_op_gate_tests {
             err.contains("not available in this context"),
             "expected host-op rejection, got: {err}"
         );
+        // Prove the gate fires before any host side-effect: none of the
+        // downstream errors (rustup spawn, build-dir write) may appear, so a
+        // "spawn-then-deny" implementation could not pass this test.
+        assert!(
+            !err.contains("failed to run rustup") && !err.contains("failed to create build dir"),
+            "gate must fire before rustup spawn or build-dir write, got: {err}"
+        );
     }
 
     /// With host ops allowed (the local stdio MCP context), the gate does not
@@ -832,6 +853,36 @@ mod host_op_gate_tests {
         assert!(
             !err.contains("not available in this context"),
             "host-trusted context must not reject host ops, got: {err}"
+        );
+    }
+
+    /// Symmetric positive case for `compile_wasm`. `upload_wasm` and
+    /// `compile_wasm` share a single guarded match arm, so this proves the same
+    /// arm lets `compile_wasm` through when host ops are permitted — the gate is
+    /// the capability flag, not a hardcoded block on either method.
+    ///
+    /// This must not trigger a real `cargo build` (minutes long). The `ctx`
+    /// helper leaves `binary_path: None`, so `compile_wasm` fails at
+    /// `resolve_sdk_path`: the test binary's cwd is the package root
+    /// (`crates/temper-sandbox`, per Cargo), which has no
+    /// `crates/temper-wasm-sdk`. That check runs after the rustup probe and the
+    /// `/tmp` build-dir creation but *before* the crate files are written or
+    /// `cargo` is spawned, so no build happens. (Without the wasm32 target it
+    /// fails even earlier, at the rustup probe.) Either way the error is a
+    /// downstream environment failure, never the gate rejection, so the gate is
+    /// proven open for `compile_wasm` without a build. A real build would need
+    /// the test binary's cwd at the workspace root *and* wasm32 installed —
+    /// which is not how `cargo test [--workspace]` runs.
+    #[tokio::test]
+    async fn compile_wasm_allowed_with_host_ops_passes_the_gate() {
+        let client = reqwest::Client::new();
+        let args = str_args(&["mod", "pub fn main() {}"]);
+        let err = dispatch_temper_method(&ctx(&client, true), "compile_wasm", &args, &[])
+            .await
+            .expect_err("compile_wasm must fail downstream (no SDK/toolchain), not at the gate");
+        assert!(
+            !err.contains("not available in this context"),
+            "host-trusted context must not reject compile_wasm, got: {err}"
         );
     }
 }

--- a/crates/temper-sandbox/src/repl.rs
+++ b/crates/temper-sandbox/src/repl.rs
@@ -82,3 +82,90 @@ pub async fn run_repl(config: &ReplConfig, code: &str) -> Result<String> {
     )
     .await
 }
+
+#[cfg(test)]
+mod host_op_propagation_tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn config(port: u16, allow_host_ops: bool) -> ReplConfig {
+        // Return a valid credential so upload_wasm proceeds to the socket when
+        // the gate is open; when the gate is closed it never mints one.
+        let issuer: crate::http::InternalRequestCredentialIssuer = Arc::new(|_method, _url| {
+            crate::http::InternalRequestCredential::new(
+                "test-token".to_string(),
+                "default".to_string(),
+            )
+        });
+        ReplConfig {
+            server_port: port,
+            tenant: "default".to_string(),
+            agent_id: None,
+            session_id: None,
+            internal_credential_issuer: issuer,
+            allow_host_ops,
+        }
+    }
+
+    /// Run `temper.upload_wasm` against a stand-in listener and report whether a
+    /// connection reached it. The acceptor accepts then immediately drops the
+    /// stream, so the REPL's HTTP client sees the peer close and errors out fast
+    /// rather than blocking on a response the test never sends (no client
+    /// timeout is configured). It signals each accepted connection on a channel,
+    /// so the observation is event-driven — no fixed sleep, no shared counter.
+    async fn upload_wasm_reaches_server(allow_host_ops: bool) -> bool {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<()>(4);
+        let acceptor = tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                drop(stream);
+                if tx.send(()).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        // Read a real, self-created file so the read cannot fail for reasons
+        // unrelated to the gate; the file is portable (temp dir), unlike
+        // /etc/hosts. With the gate open, upload_wasm reads it then POSTs.
+        let wasm_path =
+            std::env::temp_dir().join(format!("temper-arn166-{}.wasm", uuid::Uuid::new_v4()));
+        tokio::fs::write(&wasm_path, b"\0asm\x01\0\0\0")
+            .await
+            .unwrap();
+        let code = format!("temper.upload_wasm('m', '{}')", wasm_path.display());
+
+        let _ = run_repl(&config(port, allow_host_ops), &code).await;
+        let _ = tokio::fs::remove_file(&wasm_path).await;
+
+        // A connection either already sits in the accept backlog (gate open) or
+        // never comes (gate closed). Bound the wait so the closed case returns.
+        let reached = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+            .await
+            .ok()
+            .flatten()
+            .is_some();
+        acceptor.abort();
+        reached
+    }
+
+    /// End-to-end proof that config.allow_host_ops propagates through run_repl to
+    /// the dispatch gate — closing the "flip the literal, tests still pass" gap.
+    /// A connection to the stand-in server is the observable:
+    ///   - allow_host_ops=false → the gate suppresses the whole operation → no connection.
+    ///   - allow_host_ops=true  → upload_wasm reads its file and POSTs → a connection.
+    /// The only variable between the two runs is the flag, so a connection on the
+    /// `false` run (or none on `true`) means the flag failed to reach the gate.
+    #[tokio::test]
+    async fn allow_host_ops_propagates_from_config_to_the_dispatch_gate() {
+        assert!(
+            !upload_wasm_reaches_server(false).await,
+            "with allow_host_ops=false the gate must suppress the operation before any server call"
+        );
+        assert!(
+            upload_wasm_reaches_server(true).await,
+            "with allow_host_ops=true the operation must proceed to the server — proving the flag, not a hardcoded block, governs the gate and that it propagates through run_repl"
+        );
+    }
+}

--- a/crates/temper-sandbox/src/repl.rs
+++ b/crates/temper-sandbox/src/repl.rs
@@ -23,6 +23,12 @@ pub struct ReplConfig {
     pub session_id: Option<String>,
     /// Per-request credential issuer for authenticated loopback calls.
     pub internal_credential_issuer: crate::http::InternalRequestCredentialIssuer,
+    /// Whether host-process ops (`upload_wasm`/`compile_wasm`) are permitted.
+    ///
+    /// The server-hosted REPL sets this false: those ops would read the server's
+    /// filesystem and spawn `cargo` as the server user (ARN-166). The local
+    /// stdio MCP runner — the developer's own machine — sets it true.
+    pub allow_host_ops: bool,
 }
 
 /// Run Python code in the Temper Monty sandbox via the REPL endpoint.
@@ -38,6 +44,7 @@ pub async fn run_repl(config: &ReplConfig, code: &str) -> Result<String> {
     let agent_id = config.agent_id.clone();
     let session_id = config.session_id.clone();
     let internal_credential_issuer = config.internal_credential_issuer.clone();
+    let allow_host_ops = config.allow_host_ops;
 
     run_sandbox(
         code,
@@ -67,6 +74,7 @@ pub async fn run_repl(config: &ReplConfig, code: &str) -> Result<String> {
                     binary_path: None,
                     api_key: None,
                     internal_credential_issuer: Some(&internal_credential_issuer),
+                    allow_host_ops,
                 };
                 dispatch_temper_method(&ctx, &function_name, args, &kwargs).await
             }

--- a/crates/temper-server/src/api/repl.rs
+++ b/crates/temper-server/src/api/repl.rs
@@ -55,6 +55,31 @@ pub(crate) struct ReplRequest {
 /// Security: 180s timeout, 64MB memory, method allowlisting, no filesystem or
 /// network access. External APIs go through `[[integration]]` in IOA specs.
 #[instrument(skip_all, fields(otel.name = "POST /api/repl"))]
+/// Build the `ReplConfig` for the server-hosted REPL.
+///
+/// `allow_host_ops` is hardcoded false here and only here: the server-hosted
+/// REPL's host process is the Temper server, so `upload_wasm`/`compile_wasm`
+/// would read server files and spawn `cargo` as the server user (ARN-166,
+/// ADR-0158). Host ops belong to the local MCP server on the developer's own
+/// machine. Centralised in one constructor so the invariant has a single tested
+/// home rather than an inline literal that a refactor could flip unnoticed.
+fn server_repl_config(
+    server_port: u16,
+    tenant: String,
+    agent_id: String,
+    session_id: Option<String>,
+    internal_credential_issuer: temper_sandbox::http::InternalRequestCredentialIssuer,
+) -> temper_sandbox::repl::ReplConfig {
+    temper_sandbox::repl::ReplConfig {
+        server_port,
+        tenant,
+        agent_id: Some(agent_id),
+        session_id,
+        internal_credential_issuer,
+        allow_host_ops: false,
+    }
+}
+
 pub(crate) async fn handle_repl(
     State(state): State<ServerState>,
     headers: HeaderMap,
@@ -117,13 +142,13 @@ pub(crate) async fn handle_repl(
             .build()
             .expect("failed to create REPL runtime"); // determinism-ok: one-shot runtime for sandbox
         rt.block_on(async move {
-            let config = temper_sandbox::repl::ReplConfig {
-                server_port: port,
-                tenant: tenant_for_repl,
-                agent_id: Some(agent_id_for_repl),
+            let config = server_repl_config(
+                port,
+                tenant_for_repl,
+                agent_id_for_repl,
                 session_id,
                 internal_credential_issuer,
-            };
+            );
             temper_sandbox::repl::run_repl(&config, &code).await
         })
     })
@@ -204,6 +229,28 @@ mod tests {
     use super::require_repl_authorization;
     use crate::registry::SpecRegistry;
     use crate::state::ServerState;
+
+    use super::server_repl_config;
+
+    /// The server-hosted REPL must never permit host ops (ARN-166). This guards
+    /// the exact production constructor, so a future flip of the `allow_host_ops`
+    /// literal is caught here rather than reopening the RCE silently.
+    #[test]
+    fn server_repl_config_never_allows_host_ops() {
+        let issuer: temper_sandbox::http::InternalRequestCredentialIssuer =
+            std::sync::Arc::new(|_method, _url| Err("unused".to_string()));
+        let config = server_repl_config(
+            3000,
+            "tenant-a".to_string(),
+            "agent-1".to_string(),
+            Some("session-1".to_string()),
+            issuer,
+        );
+        assert!(
+            !config.allow_host_ops,
+            "the server-hosted REPL must not permit host-process ops"
+        );
+    }
 
     #[test]
     fn repl_requires_explicit_tenant_resource_authority() {

--- a/crates/temper-server/src/api/repl.rs
+++ b/crates/temper-server/src/api/repl.rs
@@ -47,14 +47,6 @@ pub(crate) struct ReplRequest {
     code: String,
 }
 
-/// POST /api/repl — execute Python code in the Temper Monty sandbox.
-///
-/// The sandbox provides `temper.*` methods (create, action, submit_specs, etc.)
-/// that loop back to this server via single-use, request-bound credentials.
-///
-/// Security: 180s timeout, 64MB memory, method allowlisting, no filesystem or
-/// network access. External APIs go through `[[integration]]` in IOA specs.
-#[instrument(skip_all, fields(otel.name = "POST /api/repl"))]
 /// Build the `ReplConfig` for the server-hosted REPL.
 ///
 /// `allow_host_ops` is hardcoded false here and only here: the server-hosted
@@ -80,6 +72,16 @@ fn server_repl_config(
     }
 }
 
+/// POST /api/repl — execute Python code in the Temper Monty sandbox.
+///
+/// The sandbox provides `temper.*` methods (create, action, submit_specs, etc.)
+/// that loop back to this server via single-use, request-bound credentials.
+///
+/// Security: 180s timeout, 64MB memory, method allowlisting, no filesystem or
+/// network access. Host ops (`upload_wasm`/`compile_wasm`) are gated off via
+/// `server_repl_config` (ARN-166). External APIs go through `[[integration]]`
+/// in IOA specs.
+#[instrument(skip_all, fields(otel.name = "POST /api/repl"))]
 pub(crate) async fn handle_repl(
     State(state): State<ServerState>,
     headers: HeaderMap,

--- a/docs/adrs/0158-repl-host-op-isolation.md
+++ b/docs/adrs/0158-repl-host-op-isolation.md
@@ -46,6 +46,12 @@ same two methods proceed normally — verified by a test that exercises both arm
 - The RCE/file-read vector on the server-hosted REPL is closed at the dispatch
   boundary, independent of authorization. Even a fully authorized `execute_repl`
   caller cannot drive host ops in the server process.
+- The denial is surfaced to the operator channel: the gate emits a
+  `tracing::warn!` (`target: temper.repl.host_op`, with method/tenant/agent) before
+  returning the error. The Monty runtime collapses a dispatch error into a `null`
+  program result, so the HTTP caller sees no error field — a broader observability
+  gap tracked separately — but the refusal is now visible in logs/Datadog rather
+  than indistinguishable from a no-op.
 - All other `temper.*` methods (entity CRUD, specs, governance, evolution,
   non-host WASM registry reads) remain available in the server REPL — the fix
   removes only the two host-process sinks, not the REPL's usefulness.

--- a/docs/adrs/0158-repl-host-op-isolation.md
+++ b/docs/adrs/0158-repl-host-op-isolation.md
@@ -1,0 +1,63 @@
+# ADR-0158: REPL host-operation isolation
+
+**Status:** Accepted
+**Date:** 2026-08-14
+**Issue:** ARN-166 (kernel `/api/repl` unauthenticated → arbitrary host file-read + RCE)
+
+## Context
+
+`temper.*` methods are dispatched from Python REPL code through
+`temper_sandbox::dispatch::dispatch_temper_method`. Two of those methods,
+`upload_wasm` and `compile_wasm`, are **host-process operations**: `upload_wasm`
+reads a WASM file from the local filesystem, and `compile_wasm` writes a crate
+to disk and spawns `cargo build`.
+
+The same dispatch path runs in two very different host processes:
+
+1. **Local stdio MCP server** — runs on the *developer's own machine*. Reading a
+   local file and running `cargo` there is exactly what the developer intends.
+2. **Server-hosted REPL** (`POST /api/repl`) — runs *inside the Temper server
+   process*. There, `upload_wasm` reads the **server's** filesystem and
+   `compile_wasm` runs `cargo` **as the server user**.
+
+ARN-170 (merged) already made `/api/repl` require an authenticated credential and
+a Cedar `execute_repl` permit. But authentication alone does not close ARN-166:
+an *authorized* caller could still invoke `compile_wasm` and achieve arbitrary
+file read + code execution as the server user. Authorization answers "may this
+principal use the REPL"; it does not answer "may the REPL reach the host."
+
+## Decision
+
+Make host reachability an explicit capability of the dispatch context, not an
+ambient property of the method.
+
+- `DispatchContext` gains `allow_host_ops: bool`.
+- `dispatch_temper_method` rejects `upload_wasm`/`compile_wasm` **before touching
+  the filesystem** when `allow_host_ops` is false, with a message that names
+  where those ops belong (the local MCP server).
+- The server-hosted REPL sets `allow_host_ops = false` (via `ReplConfig`).
+- The local stdio MCP server sets `allow_host_ops = true`.
+
+The gate is the capability flag, not a hardcoded block: with the flag set, the
+same two methods proceed normally — verified by a test that exercises both arms.
+
+## Consequences
+
+- The RCE/file-read vector on the server-hosted REPL is closed at the dispatch
+  boundary, independent of authorization. Even a fully authorized `execute_repl`
+  caller cannot drive host ops in the server process.
+- All other `temper.*` methods (entity CRUD, specs, governance, evolution,
+  non-host WASM registry reads) remain available in the server REPL — the fix
+  removes only the two host-process sinks, not the REPL's usefulness.
+- Local developer workflows (`temper.upload_wasm`, `temper.compile_wasm` via the
+  MCP server) are unchanged.
+
+## Alternatives considered
+
+- **Rely on the ARN-170 auth gate alone.** Rejected: authorization is not
+  isolation; an authorized principal would still get RCE as the server user.
+- **Remove `upload_wasm`/`compile_wasm` from dispatch entirely.** Rejected:
+  removes a legitimate local developer capability; the two contexts have
+  genuinely different trust, so the capability, not the method, is what varies.
+- **Sandbox the server-side `cargo` invocation.** Larger surface, still leaves
+  local file reads; the capability gate is the smaller, complete fix.


### PR DESCRIPTION
# ARN-166: isolate REPL host operations from the server process

**Closes ARN-166.** Supersedes the stale PR #342 (that branch was 67 commits behind main; its authorization half is already on main via the ARN-170 merge, and its ADR slot collided).

## The remaining vulnerability

ARN-170 (merged) made `/api/repl` require an authenticated credential and a Cedar `execute_repl` permit — it gates **who may use the REPL**. It does **not** stop the REPL from reaching the host. On current main, the REPL method dispatch still routes two methods ungated:

- `upload_wasm` → `tokio::fs::read` of a caller-supplied local path
- `compile_wasm` → writes a crate and spawns `cargo` / `rustup`

In the **server-hosted** REPL those run **as the server user** — arbitrary host file read + RCE — reachable by any authenticated, `execute_repl`-authorized caller. **Authorization is not isolation.**

## The fix

Make host reachability an explicit capability of the dispatch context, not an ambient property of the method:

- `DispatchContext.allow_host_ops: bool`. `dispatch_temper_method` rejects `upload_wasm`/`compile_wasm` **before touching the filesystem or spawning a process** when it is false.
- The server-hosted REPL sets it **false** — centralised in `server_repl_config` (one tested home, not an inline literal).
- The local stdio MCP server — the developer's own machine — sets it **true**.
- The flag is a compile-time/config property, **never derived from the request** (headers, body, or principal), and the new field is **compiler-forced** at every construction site.

`upload_wasm`/`compile_wasm` are the **complete set** of host-op sinks in dispatch (audited: every other arm is a credentialed loopback HTTP call or pure); all their sub-functions are reachable only through the two gated arms. This closes the class, not two instances.

## Verification

- **3 dispatch tests** discriminate both arms: `false` → rejected before any fs/process; `true` → proceeds to the fs read (proving the flag governs, not a hardcoded block).
- **Server-side test** (`server_repl_config_never_allows_host_ops`) guards the production constructor, so a future flip of the flag is caught rather than silently reopening the RCE.
- **Live E2E** on a running server: `/api/repl` no credential → 401, operator without permit → 403, authorized benign → 200 (executes), authorized host op → returns no file content and does not complete.
- Independent fresh-context security review: **PASS** (no P0/P1/P2); it independently confirmed completeness, that the flag can't be request-influenced, and that the tests discriminate.
- fmt + clippy clean; temper-sandbox / temper-mcp / temper-server(repl) suites green; full non-DST temper-server suite green.

## Residual notes (out of scope, recorded)

- The isolation rests on the Monty sandbox exposing no host builtins to REPL Python — the `temper` callback is the only native bridge. Pre-existing sandbox contract.
- `navigate` formats a caller path into the credentialed loopback API (path-injection shape into the server's own HTTP surface) — pre-existing, not a host-op sink, flagged for a separate hardening pass.
- **Observability gap found:** `handle_repl` collapses REPL execution errors to a `null` HTTP result, so the host-op refusal string isn't visible via HTTP (the fix is proven at the dispatch-test level instead). Worth a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR isolates server-hosted REPL execution from local filesystem and process capabilities while retaining those developer operations in the local stdio MCP.
- Adds an explicit host-operation capability to sandbox dispatch and rejects WASM upload/compilation before host access in untrusted contexts.
- Centralizes the server REPL configuration with host operations disabled while enabling them for local MCP execution.
- Adds direct gate, propagation, constructor, and CI coverage plus an ADR documenting the trust boundary.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/temper-sandbox/src/dispatch.rs | Adds the central capability gate before the two filesystem/process-backed WASM operations and covers both denied and permitted behavior. |
| crates/temper-sandbox/src/repl.rs | Propagates the immutable REPL capability into dispatch and verifies propagation using an observable loopback connection. |
| crates/temper-server/src/api/repl.rs | Centralizes production server REPL configuration with host operations disabled and tests that invariant. |
| crates/temper-mcp/src/runtime.rs | Explicitly retains host operations for the separate local stdio developer workflow. |
| .github/workflows/ci.yml | Explicitly executes the observe-gated server REPL unit tests in CI. |
| docs/adrs/0158-repl-host-op-isolation.md | Documents the server-versus-local trust distinction and the capability-gating decision. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  HTTP["Authorized POST /api/repl"] --> SRC["server_repl_config"]
  SRC -->|"allow_host_ops = false"| REPL["Monty REPL"]
  MCP["Local stdio MCP"] -->|"allow_host_ops = true"| DISPATCH["temper.* dispatch"]
  REPL --> DISPATCH
  DISPATCH --> GATE{"upload_wasm or compile_wasm?"}
  GATE -->|No| API["Credentialed loopback HTTP / pure operation"]
  GATE -->|"Yes, false"| DENY["Warn and reject before host access"]
  GATE -->|"Yes, true"| HOST["Local file read / cargo build"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(sandbox,server): harden REPL host-o..."](https://github.com/nerdsane/temper/commit/25e1995ee90dbaf8031d8cef0626f82a742375a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53379630)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [temper-server](https://app.greptile.com/arni-labs/-/custom-context/knowledge-base/nerdsane/temper/-/docs/temper-server.md)
- Knowledge Base — [temper-mcp: MCP Stdio Server for Temper Code Mode](https://app.greptile.com/arni-labs/-/custom-context/knowledge-base/nerdsane/temper/-/docs/temper-mcp.md)
- Knowledge Base — [Temper WASM Runtime](https://app.greptile.com/arni-labs/-/custom-context/knowledge-base/nerdsane/temper/-/docs/temper-wasm.md)
</details>

<!-- /greptile_comment -->