### PR TITLE
fix(server): stop forwarding caller credentials to WASM guests (ARN-208)

### DIFF
--- a/crates/temper-server/src/router.rs
+++ b/crates/temper-server/src/router.rs
@@ -210,6 +210,82 @@ async fn http_endpoint_fallback(
     dispatch_matched_route(state, authenticated, method, uri, headers, _body, route).await
 }
 
+/// Request headers that carry an ambient caller credential and must never be
+/// forwarded into a WASM guest's invocation context.
+///
+/// A guest runs untrusted module code and can read everything it is handed, so any
+/// credential here is one it could replay — against this server, an upstream, or an
+/// identity-aware proxy fronting us. The list therefore covers direct credentials,
+/// the forwarded-auth family injected by such proxies, and cloud instance tokens
+/// (ARN-208).
+///
+/// This is the *inbound* guard (host → guest). The separate *outbound* sanitizer
+/// for guest-supplied headers on internal re-entry lives in
+/// `temper_wasm::host_trait::internal_http::internal_header_allowed`, and the two
+/// lists are deliberately **not** the same set: that one also drops routing and
+/// tenant-identity headers (`host`, `forwarded`, `x-forwarded-for`, `x-tenant-id`,
+/// the `x-temper-*` authority namespace) which are legitimate context on the way
+/// in. Adding a credential header here does not imply an edit there.
+pub(crate) const GUEST_FORBIDDEN_CREDENTIAL_HEADERS: [&str; 16] = [
+    "authorization",
+    "proxy-authorization",
+    "cookie",
+    "x-api-key",
+    // Forwarded-auth family: whatever an identity-aware proxy injects once it has
+    // authenticated the caller. None of these are used by the current deployment;
+    // they are stripped defensively so putting Temper behind such a proxy never
+    // silently starts handing live IdP tokens to guest modules.
+    "x-forwarded-authorization",
+    "x-forwarded-access-token",
+    // Google IAP
+    "x-goog-iap-jwt-assertion",
+    // Cloudflare Access
+    "cf-access-jwt-assertion",
+    // AWS ALB `authenticate-oidc`
+    "x-amzn-oidc-accesstoken",
+    "x-amzn-oidc-data",
+    "x-amzn-oidc-identity",
+    // Azure App Service EasyAuth
+    "x-ms-token-aad-access-token",
+    "x-ms-token-aad-id-token",
+    "x-ms-token-aad-refresh-token",
+    // oauth2-proxy `--set-xauthrequest`
+    "x-auth-request-access-token",
+    // Cloud instance credential.
+    "x-amz-security-token",
+];
+
+/// Whether a request header carries an ambient caller credential and must not be
+/// forwarded into a WASM guest's invocation context.
+pub(crate) fn is_credential_header(name: &str) -> bool {
+    GUEST_FORBIDDEN_CREDENTIAL_HEADERS
+        .iter()
+        .any(|candidate| name.eq_ignore_ascii_case(candidate))
+}
+
+/// Build the header list a WASM guest sees for an inbound HTTP dispatch.
+///
+/// Today this is the only place inbound headers cross into guest-visible state, so
+/// the credential filter lives here rather than inline at the call site: one audited
+/// home, and testable against its real output. `pub(crate)` so any future
+/// guest-context constructor reuses it instead of reimplementing the filter.
+///
+/// Note this covers *headers* only. The request path handed to the guest includes
+/// the query string (deliberately — git needs `service=`), so a credential passed as
+/// `?access_token=…` is a different carrier of the same invariant; tracked with the
+/// outbound mirror in ARN-346 (ARN-208).
+pub(crate) fn guest_visible_headers(headers: &HeaderMap) -> Vec<(String, String)> {
+    headers
+        .iter()
+        .filter(|(name, _)| !is_credential_header(name.as_str()))
+        .filter_map(|(k, v)| {
+            v.to_str()
+                .ok()
+                .map(|s| (k.as_str().to_string(), s.to_string()))
+        })
+        .collect()
+}
+
 /// End-to-end dispatch: open an InboundExchange on the shared
 /// HttpStreamRegistry, spawn tasks to pump axum body into the
 /// guest-visible request-body handle and build an axum Response
@@ -293,16 +369,10 @@ async fn dispatch_matched_route(
     };
     tokio::spawn(pump_task); // determinism-ok: detached HTTP body pump, not simulation state
 
