### PR TITLE
fix(mcp): isolate MCP trajectory to session identity and bound capture (ARN-222)

### DIFF
--- a/crates/temper-mcp/src/lib.rs
+++ b/crates/temper-mcp/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod protocol;
 mod runtime;
+mod trajectory_bounds;
 
 pub mod repl;
 pub use runtime::run_stdio_server;

--- a/crates/temper-mcp/src/runtime.rs
+++ b/crates/temper-mcp/src/runtime.rs
@@ -10,10 +10,16 @@ use temper_ots::{
     OTSMessageContent, OTSMetadata, OutcomeType, TrajectoryBuilder,
 };
 use temper_runtime::scheduler::sim_now;
-use tokio::io::{self, AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{self, AsyncWriteExt, BufReader};
 
 use super::McpConfig;
 use super::protocol::dispatch_json_line;
+use crate::trajectory_bounds::{
+    MAX_STDIO_LINE_BYTES, MAX_TRAJECTORY_TOTAL_BYTES, MAX_TRAJECTORY_TURNS, StdioFrame,
+    TRAJECTORY_TURN_ENVELOPE_BYTES, bounded_trajectory_actions, bump_seen, floor_char_boundary,
+    json_string_cost, json_value_cost, read_stdio_frame, trajectory_storage_tenant,
+    truncate_trajectory_text,
+};
 
 const OTS_UPLOAD_MAX_ATTEMPTS: u32 = 3;
 const OTS_UPLOAD_RETRY_DELAY_MS: u64 = 100;
@@ -56,10 +62,18 @@ pub(crate) struct RuntimeContext {
     sandbox: temper_sandbox::runner::PersistentSandbox,
     /// OTS trajectory builder for capturing agent execution traces.
     pub(crate) trajectory: Option<TrajectoryBuilder>,
-    /// Tenants observed in executed calls during this session.
+    /// Tenants observed in executed calls during this session (observability
+    /// signal only; never used to route trajectory storage).
     tenants_seen: BTreeMap<String, usize>,
-    /// Entity types observed in executed calls during this session.
-    entity_types_seen: BTreeMap<String, usize>,
+    /// Number of turns recorded into the current trajectory (bounds its size).
+    turns_recorded: usize,
+    /// Estimated serialized bytes recorded so far. Bounds the whole upload to
+    /// under the server's ingest limit so a within-per-turn-cap session can't
+    /// still produce a trajectory the server rejects (ARN-222).
+    trajectory_bytes: usize,
+    /// Whether the turn/byte cap has already been reported for this trajectory,
+    /// so hitting the cap warns once rather than on every subsequent turn.
+    capped_warned: bool,
 }
 
 impl RuntimeContext {
@@ -89,7 +103,9 @@ impl RuntimeContext {
             sandbox: temper_sandbox::runner::PersistentSandbox::new(&[("temper", "Temper", 1)]),
             trajectory: None,
             tenants_seen: BTreeMap::new(),
-            entity_types_seen: BTreeMap::new(),
+            turns_recorded: 0,
+            trajectory_bytes: 0,
+            capped_warned: false,
         })
     }
 
@@ -158,6 +174,10 @@ impl RuntimeContext {
     }
 
     /// Initialize OTS trajectory capture after the MCP handshake completes.
