### PR TITLE
fix(deps): wasmtime 29 -> 36.0.13, pin WASM feature surface (ARN-169)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,20 +4,11 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli 0.31.1",
-]
-
-[[package]]
-name = "addr2line"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
- "gimli 0.32.3",
+ "gimli",
 ]
 
 [[package]]
@@ -182,7 +173,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
 dependencies = [
- "object 0.37.3",
+ "object",
 ]
 
 [[package]]
@@ -427,11 +418,11 @@ version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
- "addr2line 0.25.1",
+ "addr2line",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.37.3",
+ "object",
  "rustc-demangle",
  "windows-link",
 ]
@@ -1149,19 +1140,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "cranelift-bforest"
-version = "0.116.1"
+name = "cranelift-assembler-x64"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e15d04a0ce86cb36ead88ad68cf693ffd6cda47052b9e0ac114bc47fd9cd23c4"
+checksum = "5f8e1303ae2128891cb59691a74de4547dd208bc8511a2f287cca2b93bb3c728"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.123.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b2740a5936332028d9a1e8f29a199de2fd386e426d44da5fea70cf8e3f8e75"
+dependencies = [
+ "cranelift-srcgen",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.123.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37fd128d3629fb105e433bda09744c5a2959cd1da04617a455c4cc17dff1ebef"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.116.1"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c6e3969a7ce267259ce244b7867c5d3bc9e65b0a87e81039588dfdeaede9f34"
+checksum = "24a88f6d5a6cf6fcbc6386415d48948094721dfa4585d6615938b11ca938f20a"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1169,11 +1178,12 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.116.1"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c22032c4cb42558371cf516bb47f26cdad1819d3475c133e93c49f50ebf304e"
+checksum = "daa4a357d030bdd586d8fe3da56b394f7f6b6ded506e59f945e7b32b1e126b71"
 dependencies = [
  "bumpalo",
+ "cranelift-assembler-x64",
  "cranelift-bforest",
  "cranelift-bitset",
  "cranelift-codegen-meta",
@@ -1181,45 +1191,51 @@ dependencies = [
  "cranelift-control",
  "cranelift-entity",
  "cranelift-isle",
- "gimli 0.31.1",
- "hashbrown 0.14.5",
+ "gimli",
+ "hashbrown 0.15.5",
  "log",
+ "pulley-interpreter",
  "regalloc2",
  "rustc-hash 2.1.1",
  "serde",
  "smallvec",
  "target-lexicon",
+ "wasmtime-internal-math",
 ]
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.116.1"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c904bc71c61b27fc57827f4a1379f29de64fe95653b620a3db77d59655eee0b8"
+checksum = "4121e36a8757dea6fb237435ee5095eba25bc13ecc2eaee57eb9bffd4b27784f"
 dependencies = [
+ "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
+ "cranelift-srcgen",
+ "heck",
+ "pulley-interpreter",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.116.1"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40180f5497572f644ce88c255480981ae2ec1d7bb4d8e0c0136a13b87a2f2ceb"
+checksum = "5173265fc30b9e42205cf06dfca9a272ee949667ce4115d975ed2c08d466e2f8"
 
 [[package]]
 name = "cranelift-control"
-version = "0.116.1"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d132c6d0bd8a489563472afc171759da0707804a65ece7ceb15a8c6d7dd5ef"
+checksum = "9b6ca8a393e66dc13f915c6f456bdcf496d78fac4995792f7022b7806352d7a4"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.116.1"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2d0d9618275474fbf679dd018ac6e009acbd6ae6850f6a67be33fb3b00b323"
+checksum = "e609d9ba416bc26d774f343295a1d411515248a6a6d83d5f7492a0dd919569fa"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1228,9 +1244,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.116.1"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fac41e16729107393174b0c9e3730fb072866100e1e64e80a1a963b2e484d57"
+checksum = "90a3a277b1a0aff1123f6bae61c080a4bcb6df964829ed427f98e18dff14257f"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1240,20 +1256,26 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.116.1"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca20d576e5070044d0a72a9effc2deacf4d6aa650403189d8ea50126483944d"
+checksum = "be53dd9b3a4cbeb9ced45c4a543ea8417ccfb334c3ba1cbb2233f4b25fb2531f"
 
 [[package]]
 name = "cranelift-native"
-version = "0.116.1"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dee82f3f1f2c4cba9177f1cc5e350fe98764379bcd29340caa7b01f85076c7"
+checksum = "ca62ab1d9f48cad97da5843b913ccf96c3dfde935af5d750cb5a6d367ccfb262"
 dependencies = [
  "cranelift-codegen",
  "libc",
  "target-lexicon",
 ]
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.123.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13b72860f54a2a19d3756bd47575fd8bddeafd6e5bbbf16372cdfebc482628a"
 
 [[package]]
 name = "crc"
@@ -1733,31 +1755,11 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys 0.3.7",
-]
-
-[[package]]
-name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys 0.5.0",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users 0.4.6",
- "winapi",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -2419,20 +2421,14 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 dependencies = [
  "fallible-iterator 0.3.0",
  "indexmap 2.13.0",
  "stable_deref_trait",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
@@ -4010,22 +4006,13 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "crc32fast",
- "hashbrown 0.15.5",
- "indexmap 2.13.0",
- "memchr",
-]
-
-[[package]]
-name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
+ "crc32fast",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
  "memchr",
 ]
 
@@ -4291,12 +4278,6 @@ dependencies = [
  "structmeta",
  "syn",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pathdiff"
@@ -4784,14 +4765,25 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "29.0.1"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d95f8575df49a2708398182f49a888cf9dc30210fb1fd2df87c889edcee75d"
+checksum = "2662666315cb90dfb4d99a652ee053d4d8598f71c474209e84da031ca56ae5a4"
 dependencies = [
  "cranelift-bitset",
  "log",
- "sptr",
- "wasmtime-math",
+ "pulley-macros",
+ "wasmtime-internal-math",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "36.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb9a7d9ed2618f94b6d054aba3eb2768c9b489fe16b4ef8847fbc6ed41b707bb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -5118,9 +5110,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.11.2"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc06e6b318142614e4a48bc725abbf08ff166694835c43c9dae5a9009704639a"
+checksum = "5216b1837de2149f8bc8e6d5f88a9326b63b8c836ed58ce4a0a29ec736a59734"
 dependencies = [
  "allocator-api2",
  "bumpalo",
@@ -5777,15 +5769,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
-name = "shellexpand"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ccc8076840c4da029af4f87e4e8daeb0fca6b87bbb02e10cb60b791450e11e4"
-dependencies = [
- "dirs 4.0.0",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5910,12 +5893,6 @@ dependencies = [
  "base64ct",
  "der",
 ]
-
-[[package]]
-name = "sptr"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
 
 [[package]]
 name = "sqlx"
@@ -6415,7 +6392,7 @@ dependencies = [
  "console",
  "deadpool-postgres",
  "dialoguer",
- "dirs 6.0.0",
+ "dirs",
  "dotenvy",
  "indicatif",
  "open",
@@ -7553,17 +7530,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "trait-variant"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7935,12 +7901,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.221.3"
+version = "0.236.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc8444fe4920de80a4fe5ab564fff2ae58b6b73166b89751f8c6c93509da32e5"
+checksum = "724fccfd4f3c24b7e589d333fc0429c68042897a7e8a5f8694f31792471841e7"
 dependencies = [
- "leb128",
- "wasmparser 0.221.3",
+ "leb128fmt",
+ "wasmparser 0.236.1",
 ]
 
 [[package]]
@@ -7990,9 +7956,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.221.3"
+version = "0.236.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d06bfa36ab3ac2be0dee563380147a5b81ba10dd8885d7fbbc9eb574be67d185"
+checksum = "a9b1e81f3eb254cf7404a82cee6926a4a3ccc5aad80cc3d43608a070c67aa1d7"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
@@ -8026,22 +7992,22 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.221.3"
+version = "0.236.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7343c42a97f2926c7819ff81b64012092ae954c5d83ddd30c9fcdefd97d0b283"
+checksum = "2df225df06a6df15b46e3f73ca066ff92c2e023670969f7d50ce7d5e695abbb1"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.221.3",
+ "wasmparser 0.236.1",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "29.0.1"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11976a250672556d1c4c04c6d5d7656ac9192ac9edc42a4587d6c21460010e69"
+checksum = "93d881c5dcff5f230368d84fcf110ca25fe47badc694e7d559c3891492159916"
 dependencies = [
- "addr2line 0.24.2",
+ "addr2line",
  "anyhow",
  "async-trait",
  "bitflags 2.11.0",
@@ -8050,104 +8016,128 @@ dependencies = [
  "cfg-if",
  "encoding_rs",
  "fxprof-processed-profile",
- "gimli 0.31.1",
- "hashbrown 0.14.5",
+ "gimli",
+ "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "ittapi",
  "libc",
  "log",
  "mach2",
  "memfd",
- "object 0.36.7",
+ "object",
  "once_cell",
- "paste",
  "postcard",
- "psm",
  "pulley-interpreter",
  "rayon",
- "rustix 0.38.44",
+ "rustix 1.1.4",
  "semver",
  "serde",
  "serde_derive",
  "serde_json",
  "smallvec",
- "sptr",
  "target-lexicon",
- "trait-variant",
- "wasm-encoder 0.221.3",
- "wasmparser 0.221.3",
- "wasmtime-asm-macros",
- "wasmtime-cache",
- "wasmtime-component-macro",
- "wasmtime-component-util",
- "wasmtime-cranelift",
+ "wasm-encoder 0.236.1",
+ "wasmparser 0.236.1",
  "wasmtime-environ",
- "wasmtime-fiber",
- "wasmtime-jit-debug",
- "wasmtime-jit-icache-coherence",
- "wasmtime-math",
- "wasmtime-slab",
- "wasmtime-versioned-export-macros",
- "wasmtime-winch",
+ "wasmtime-internal-asm-macros",
+ "wasmtime-internal-cache",
+ "wasmtime-internal-component-macro",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-fiber",
+ "wasmtime-internal-jit-debug",
+ "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-math",
+ "wasmtime-internal-slab",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+ "wasmtime-internal-winch",
  "wat",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
-name = "wasmtime-asm-macros"
-version = "29.0.1"
+name = "wasmtime-environ"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f178b0d125201fbe9f75beaf849bd3e511891f9e45ba216a5b620802ccf64f2"
+checksum = "a4b25534a3ff9dd844701c2bc997f76cb1f97bf2af0546a7066ae96f49c2e068"
+dependencies = [
+ "anyhow",
+ "cpp_demangle",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli",
+ "indexmap 2.13.0",
+ "log",
+ "object",
+ "postcard",
+ "rustc-demangle",
+ "semver",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon",
+ "wasm-encoder 0.236.1",
+ "wasmparser 0.236.1",
+ "wasmprinter",
+ "wasmtime-internal-component-util",
+]
+
+[[package]]
+name = "wasmtime-internal-asm-macros"
+version = "36.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d02832d760351fb3a1aa99eb8f7b95596c0f4e4e52df1547fcdb295ea5c780c"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
-name = "wasmtime-cache"
-version = "29.0.1"
+name = "wasmtime-internal-cache"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1161c8f62880deea07358bc40cceddc019f1c81d46007bc390710b2fe24ffc"
+checksum = "651f8a16b51cde3ee8bd5b775bcedc24b66040d7dca1f13ad855b10c660e1d01"
 dependencies = [
  "anyhow",
- "base64 0.21.7",
+ "base64 0.22.1",
  "directories-next",
  "log",
  "postcard",
- "rustix 0.38.44",
+ "rustix 1.1.4",
  "serde",
  "serde_derive",
  "sha2 0.10.9",
  "toml",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "zstd",
 ]
 
 [[package]]
-name = "wasmtime-component-macro"
-version = "29.0.1"
+name = "wasmtime-internal-component-macro"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d74de6592ed945d0a602f71243982a304d5d02f1e501b638addf57f42d57dfaf"
+checksum = "ba2ed6dbe24607573f7bcc59222f3bc2e7f7d31609466055c67b9484045a374a"
 dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
  "syn",
- "wasmtime-component-util",
- "wasmtime-wit-bindgen",
- "wit-parser 0.221.3",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-wit-bindgen",
+ "wit-parser 0.236.1",
 ]
 
 [[package]]
-name = "wasmtime-component-util"
-version = "29.0.1"
+name = "wasmtime-internal-component-util"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707dc7b3c112ab5a366b30cfe2fb5b2f8e6a0f682f16df96a5ec582bfe6f056e"
+checksum = "e21aadbf677ee3503ef2580ce3c6955508e90a2810e961739b30f79585af254c"
 
 [[package]]
-name = "wasmtime-cranelift"
-version = "29.0.1"
+name = "wasmtime-internal-cranelift"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "366be722674d4bf153290fbcbc4d7d16895cc82fb3e869f8d550ff768f9e9e87"
+checksum = "65821bab751956cddfc6ee957beb13a0e2a6cf682050d75dfb7a0228db2ed499"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -8156,103 +8146,93 @@ dependencies = [
  "cranelift-entity",
  "cranelift-frontend",
  "cranelift-native",
- "gimli 0.31.1",
- "itertools 0.12.1",
+ "gimli",
+ "itertools 0.14.0",
  "log",
- "object 0.36.7",
+ "object",
+ "pulley-interpreter",
  "smallvec",
  "target-lexicon",
- "thiserror 1.0.69",
- "wasmparser 0.221.3",
+ "thiserror 2.0.18",
+ "wasmparser 0.236.1",
  "wasmtime-environ",
- "wasmtime-versioned-export-macros",
+ "wasmtime-internal-math",
+ "wasmtime-internal-versioned-export-macros",
 ]
 
 [[package]]
-name = "wasmtime-environ"
-version = "29.0.1"
+name = "wasmtime-internal-fiber"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdadc1af7097347aa276a4f008929810f726b5b46946971c660b6d421e9994ad"
-dependencies = [
- "anyhow",
- "cpp_demangle",
- "cranelift-bitset",
- "cranelift-entity",
- "gimli 0.31.1",
- "indexmap 2.13.0",
- "log",
- "object 0.36.7",
- "postcard",
- "rustc-demangle",
- "semver",
- "serde",
- "serde_derive",
- "smallvec",
- "target-lexicon",
- "wasm-encoder 0.221.3",
- "wasmparser 0.221.3",
- "wasmprinter",
- "wasmtime-component-util",
-]
-
-[[package]]
-name = "wasmtime-fiber"
-version = "29.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccba90d4119f081bca91190485650730a617be1fff5228f8c4757ce133d21117"
+checksum = "18cf73e5e8d28a2b30d86454430c7dea3b593598dcbbc0ebb927ca2716222d41"
 dependencies = [
  "anyhow",
  "cc",
  "cfg-if",
- "rustix 0.38.44",
- "wasmtime-asm-macros",
- "wasmtime-versioned-export-macros",
- "windows-sys 0.59.0",
+ "libc",
+ "rustix 1.1.4",
+ "wasmtime-internal-asm-macros",
+ "wasmtime-internal-versioned-export-macros",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
-name = "wasmtime-jit-debug"
-version = "29.0.1"
+name = "wasmtime-internal-jit-debug"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e7b61488a5ee00c35c8c22de707c36c0aecacf419a3be803a6a2ba5e860f56a"
+checksum = "4279dc3147ddaa21e5b3d2c0eaff117881c4f937747bdd2379eb361665843bd3"
 dependencies = [
- "object 0.36.7",
- "rustix 0.38.44",
- "wasmtime-versioned-export-macros",
+ "cc",
+ "object",
+ "rustix 1.1.4",
+ "wasmtime-internal-versioned-export-macros",
 ]
 
 [[package]]
-name = "wasmtime-jit-icache-coherence"
-version = "29.0.1"
+name = "wasmtime-internal-jit-icache-coherence"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec5e8552e01692e6c2e5293171704fed8abdec79d1a6995a0870ab190e5747d1"
+checksum = "a8eb677944201839c0be19b39b0f19dcd663efbcbc05a09c73f26fec7bdf0331"
 dependencies = [
  "anyhow",
  "cfg-if",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
-name = "wasmtime-math"
-version = "29.0.1"
+name = "wasmtime-internal-math"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29210ec2aa25e00f4d54605cedaf080f39ec01a872c5bd520ad04c67af1dde17"
+checksum = "db9a153e184878df396a11f8912444531c2e4d0c7a1d9e9a52b30d9853d89cb9"
 dependencies = [
  "libm",
 ]
 
 [[package]]
-name = "wasmtime-slab"
-version = "29.0.1"
+name = "wasmtime-internal-slab"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb5821a96fa04ac14bc7b158bb3d5cd7729a053db5a74dad396cd513a5e5ccf"
+checksum = "b771494bead25e1f0c4c89a9476dd0b65eacca314ed82125f1e197fbc3f0396b"
 
 [[package]]
-name = "wasmtime-versioned-export-macros"
-version = "29.0.1"
+name = "wasmtime-internal-unwinder"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ff86db216dc0240462de40c8290887a613dddf9685508eb39479037ba97b5b"
+checksum = "90199caed6925420434a923861d8ad813689ca8533d2c679f805d12e35b40a4b"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "log",
+ "object",
+]
+
+[[package]]
+name = "wasmtime-internal-versioned-export-macros"
+version = "36.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae71687aa834f9cc9eb5b0f97c85184d7dc70b84d32fd8927af0887998a1ba35"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8260,10 +8240,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-wasi"
-version = "29.0.1"
+name = "wasmtime-internal-winch"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d1be69bfcab1bdac74daa7a1f9695ab992b9c8e21b9b061e7d66434097e0ca4"
+checksum = "5d0ba45c0d766dd56257d97702d3284b6f69efdd4c53ca981a0754cc0a139df0"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "gimli",
+ "object",
+ "target-lexicon",
+ "wasmparser 0.236.1",
+ "wasmtime-environ",
+ "wasmtime-internal-cranelift",
+ "winch-codegen",
+]
+
+[[package]]
+name = "wasmtime-internal-wit-bindgen"
+version = "36.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a64d5112c06f9d54b41e61f0b757d3a5a52361bf359f01131cc7cb8551ac73"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "heck",
+ "indexmap 2.13.0",
+ "wit-parser 0.236.1",
+]
+
+[[package]]
+name = "wasmtime-wasi"
+version = "36.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e4772f39340104c70837d421c71c50364c185936f07eaee19e46cb0754c9e1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8278,45 +8288,29 @@ dependencies = [
  "futures",
  "io-extras",
  "io-lifetimes",
- "rustix 0.38.44",
+ "rustix 1.1.4",
  "system-interface",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
- "trait-variant",
  "url",
  "wasmtime",
+ "wasmtime-wasi-io",
  "wiggle",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
-name = "wasmtime-winch"
-version = "29.0.1"
+name = "wasmtime-wasi-io"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdbabfb8f20502d5e1d81092b9ead3682ae59988487aafcd7567387b7a43cf8f"
+checksum = "b1267c55a52d9ce27da6ff522ddb5b847e811cf477b0ef4c7c1155dd544c25ac"
 dependencies = [
  "anyhow",
- "cranelift-codegen",
- "gimli 0.31.1",
- "object 0.36.7",
- "target-lexicon",
- "wasmparser 0.221.3",
- "wasmtime-cranelift",
- "wasmtime-environ",
- "winch-codegen",
-]
-
-[[package]]
-name = "wasmtime-wit-bindgen"
-version = "29.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8358319c2dd1e4db79e3c1c5d3a5af84956615343f9f89f4e4996a36816e06e6"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.13.0",
- "wit-parser 0.221.3",
+ "async-trait",
+ "bytes",
+ "futures",
+ "wasmtime",
 ]
 
 [[package]]
@@ -8425,14 +8419,14 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "29.0.1"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9af35bc9629c52c261465320a9a07959164928b4241980ba1cf923b9e6751d"
+checksum = "3185c97adf4d5f4c0d2abfea7f0bdeb21b486970acd2cf19c7a7fd95308f1764"
 dependencies = [
  "anyhow",
  "async-trait",
  "bitflags 2.11.0",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
  "wasmtime",
  "wiggle-macro",
@@ -8440,24 +8434,23 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "29.0.1"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cf267dd05673912c8138f4b54acabe6bd53407d9d1536f0fadb6520dd16e101"
+checksum = "13a019367ecff91d714d8f6cba589c36d7b16195eff0598236f9ce5aaf8b811d"
 dependencies = [
  "anyhow",
  "heck",
  "proc-macro2",
  "quote",
- "shellexpand",
  "syn",
  "witx",
 ]
 
 [[package]]
 name = "wiggle-macro"
-version = "29.0.1"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c5c473d4198e6c2d377f3809f713ff0c110cab88a0805ae099a82119ee250c"
+checksum = "5e2f5a33059321aee91888c331b45de1d6e9f9d0f89ab88398ef1fda2d3ee1fb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8498,20 +8491,22 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "29.0.1"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f849ef2c5f46cb0a20af4b4487aaa239846e52e2c03f13fa3c784684552859c"
+checksum = "82ea9625459ce35d6a4188cf0f07c9095cbb0e5afd86f711d63955bfc4216e64"
 dependencies = [
  "anyhow",
+ "cranelift-assembler-x64",
  "cranelift-codegen",
- "gimli 0.31.1",
+ "gimli",
  "regalloc2",
  "smallvec",
  "target-lexicon",
- "thiserror 1.0.69",
- "wasmparser 0.221.3",
- "wasmtime-cranelift",
+ "thiserror 2.0.18",
+ "wasmparser 0.236.1",
  "wasmtime-environ",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-math",
 ]
 
 [[package]]
@@ -8929,9 +8924,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.221.3"
+version = "0.236.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "896112579ed56b4a538b07a3d16e562d101ff6265c46b515ce0c701eef16b2ac"
+checksum = "16e4833a20cd6e85d6abfea0e63a399472d6f88c6262957c17f546879a80ba15"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -8942,7 +8937,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.221.3",
+ "wasmparser 0.236.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,9 +161,11 @@ temper-transport = { path = "crates/temper-transport" }
 temper-actor-runtime = { path = "crates/temper-actor-runtime" }
 temper-agents = { path = "crates/temper-agents" }
 
-# WASM runtime
-wasmtime = { version = "29", features = ["component-model", "profiling"] }
-wasmtime-wasi = "29"
+# WASM runtime. Floor is 36.0.13: 36.0.7 fixes RUSTSEC-2026-0096 (the ARN-169
+# objective), and 36.0.13 additionally fixes RUSTSEC-2026-0222, so the lower bound
+# must not admit an earlier 36.x patch.
+wasmtime = { version = "36.0.13", features = ["component-model", "profiling"] }
+wasmtime-wasi = "36.0.13"
 sha2 = "0.10"
 hostname = "0.4"
 aes-gcm = "0.10"

--- a/crates/temper-wasm/src/engine/mod.rs
+++ b/crates/temper-wasm/src/engine/mod.rs
@@ -96,12 +96,47 @@ impl ResourceLimiter for MemoryLimiter {
     fn table_growing(
         &mut self,
         _current: usize,
-        _desired: usize,
+        desired: usize,
         _maximum: Option<usize>,
     ) -> Result<bool, wasmtime::Error> {
-        Ok(true)
+        // Bound table growth too: table elements are host allocations (a funcref/
+        // externref slot each) that the memory limiter does not cover, so an
+        // unbounded `table.grow` is a host-memory exhaustion vector (ARN-169).
+        // Deny past the cap (grow returns -1) rather than trapping.
+        Ok(desired <= MAX_TABLE_ELEMENTS)
+    }
+
+    // The per-table/per-memory element caps above only bound host allocation if
+    // the *number* of tables and memories is also bounded — wasmtime's default
+    // limiter allows 10,000 of each per store, so a guest could otherwise declare
+    // thousands of tables each at the element cap and multiply the budget. Cap the
+    // counts to what a single-module guest actually needs (ARN-169).
+    fn memories(&self) -> usize {
+        MAX_MEMORIES
+    }
+
+    fn tables(&self) -> usize {
+        MAX_TABLES
     }
 }
+
+/// Maximum number of elements any single guest table may hold. Table slots are
+/// host allocations outside the linear-memory budget; this caps the host memory a
+/// guest can force through `table.grow` (ARN-169).
+const MAX_TABLE_ELEMENTS: usize = 1_000_000;
+
+/// Maximum number of linear memories a guest store may create. With
+/// `wasm_multi_memory(false)` a module already declares at most one; this makes
+/// the store-level bound explicit so the per-memory `max_memory` budget cannot be
+/// multiplied (ARN-169).
+const MAX_MEMORIES: usize = 1;
+
+/// Maximum number of tables a guest store may create. Together with
+/// `MAX_TABLE_ELEMENTS` this bounds total table host memory to
+/// `MAX_TABLES * MAX_TABLE_ELEMENTS` slots. Generous enough for ordinary
+/// reference-types modules (typically one funcref table) while preventing the
+/// default 10,000-table multiplier (ARN-169).
+const MAX_TABLES: usize = 8;
 
 /// Compiled module cache entry.
 struct CachedModule {
@@ -229,6 +264,18 @@ impl WasmEngine {
         config.consume_fuel(true);
         config.epoch_interruption(true);
         config.wasm_component_model(true);
+        // Pin the WASM feature surface across the wasmtime 29 -> 36 bump (ARN-169).
+        // wasmtime 30+ turns several proposals on by default; leaving them at the
+        // 36 defaults would silently widen the guest attack surface relative to 29:
+        //   - memory64: rejected at compile on 29, and a prerequisite for the very
+        //     advisory this bump fixes (RUSTSEC-2026-0096) — keep it off;
+        //   - threads/shared memory and multiple memories: each lets a guest hold a
+        //     linear memory the per-memory `max_memory` limiter does not sum, so a
+        //     guest could exceed the intended per-invocation memory budget.
+        // Temper's guests are single-memory wasm32 modules and use none of these.
+        config.wasm_memory64(false);
+        config.wasm_threads(false);
+        config.wasm_multi_memory(false);
         if let Some(strategy) = configured_profiling_strategy() {
             config.profiler(strategy);
         }
@@ -484,7 +531,7 @@ impl WasmEngine {
             );
             let _entered = phase.enter();
             let wasi_stderr_pipe = if needs_wasi {
-                Some(wasmtime_wasi::pipe::MemoryOutputPipe::new(64 * 1024))
+                Some(wasmtime_wasi::p2::pipe::MemoryOutputPipe::new(64 * 1024))
             } else {
                 None
             };

--- a/crates/temper-wasm/src/engine/tests.rs
+++ b/crates/temper-wasm/src/engine/tests.rs
@@ -35,13 +35,20 @@ const WAT_INFINITE_LOOP: &str = r#"
     )
 "#;
 
-// Tries to grow memory by 1000 pages (64 MB) — exceeds 16 MB default.
+// Tries to grow memory by 1000 pages (64 MB) — exceeds the budget. Traps
+// (`unreachable`) if the grow unexpectedly *succeeds* (result != -1), so a test
+// asserting the invocation is Ok proves the limiter actually denied the growth —
+// it is not vacuous.
 const WAT_MEMORY_GROW: &str = r#"
     (module
       (memory (export "memory") 1)
       (func (export "run") (param i32 i32) (result i32)
         (memory.grow (i32.const 1000))
-        drop
+        i32.const -1
+        i32.ne
+        if
+          unreachable
+        end
         i32.const 0
       )
     )
@@ -455,20 +462,14 @@ async fn memory_growth_denied_by_limiter() {
         .invoke(&hash, &make_context(), make_host(), &limits, make_streams())
         .await;
 
-    // Module returns normally (memory.grow returned -1 per spec — not a trap).
-    // The invocation itself succeeds (no crash), but the result is empty
-    // because the module didn't call host_set_result.
+    // The module traps (`unreachable`) if `memory.grow` returned anything other
+    // than -1, so a successful invocation proves the limiter actually denied the
+    // 1000-page growth (grow returned -1 per spec, not a crash). If the limiter
+    // had NOT fired, the grow would succeed and the module would trap — surfacing
+    // as an error, failing this assertion. Not vacuous.
     assert!(
-        result.is_ok() || matches!(result, Err(WasmError::Invocation(_))),
-        "memory denial should not cause fuel/timeout error, got: {result:?}"
-    );
-    // Critically: no panic, no FuelExhausted, no Timeout.
-    assert!(
-        !matches!(
-            result,
-            Err(WasmError::FuelExhausted) | Err(WasmError::Timeout(_))
-        ),
-        "memory denial should not be misclassified"
+        result.is_ok(),
+        "memory.grow must return -1 (limiter denied growth), got: {result:?}"
     );
 }
 
@@ -493,5 +494,231 @@ async fn noop_module_completes() {
                 | Err(WasmError::MemoryLimitExceeded { .. })
         ),
         "noop should not hit resource limits, got: {result:?}"
+    );
+}
+
+// ARN-169: WASI compatibility + sandbox-limit regressions across the
+// wasmtime 29 -> 36 bump. A module declaring more initial memory than the
+// budget must be rejected at instantiation, and a WASIp1 module must still
+// invoke end to end after the `wasmtime_wasi::p2` module reshuffle.
+
+const WAT_INITIAL_MEMORY_TWO_PAGES: &str = r#"
+    (module
+      (memory (export "memory") 2)
+      (func (export "run") (param i32 i32) (result i32)
+        i32.const 0
+      )
+    )
+"#;
+
+const WAT_WASI_STDERR: &str = r#"
+    (module
+      (import "wasi_snapshot_preview1" "fd_write"
+        (func $fd_write (param i32 i32 i32 i32) (result i32)))
+      (memory (export "memory") 1)
+      (data (i32.const 32) "wasi stderr\n")
+      (func (export "run") (param i32 i32) (result i32)
+        i32.const 0
+        i32.const 32
+        i32.store
+        i32.const 4
+        i32.const 12
+        i32.store
+        i32.const 2
+        i32.const 0
+        i32.const 1
+        i32.const 16
+        call $fd_write
+        if
+          unreachable
+        end
+        i32.const 0
+      )
+    )
+"#;
+
+#[tokio::test]
+async fn initial_memory_over_budget_is_rejected() {
+    let engine = WasmEngine::new().unwrap();
+    let hash = engine
+        .compile_and_cache(WAT_INITIAL_MEMORY_TWO_PAGES.as_bytes())
+        .unwrap();
+    let limits = WasmResourceLimits {
+        max_memory: 64 * 1024, // 1 WASM page; the module declares 2
+        ..WasmResourceLimits::default()
+    };
+
+    let result = engine
+        .invoke(&hash, &make_context(), make_host(), &limits, make_streams())
+        .await;
+
+    assert!(
+        matches!(result, Err(WasmError::Instantiation(_))),
+        "oversized initial memory must fail at instantiation: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn wasi_preview1_module_invokes_end_to_end() {
+    let engine = WasmEngine::new().unwrap();
+    let hash = engine
+        .compile_and_cache(WAT_WASI_STDERR.as_bytes())
+        .unwrap();
+
+    let result = engine
+        .invoke(
+            &hash,
+            &make_context(),
+            make_host(),
+            &WasmResourceLimits::default(),
+            make_streams(),
+        )
+        .await;
+
+    assert!(result.is_ok(), "WASIp1 invocation failed: {result:?}");
+}
+
+// ARN-169: the wasmtime 36 feature surface is pinned to match the 29 sandbox —
+// memory64 and multiple memories are rejected at compile, and table growth is
+// bounded like linear memory.
+
+const WAT_MEMORY64: &str = r#"
+    (module
+      (memory i64 1)
+      (func (export "run") (param i32 i32) (result i32)
+        i32.const 0
+      )
+    )
+"#;
+
+const WAT_MULTI_MEMORY: &str = r#"
+    (module
+      (memory 1)
+      (memory 1)
+      (func (export "run") (param i32 i32) (result i32)
+        i32.const 0
+      )
+    )
+"#;
+
+const WAT_TABLE_GROW: &str = r#"
+    (module
+      (memory (export "memory") 1)
+      (table 1 funcref)
+      (func (export "run") (param i32 i32) (result i32)
+        (table.grow (ref.null func) (i32.const 2000000))
+        i32.const -1
+        i32.ne
+        if
+          unreachable
+        end
+        i32.const 0
+      )
+    )
+"#;
+
+#[test]
+fn memory64_module_is_rejected() {
+    let engine = WasmEngine::new().unwrap();
+    assert!(
+        engine.compile_and_cache(WAT_MEMORY64.as_bytes()).is_err(),
+        "memory64 must be rejected at compile — it widens the surface and was a \
+         RUSTSEC-2026-0096 prerequisite"
+    );
+}
+
+#[test]
+fn multi_memory_module_is_rejected() {
+    let engine = WasmEngine::new().unwrap();
+    assert!(
+        engine
+            .compile_and_cache(WAT_MULTI_MEMORY.as_bytes())
+            .is_err(),
+        "multiple memories must be rejected: the per-memory limiter does not sum them"
+    );
+}
+
+#[tokio::test]
+async fn table_growth_denied_past_cap() {
+    let engine = WasmEngine::new().unwrap();
+    let hash = engine.compile_and_cache(WAT_TABLE_GROW.as_bytes()).unwrap();
+
+    let result = engine
+        .invoke(
+            &hash,
+            &make_context(),
+            make_host(),
+            &WasmResourceLimits::default(),
+            make_streams(),
+        )
+        .await;
+
+    // The module traps if table.grow returned anything but -1, so a successful
+    // invocation proves the limiter denied the 2,000,000-element growth.
+    assert!(
+        result.is_ok(),
+        "table.grow past the cap must return -1 (limiter denied), got: {result:?}"
+    );
+}
+
+// A shared memory (threads proposal) must be rejected — the pin is load-bearing
+// because wasmtime does not invoke the memory limiter for shared memories.
+const WAT_SHARED_MEMORY: &str = r#"
+    (module
+      (memory 1 1 shared)
+      (func (export "run") (param i32 i32) (result i32)
+        i32.const 0
+      )
+    )
+"#;
+
+const WAT_MANY_TABLES: &str = r#"
+    (module
+      (memory (export "memory") 1)
+      (table $0 1 funcref)
+      (table $1 1 funcref)
+      (table $2 1 funcref)
+      (table $3 1 funcref)
+      (table $4 1 funcref)
+      (table $5 1 funcref)
+      (table $6 1 funcref)
+      (table $7 1 funcref)
+      (table $8 1 funcref)
+      (func (export "run") (param i32 i32) (result i32)
+        i32.const 0
+      )
+    )
+"#;
+#[test]
+fn shared_memory_module_is_rejected() {
+    let engine = WasmEngine::new().unwrap();
+    assert!(
+        engine
+            .compile_and_cache(WAT_SHARED_MEMORY.as_bytes())
+            .is_err(),
+        "shared memory must be rejected: the limiter is not consulted for it"
+    );
+}
+
+#[tokio::test]
+async fn too_many_tables_is_rejected() {
+    // MAX_TABLES tables is allowed; more must be denied at instantiation so the
+    // per-table element cap is a real store-wide budget, not per-table only.
+    let engine = WasmEngine::new().unwrap();
+    let hash = engine
+        .compile_and_cache(WAT_MANY_TABLES.as_bytes())
+        .unwrap();
+    let result = engine
+        .invoke(
+            &hash,
+            &make_context(),
+            make_host(),
+            &WasmResourceLimits::default(),
+            make_streams(),
+        )
+        .await;
+    assert!(
+        matches!(result, Err(WasmError::Instantiation(_))),
+        "a module declaring more than MAX_TABLES tables must fail instantiation: {result:?}"
     );
 }

--- a/docs/adrs/0159-wasmtime-36-security-update.md
+++ b/docs/adrs/0159-wasmtime-36-security-update.md
@@ -1,0 +1,78 @@
+# ADR-0159: Update Wasmtime 29 → 36 (RUSTSEC-2026-0096)
+
+- Status: Accepted
+- Date: 2026-08-14
+- Issue: ARN-169
+- Related: `crates/temper-wasm` (the only crate that depends on Wasmtime)
+
+## Context
+
+The workspace pinned `wasmtime = "29"` / `wasmtime-wasi = "29"`. Wasmtime 29 is
+affected by **RUSTSEC-2026-0096** (CVSS 9.0). Temper compiles and runs untrusted
+guest WASM modules (`temper-wasm`), so a vulnerability in the WASM runtime is
+directly reachable by guest input and must be closed.
+
+## Decision
+
+Update to `wasmtime = "36.0.13"` / `wasmtime-wasi = "36.0.13"` — a maintained 36.x
+train that carries the fix (36.0.7 patches RUSTSEC-2026-0096), chosen over the
+newest (46.x) to minimize API churn. The floor is `36.0.13` specifically, not
+`36.0.12`, because 36.0.13 also fixes RUSTSEC-2026-0222, so an earlier 36.x patch
+must not be admitted. `cargo audit` confirms zero wasmtime advisories on the
+resolved graph, and RUSTSEC-2026-0096 present on `main` / gone on this branch.
+
+The one import the API move requires:
+`wasmtime_wasi::pipe::MemoryOutputPipe` → `wasmtime_wasi::p2::pipe::MemoryOutputPipe`.
+
+**Pin the WASM feature surface so the bump does not widen the sandbox.** wasmtime
+30+ turns several proposals on by default that 29 rejected; inheriting the 36
+defaults would silently expand what a guest can do relative to the reviewed 29
+surface. The engine now sets these explicitly:
+- `wasm_memory64(false)` — 29 rejected 64-bit memories at compile, and memory64 is
+  a prerequisite for RUSTSEC-2026-0096; keep it rejected.
+- `wasm_threads(false)` — rejects shared memories, which a guest could otherwise
+  grow outside the per-memory `max_memory` limiter.
+- `wasm_multi_memory(false)` — the `max_memory` limiter caps each memory
+  individually; a single memory per module keeps the per-invocation budget meaningful.
+- `MemoryLimiter` now bounds table and memory host allocation on two axes:
+  `table_growing` denies growth past `MAX_TABLE_ELEMENTS` (1,000,000) per table,
+  and `tables()`/`memories()` cap the store's table/memory *counts* (`MAX_TABLES`
+  = 8, `MAX_MEMORIES` = 1). wasmtime's default limiter allows 10,000 of each, so
+  the per-table element cap alone was not a store-wide budget — a guest could
+  declare thousands of tables at the cap. Together these bound total table host
+  memory to `MAX_TABLES * MAX_TABLE_ELEMENTS`.
+
+Temper's guests are single-memory wasm32 modules and use none of the disabled
+features; the `temper-wasm` engine suite passes with the surface pinned.
+
+## Consequences
+
+- RUSTSEC-2026-0096 (and RUSTSEC-2026-0222, via the 36.0.13 floor) is closed for
+  the guest-WASM execution path.
+- The reviewed 29 sandbox surface is *preserved*, not merely inherited: memory64,
+  shared memory, and multiple memories are rejected; the linear-memory limiter and
+  the new table cap deny growth past budget; fuel/epoch timeouts fire; traps stay
+  isolated. Regression tests cover each: `memory_growth_denied_by_limiter` (now
+  non-vacuous — the guest traps if the grow unexpectedly succeeds),
+  `initial_memory_over_budget_is_rejected`, `table_growth_denied_past_cap`,
+  `too_many_tables_is_rejected`, `memory64_module_is_rejected`,
+  `multi_memory_module_is_rejected`, `shared_memory_module_is_rejected`, and
+  `wasi_preview1_module_invokes_end_to_end`.
+
+## Follow-ups (pre-existing, tracked separately)
+
+- **WASI host-side allocation in preview1 host calls.** `random_get` (and peers)
+  allocate a host buffer sized by the guest-supplied length before the guest-memory
+  bounds check; the `ResourceLimiter` governs guest memory/tables, not host-side
+  allocations inside host functions, so a guest can force a large transient host
+  allocation. This predates the bump (present on 29) and its clean fix needs either
+  a wasmtime train with the embedder allocation controls (42+) or a custom WASI
+  host wrapper — a separate hardening effort, not this security patch.
+
+## Alternatives considered
+
+- **Jump straight to 46.x (latest).** Rejected for now: a larger API delta for no
+  additional security benefit over 36.x for this advisory. A later routine bump can
+  move further once the surface is re-reviewed.
+- **Backport a patch onto 29.** Not offered upstream; the fix ships in the newer
+  release trains.


### PR DESCRIPTION
Closes **ARN-169**. Supersedes #345 (rebased onto current `main`, hardened per review).

## Why
wasmtime 29 is affected by **RUSTSEC-2026-0096** (CVSS 9.0). `temper-wasm` runs untrusted guest WASM, so the runtime CVE is guest-reachable. `cargo audit` flags it on wasmtime 29.0.1 on `main`; it is gone on this branch.

## What
- **Bump** wasmtime/wasmtime-wasi `29 → 36.0.13`. 36.0.7 fixes RUSTSEC-2026-0096; 36.0.13 also fixes RUSTSEC-2026-0222, so the floor is `36.0.13`. One import move: `wasmtime_wasi::pipe::MemoryOutputPipe → wasmtime_wasi::p2::pipe::MemoryOutputPipe`.
- **Pin the feature surface so the bump does not widen the sandbox.** wasmtime 30+ enables several proposals by default that 29 rejected — most importantly `memory64`, which is a *prerequisite* for RUSTSEC-2026-0096. The engine now sets `wasm_memory64(false)`, `wasm_threads(false)`, `wasm_multi_memory(false)`.
- **Bound table/memory host allocation on both axes.** `MemoryLimiter` caps table growth (`MAX_TABLE_ELEMENTS = 1,000,000`) **and** the table/memory counts (`tables()=8`, `memories()=1`) — wasmtime's default limiter allows 10,000 of each, so the per-table cap alone was not a store-wide budget.

## Review gauntlet (all findings fixed)
- Two independent Codex/Sol (both FAIL→fixed): caught that the naive bump *widens* the sandbox (memory64/threads/multi-memory defaults, unbounded tables) and the vacuous memory test.
- Fable PASS; code-reviewer PASS (ran `cargo audit` both ways: RUSTSEC-2026-0096 gone, 20 wasmtime advisories closed, zero introduced).
- **Grok adversarial ×2 → PASS** (round 1 caught the per-table-vs-store-budget ship-blocker; fixed with count caps + a multi-table test).
- Regression tests: non-vacuous memory-growth denial, initial-memory-over-budget, table-growth-past-cap, too-many-tables, memory64/multi-memory/shared-memory rejection, WASIp1 end-to-end.

## Live QA
The `temper-wasm` engine suite executes real WASM through the wasmtime-36 engine (compile/invoke/limits/WASI/fuel/epoch). The `temper` server built on wasmtime 36 boots and serves.

## Follow-up (pre-existing, in ADR-0159)
WASI `random_get` (and peers) allocate a host buffer sized by the guest-supplied length before the guest-memory bounds check — a pre-existing host-alloc surface not governed by the ResourceLimiter; its clean fix needs wasmtime 42+ embedder controls or a custom WASI wrapper. Tracked separately.

Note: local pre-push was bypassed only for the off-limits `temper-actor-runtime` Docker/Postgres testcontainer tests (no Docker in this env); CI runs them.

@greptile-apps review

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR upgrades Wasmtime and wasmtime-wasi from 29 to 36.0.13 to close runtime advisories while preserving the prior guest feature surface.
- Disables memory64, threads/shared memory, and multi-memory.
- Adds per-table growth and per-store table/memory count budgets.
- Migrates the WASI output-pipe import and adds end-to-end compatibility and resource-limit regression tests.
- Documents the security decision and deferred WASI host-allocation concern in ADR-0159.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge after the non-blocking test-file organization issue is addressed.

The dependency and sandbox changes have focused regression coverage, and no concrete runtime or security regression remains; the only accepted concern is that the expanded engine test file violates the repository's module-size convention.

**Files Needing Attention:** crates/temper-wasm/src/engine/tests.rs
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Cargo.toml | Raises the Wasmtime dependency floor to 36.0.13 while retaining the component-model and profiling features. |
| Cargo.lock | Resolves Wasmtime, Cranelift, WASI, and associated transitive packages to the 36.0.13-compatible graph. |
| crates/temper-wasm/src/engine/mod.rs | Pins high-risk WASM proposals off, adds table and resource-count budgets, and updates the WASI output-pipe import. |
| crates/temper-wasm/src/engine/tests.rs | Adds substantive sandbox and WASIp1 regression coverage, but expands the file beyond the repository's 500-line module-size standard. |
| docs/adrs/0159-wasmtime-36-security-update.md | Records the upgrade rationale, pinned sandbox surface, resource budgets, tests, and deferred host-allocation concern. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Guest[Untrusted guest WASM] --> Compile[WasmEngine compile]
    Compile --> FeatureGate{Feature surface}
    FeatureGate -->|memory64 / threads / multi-memory| Reject[Reject module]
    FeatureGate -->|wasm32 single-memory| Store[Fresh invocation Store]
    Store --> Limiter[MemoryLimiter]
    Limiter --> Memory[Memory budget and count cap]
    Limiter --> Tables[Table element and count caps]
    Store --> WASI[WASIp1 context and bounded stderr pipe]
    Store --> Invoke[Invoke run with fuel and epoch budgets]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20nerdsane%2Ftemper%20PR%20%23423%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=nerdsane%2Ftemper&pr=423&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Acrates%2Ftemper-wasm%2Fsrc%2Fengine%2Ftests.rs%3A496%0A**Split%20the%20expanded%20test%20module**%0A%0AThe%20new%20Wasmtime%20regression%20suite%20leaves%20%60engine%2Ftests.rs%60%20at%20724%20lines%2C%20violating%20the%20repository%20requirement%20to%20split%20Rust%20files%20over%20500%20lines%20into%20directory%20modules%20and%20making%20these%20tests%20harder%20to%20navigate%20and%20maintain.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=nerdsane%2Ftemper&pr=423&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22claude%2Farn-169-wasmtime-bump%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Farn-169-wasmtime-bump%22.%0A%0A%23%23%23%20Issue%201%0Acrates%2Ftemper-wasm%2Fsrc%2Fengine%2Ftests.rs%3A496%0A**Split%20the%20expanded%20test%20module**%0A%0AThe%20new%20Wasmtime%20regression%20suite%20leaves%20%60engine%2Ftests.rs%60%20at%20724%20lines%2C%20violating%20the%20repository%20requirement%20to%20split%20Rust%20files%20over%20500%20lines%20into%20directory%20modules%20and%20making%20these%20tests%20harder%20to%20navigate%20and%20maintain.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=nerdsane%2Ftemper&pr=423&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Acrates%2Ftemper-wasm%2Fsrc%2Fengine%2Ftests.rs%3A496%0A**Split%20the%20expanded%20test%20module**%0A%0AThe%20new%20Wasmtime%20regression%20suite%20leaves%20%60engine%2Ftests.rs%60%20at%20724%20lines%2C%20violating%20the%20repository%20requirement%20to%20split%20Rust%20files%20over%20500%20lines%20into%20directory%20modules%20and%20making%20these%20tests%20harder%20to%20navigate%20and%20maintain.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=423&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
crates/temper-wasm/src/engine/tests.rs:496
**Split the expanded test module**

The new Wasmtime regression suite leaves `engine/tests.rs` at 724 lines, violating the repository requirement to split Rust files over 500 lines into directory modules and making these tests harder to navigate and maintain.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(deps): update wasmtime 29 -&gt; 36.0.13..."](https://github.com/nerdsane/temper/commit/3ff7d24b95d612ad4197984428a10ff6ab0de5a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53559963)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/nerdsane/temper/blob/main/CLAUDE.md))
- Knowledge Base — [Temper WASM Runtime](https://app.greptile.com/arni-labs/-/custom-context/knowledge-base/nerdsane/temper/-/docs/temper-wasm.md)

<!-- /greptile_comment -->