### PR TITLE
fix(deps): clear reachable RUSTSEC advisories in transitive deps (ARN-169)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -158,7 +158,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1409,9 +1409,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1771,7 +1771,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1981,7 +1981,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2388,11 +2388,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2402,11 +2400,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2854,7 +2854,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3134,7 +3134,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3876,7 +3876,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4506,9 +4506,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56201207dac53e2f38e848e31b4b91616a6bb6e0c7205b77718994a7f49e70fc"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -4524,9 +4524,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc729a129e682e8d24170cd30ae1aa01b336b096cbb56df6d534ffec133d186"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
 dependencies = [
  "bytes",
  "chrono",
@@ -4803,9 +4803,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",
@@ -4824,7 +4824,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.37",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4833,14 +4833,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.10.1",
+ "rand_pcg",
  "ring",
  "rustc-hash 2.1.1",
  "rustls 0.23.37",
@@ -4861,7 +4862,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4984,6 +4985,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "rand_xorshift"
@@ -5356,7 +5366,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5392,7 +5402,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -5454,9 +5464,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5863,7 +5873,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6858,7 +6868,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6867,7 +6877,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7130,9 +7140,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd8df5ef180f6364759a6f00f7aadda4fbbac86cdee37480826a6ff9f3574ce"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -8480,7 +8490,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2089,6 +2089,12 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
@@ -3255,7 +3261,7 @@ dependencies = [
  "ena",
  "itertools 0.14.0",
  "lalrpop-util",
- "petgraph",
+ "petgraph 0.7.1",
  "pico-args",
  "regex",
  "regex-syntax",
@@ -3812,6 +3818,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4308,11 +4320,21 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset 0.4.2",
+ "indexmap 2.13.0",
+]
+
+[[package]]
+name = "petgraph"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.5.7",
  "indexmap 2.13.0",
 ]
 
@@ -4566,8 +4588,10 @@ dependencies = [
  "log",
  "nix",
  "once_cell",
- "protobuf",
- "protobuf-codegen-pure",
+ "prost 0.12.6",
+ "prost-build",
+ "prost-derive 0.12.6",
+ "sha2 0.10.9",
  "smallvec",
  "spin 0.10.0",
  "symbolic-demangle",
@@ -4681,6 +4705,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-build"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
+dependencies = [
+ "bytes",
+ "heck",
+ "itertools 0.10.5",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph 0.6.5",
+ "prettyplease",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
+ "regex",
+ "syn",
+ "tempfile",
+]
+
+[[package]]
 name = "prost-derive"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4721,36 +4766,20 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
+dependencies = [
+ "prost 0.12.6",
+]
+
+[[package]]
+name = "prost-types"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost 0.14.3",
-]
-
-[[package]]
-name = "protobuf"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
-
-[[package]]
-name = "protobuf-codegen"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "033460afb75cf755fcfc16dfaed20b86468082a2ea24e05ac35ab4a099a017d6"
-dependencies = [
- "protobuf",
-]
-
-[[package]]
-name = "protobuf-codegen-pure"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a29399fc94bcd3eeaa951c715f7bea69409b2445356b00519740bcd6ddd865"
-dependencies = [
- "protobuf",
- "protobuf-codegen",
 ]
 
 [[package]]
@@ -6342,7 +6371,7 @@ dependencies = [
  "chrono",
  "deadpool-postgres",
  "prost 0.14.3",
- "prost-types",
+ "prost-types 0.14.3",
  "serde",
  "serde_json",
  "temper-jit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ tracing-opentelemetry = "0.29"
 dotenvy = "0.15"
 
 # XML (CSDL parsing)
-quick-xml = { version = "0.37", features = ["serialize"] }
+quick-xml = { version = "0.41", features = ["serialize"] }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/temper-server/Cargo.toml
+++ b/crates/temper-server/Cargo.toml
@@ -67,7 +67,11 @@ tempfile = "3"
 # ADR-0055: CPU profile capture. pprof-rs is used because crates.io
 # `datadog-profiling` is currently an empty placeholder (see ADR for
 # details). `flamegraph` feature brings in inferno for SVG rendering.
-pprof = { version = "0.14", features = ["protobuf", "protobuf-codec"] }
+# `prost-codec` rather than `protobuf-codec`: the latter pulls protobuf 2.x,
+# which carries RUSTSEC-2024-0437 with no fix on the 2.x line. Both codecs emit
+# the same pprof protobuf wire format, so the uploaded profile is unchanged
+# (ARN-169).
+pprof = { version = "0.14", features = ["prost-codec"] }
 
 [dev-dependencies]
 tokio-test = { workspace = true }

--- a/crates/temper-server/src/profiling.rs
+++ b/crates/temper-server/src/profiling.rs
@@ -155,8 +155,14 @@ async fn capture_profile_body(
         }
     };
 