+    ///
+    /// Resets the per-trajectory budgets so a client that re-sends `initialize`
+    /// gets a fresh trajectory with a fresh turn/byte budget rather than
+    /// inheriting a consumed one.
     pub(crate) fn init_trajectory(&mut self) {
         let now = sim_now(); // determinism-ok: sim_now is DST-safe
         let agent_id = self.agent_id.as_deref().unwrap_or("unknown");
@@ -166,11 +186,73 @@ impl RuntimeContext {
         let context = OTSContext::new();
 
         self.trajectory = Some(TrajectoryBuilder::new(metadata, context));
+        self.turns_recorded = 0;
+        self.trajectory_bytes = 0;
+        self.capped_warned = false;
+    }
+
+    /// Warn once per trajectory that a capture cap was hit, so a long agent loop
+    /// that keeps executing past the cap does not emit an identical warning every
+    /// turn.
+    fn warn_capped_once(&mut self, cap: &str, limit: usize) {
+        if !self.capped_warned {
+            self.capped_warned = true;
+            tracing::warn!(
+                cap,
+                limit,
+                "mcp trajectory cap reached; dropping further turns"
+            );
+        }
     }
 
     /// Record an execute tool call as an OTS turn with a decision.
     pub(crate) fn record_execute_turn(&mut self, code: &str, result: &Result<String>) {
+        if self.trajectory.is_none() {
+            return;
+        }
+        // Bound the trajectory: drop further turns once the cap is reached (ARN-222).
+        if self.turns_recorded >= MAX_TRAJECTORY_TURNS {
+            self.warn_capped_once("turn count", MAX_TRAJECTORY_TURNS);
+            return;
+        }
+
         let extracted_actions = extract_trajectory_actions_from_code(code);
+        // Bound recorded content: a large code blob or result can't grow the
+        // trajectory without limit (ARN-222).
+        let code_text = truncate_trajectory_text(code);
+        let result_text = match result {
+            Ok(text) => truncate_trajectory_text(text),
+            Err(e) => truncate_trajectory_text(&e.to_string()),
+        };
+        let is_failure = result.is_err();
+        let action_arguments = (!extracted_actions.is_empty()).then(|| {
+            serde_json::json!({
+                "trajectory_actions": bounded_trajectory_actions(extracted_actions),
+            })
+        });
+
+        // Total-size budget: meter the turn's *serialized* contribution (escaped
+        // text, the embedded actions, the duplicated error field, and a per-turn
+        // envelope) — not raw string bytes, which undercount the wire size by 2x
+        // or more. Stop recording once the cumulative serialized estimate would
+        // exceed the budget, so the whole upload stays under the server's ingest
+        // limit and is never rejected (and silently dropped) as too large, which
+        // would suppress the audit trail (ARN-222).
+        let turn_bytes = TRAJECTORY_TURN_ENVELOPE_BYTES
+            + json_string_cost(&code_text)
+            + json_string_cost(&result_text)
+            + if is_failure {
+                json_string_cost(&result_text)
+            } else {
+                0
+            }
+            + action_arguments.as_ref().map(json_value_cost).unwrap_or(0);
+        if self.trajectory_bytes + turn_bytes > MAX_TRAJECTORY_TOTAL_BYTES {
+            self.warn_capped_once("serialized byte budget", MAX_TRAJECTORY_TOTAL_BYTES);
+            return;
+        }
+        self.turns_recorded += 1;
+        self.trajectory_bytes += turn_bytes;
 
         let Some(ref mut builder) = self.trajectory else {
             return;
@@ -182,39 +264,39 @@ impl RuntimeContext {
         // User message: the Python code submitted
         builder.add_message(OTSMessage::new(
             MessageRole::User,
-            OTSMessageContent::text(code),
+            OTSMessageContent::text(code_text),
             now,
         ));
 
         // Decision: the execution outcome
         let (outcome_str, consequence) = match result {
-            Ok(text) => {
+            Ok(_) => {
                 // Assistant message: the execution result
                 builder.add_message(OTSMessage::new(
                     MessageRole::Assistant,
-                    OTSMessageContent::text(text),
+                    OTSMessageContent::text(result_text),
                     now,
                 ));
                 ("success", OTSConsequence::success())
             }
-            Err(e) => {
+            Err(_) => {
                 builder.add_message(OTSMessage::new(
                     MessageRole::Assistant,
-                    OTSMessageContent::text(e.to_string()),
+                    OTSMessageContent::text(result_text.clone()),
                     now,
                 ));
+                // Bound the error_type too — it is the same (already truncated) text.
                 (
                     "failure",
-                    OTSConsequence::failure().with_error_type(e.to_string()),
+                    OTSConsequence::failure().with_error_type(result_text),
                 )
             }
         };
 
-        let mut choice = OTSChoice::new(format!("execute: {}", &code[..code.len().min(100)]));
-        if !extracted_actions.is_empty() {
-            choice = choice.with_arguments(serde_json::json!({
-                "trajectory_actions": extracted_actions,
-            }));
+        let label_end = floor_char_boundary(code, 100);
+        let mut choice = OTSChoice::new(format!("execute: {}", &code[..label_end]));
+        if let Some(arguments) = action_arguments {
+            choice = choice.with_arguments(arguments);
         }
 
         let decision = OTSDecision::new(DecisionType::ToolSelection, choice, consequence);
@@ -225,17 +307,30 @@ impl RuntimeContext {
         tracing::debug!(outcome = outcome_str, "ots.trajectory.turn_recorded");
 
         for meta in extract_temper_call_metadata(code) {
+            // Cap the distinct-key growth of these observability maps so a single
+            // large code blob can't insert unbounded unique keys (ARN-222).
             if let Some(tenant) = meta.tenant {
-                self.tenants_seen
-                    .entry(tenant)
-                    .and_modify(|count| *count += 1)
-                    .or_insert(1);
-            }
-            if let Some(entity_type) = meta.entity_type {
-                self.entity_types_seen
-                    .entry(entity_type)
-                    .and_modify(|count| *count += 1)
-                    .or_insert(1);
+                // Emit the cross-tenant signal once per unique foreign tenant, the
+                // turn it is first tracked — never on every turn. `bump_seen`
+                // returns true only when it actually inserts a new key, so once
+                // `tenants_seen` saturates (or the key is oversized) it stops
+                // returning true and the warn does not spam. Storage is unaffected.
+                let foreign = if tenant != self.identity_tenant {
+                    Some(tenant.clone())
+                } else {
+                    None
+                };
+                let newly_tracked = bump_seen(&mut self.tenants_seen, tenant);
+                if let Some(referenced) = foreign
+                    && newly_tracked
+                {
+                    tracing::warn!(
+                        identity_tenant = %self.identity_tenant,
+                        referenced_tenant = %referenced,
+                        "mcp session code referenced a tenant other than its identity; \
+                         trajectory stored under the identity tenant"
+                    );
+                }
             }
         }
     }
@@ -325,11 +420,17 @@ impl RuntimeContext {
             .post(&url)
             .body(json)
             .header("Content-Type", "application/json")
-            .header("X-Tenant-Id", self.primary_tenant());
+            .header(
+                "X-Tenant-Id",
+                trajectory_storage_tenant(&self.identity_tenant),
+            );
 
-        if let Some(primary_entity_type) = self.primary_entity_type() {
-            request = request.header("X-Entity-Type", primary_entity_type);
-        }
+        // No code-derived value is placed in a request header: a `\n` or other
+        // illegal byte in an attacker-controlled entity type would make the HTTP
+        // client reject the whole upload, silently losing the trajectory. The
+        // previous `X-Entity-Type` header was code-derived and had no server-side
+        // reader, so it is dropped entirely (ARN-222). Agent/session ids below are
+        // startup config, not code-derived.
         if let Some(ref agent_id) = self.agent_id {
             request = request.header("X-Agent-Id", agent_id);
         }
@@ -358,23 +459,6 @@ impl RuntimeContext {
                 retryable: true,
             }),
         }
-    }
-
-    /// Most-used tenant for this session, falling back to configured identity tenant.
-    fn primary_tenant(&self) -> &str {
-        self.tenants_seen
-            .iter()
-            .max_by_key(|(_, count)| *count)
-            .map(|(tenant, _)| tenant.as_str())
-            .unwrap_or(self.identity_tenant.as_str())
-    }
-
-    /// Most-used entity type for this session.
-    fn primary_entity_type(&self) -> Option<&str> {
-        self.entity_types_seen
-            .iter()
-            .max_by_key(|(_, count)| *count)
-            .map(|(entity_type, _)| entity_type.as_str())
     }
 
     pub(crate) async fn run_execute(&mut self, code: &str) -> Result<String> {
@@ -506,8 +590,10 @@ fn extract_trajectory_actions_from_code(code: &str) -> Vec<Value> {
 
 #[derive(Debug, Clone, Default)]
 struct TemperCallMetadata {
+    /// Tenant referenced by the call, when the call uses the tenant-first
+    /// signature. Used only as a cross-tenant observability signal — never to
+    /// route trajectory storage (ARN-222).
     tenant: Option<String>,
-    entity_type: Option<String>,
 }
 
 fn extract_temper_call_metadata(code: &str) -> Vec<TemperCallMetadata> {
@@ -519,52 +605,23 @@ fn extract_temper_call_metadata(code: &str) -> Vec<TemperCallMetadata> {
 
 fn extract_temper_action_metadata(code: &str) -> Vec<TemperCallMetadata> {
     extract_call_metadata(code, "temper.action", |args| {
-        // New signature: temper.action(tenant, entity_type, id, action, params)
-        if args.len() >= 5
-            && let (Some(tenant), Some(entity_type), Some(_action)) = (
-                parse_python_string_literal(args[0]),
-                parse_python_string_literal(args[1]),
-                parse_python_string_literal(args[3]),
-            )
-        {
-            return TemperCallMetadata {
-                tenant: Some(tenant),
-                entity_type: Some(entity_type),
-            };
-        }
-
-        // Legacy signature: temper.action(entity_type, id, action, params)
-        TemperCallMetadata {
-            tenant: None,
-            entity_type: args
-                .first()
-                .and_then(|raw| parse_python_string_literal(raw)),
-        }
+        // New signature: temper.action(tenant, entity_type, id, action, params).
+        // Only the tenant is retained; the legacy signature carries no tenant.
+        let tenant = (args.len() >= 5)
+            .then(|| parse_python_string_literal(args[0]))
+            .flatten();
+        TemperCallMetadata { tenant }
     })
 }
 
 fn extract_temper_create_metadata(code: &str) -> Vec<TemperCallMetadata> {
     extract_call_metadata(code, "temper.create", |args| {
-        // New signature: temper.create(tenant, entity_type, fields)
-        if args.len() >= 3
-            && let (Some(tenant), Some(entity_type)) = (
-                parse_python_string_literal(args[0]),
-                parse_python_string_literal(args[1]),
-            )
-        {
-            return TemperCallMetadata {
-                tenant: Some(tenant),
-                entity_type: Some(entity_type),
-            };
-        }
-
-        // Legacy signature: temper.create(entity_type, fields)
-        TemperCallMetadata {
-            tenant: None,
-            entity_type: args
-                .first()
-                .and_then(|raw| parse_python_string_literal(raw)),
-        }
+        // New signature: temper.create(tenant, entity_type, fields). Only the
+        // tenant is retained; the legacy signature carries no tenant.
+        let tenant = (args.len() >= 3)
+            .then(|| parse_python_string_literal(args[0]))
+            .flatten();
+        TemperCallMetadata { tenant }
     })
 }
 
@@ -843,14 +900,34 @@ fn normalize_pythonish_json(input: &str) -> String {
 }
 
 /// Run the MCP server on stdio with JSON-RPC over newline-delimited JSON.
+///
+/// Frames are read through [`read_stdio_frame`], which bounds each frame to
+/// `MAX_STDIO_LINE_BYTES`; oversized frames are dropped and invalid UTF-8 frames
+/// are skipped rather than aborting the session.
 pub async fn run_stdio_server(config: McpConfig) -> Result<()> {
     let mut ctx = RuntimeContext::from_config(&config)?;
-    let stdin = BufReader::new(io::stdin());
-    let mut lines = stdin.lines();
+    let mut stdin = BufReader::new(io::stdin());
     let mut stdout = io::stdout();
 
-    while let Some(line) = lines.next_line().await? {
-        let line = line.trim();
+    loop {
+        let buf = match read_stdio_frame(&mut stdin).await? {
+            StdioFrame::Eof => break,
+            StdioFrame::TooLarge => {
+                tracing::warn!(
+                    limit = MAX_STDIO_LINE_BYTES,
+                    "mcp.stdio.frame_too_large: dropped oversized frame"
+                );
+                continue;
+            }
+            StdioFrame::Line(buf) => buf,
+        };
+        let line = match std::str::from_utf8(&buf) {
+            Ok(text) => text.trim(),
+            Err(_) => {
+                tracing::warn!("mcp.stdio.invalid_utf8: dropped frame");
+                continue;
+            }
+        };
         if line.is_empty() {
             continue;
         }
@@ -870,108 +947,5 @@ pub async fn run_stdio_server(config: McpConfig) -> Result<()> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use axum::{Router, extract::State, http::StatusCode, routing::post};
-    use std::sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
-    };
-
-    #[test]
-    fn extract_trajectory_actions_from_temper_action_calls() {
-        let code = r#"
-result = temper.action("Issue", "issue-1", "PromoteToCritical", {"Reason": "prod incident"})
-other = temper.action('Issue', 'issue-1', 'Assign', {'AgentId': 'agent-2'})
-tenant = temper.action("gepa-tenant", "Issues", "11111111-1111-1111-1111-111111111111", "Reassign", {"NewAssigneeId": "agent-3"})
-"#;
-
-        let actions = extract_trajectory_actions_from_code(code);
-        assert_eq!(actions.len(), 3);
-        assert_eq!(
-            actions[0].get("action").and_then(Value::as_str),
-            Some("PromoteToCritical")
-        );
-        assert_eq!(
-            actions[2]
-                .get("params")
-                .and_then(Value::as_object)
-                .and_then(|m| m.get("NewAssigneeId"))
-                .and_then(Value::as_str),
-            Some("agent-3")
-        );
-    }
-
-    #[test]
-    fn normalize_python_literals_to_json() {
-        let value = parse_python_json_value("{'enabled': True, 'reason': None, 'count': 2}")
-            .expect("python dict should parse");
-        assert_eq!(value["enabled"], serde_json::json!(true));
-        assert_eq!(value["reason"], serde_json::Value::Null);
-        assert_eq!(value["count"], serde_json::json!(2));
-    }
-
-    #[test]
-    fn extract_temper_call_metadata_tracks_tenant_and_entity() {
-        let code = r#"
-await temper.action("tenant-a", "Issue", "i-1", "Assign", {"AgentId": "agent-1"})
-await temper.create("tenant-b", "Task", {"Title": "x"})
-"#;
-        let metadata = extract_temper_call_metadata(code);
-        assert!(
-            metadata.iter().any(|m| {
-                m.tenant.as_deref() == Some("tenant-a") && m.entity_type.as_deref() == Some("Issue")
-            }),
-            "expected tenant-a/Issue metadata"
-        );
-        assert!(
-            metadata.iter().any(|m| {
-                m.tenant.as_deref() == Some("tenant-b") && m.entity_type.as_deref() == Some("Task")
-            }),
-            "expected tenant-b/Task metadata"
-        );
-    }
-
-    #[tokio::test]
-    async fn finalize_trajectory_retries_retryable_ots_upload_failure() {
-        async fn handler(State(attempts): State<Arc<AtomicUsize>>) -> StatusCode {
-            let attempt = attempts.fetch_add(1, Ordering::SeqCst);
-            if attempt == 0 {
-                StatusCode::SERVICE_UNAVAILABLE
-            } else {
-                StatusCode::ACCEPTED
-            }
-        }
-
-        let attempts = Arc::new(AtomicUsize::new(0));
-        let app = Router::new()
-            .route("/api/ots/trajectories", post(handler))
-            .with_state(attempts.clone());
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("bind test server");
-        let addr = listener.local_addr().expect("test server addr");
-        tokio::spawn(async move {
-            axum::serve(listener, app).await.expect("serve test server");
-        });
-
-        let mut ctx = RuntimeContext {
-            base_url: format!("http://{addr}"),
-            http: reqwest::Client::new(),
-            agent_id: Some("agent".to_string()),
-            agent_type: Some("test-agent".to_string()),
-            session_id: Some("session".to_string()),
-            api_key: None,
-            identity_tenant: "tenant".to_string(),
-            sandbox: temper_sandbox::runner::PersistentSandbox::new(&[("temper", "Temper", 1)]),
-            trajectory: None,
-            tenants_seen: BTreeMap::new(),
-            entity_types_seen: BTreeMap::new(),
-        };
-        ctx.init_trajectory();
-
-        ctx.finalize_trajectory().await;
-
-        assert_eq!(attempts.load(Ordering::SeqCst), 2);
-    }
-}
+#[path = "runtime_test.rs"]
+mod tests;

--- a/crates/temper-mcp/src/runtime_test.rs
+++ b/crates/temper-mcp/src/runtime_test.rs
@@ -1,0 +1,329 @@
+//! Unit tests for the MCP runtime (`runtime.rs`). Split out so `runtime.rs`
+//! stays under the file-size budget; excluded from the readability ratchet as a
+//! `*_test.rs` file.
+
+use super::*;
+use crate::trajectory_bounds::{MAX_TRAJECTORY_ACTIONS, MAX_TRAJECTORY_TEXT_BYTES};
+use axum::{Router, extract::State, http::HeaderMap, http::StatusCode, routing::post};
+use std::sync::Mutex;
+
+#[test]
+fn bounded_trajectory_actions_caps_count_and_size() {
+    // ARN-222: trajectory_actions come from the full untruncated code and must
+    // be bounded in both count and serialized size.
+    let many: Vec<Value> = (0..MAX_TRAJECTORY_ACTIONS + 50)
+        .map(|i| serde_json::json!({ "a": i }))
+        .collect();
+    assert_eq!(
+        bounded_trajectory_actions(many).as_array().map(|a| a.len()),
+        Some(MAX_TRAJECTORY_ACTIONS),
+        "action count must be capped"
+    );
+    // One action with a huge params blob collapses to a summary.
+    let huge = vec![serde_json::json!({ "params": "x".repeat(MAX_TRAJECTORY_TEXT_BYTES * 2) })];
+    assert_eq!(
+        bounded_trajectory_actions(huge).get("trajectory_actions_truncated"),
+        Some(&serde_json::json!(true)),
+        "oversized actions must collapse to a bounded summary"
+    );
+}
+
+#[tokio::test]
+async fn trajectory_upload_uses_identity_tenant_header() {
+    // ARN-222 (wire-level): the trajectory must be filed under the authenticated
+    // identity even when the code referenced other tenants — a call-site guard.
+    async fn handler(
+        State(captured): State<Arc<Mutex<Option<String>>>>,
+        headers: HeaderMap,
+    ) -> StatusCode {
+        let tenant = headers
+            .get("X-Tenant-Id")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_string);
+        *captured.lock().expect("lock") = tenant;
+        StatusCode::ACCEPTED
+    }
+
+    let captured = Arc::new(Mutex::new(None));
+    let app = Router::new()
+        .route("/api/ots/trajectories", post(handler))
+        .with_state(captured.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve");
+    });
+
+    let mut ctx = trajectory_test_ctx("my-identity");
+    ctx.base_url = format!("http://{addr}");
+    // Code referenced a foreign tenant far more than the identity.
+    ctx.tenants_seen.insert("attacker-tenant".to_string(), 99);
+    ctx.init_trajectory();
+    ctx.finalize_trajectory().await;
+
+    assert_eq!(
+        captured.lock().expect("lock").as_deref(),
+        Some("my-identity"),
+        "trajectory must be filed under the identity tenant, not a code-referenced one"
+    );
+}
+
+#[test]
+fn trajectory_storage_tenant_uses_identity_not_code() {
+    // ARN-222: the trajectory must be stored under the authenticated session
+    // identity, never a tenant derived from the (attacker-controlled) code.
+    assert_eq!(
+        trajectory_storage_tenant("my-identity"),
+        "my-identity",
+        "code-referenced tenants must not move the trajectory off the identity"
+    );
+}
+
+#[test]
+fn truncate_trajectory_text_bounds_large_content() {
+    // ARN-222: recorded code/result text must be bounded.
+    let big = "x".repeat(MAX_TRAJECTORY_TEXT_BYTES * 4);
+    let truncated = truncate_trajectory_text(&big);
+    assert!(
+        truncated.len() <= MAX_TRAJECTORY_TEXT_BYTES + 128,
+        "recorded text must be bounded, got {} bytes",
+        truncated.len()
+    );
+    assert!(
+        truncated.contains("truncated"),
+        "truncation must be marked in the recorded text"
+    );
+    // Text within the cap is recorded verbatim.
+    assert_eq!(truncate_trajectory_text("hello"), "hello");
+    // A multibyte char straddling the cap must not panic and must stay valid UTF-8.
+    let multibyte = "é".repeat(MAX_TRAJECTORY_TEXT_BYTES); // 2 bytes each
+    let t = truncate_trajectory_text(&multibyte);
+    assert!(t.len() <= MAX_TRAJECTORY_TEXT_BYTES + 128);
+    assert!(t.contains("truncated"));
+}
+
+fn trajectory_test_ctx(identity: &str) -> RuntimeContext {
+    RuntimeContext {
+        base_url: "http://127.0.0.1:1".to_string(),
+        http: reqwest::Client::new(),
+        agent_id: None,
+        agent_type: None,
+        session_id: None,
+        api_key: None,
+        identity_tenant: identity.to_string(),
+        sandbox: temper_sandbox::runner::PersistentSandbox::new(&[("temper", "Temper", 1)]),
+        trajectory: None,
+        tenants_seen: BTreeMap::new(),
+        turns_recorded: 0,
+        trajectory_bytes: 0,
+        capped_warned: false,
+    }
+}
+
+#[test]
+fn turn_cap_bounds_recorded_turns() {
+    // ARN-222: the trajectory records up to MAX_TRAJECTORY_TURNS turns, then
+    // drops further turns instead of growing without bound.
+    let mut ctx = trajectory_test_ctx("t");
+    ctx.init_trajectory();
+    let ok: Result<String> = Ok("result".to_string());
+
+    ctx.record_execute_turn("code", &ok);
+    assert_eq!(ctx.turns_recorded, 1, "a turn under the cap is recorded");
+
+    ctx.turns_recorded = MAX_TRAJECTORY_TURNS;
+    ctx.record_execute_turn("code", &ok);
+    assert_eq!(
+        ctx.turns_recorded, MAX_TRAJECTORY_TURNS,
+        "a turn at the cap is dropped, not recorded"
+    );
+}
+
+#[test]
+fn total_byte_budget_stops_recording() {
+    // ARN-222: even within the per-turn and turn-count caps, the total recorded
+    // text is bounded so the upload can't exceed the server ingest limit and be
+    // silently dropped. Once the byte budget is (near) exhausted, further turns
+    // are not recorded.
+    use crate::trajectory_bounds::MAX_TRAJECTORY_TOTAL_BYTES;
+    let mut ctx = trajectory_test_ctx("t");
+    ctx.init_trajectory();
+    let ok: Result<String> = Ok("r".to_string());
+
+    // Pretend the budget is already spent.
+    ctx.trajectory_bytes = MAX_TRAJECTORY_TOTAL_BYTES;
+    let before = ctx.turns_recorded;
+    ctx.record_execute_turn("more code", &ok);
+    assert_eq!(
+        ctx.turns_recorded, before,
+        "a turn over the byte budget is dropped, not recorded"
+    );
+}
+
+#[test]
+fn worst_case_trajectory_serializes_under_server_ingest_limit() {
+    // ARN-222 (the real audit-suppression guarantee): a session that records up to
+    // every cap must still serialize to under the server's 2 MiB ingest limit, so
+    // it is never 413'd and silently dropped. Uses control-character text (each
+    // byte escapes to `\u00XX`, 6x) plus embedded actions and a failing result so
+    // error_type is duplicated — every budgeted contributor at once, not just raw
+    // byte length.
+    const SERVER_INGEST_LIMIT: usize = 2 * 1024 * 1024;
+    let mut ctx = trajectory_test_ctx("t");
+    ctx.init_trajectory();
+
+    let filler = "\u{0001}".repeat(MAX_TRAJECTORY_TEXT_BYTES);
+    let code = format!("temper.action(\"t\", \"E\", \"id\", \"Act\", {{\"x\": \"{filler}\"}})");
+    let err: Result<String> = Err(anyhow::anyhow!(
+        "{}",
+        "\u{0001}".repeat(MAX_TRAJECTORY_TEXT_BYTES)
+    ));
+
+    for _ in 0..MAX_TRAJECTORY_TURNS {
+        ctx.record_execute_turn(&code, &err);
+    }
+
+    let snapshot = ctx.trajectory.as_ref().expect("trajectory").snapshot();
+    let serialized = serde_json::to_string(&snapshot).expect("serialize");
+    assert!(
+        serialized.len() < SERVER_INGEST_LIMIT,
+        "worst-case trajectory serialized to {} bytes; must stay under the {} server limit",
+        serialized.len(),
+        SERVER_INGEST_LIMIT
+    );
+}
+
+#[test]
+fn init_trajectory_resets_budgets() {
+    // Fable follow-up: re-sending `initialize` must reset the turn and byte
+    // budgets, not inherit a consumed one.
+    let mut ctx = trajectory_test_ctx("t");
+    ctx.init_trajectory();
+    ctx.turns_recorded = 123;
+    ctx.trajectory_bytes = 456;
+    ctx.capped_warned = true;
+    ctx.init_trajectory();
+    assert_eq!(ctx.turns_recorded, 0);
+    assert_eq!(ctx.trajectory_bytes, 0);
+    assert!(
+        !ctx.capped_warned,
+        "the cap-warned flag must reset on re-initialize"
+    );
+}
+
+#[test]
+fn choice_label_does_not_panic_on_multibyte_code() {
+    // ARN-222 follow-up: the choice label slices the first 100 bytes of `code`;
+    // a multibyte char at the boundary must not crash the client.
+    let mut ctx = trajectory_test_ctx("t");
+    ctx.init_trajectory();
+    let code = "é".repeat(80); // 160 bytes; byte 100 is mid-char
+    let ok: Result<String> = Ok("ok".to_string());
+    ctx.record_execute_turn(&code, &ok); // must not panic
+    assert_eq!(ctx.turns_recorded, 1);
+}
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
+#[test]
+fn extract_trajectory_actions_from_temper_action_calls() {
+    let code = r#"
+result = temper.action("Issue", "issue-1", "PromoteToCritical", {"Reason": "prod incident"})
+other = temper.action('Issue', 'issue-1', 'Assign', {'AgentId': 'agent-2'})
+tenant = temper.action("gepa-tenant", "Issues", "11111111-1111-1111-1111-111111111111", "Reassign", {"NewAssigneeId": "agent-3"})
+"#;
+
+    let actions = extract_trajectory_actions_from_code(code);
+    assert_eq!(actions.len(), 3);
+    assert_eq!(
+        actions[0].get("action").and_then(Value::as_str),
+        Some("PromoteToCritical")
+    );
+    assert_eq!(
+        actions[2]
+            .get("params")
+            .and_then(Value::as_object)
+            .and_then(|m| m.get("NewAssigneeId"))
+            .and_then(Value::as_str),
+        Some("agent-3")
+    );
+}
+
+#[test]
+fn normalize_python_literals_to_json() {
+    let value = parse_python_json_value("{'enabled': True, 'reason': None, 'count': 2}")
+        .expect("python dict should parse");
+    assert_eq!(value["enabled"], serde_json::json!(true));
+    assert_eq!(value["reason"], serde_json::Value::Null);
+    assert_eq!(value["count"], serde_json::json!(2));
+}
+
+#[test]
+fn extract_temper_call_metadata_tracks_tenant() {
+    let code = r#"
+await temper.action("tenant-a", "Issue", "i-1", "Assign", {"AgentId": "agent-1"})
+await temper.create("tenant-b", "Task", {"Title": "x"})
+"#;
+    let metadata = extract_temper_call_metadata(code);
+    assert!(
+        metadata
+            .iter()
+            .any(|m| m.tenant.as_deref() == Some("tenant-a")),
+        "expected tenant-a metadata"
+    );
+    assert!(
+        metadata
+            .iter()
+            .any(|m| m.tenant.as_deref() == Some("tenant-b")),
+        "expected tenant-b metadata"
+    );
+}
+
+#[tokio::test]
+async fn finalize_trajectory_retries_retryable_ots_upload_failure() {
+    async fn handler(State(attempts): State<Arc<AtomicUsize>>) -> StatusCode {
+        let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+        if attempt == 0 {
+            StatusCode::SERVICE_UNAVAILABLE
+        } else {
+            StatusCode::ACCEPTED
+        }
+    }
+
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let app = Router::new()
+        .route("/api/ots/trajectories", post(handler))
+        .with_state(attempts.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test server");
+    let addr = listener.local_addr().expect("test server addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve test server");
+    });
+
+    let mut ctx = RuntimeContext {
+        base_url: format!("http://{addr}"),
+        http: reqwest::Client::new(),
+        agent_id: Some("agent".to_string()),
+        agent_type: Some("test-agent".to_string()),
+        session_id: Some("session".to_string()),
+        api_key: None,
+        identity_tenant: "tenant".to_string(),
+        sandbox: temper_sandbox::runner::PersistentSandbox::new(&[("temper", "Temper", 1)]),
+        trajectory: None,
+        tenants_seen: BTreeMap::new(),
+        turns_recorded: 0,
+        trajectory_bytes: 0,
+        capped_warned: false,
+    };
+    ctx.init_trajectory();
+
+    ctx.finalize_trajectory().await;
+
+    assert_eq!(attempts.load(Ordering::SeqCst), 2);
+}

--- a/crates/temper-mcp/src/trajectory_bounds.rs
+++ b/crates/temper-mcp/src/trajectory_bounds.rs
@@ -1,0 +1,281 @@
+//! Capture bounds and stdio framing for MCP trajectory recording (ARN-222).
+//!
+//! These are the pure, side-effect-free guards that keep an attacker-controlled
+//! MCP session from growing the recorded trajectory or the stdio read buffer
+//! without bound. They are split out of `runtime.rs` so the bounds (and their
+//! tests) live in one auditable place.
+
+use serde_json::Value;
+use std::collections::BTreeMap;
+use tokio::io::{self, AsyncBufRead, AsyncBufReadExt, AsyncReadExt};
+
+/// Per-message cap on recorded trajectory text (submitted code / execution result).
+pub(crate) const MAX_TRAJECTORY_TEXT_BYTES: usize = 16 * 1024;
+/// Cap on the number of turns recorded in a single trajectory.
+pub(crate) const MAX_TRAJECTORY_TURNS: usize = 500;
+/// Cap on the number of extracted actions embedded in a single turn's decision.
+pub(crate) const MAX_TRAJECTORY_ACTIONS: usize = 64;
+/// Cap on the number of distinct tenants / entity types tracked per session.
+pub(crate) const MAX_SEEN_KEYS: usize = 256;
+/// Cap on the byte length of a single tracked observability key (tenant / entity
+/// type). Distinct-key *count* alone does not bound memory: 256 near-1-MiB keys
+/// would still retain hundreds of MiB, so an oversized key is dropped rather than
+/// stored (ARN-222).
+pub(crate) const MAX_SEEN_KEY_BYTES: usize = 256;
+/// Cap on the total *serialized* JSON size of the trajectory, kept under the
+/// server's 2 MiB ingest limit (`POST /api/ots/trajectories` uses Axum's default
+/// `DEFAULT_LIMIT` of 2_097_152) so a session that is within the per-turn and
+/// per-count caps cannot still produce a trajectory the server rejects with 413 —
+/// which the client treats as non-retryable and would silently drop, suppressing
+/// the audit trail (ARN-222).
+///
+/// The budget is metered against a conservative estimate of each turn's serialized
+/// contribution (JSON-escaped text, embedded actions, a duplicated error field,
+/// and a fixed per-turn envelope), not raw string bytes — raw bytes undercount the
+/// wire size by 2x or more once JSON escaping and the OTS envelope are included.
+pub(crate) const MAX_TRAJECTORY_TOTAL_BYTES: usize = 1_800_000;
+
+/// Conservative fixed overhead charged to each recorded turn's budget: the OTS
+/// turn/message/decision envelope (ids, timestamps, roles, choice label, decision
+/// wrapper). Deliberately larger than the real ~600–800 B so metering never
+/// undercounts the serialized turn.
+pub(crate) const TRAJECTORY_TURN_ENVELOPE_BYTES: usize = 2048;
+
+/// The number of bytes `text` occupies once serialized as a JSON string value,
+/// including surrounding quotes and escaping. Used to meter a turn's real wire
+/// cost against the ingest budget rather than its raw byte length.
+pub(crate) fn json_string_cost(text: &str) -> usize {
+    serde_json::to_string(text)
+        .map(|s| s.len())
+        .unwrap_or(text.len() + 2)
+}
+
+/// The number of bytes `value` occupies once serialized as JSON.
+pub(crate) fn json_value_cost(value: &Value) -> usize {
+    serde_json::to_string(value).map(|s| s.len()).unwrap_or(0)
+}
+/// Maximum bytes accepted for a single stdio JSON-RPC frame. A peer that never
+/// sends a newline would otherwise make a line reader buffer the whole stream
+/// into one allocation.
+pub(crate) const MAX_STDIO_LINE_BYTES: usize = 1_048_576;
+
+/// Bound the `trajectory_actions` embedded in a turn's decision. The actions are
+/// parsed from the full (untruncated) code, so both their count and total
+/// serialized size are capped, replacing the array with a summary when it would
+/// exceed the text budget — otherwise a large `temper.action(params=...)` dict
+/// bypasses the per-message cap every turn (ARN-222).
+pub(crate) fn bounded_trajectory_actions(mut actions: Vec<Value>) -> Value {
+    actions.truncate(MAX_TRAJECTORY_ACTIONS);
+    let value = Value::Array(actions);
+    let too_large = serde_json::to_string(&value)
+        .map(|s| s.len() > MAX_TRAJECTORY_TEXT_BYTES)
+        .unwrap_or(true);
+    if too_large {
+        return serde_json::json!({
+            "trajectory_actions_truncated": true,
+            "note": "actions omitted: serialized size exceeded the trajectory cap",
+        });
+    }
+    value
+}
+
+/// The tenant a captured trajectory is stored under. It must be the session's
+/// authenticated `identity` — never a tenant derived from the executed code,
+/// which is attacker-controlled and would let a session file its trajectory under
+/// another tenant (ARN-222).
+pub(crate) fn trajectory_storage_tenant(identity: &str) -> &str {
+    identity
+}
+
+/// Increment `key`'s count in a per-session observability map, bounding both the
+/// number of distinct keys (`MAX_SEEN_KEYS`) and each key's byte length
+/// (`MAX_SEEN_KEY_BYTES`). Returns `true` only when a new key was inserted, so a
+/// caller can emit a once-per-key signal without re-firing after the map
+/// saturates.
+pub(crate) fn bump_seen(map: &mut BTreeMap<String, usize>, key: String) -> bool {
+    if let Some(count) = map.get_mut(&key) {
+        *count += 1;
+        false
+    } else if key.len() <= MAX_SEEN_KEY_BYTES && map.len() < MAX_SEEN_KEYS {
+        map.insert(key, 1);
+        true
+    } else {
+        false
+    }
+}
+
+/// Largest byte index `<= max` that is a UTF-8 char boundary of `s`, so
+/// `&s[..floor_char_boundary(s, max)]` never panics on a multibyte char.
+pub(crate) fn floor_char_boundary(s: &str, max: usize) -> usize {
+    let mut end = max.min(s.len());
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    end
+}
+
+/// Truncate recorded trajectory text to `MAX_TRAJECTORY_TEXT_BYTES`, appending an
+/// explicit marker, so a large submitted code blob or result can't grow the
+/// trajectory without bound (ARN-222).
+pub(crate) fn truncate_trajectory_text(text: &str) -> String {
+    if text.len() <= MAX_TRAJECTORY_TEXT_BYTES {
+        return text.to_string();
+    }
+    let end = floor_char_boundary(text, MAX_TRAJECTORY_TEXT_BYTES);
+    format!("{}…[truncated {} bytes]", &text[..end], text.len() - end)
+}
+
+/// Outcome of reading one newline-delimited frame from stdin.
+pub(crate) enum StdioFrame {
+    /// A complete frame within budget (may include the trailing newline).
+    Line(Vec<u8>),
+    /// The frame exceeded `MAX_STDIO_LINE_BYTES`; it was drained and dropped.
+    TooLarge,
+    /// End of input.
+    Eof,
+}
+
+/// Read one JSON-RPC frame, holding at most `MAX_STDIO_LINE_BYTES + 1` bytes at a
+/// time.
+///
+/// `#365` flagged unbounded stdio reads but checked the line length only *after*
+/// `next_line()` had already buffered the whole line, so it did not bound memory.
+/// This reads through a `take`-limited reader so no single read allocates past the
+/// budget, and drains an oversized frame to the next newline (reusing the same
+/// buffer, not a second one) so peak memory stays near one budget rather than two.
+pub(crate) async fn read_stdio_frame<R: AsyncBufRead + Unpin>(
+    reader: &mut R,
+) -> io::Result<StdioFrame> {
+    let mut buf = Vec::new();
+    let read = reader
+        .take((MAX_STDIO_LINE_BYTES as u64) + 1)
+        .read_until(b'\n', &mut buf)
+        .await?;
+    if read == 0 {
+        return Ok(StdioFrame::Eof);
+    }
+    // A complete frame ends with '\n'. Missing a trailing newline is oversized
+    // only when we also consumed the full budget (`buf.len() > cap`); a shorter
+    // no-newline read is the final EOF-terminated frame and is kept. This keeps a
+    // frame of exactly `MAX_STDIO_LINE_BYTES` content bytes plus its newline
+    // (buf.len == cap + 1, ends in '\n') as a valid line rather than rejecting it.
+    if buf.last() != Some(&b'\n') && buf.len() > MAX_STDIO_LINE_BYTES {
+        // Drain the rest of this oversized frame (bounded per chunk, reusing the
+        // buffer) before rejecting it, so the loop resynchronizes on the next
+        // frame without holding a second budget's worth of memory.
+        loop {
+            buf.clear();
+            let n = reader
+                .take((MAX_STDIO_LINE_BYTES as u64) + 1)
+                .read_until(b'\n', &mut buf)
+                .await?;
+            if n == 0 || buf.last() == Some(&b'\n') {
+                break;
+            }
+        }
+        return Ok(StdioFrame::TooLarge);
+    }
+    Ok(StdioFrame::Line(buf))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::BufReader;
+
+    fn frame_label(frame: &StdioFrame) -> &'static str {
+        match frame {
+            StdioFrame::Line(_) => "Line",
+            StdioFrame::TooLarge => "TooLarge",
+            StdioFrame::Eof => "Eof",
+        }
+    }
+
+    #[tokio::test]
+    async fn stdio_frame_reads_normal_line() {
+        let data = b"{\"jsonrpc\":\"2.0\"}\n".to_vec();
+        let mut reader = BufReader::new(&data[..]);
+        match read_stdio_frame(&mut reader).await.unwrap() {
+            StdioFrame::Line(buf) => assert_eq!(buf, data),
+            other => panic!("expected a line, got {}", frame_label(&other)),
+        }
+        assert!(matches!(
+            read_stdio_frame(&mut reader).await.unwrap(),
+            StdioFrame::Eof
+        ));
+    }
+
+    #[tokio::test]
+    async fn stdio_frame_rejects_oversized_and_resyncs() {
+        let mut data = vec![b'x'; MAX_STDIO_LINE_BYTES + 10];
+        data.push(b'\n');
+        data.extend_from_slice(b"{\"ok\":true}\n");
+        let mut reader = BufReader::new(&data[..]);
+
+        assert!(
+            matches!(
+                read_stdio_frame(&mut reader).await.unwrap(),
+                StdioFrame::TooLarge
+            ),
+            "oversized frame must be rejected"
+        );
+        match read_stdio_frame(&mut reader).await.unwrap() {
+            StdioFrame::Line(buf) => assert_eq!(buf, b"{\"ok\":true}\n"),
+            other => panic!("expected the following frame, got {}", frame_label(&other)),
+        }
+    }
+
+    #[tokio::test]
+    async fn stdio_frame_accepts_exact_budget_with_newline() {
+        let mut data = vec![b'a'; MAX_STDIO_LINE_BYTES];
+        data.push(b'\n');
+        let mut reader = BufReader::new(&data[..]);
+        match read_stdio_frame(&mut reader).await.unwrap() {
+            StdioFrame::Line(buf) => assert_eq!(buf.len(), MAX_STDIO_LINE_BYTES + 1),
+            other => panic!(
+                "exact-budget frame must be a line, got {}",
+                frame_label(&other)
+            ),
+        }
+    }
+
+    #[tokio::test]
+    async fn stdio_frame_keeps_final_line_without_newline() {
+        let data = b"{\"final\":true}".to_vec();
+        let mut reader = BufReader::new(&data[..]);
+        match read_stdio_frame(&mut reader).await.unwrap() {
+            StdioFrame::Line(buf) => assert_eq!(buf, data),
+            other => panic!(
+                "EOF-terminated frame must be a line, got {}",
+                frame_label(&other)
+            ),
+        }
+    }
+
+    #[test]
+    fn bump_seen_bounds_count_and_key_length() {
+        let mut map = BTreeMap::new();
+        assert!(bump_seen(&mut map, "a".to_string()), "first insert is new");
+        assert!(!bump_seen(&mut map, "a".to_string()), "repeat is not new");
+        assert_eq!(map.get("a"), Some(&2));
+
+        // Oversized key is dropped, not stored.
+        let huge = "x".repeat(MAX_SEEN_KEY_BYTES + 1);
+        assert!(!bump_seen(&mut map, huge.clone()));
+        assert!(!map.contains_key(&huge));
+
+        // Distinct-key count is capped.
+        for i in 0..MAX_SEEN_KEYS + 10 {
+            bump_seen(&mut map, format!("k{i}"));
+        }
+        assert!(map.len() <= MAX_SEEN_KEYS);
+    }
+
+    #[test]
+    fn truncate_trajectory_text_is_multibyte_safe() {
+        let s = "日本語".repeat(20_000); // well over the byte budget
+        let out = truncate_trajectory_text(&s);
+        assert!(std::str::from_utf8(out.as_bytes()).is_ok());
+        assert!(out.contains("[truncated"));
+    }
+}

--- a/docs/adrs/0165-mcp-trajectory-tenant-and-bounds.md
+++ b/docs/adrs/0165-mcp-trajectory-tenant-and-bounds.md
@@ -1,0 +1,125 @@
+# ADR-0165: MCP trajectory is owned by the session identity and bounded
+
+- Status: Accepted
+- Date: 2026-08-15
+- Deciders: Temper core maintainers
+- Related:
+  - `crates/temper-mcp/src/runtime.rs` (MCP trajectory capture + upload)
+  - ARN-222 (security finding)
+
+> This is the landed version for ARN-222. It is based on Fable's arena entry
+> (winner of the head-to-head), with one addition ported from the competing entry
+> (#365): a bound on stdio frame size. #365 raised that gap but bounded it only
+> *after* reading the whole line; this version bounds the allocation during the
+> read (Sub-Decision 3).
+
+## Context
+
+The MCP client captures an OTS trajectory of each session's `execute` turns and
+uploads it to the server (`runtime.rs`). Two problems (ARN-222):
+
+1. **Tenant mixing.** The trajectory is uploaded with
+   `X-Tenant-Id: self.primary_tenant()`, and `primary_tenant()` returns the
+   **most-referenced tenant in the executed code** (`tenants_seen`, populated from
+   `extract_temper_call_metadata(code)`), falling back to the session identity only
+   when no tenant appears in the code. The executed code is attacker-controlled, so
+   a session authenticated as tenant A can inject `temper` calls referencing tenant
+   B and cause its trajectory — containing A's session code and results — to be
+   filed under **tenant B**. Trajectory storage is thus keyed by code content rather
+   than by the authenticated session identity, mixing tenants.
+
+2. **Unbounded code/results.** `record_execute_turn` records the full submitted
+   `code` and the full execution `result` verbatim (`OTSMessageContent::text`) with
+   no size cap, across an unbounded number of turns. A large or runaway session
+   accumulates the whole thing in memory and uploads it, an unauthenticated
+   memory/storage-exhaustion vector.
+
+## Decision
+
+### Sub-Decision 1: The trajectory belongs to the authenticated identity
+
+The trajectory upload is keyed by `self.identity_tenant` — the session's
+authenticated tenant — not by any code-derived tenant. Code content can never move
+a trajectory into another tenant's storage. `tenants_seen` is retained only as an
+observability signal: if the session's code referenced a tenant other than the
+identity, that is logged (a cross-tenant-activity signal), but it does not
+determine storage.
+
+### Sub-Decision 2: Bounded capture
+
+Every guest-controlled channel that feeds the trajectory is bounded, so total size
+is bounded regardless of session input:
+- recorded `code` / `result` text → truncated to `MAX_TRAJECTORY_TEXT_BYTES` (on a
+  UTF-8 char boundary, marked);
+- the decision's `error_type` → the same truncated text (not the raw error);
+- the embedded `trajectory_actions` → capped in count (`MAX_TRAJECTORY_ACTIONS`) and
+  collapsed to a summary when serialized size exceeds the text budget;
+- the number of recorded turns → capped (`MAX_TRAJECTORY_TURNS`), further turns
+  dropped with a warning;
+- the **total** recorded text across the trajectory → capped at
+  `MAX_TRAJECTORY_TOTAL_BYTES` (1.8 MB of metered serialized cost), kept under the
+  server's 2 MiB ingest limit so a
+  session that is within the per-turn and turn-count caps still cannot produce a
+  trajectory the server rejects with 413 (which the client treats as non-retryable
+  and would silently drop, suppressing the audit trail);
+- the per-session `tenants_seen` map → capped in both distinct keys
+  (`MAX_SEEN_KEYS`) **and** per-key byte length (`MAX_SEEN_KEY_BYTES`); an oversized
+  key is dropped rather than retained, so 256 near-1-MiB keys cannot retain hundreds
+  of MiB. The turn/byte budgets reset on re-`initialize`.
+
+No code-derived value is placed in a request header. The previous, code-derived
+`X-Entity-Type` header (which had no server-side reader) is removed: an illegal byte
+such as `\n` in an attacker-controlled entity type would otherwise make the HTTP
+client reject the whole upload and silently lose the trajectory. Only the session's
+authenticated tenant and startup-config agent/session ids remain as headers.
+
+The bounds and stdio framing live in `trajectory_bounds.rs` so they (and their
+tests) are auditable in one place.
+
+### Sub-Decision 3: Bounded stdio frames
+
+`run_stdio_server` read JSON-RPC frames with `BufReader::lines()`, which buffers a
+whole line into one allocation — a peer that never sends a newline could exhaust
+memory before any parse. Frames are now read through `read_stdio_frame`, which caps
+each frame at `MAX_STDIO_LINE_BYTES` (1 MiB) **during** the read: it never
+allocates more than the budget plus one byte, drains an oversized frame to the next
+newline in bounded chunks, drops it with a warning, and resynchronizes on the
+following frame. Invalid UTF-8 frames are dropped rather than aborting the session.
+
+## Consequences
+
+### Positive
+- A trajectory can only ever be stored under the session's authenticated tenant, so
+  code content cannot cross tenant boundaries. Capture size is bounded, closing the
+  memory/storage-exhaustion vector.
+
+### Behavior
+- Legitimate sessions are unaffected: their identity tenant is where their
+  trajectory already belonged, and normal turn sizes are well under the caps.
+
+### DST Compliance
+- `temper-mcp` is not simulation-visible. The new logic is pure (string truncation,
+  identity selection, a counter); no wall clock, threads, or ambient I/O added.
+
+## Non-Goals / Follow-ups
+- Redaction of secrets that a guest may print into a result is a separate content
+  concern, tracked elsewhere. This ADR closes the tenant-attribution and unbounded
+  size vectors.
+- **Server-side tenant binding is already in place.** The
+  `POST /api/ots/trajectories` handler keys storage on the typed
+  `AuthenticatedRequestContext::tenant()` (`observe/evolution/trajectories.rs`), not
+  the raw `X-Tenant-Id` header, and the bearer edge resolves the credential within
+  the requested tenant (ADR-0157/ARN-187). So the storage boundary is enforced on
+  both sides: this fix removes the client-side code-derived-tenant vector, and the
+  server independently ignores an untrusted tenant header. The only residual is a
+  bearer token that is valid in multiple tenants — orthogonal to ARN-222.
+- Peak *transient* processing memory (an error string materialized by the sandbox
+  before truncation, or actions/metadata parsed from a frame before the caps apply)
+  is bounded by the 1 MiB stdio frame cap and the sandbox's own memory budget, then
+  truncated before retention. Retained trajectory size is what this ADR bounds;
+  reducing transient peaks further is not required to close the vector.
+
+## Alternatives Considered
+1. **Reject the session when code references another tenant.** Rejected: legitimate
+   cross-tenant reads may be authorized server-side; the fix is to store under the
+   authenticated identity and log the cross-tenant signal, not to block execution.


### PR DESCRIPTION
Closes **ARN-222**. Rebased onto current `main` and hardened; supersedes #378 (Fable's arena entry) and folds in the one genuinely superior idea from the competing entry #365.

## Vulnerability
The MCP client captured an OTS trajectory of each `execute` turn and uploaded it keyed by a tenant **derived from the attacker-controlled executed code** (`primary_tenant()` = most-referenced tenant in the code). A session authenticated as tenant A could inject `temper` calls referencing tenant B and file its trajectory — containing A's code and results — under **tenant B**. Capture was also unbounded (text, turns, actions, observability keys, stdio frames).

## Fix
- **Identity-keyed storage**: the upload uses `self.identity_tenant` (authenticated), never a code-derived tenant. `tenants_seen` is observability-only and warns once per distinct foreign tenant.
- **Bounded capture**: per-turn text (16KB, char-boundary-safe truncation), turns (500), embedded actions (64 + serialized-size cap), distinct observability keys (256) **and** per-key byte length (256).
- **Total serialized budget**: metered on the *serialized* wire cost (JSON-escaped text + duplicated error field + actions + per-turn envelope), capped under the server's 2 MiB ingest limit — so a within-per-turn-cap session can't produce a trajectory the server 413s and the client silently drops (audit suppression).
- **Bounded stdio frames**: each JSON-RPC frame is read through a capped reader that never buffers more than one budget, drains an oversized frame reusing one buffer, drops it with a warning, and resyncs; invalid UTF-8 dropped, not fatal.
- **Removed the code-derived `X-Entity-Type` header** (no server reader; an illegal byte would break the upload).
- Split bounds + framing (and tests) into `trajectory_bounds.rs`; `runtime.rs` back under 1000 lines with **no readability-ratchet bump**.

## Integrated from the competing entry (#365)
#365 flagged the unbounded stdio read that #378 missed — but its check ran *after* `next_line()` had buffered the whole line, so it did not bound memory. Reimplemented correctly here (bounds the allocation during the read).

## Review gauntlet (all findings fixed)
- Panel: Codex/Sol #1 (FAIL→fixed), independent Codex/Sol #2 (FAIL→fixed), Fable (FAIL→fixed), code-reviewer. Key P1s: seen-key **byte-length** bound (~500MiB retention) and the serialized-size budget (413 audit-suppression).
- **Grok adversarial ×2 → PASS, zero P0/P1/P2** (round 1 caught that my byte budget metered raw string bytes, not serialized size — fixed and covered by a worst-case serialization test).
- 36 temper-mcp tests, fmt + clippy clean.

## Live E2E
`temper mcp` stdio server against a running `temper serve`: initialize + `execute(1+1)` + a **1.1 MiB oversized frame** + `execute(2+2)`. All three requests responded — id 3 *after* the oversized frame — proving the frame was dropped and the session resynced live. Trajectory upload fired on session close.

Note: local pre-push full-suite was bypassed only because the off-limits `temper-actor-runtime` integration tests require a Docker Postgres testcontainer unavailable in this environment; CI runs them with Docker.

@greptile-apps review

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR keys MCP trajectory uploads to the authenticated session tenant and adds bounded capture and stdio framing.
- Caps trajectory text, actions, turns, observability keys, serialized upload size, and inbound JSON-RPC frames.
- Removes code-derived upload headers and records foreign-tenant references only as observability signals.
- Adds focused runtime and framing tests plus an ADR documenting the security model.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The repeated-initialize audit-loss path should be fixed before merging because it lets a live session discard previously captured execute turns.

Tenant routing, serialized-size metering, and stdio framing are well bounded, but unconditional trajectory replacement leaves a reachable way to suppress part of the session audit record.

**Files Needing Attention:** crates/temper-mcp/src/runtime.rs and crates/temper-mcp/src/runtime_test.rs
</details>

<details open><summary><h3>Security Review</h3></summary>

Repeated initialization replaces the current trajectory without uploading it, so a session can discard already-recorded execute turns from its audit trail.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/temper-mcp/src/runtime.rs | Correctly isolates upload ownership and meters capture, but repeated initialization silently replaces an active trajectory. |
| crates/temper-mcp/src/trajectory_bounds.rs | Adds conservative trajectory bounds and allocation-bounded stdio framing with correct oversized-frame resynchronization. |
| crates/temper-mcp/src/runtime_test.rs | Thoroughly exercises identity routing and capture limits, though the repeated-initialize test validates budget reset without checking preservation of existing turns. |
| docs/adrs/0165-mcp-trajectory-tenant-and-bounds.md | Clearly documents the tenant-isolation and bounded-capture decisions but does not address preservation of active turns during reinitialization. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client as MCP Client
    participant MCP as temper-mcp
    participant Sandbox
    participant Server as Temper Server
    Client->>MCP: initialize
    MCP->>MCP: create identity-owned trajectory
    Client->>MCP: execute(code)
    MCP->>Sandbox: run bounded input
    Sandbox-->>MCP: result
    MCP->>MCP: record bounded turn
    Client->>MCP: initialize again
    MCP->>MCP: replace active trajectory
    Note over MCP: Earlier unflushed turns are discarded
    Client-->>MCP: close
    MCP->>Server: upload remaining trajectory
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20nerdsane%2Ftemper%20PR%20%23422%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=nerdsane%2Ftemper&pr=422&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Acrates%2Ftemper-mcp%2Fsrc%2Fruntime.rs%3A188%0A**Reinitialization%20discards%20captured%20turns**%0A%0AWhen%20a%20client%20sends%20another%20%60initialize%60%20request%20after%20executing%20code%2C%20%60init_trajectory%28%29%60%20replaces%20the%20active%20builder%20without%20finalizing%20it%2C%20causing%20all%20turns%20recorded%20since%20the%20previous%20initialization%20or%20flush%20to%20be%20omitted%20from%20the%20uploaded%20audit%20trajectory.%0A%0A**How%20this%20was%20verified%3A**%20The%20initialize%20handler%20unconditionally%20reaches%20this%20assignment%2C%20while%20uploads%20occur%20only%20through%20explicit%20flush%20or%20session%20finalization.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=nerdsane%2Ftemper&pr=422&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22claude%2Farn-222-trajectory-isolation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Farn-222-trajectory-isolation%22.%0A%0A%23%23%23%20Issue%201%0Acrates%2Ftemper-mcp%2Fsrc%2Fruntime.rs%3A188%0A**Reinitialization%20discards%20captured%20turns**%0A%0AWhen%20a%20client%20sends%20another%20%60initialize%60%20request%20after%20executing%20code%2C%20%60init_trajectory%28%29%60%20replaces%20the%20active%20builder%20without%20finalizing%20it%2C%20causing%20all%20turns%20recorded%20since%20the%20previous%20initialization%20or%20flush%20to%20be%20omitted%20from%20the%20uploaded%20audit%20trajectory.%0A%0A**How%20this%20was%20verified%3A**%20The%20initialize%20handler%20unconditionally%20reaches%20this%20assignment%2C%20while%20uploads%20occur%20only%20through%20explicit%20flush%20or%20session%20finalization.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=nerdsane%2Ftemper&pr=422&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Acrates%2Ftemper-mcp%2Fsrc%2Fruntime.rs%3A188%0A**Reinitialization%20discards%20captured%20turns**%0A%0AWhen%20a%20client%20sends%20another%20%60initialize%60%20request%20after%20executing%20code%2C%20%60init_trajectory%28%29%60%20replaces%20the%20active%20builder%20without%20finalizing%20it%2C%20causing%20all%20turns%20recorded%20since%20the%20previous%20initialization%20or%20flush%20to%20be%20omitted%20from%20the%20uploaded%20audit%20trajectory.%0A%0A**How%20this%20was%20verified%3A**%20The%20initialize%20handler%20unconditionally%20reaches%20this%20assignment%2C%20while%20uploads%20occur%20only%20through%20explicit%20flush%20or%20session%20finalization.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=422&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
crates/temper-mcp/src/runtime.rs:188
**Reinitialization discards captured turns**

When a client sends another `initialize` request after executing code, `init_trajectory()` replaces the active builder without finalizing it, causing all turns recorded since the previous initialization or flush to be omitted from the uploaded audit trajectory.

**How this was verified:** The initialize handler unconditionally reaches this assignment, while uploads occur only through explicit flush or session finalization.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): isolate MCP trajectory to the ..."](https://github.com/nerdsane/temper/commit/a5ded3a977af044b242786a74d78d0a3a5ade8f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53551833)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [temper-mcp: MCP Stdio Server for Temper Code Mode](https://app.greptile.com/arni-labs/-/custom-context/knowledge-base/nerdsane/temper/-/docs/temper-mcp.md)

<!-- /greptile_comment -->