-    // Build the invocation context.
-    let header_pairs: Vec<(String, String)> = headers
-        .iter()
-        .filter(|(name, _)| !name.as_str().eq_ignore_ascii_case("authorization"))
-        .filter_map(|(k, v)| {
-            v.to_str()
-                .ok()
-                .map(|s| (k.as_str().to_string(), s.to_string()))
-        })
-        .collect();
+    // Build the invocation context. Guest-visible headers go through
+    // `guest_visible_headers` so caller credentials are stripped in one audited
+    // place (ARN-208).
+    let header_pairs: Vec<(String, String)> = guest_visible_headers(&headers);
     let route_params = git_route_params_for_http_dispatch(
         &route.route.integration_module,
         uri.path(),

--- a/crates/temper-server/src/router_test.rs
+++ b/crates/temper-server/src/router_test.rs
@@ -2506,3 +2506,117 @@ fn bridge_short_circuit_response_absent_is_none() {
     .expect("missing status still short-circuits");
     assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
 }
+
+#[test]
+fn credential_headers_are_not_forwarded_to_wasm_guests() {
+    // ARN-208: a WASM guest reads everything in its invocation context's headers.
+    // This asserts the invariant against the shared extraction point
+    // (`guest_visible_headers`) rather than the classifier alone, so deleting the
+    // filter inside that function fails here. It does NOT assert the dispatch call
+    // site: re-inlining the filter_map in `dispatch_matched_route` would still pass.
+    // A true wire-level assertion needs a guest fixture that echoes its invocation
+    // context; that is deferred with the outbound-header work in ARN-346.
+    let mut headers = HeaderMap::new();
+    for (name, value) in [
+        ("authorization", "Bearer caller-token"),
+        ("proxy-authorization", "Basic proxy"),
+        ("cookie", "session=abc"),
+        ("x-api-key", "sk-live-123"),
+        ("x-forwarded-authorization", "Bearer upstream"),
+        ("x-forwarded-access-token", "at-456"),
+        ("x-goog-iap-jwt-assertion", "iap-jwt"),
+        ("cf-access-jwt-assertion", "cf-jwt"),
+        ("x-amzn-oidc-accesstoken", "alb-access"),
+        ("x-amzn-oidc-data", "alb-data"),
+        ("x-amzn-oidc-identity", "alb-identity"),
+        ("x-ms-token-aad-access-token", "aad-access"),
+        ("x-ms-token-aad-id-token", "aad-id"),
+        ("x-ms-token-aad-refresh-token", "aad-refresh"),
+        ("x-auth-request-access-token", "oauth2p-access"),
+        ("x-amz-security-token", "aws-token"),
+        // Ordinary headers the guest legitimately needs.
+        ("content-type", "application/json"),
+        ("accept", "*/*"),
+        ("user-agent", "curl/8"),
+        ("x-request-id", "req-1"),
+    ] {
+        headers.insert(
+            axum::http::HeaderName::from_static(name),
+            axum::http::HeaderValue::from_static(value),
+        );
+    }
+
+    // Forces the next author who grows the const to also plant a header/value here:
+    // the name loop below iterates the const and would otherwise pass trivially for
+    // an unplanted entry.
+    assert_eq!(
+        GUEST_FORBIDDEN_CREDENTIAL_HEADERS.len(),
+        16,
+        "a credential header was added or removed — plant it in this test too"
+    );
+
+    let visible = guest_visible_headers(&headers);
+    let names: Vec<String> = visible
+        .iter()
+        .map(|(k, _)| k.to_ascii_lowercase())
+        .collect();
+
+    for forbidden in GUEST_FORBIDDEN_CREDENTIAL_HEADERS {
+        assert!(
+            !names.iter().any(|n| n == forbidden),
+            "{forbidden} carries a caller credential and must not reach a guest; got {names:?}"
+        );
+    }
+    // No credential VALUE survives either. This catches a renamed-but-same-value
+    // leak, and — unlike the name loop, which iterates the const itself and so
+    // shrinks with it — every planted secret is asserted independently, so removing
+    // any single entry from GUEST_FORBIDDEN_CREDENTIAL_HEADERS fails here.
+    let values: Vec<&str> = visible.iter().map(|(_, v)| v.as_str()).collect();
+    for secret in [
+        "Bearer caller-token",
+        "Basic proxy",
+        "session=abc",
+        "sk-live-123",
+        "Bearer upstream",
+        "at-456",
+        "iap-jwt",
+        "cf-jwt",
+        "alb-access",
+        "alb-data",
+        "alb-identity",
+        "aad-access",
+        "aad-id",
+        "aad-refresh",
+        "oauth2p-access",
+        "aws-token",
+    ] {
+        assert!(
+            !values.contains(&secret),
+            "credential value {secret:?} leaked to the guest: {values:?}"
+        );
+    }
+    // Ordinary request context still reaches the guest.
+    for expected in ["content-type", "accept", "user-agent", "x-request-id"] {
+        assert!(
+            names.iter().any(|n| n == expected),
+            "{expected} is not a credential and must still be forwarded; got {names:?}"
+        );
+    }
+}
+
+#[test]
+fn credential_header_classifier_is_case_insensitive() {
+    for name in [
+        "Authorization",
+        "COOKIE",
+        "X-Api-Key",
+        "Cf-Access-Jwt-Assertion",
+    ] {
+        assert!(
+            is_credential_header(name),
+            "{name} must be classified as a credential"
+        );
+    }
+    assert!(!is_credential_header("x-temper-observe-session-id"));
+    assert!(!is_credential_header("content-type"));
+}


### PR DESCRIPTION
Closes the **residual** of ARN-208. Supersedes #360 for this part; that PR's core (governed WASM host + Cedar-gated secrets) is already on `main` via `authorized_http_endpoint_host`, so this ports only the one gap triage found still open.

## The gap
When the server dispatches an inbound HTTP request to a WASM guest, it built the guest-visible header list filtering **only `authorization`**. So `cookie`, `x-api-key` and `proxy-authorization` — ambient caller credentials — were handed to untrusted guest module code, which reads its whole invocation context and can replay whatever it finds.

## Fix
- **`GUEST_FORBIDDEN_CREDENTIAL_HEADERS`** — direct credentials, the forwarded-auth family (Google IAP, Cloudflare Access, **AWS ALB `authenticate-oidc`**, **Azure EasyAuth**, **oauth2-proxy**), and the AWS instance token. None are used by the current deployment; they're stripped defensively so putting Temper behind an identity-aware proxy never silently starts leaking live IdP tokens to guests.
- **`guest_visible_headers`** — extracted as the single place inbound headers become guest-visible, so the filter has one audited home. `pub(crate)` so a future guest-context constructor reuses it rather than reimplementing it.
- Verified this is genuinely the only such path: every other `WasmInvocationContext` site sets `http_request: None`, and the webhook receiver takes action params from the query map, never headers.

## Review gauntlet
- **Fable** — FAIL→fixed. Caught that my first test locked the *classifier*, not the *wiring*: deleting the `.filter(...)` would have left every test green. That drove the extraction + a test against the real output. It also flagged the outbound mirror, filed as **ARN-346**.
- **Grok adversarial** — PASS. Its two P3s fixed: my comment wrongly described `internal_http::internal_header_allowed` as a parallel inbound allowlist (it's an *outbound* sanitizer with a deliberately different set), and my value-lock asserted only 6 of 9 secrets so dropping one const entry could leak silently.
- **Final review** — FAIL→**PASS**. Caught that the doc claimed to cover "the forwarded-auth family" while omitting AWS/Azure/oauth2-proxy — inconsistent, since IAP/CF were already included defensively. Now 16 names, all planted in the test.

**Mutation-tested twice:** deleting the filter fails the test, and removing only `proxy-authorization` from the const fails with `credential value "Basic proxy" leaked to the guest`. A length assertion forces the next author who grows the const to plant it in the test too.

## Deliberately out of scope (recorded on ARN-346, not silently dropped)
The query string still reaches the guest verbatim (git needs `service=`), guest **response** headers are still stitched verbatim (Set-Cookie/CORS on the shared origin), and the outbound sanitizer doesn't yet know these names.

@greptile-apps review

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR centralizes filtering of guest-visible inbound headers and expands the credential denylist before constructing the WASM invocation context.
- Adds case-insensitive filtering for direct credentials and common identity-proxy token headers.
- Routes production HTTP guest dispatch through the shared filtering helper.
- Adds tests covering every denied header and preservation of ordinary request metadata.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/temper-server/src/router.rs | Centralizes guest-visible header construction and applies the expanded credential filter on the production WASM HTTP-dispatch path. |
| crates/temper-server/src/router_test.rs | Verifies all listed credentials are removed, ordinary headers remain visible, and classification is case-insensitive. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Server as temper-server
    participant Filter as guest_visible_headers
    participant Guest as WASM guest
    Client->>Server: HTTP request with headers
    Server->>Filter: inbound HeaderMap
    Filter->>Filter: remove credential-bearing headers
    Filter-->>Server: guest-visible header pairs
    Server->>Guest: WasmInvocationContext
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(server): stop forwarding caller cred..."](https://github.com/nerdsane/temper/commit/f651172cafe8549906ed42ce8367132865537a2f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53874971)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [temper-server](https://app.greptile.com/arni-labs/-/custom-context/knowledge-base/nerdsane/temper/-/docs/temper-server.md)
- Knowledge Base — [temper-platform authentication and tenant boundary](https://app.greptile.com/arni-labs/-/custom-context/knowledge-base/nerdsane/temper/-/docs/temper-platform.md)
- Knowledge Base — [Temper WASM Runtime](https://app.greptile.com/arni-labs/-/custom-context/knowledge-base/nerdsane/temper/-/docs/temper-wasm.md)
</details>

<!-- /greptile_comment -->