+    // `encode` is prost's serializer (pprof's `prost-codec` feature); it emits the
+    // same pprof protobuf wire format that protobuf-rs `write_to_vec` did — both
+    // codecs are generated from the same `profile.proto`, so the upload stays
+    // wire-compatible (ARN-169). Not byte-identical: pprof builds its string table
+    // from a HashSet, so output ordering already varies run to run under either
+    // codec.
     let mut body = Vec::new();
-    if let Err(e) = profile.write_to_vec(&mut body) {
+    if let Err(e) = profile.encode(&mut body) {
         record_capture_error(profile_type, mode, "pprof_serialize");
         return Err(format!("pprof serialize failed: {e}"));
     }
@@ -174,7 +180,7 @@ async fn capture_profile_body(
 }
 
 fn non_empty_env(var_name: &str) -> Option<String> {
-    std::env::var(var_name)
+    std::env::var(var_name) // determinism-ok: observability config, read outside simulation
         .ok()
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())

--- a/crates/temper-server/src/profiling/tests.rs
+++ b/crates/temper-server/src/profiling/tests.rs
@@ -149,3 +149,31 @@ fn datadog_profile_event_uses_agent_intake_envelope() {
         std::env::remove_var("DD_PROFILING_ENABLED");
     }
 }
+
+#[test]
+fn pprof_profile_encodes_to_decodable_protobuf() {
+    // ARN-169: profile serialization runs through pprof's `prost-codec` feature
+    // (rather than `protobuf-codec`, which pinned the vulnerable protobuf 2.x).
+    // Both codecs are generated from the same `profile.proto`, so the emitted
+    // bytes stay valid pprof protobuf. This guards the codec itself: if a future
+    // pprof bump silently reverted the feature, `encode`/`decode` would no longer
+    // resolve to prost's trait methods and this stops compiling — and if the
+    // encoding ever produced something undecodable, it fails.
+    use pprof::protos::{Profile, ValueType};
+
+    let profile = Profile {
+        string_table: vec![String::new(), "samples".to_string(), "count".to_string()],
+        sample_type: vec![ValueType { ty: 1, unit: 2 }],
+        period: 10_000_000,
+        ..Default::default()
+    };
+
+    let mut body = Vec::new();
+    profile.encode(&mut body).expect("profile must encode");
+    assert!(!body.is_empty(), "encoded pprof profile must not be empty");
+
+    let decoded = Profile::decode(&body[..]).expect("encoded bytes must be valid pprof protobuf");
+    assert_eq!(decoded.period, 10_000_000);
+    assert_eq!(decoded.sample_type.len(), 1);
+    assert_eq!(decoded.string_table[1], "samples");
+}

--- a/crates/temper-spec/src/csdl/parser/elements.rs
+++ b/crates/temper-spec/src/csdl/parser/elements.rs
@@ -164,8 +164,19 @@ pub(super) fn parse_annotation_children(
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(quick_xml::events::Event::Start(ref element)) if local_name(element) == "String" => {
-                let text = reader.read_text(element.name()).unwrap_or_default();
-                let text = text.trim().to_string();
+                // quick-xml 0.41 changed `read_text` to return a `BytesText`
+                // instead of an owned `String`; call `.decode()` to get the text.
+                // Behavior is preserved exactly: 0.37's `read_text` also only
+                // charset-decoded and did NOT unescape XML entities (its rustdoc:
+                // "does not unescape read data"), matching the inline-attribute
+                // path (`attr_str`). Proper entity unescaping here (and the
+                // parse->emit double-escape it would fix) is a separate pre-existing
+                // correctness gap, out of scope for a dependency bump.
+                let text = reader
+                    .read_text(element.name())
+                    .ok()
+                    .and_then(|raw| raw.decode().ok().map(|s| s.trim().to_string()))
+                    .unwrap_or_default();
                 if !text.is_empty() {
                     collection_items.push(text);
                 }

--- a/crates/temper-spec/src/csdl/parser/tests.rs
+++ b/crates/temper-spec/src/csdl/parser/tests.rs
@@ -149,3 +149,51 @@ fn assert_example_container(schema: &Schema) {
     assert_eq!(orders_set.entity_type, "Temper.Example.Order");
     assert_eq!(orders_set.navigation_bindings.len(), 3);
 }
+
+#[test]
+fn test_parse_collection_annotation_preserved_across_quick_xml_bump() {
+    // Regression guard for the quick-xml 0.37 -> 0.41 bump (ARN-169): 0.41's
+    // read_text returns a raw BytesText rather than an owned String, so the
+    // Collection<String> path decodes it explicitly. Behavior is preserved:
+    // ordinary state-list strings parse, and — matching 0.37, whose read_text
+    // also did not unescape — an XML entity stays literal (the pre-existing
+    // entity-unescaping gap is out of scope for this dependency bump).
+    let xml = r#"<?xml version="1.0"?>
+    <edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+      <edmx:DataServices>
+        <Schema Namespace="Test" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+          <EntityType Name="Widget">
+            <Key><PropertyRef Name="Id"/></Key>
+            <Property Name="Id" Type="Edm.Guid" Nullable="false"/>
+            <Annotation Term="Test.States">
+              <Collection>
+                <String>Draft</String>
+                <String>Active</String>
+                <String>A &amp; B</String>
+              </Collection>
+            </Annotation>
+          </EntityType>
+        </Schema>
+      </edmx:DataServices>
+    </edmx:Edmx>"#;
+    let doc = parse_csdl(xml).unwrap();
+    let widget = doc.schemas[0].entity_type("Widget").unwrap();
+    let ann = widget
+        .annotations
+        .iter()
+        .find(|a| a.term == "Test.States")
+        .expect("Test.States annotation present");
+    match &ann.value {
+        crate::csdl::types::AnnotationValue::Collection(items) => {
+            assert_eq!(
+                items,
+                &vec![
+                    "Draft".to_string(),
+                    "Active".to_string(),
+                    "A &amp; B".to_string(),
+                ]
+            );
+        }
+        other => panic!("expected Collection, got {other:?}"),
+    }
+}

--- a/docs/adrs/0160-clear-rustsec-advisories.md
+++ b/docs/adrs/0160-clear-rustsec-advisories.md
@@ -16,11 +16,15 @@ a cascading parent upgrade. Cleared here (crate → advisories):
 - `quick-xml` 0.37.5 → 0.41 — RUSTSEC-2026-0194, -0195 (DoS)
 - `rustls-webpki` (0.103 line) 0.103.9 → 0.103.13 — RUSTSEC-2026-0049, -0098, -0099, -0104
 - `crossbeam-epoch` 0.9.18 → 0.9.20 — RUSTSEC-2026-0204
+- `protobuf` 2.28.0 — RUSTSEC-2024-0437, removed from the tree entirely (see below)
 
 ## Decision
 
-All but one are plain `cargo update` (same major, no source change). The one
-source change is `quick-xml` 0.37 → 0.41, which is pinned by our own `temper-spec`
+Most are plain `cargo update` (same major, no source change). Two entries need
+source changes: the `quick-xml` bump below, and the `protobuf` removal described in
+Consequences (a `pprof` feature swap plus its one-line serializer call).
+
+The first is `quick-xml` 0.37 → 0.41, which is pinned by our own `temper-spec`
 (0.41.0 is the *minimum* version patching RUSTSEC-2026-0194/-0195, so the API break
 was unavoidable — no smaller bump exists):
 
@@ -54,7 +58,7 @@ pre-existing shape of this code that the bump makes reachable; it is tracked as
 
 ## Consequences
 
-- `cargo audit` drops from 18 to 7 (11 advisory instances cleared). temper-spec's
+- `cargo audit` drops from 18 to 6 (12 advisory instances cleared). temper-spec's
   suite passes and the workspace builds clean; a server built on the bumped stack
   boots and parses seeded CSDL through the new quick-xml path without error.
 - Who is actually affected, so a future reader audits the right crate:
@@ -68,27 +72,45 @@ pre-existing shape of this code that the bump makes reachable; it is tracked as
     `libsql`, which is why the residual below is a real cascade rather than an
     oversight.
   - `quick-xml` affects only the CSDL parser in `temper-spec`.
-- The lockfile also moves crates beyond the six above, which is expected resolver
+- **`protobuf` needed no upgrade at all.** It was in the tree only because
+  `temper-server` asked `pprof` for its `protobuf-codec` feature, which pins
+  protobuf 2.x — a line with no fix for RUSTSEC-2024-0437. The same `pprof` version
+  offers `prost-codec`, so switching the feature (and `Profile::write_to_vec` →
+  prost's `Message::encode`) drops the vulnerable crate outright. Both codecs emit
+  the same pprof protobuf wire format, so uploaded profiles are unchanged.
+- The lockfile also moves crates beyond the upgrades above, which is expected resolver
   dedup rather than part of the security change: `hyper-util` / `quinn` /
   `quinn-udp` re-point from `socket2` 0.6.3 to 0.5.10, and several dependents from
   `windows-sys` 0.61.2 down to already-present 0.60/0.59/0.52/0.48 lines. Both
-  `socket2` lines already coexisted on `main`, every requirement is a range
-  (`>=0.5.9, <0.7`), no advisory covers the selected versions, and builds, clippy
+  `socket2` lines already coexisted on `main`, every requirement is a range that
+  admits 0.5.10 (`hyper-util` wants `>=0.5.9, <0.7`; `quinn`/`quinn-udp` the broader
+  `>=0.5, <0.7`), no advisory covers the selected versions, and builds, clippy
   and tests are clean. Called out explicitly because a networking-crate *downgrade*
   inside a security PR is exactly the kind of thing a later audit should not have to
-  re-derive.
+  re-derive. The `prost-codec` swap likewise adds five lock entries — `prost-build`
+  and `prost-types` 0.12.6, `petgraph` 0.6.5, `fixedbitset` 0.4.2, `multimap`
+  0.10.1 — all **build-time only** via pprof's `[build-dependencies]`; `prost`
+  itself was already in the tree via `libsql-hrana`, so no new runtime dependency
+  is introduced.
 
 ## Residual (out of scope here, tracked on ARN-169)
 
-Remaining `cargo audit` findings, each needing a major/cascading upgrade or having
-no fixed release:
+After this pass `cargo audit` reports 6. Each remaining finding needs a cascading
+parent upgrade, has no fixed release, or would cost a capability we actually use:
 
 - `rustls-webpki` 0.102.8 (RUSTSEC-2026-0049/-0098/-0099/-0104) — pulled by
-  `libsql` 0.9.x → `hyper-rustls` 0.25 → `rustls` 0.22. Clearing it needs bumping
-  `libsql` to a release on `rustls` 0.23 — a cascade into the Turso storage client
-  with real breakage risk.
-- `protobuf` 2.28.0 (RUSTSEC-2024-0437) — fix is `>=3.7.2`, a major bump; a
-  separate, larger migration.
+  `libsql` 0.9.x → `hyper-rustls` 0.25 → `rustls` 0.22. Two routes exist and both
+  are rejected deliberately, not by omission:
+  - *Upgrade:* needs `libsql` on `rustls` 0.23 — a cascade into the Turso storage
+    client with real breakage risk.
+  - *Feature toggle:* `hyper-rustls` is optional in libsql behind its default-on
+    `tls` feature, so this is structurally the same shape as the `protobuf-codec`
+    swap above. It is rejected because `temper-store-turso` calls
+    `Builder::new_remote` (`store/mod.rs`, the `libsql://` branch of the production
+    constructor), and with `tls` off libsql's `connector()` is an outright
+    `panic!("The \`tls\` feature is disabled, ...")` — so dropping it breaks remote
+    Turso at runtime, not just in theory. Removing a working capability to clear an
+    advisory needs sign-off, so it stays residual.
 - `rsa` 0.9.10 (RUSTSEC-2023-0071, Marvin timing) and `tokio-tar` 0.3.1
   (RUSTSEC-2025-0111) — no fixed release available; accept/monitor.
 - **temperpaw** carries the same dependency set and needs the equivalent pass in

--- a/docs/adrs/0160-clear-rustsec-advisories.md
+++ b/docs/adrs/0160-clear-rustsec-advisories.md
@@ -1,0 +1,97 @@
+# ADR-0160: Clear reachable RUSTSEC advisories in transitive deps (ARN-169)
+
+- Status: Accepted
+- Date: 2026-08-15
+- Issue: ARN-169 (follow-up to the wasmtime bump in ADR-0159)
+
+## Context
+
+`cargo audit` on `main` reported 18 advisories. ADR-0159 closed the critical
+wasmtime one. This pass clears the remaining advisories that are reachable without
+a cascading parent upgrade. Cleared here (crate → advisories):
+
+- `postgres-protocol` 0.6.11 → 0.6.12 — RUSTSEC-2026-0179, -0180
+- `tokio-postgres` 0.7.17 → 0.7.18 — RUSTSEC-2026-0178 (DoS panic)
+- `quinn-proto` 0.11.14 → 0.11.16 — RUSTSEC-2026-0185
+- `quick-xml` 0.37.5 → 0.41 — RUSTSEC-2026-0194, -0195 (DoS)
+- `rustls-webpki` (0.103 line) 0.103.9 → 0.103.13 — RUSTSEC-2026-0049, -0098, -0099, -0104
+- `crossbeam-epoch` 0.9.18 → 0.9.20 — RUSTSEC-2026-0204
+
+## Decision
+
+All but one are plain `cargo update` (same major, no source change). The one
+source change is `quick-xml` 0.37 → 0.41, which is pinned by our own `temper-spec`
+(0.41.0 is the *minimum* version patching RUSTSEC-2026-0194/-0195, so the API break
+was unavoidable — no smaller bump exists):
+
+- 0.41's `Reader::read_text` returns a `Result<BytesText>` instead of an owned
+  `String`. The Collection<String> annotation path (`csdl/parser/elements.rs`)
+  now calls `.decode()` on it. **Behavior is preserved exactly**: 0.37's
+  `read_text` also only charset-decoded and did *not* unescape XML entities (its
+  rustdoc: "does not unescape read data"), so `A &amp; B` stays literal under
+  both versions, consistent with the inline-attribute path (`attr_str`). A
+  regression test (`test_parse_collection_annotation_preserved_across_quick_xml_bump`)
+  locks the preserved behavior in.
+- All other `temper-spec` quick-xml uses (`read_event_into`, `element.name()`,
+  raw attribute bytes) are version-stable.
+
+Not changed here (deliberately, to keep this a behavior-neutral dep bump): the CSDL
+parser does not unescape XML entities in annotation text — neither before nor after
+this bump — and the parse→emit path double-escapes such values. Adding proper
+entity handling is a separate, pre-existing correctness fix that needs its own
+sign-off, out of scope for an advisory-clearance bump.
+
+One behavior difference exists, and only for **ill-formed** XML: 0.41 is stricter
+about a raw, un-escaped `&` in element text (its text scan is `memchr2(b'<', b'&')`
+where 0.37's was `memchr(b'<')`), so such an annotation item is dropped where 0.37
+kept it verbatim. Well-formed CSDL is unaffected (our emitter always escapes, and no
+fixture contains a raw `&`), and the surrounding document still parses. Stricter
+rejection of invalid XML is the desirable direction.
+
+That the item is *silently* dropped rather than raising `CsdlParseError` is a
+pre-existing shape of this code that the bump makes reachable; it is tracked as
+**ARN-347** rather than fixed here, so this stays a dependency bump.
+
+## Consequences
+
+- `cargo audit` drops from 18 to 7 (11 advisory instances cleared). temper-spec's
+  suite passes and the workspace builds clean; a server built on the bumped stack
+  boots and parses seeded CSDL through the new quick-xml path without error.
+- Who is actually affected, so a future reader audits the right crate:
+  - `postgres-protocol` / `tokio-postgres` reach us through `deadpool-postgres`
+    (`temper-actor-runtime`, `temper-cli`, `temper-agents`) — **not**
+    `temper-store-postgres`, which uses `sqlx`. 0.6.12 rejects SCRAM iteration
+    counts above 100_000 (Postgres defaults to 4096) and turns hstore / short
+    `DataRow` panics into errors.
+  - the `rustls-webpki` 0.103 line serves `reqwest` / `bollard` / `testcontainers` /
+    `quinn`. It is **not** the Turso TLS path — that still resolves 0.102.8 via
+    `libsql`, which is why the residual below is a real cascade rather than an
+    oversight.
+  - `quick-xml` affects only the CSDL parser in `temper-spec`.
+- The lockfile also moves crates beyond the six above, which is expected resolver
+  dedup rather than part of the security change: `hyper-util` / `quinn` /
+  `quinn-udp` re-point from `socket2` 0.6.3 to 0.5.10, and several dependents from
+  `windows-sys` 0.61.2 down to already-present 0.60/0.59/0.52/0.48 lines. Both
+  `socket2` lines already coexisted on `main`, every requirement is a range
+  (`>=0.5.9, <0.7`), no advisory covers the selected versions, and builds, clippy
+  and tests are clean. Called out explicitly because a networking-crate *downgrade*
+  inside a security PR is exactly the kind of thing a later audit should not have to
+  re-derive.
+
+## Residual (out of scope here, tracked on ARN-169)
+
+Remaining `cargo audit` findings, each needing a major/cascading upgrade or having
+no fixed release:
+
+- `rustls-webpki` 0.102.8 (RUSTSEC-2026-0049/-0098/-0099/-0104) — pulled by
+  `libsql` 0.9.x → `hyper-rustls` 0.25 → `rustls` 0.22. Clearing it needs bumping
+  `libsql` to a release on `rustls` 0.23 — a cascade into the Turso storage client
+  with real breakage risk.
+- `protobuf` 2.28.0 (RUSTSEC-2024-0437) — fix is `>=3.7.2`, a major bump; a
+  separate, larger migration.
+- `rsa` 0.9.10 (RUSTSEC-2023-0071, Marvin timing) and `tokio-tar` 0.3.1
+  (RUSTSEC-2025-0111) — no fixed release available; accept/monitor.
+- **temperpaw** carries the same dependency set and needs the equivalent pass in
+  its own repo.
+
+Consider adding `cargo audit` to CI so new advisories surface automatically.


### PR DESCRIPTION
Completes the **temper** half of ARN-169. The critical wasmtime CVE landed in #423; this clears every *remaining* advisory reachable without a cascading parent upgrade. **`cargo audit` 18 → 7.**

## Cleared
| Crate | Bump | Advisories |
|---|---|---|
| postgres-protocol | 0.6.11 → 0.6.12 | RUSTSEC-2026-0179, -0180 |
| tokio-postgres | 0.7.17 → 0.7.18 | -0178 |
| quinn-proto | 0.11.14 → 0.11.16 | -0185 |
| rustls-webpki (0.103) | 0.103.9 → 0.103.13 | -0049, -0098, -0099, -0104 |
| crossbeam-epoch | 0.9.18 → 0.9.20 | -0204 |
| quick-xml | 0.37.5 → 0.41 | -0194, -0195 |

All but quick-xml are plain `cargo update` with no source change. 0.41.0 is the *minimum* patched quick-xml, so its API break was unavoidable.

## The one source change — and a correction worth reading
quick-xml 0.41 changed `Reader::read_text` to return `BytesText` instead of an owned `String`; the CSDL `Collection<String>` path now calls `.decode()`.

I first wrote `decode() + unescape()`, believing 0.37 entity-decoded. **That was wrong** — 0.37.5's `read_text` is `decoder().decode(...)` only, and its rustdoc says *"does not unescape read data"*. Adding unescape would have been a silent semantic change to CSDL parsing (plus item-drops on dangling `&`, plus inline-vs-collection inconsistency). The Fable review caught it with a both-version harness; the code is now **decode-only** — genuine behavior preservation — and the test asserts `A &amp;amp; B` stays **literal**, exactly as on 0.37.

## Review gauntlet
- **Fable** — FAIL→fixed (the correction above; its other findings dissolve under decode-only).
- **code-reviewer** — FAIL→fixed (found I'd filtered my audit too narrowly: added tokio-postgres + crossbeam bumps; ADR accuracy).
- **Grok adversarial** — **PASS**, no P0/P1/P2. Its P3s fixed (my ADR named the wrong postgres consumer — `temper-store-postgres` uses sqlx).
- **Final review** — **PASS**, verified the port byte-for-byte against both vendored sources and empirically probed the ill-formed-XML case. Its 4 P3s all fixed here (lockfile-churn note, `temper-agents` consumer, ARN-347 follow-up, rebase).

## Live QA
Server built on the bumped stack **boots and parses seeded CSDL through the new quick-xml path** with no annotation cross-check failures and no errors — exercising exactly the changed code — then serves and stays up.

## Residual (in ADR-0160, tracked on ARN-169)
`rustls-webpki` 0.102.8 (via `libsql` → `hyper-rustls` 0.25 → `rustls` 0.22 — needs a libsql cascade), `protobuf` 2.x (major), `rsa` + `tokio-tar` (no fix available), and the **temperpaw** repo pass.

Follow-up filed: **ARN-347** (collection items silently dropped on decode failure — pre-existing shape, newly reachable).

@greptile-apps review

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR updates vulnerable transitive dependencies, migrates pprof serialization from protobuf 2.x to prost, and adapts CSDL collection parsing to quick-xml 0.41 while preserving prior entity-handling semantics.
- Removes the vulnerable protobuf 2.x dependency through pprof’s `prost-codec` feature.
- Updates the profiling serializer and adds a protobuf round-trip regression test.
- Updates quick-xml and related transitive dependencies, with a regression test for collection annotation parsing.
- Documents cleared and intentionally residual advisories in ADR-0160.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Cargo.lock | Updates the targeted vulnerable dependencies, removes protobuf 2.x, and adds the prost codec’s build-time dependency graph. |
| Cargo.toml | Raises the workspace quick-xml requirement from 0.37 to the patched 0.41 line. |
| crates/temper-server/Cargo.toml | Replaces pprof’s vulnerable protobuf codec feature with its wire-compatible prost codec. |
| crates/temper-server/src/profiling.rs | Migrates profile serialization to prost while preserving explicit serialization-error handling. |
| crates/temper-server/src/profiling/tests.rs | Adds a round-trip test confirming generated pprof bytes remain valid protobuf. |
| crates/temper-spec/src/csdl/parser/elements.rs | Explicitly decodes quick-xml 0.41 `BytesText` while retaining the prior collection parsing behavior. |
| crates/temper-spec/src/csdl/parser/tests.rs | Adds regression coverage for ordinary collection strings and preserved literal entity text. |
| docs/adrs/0160-clear-rustsec-advisories.md | Records the dependency-security changes, codec migration, behavior-preservation rationale, and deliberately deferred residual work. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(deps): drop protobuf 2.x by switchin..."](https://github.com/nerdsane/temper/commit/861530d481603a7bd9e05563b71874d1bde5738a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53869054)</sub>

<!-- /greptile_comment -->