### PR TITLE
fix(wasm): bounds-check guest reads before allocating (ARN-226)

### DIFF
--- a/crates/temper-wasm/src/engine/guest_read_bounds_test.rs
+++ b/crates/temper-wasm/src/engine/guest_read_bounds_test.rs
@@ -1,0 +1,308 @@
+//! ARN-226: guest reads are bounds-checked before the host allocates.
+//!
+//! These live in their own file (rather than `engine/tests.rs`) so the readability
+//! ratchet counts them as tests: its production-file exclusion matches
+//! `*_test.rs`, which `tests.rs` does not.
+
+use super::tests::{make_context, make_host, make_streams};
+use super::*;
+
+// ARN-226 (wiring): a guest returns a result pointer whose 4-byte length prefix is
+// forged far larger than its linear memory. The host must reject it on the bounds
+// check BEFORE allocating a buffer of that size. Memory here is 1 page (64 KiB) and
+// the forged length is 64 MiB — above LARGE_ALLOC_THRESHOLD, so the allocation
+// counter observes the *ordering*, not just the rejection.
+const WAT_FORGED_RESULT_LENGTH: &str = r#"
+    (module
+      (memory (export "memory") 1)
+      (func (export "run") (param i32 i32) (result i32)
+        ;; length prefix at address 100 = 64 MiB, far beyond the 64 KiB memory
+        i32.const 100
+        i32.const 67108864
+        i32.store
+        ;; return 104 so the host reads the prefix at 104-4 = 100
+        i32.const 104
+      )
+    )
+"#;
+
+// A result whose length is individually *smaller* than the guest's memory but whose
+// `ptr + len` runs past the end. This pins the predicate to the full range: a weaker
+// check that only compared `len` against the memory size would wrongly accept it.
+const WAT_RESULT_LENGTH_OVERRUNS_END: &str = r#"
+    (module
+      (memory (export "memory") 1)
+      (func (export "run") (param i32 i32) (result i32)
+        ;; length 10000 stored at 59996, so the host reads it for ptr = 60000.
+        ;; 10000 < 65536, but 60000 + 10000 = 70000 > 65536.
+        i32.const 59996
+        i32.const 10000
+        i32.store
+        i32.const 60000
+      )
+    )
+"#;
+
+#[tokio::test]
+async fn forged_result_length_is_rejected_before_allocating() {
+    // This test locks the WIRING, not just the predicate: it asserts the specific
+    // error the bounds check produces. Deleting the `guest_read_bounds_ok` call on
+    // the result-read path makes the host allocate the forged size and then fail
+    // with "failed to read result" instead, which fails this assertion.
+    use std::sync::atomic::Ordering;
+    let _serialize = ALLOC_OBSERVER_LOCK.lock().await;
+
+    let engine = WasmEngine::new().unwrap();
+    let hash = engine
+        .compile_and_cache(WAT_FORGED_RESULT_LENGTH.as_bytes())
+        .unwrap();
+
+    let before = LARGE_ALLOCS.load(Ordering::SeqCst);
+    let err = engine
+        .invoke(
+            &hash,
+            &make_context(),
+            make_host(),
+            &WasmResourceLimits::default(),
+            make_streams(),
+        )
+        .await
+        .expect_err("a forged result length must be rejected");
+    let large_allocs = LARGE_ALLOCS.load(Ordering::SeqCst) - before;
+
+    let message = format!("{err:?}");
+    assert!(
+        message.contains("result length exceeds guest linear memory"),
+        "expected the bounds check to reject before allocating, got: {message}"
+    );
+    // Ordering, not just rejection: moving the allocation above the guard would
+    // still produce the error above, but would trip the counter.
+    assert_eq!(
+        large_allocs, 0,
+        "the forged length must be rejected BEFORE allocating; {large_allocs} \
+         allocation(s) >= {LARGE_ALLOC_THRESHOLD} bytes were made"
+    );
+}
+
+#[tokio::test]
+async fn result_length_overrunning_memory_end_is_rejected() {
+    // Pins `ptr + len`, not just `len`: the length here is well under the guest's
+    // memory size, so only a check on the whole range rejects it.
+    let engine = WasmEngine::new().unwrap();
+    let hash = engine
+        .compile_and_cache(WAT_RESULT_LENGTH_OVERRUNS_END.as_bytes())
+        .unwrap();
+
+    let err = engine
+        .invoke(
+            &hash,
+            &make_context(),
+            make_host(),
+            &WasmResourceLimits::default(),
+            make_streams(),
+        )
+        .await
+        .expect_err("a result range running past the end of memory must be rejected");
+
+    let message = format!("{err:?}");
+    assert!(
+        message.contains("result length exceeds guest linear memory"),
+        "expected the range check to reject ptr+len past the end, got: {message}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ARN-226 (wiring, helper path): an allocation-observing guard.
+//
+// A guest calling a helper-backed host function with a huge `len` gets the same
+// `-1` back whether the bounds check runs before the allocation or after it, so
+// the return value cannot distinguish the two. This counting allocator makes the
+// ordering observable: it records allocations at or above a threshold no
+// legitimate path in this test should reach. With the guard in place the count
+// stays zero; delete the guard in `read_guest_string` / `read_guest_bytes` and
+// the host allocates the guest-chosen size first, which the assertion catches.
+// ---------------------------------------------------------------------------
+
+/// Allocation size at or above which we consider a host allocation "large".
+/// The guest memory in these tests is one 64 KiB page, so nothing legitimate in
+/// the guest-read path approaches this. It must stay **below**
+/// `WasmResourceLimits::default().max_memory` (64 MiB) so an unguarded read of a
+/// guest-chosen length is always counted — and above any legitimate allocation in
+/// this test binary (the largest is `MAX_MODULE_SIZE + 1`, 10 MiB). A future test
+/// that grows guest memory past this and reads it in-bounds would need a rethink.
+const LARGE_ALLOC_THRESHOLD: usize = 32 * 1024 * 1024;
+
+static LARGE_ALLOCS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+/// The counter is process-wide, so allocation-observing tests take this lock to
+/// avoid attributing each other's allocations. Nothing else in this crate's suite
+/// allocates near the threshold — the largest is `MAX_MODULE_SIZE + 1` (10 MiB) in
+/// `module_too_large_rejected` — so serializing these is sufficient.
+static ALLOC_OBSERVER_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+struct LargeAllocCounter;
+
+unsafe impl std::alloc::GlobalAlloc for LargeAllocCounter {
+    unsafe fn alloc(&self, layout: std::alloc::Layout) -> *mut u8 {
+        if layout.size() >= LARGE_ALLOC_THRESHOLD {
+            LARGE_ALLOCS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }
+        unsafe { std::alloc::System.alloc(layout) }
+    }
+    unsafe fn alloc_zeroed(&self, layout: std::alloc::Layout) -> *mut u8 {
+        if layout.size() >= LARGE_ALLOC_THRESHOLD {
+            LARGE_ALLOCS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }
+        unsafe { std::alloc::System.alloc_zeroed(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: std::alloc::Layout) {
+        unsafe { std::alloc::System.dealloc(ptr, layout) }
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: std::alloc::Layout, new_size: usize) -> *mut u8 {
+        if new_size >= LARGE_ALLOC_THRESHOLD {
+            LARGE_ALLOCS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }
+        unsafe { std::alloc::System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static ALLOC_COUNTER: LargeAllocCounter = LargeAllocCounter;
+
+// Calls host_emit_progress(0, 64 MiB) against a single 64 KiB page — an
+// out-of-bounds read whose length is far beyond the guest's own memory. Traps if
+// the host does NOT return the -1 error sentinel.
+const WAT_OVERSIZED_HOST_READ: &str = r#"
+    (module
+      (import "env" "host_emit_progress" (func $emit (param i32 i32) (result i32)))
+      (memory (export "memory") 1)
+      (func (export "run") (param i32 i32) (result i32)
+        i32.const 0
+        i32.const 67108864
+        call $emit
+        i32.const -1
+        i32.ne
+        if
+          unreachable
+        end
+        i32.const 0
+      )
+    )
+"#;
+
+// Same shape as WAT_OVERSIZED_HOST_READ but through `host_cache_contains`, which
+// reads via `read_guest_lossy` -> `read_guest_bytes` — the other helper. Its ABI is
+// boolean with no error sentinel (0 = not cached), so the guest cannot observe the
+// refusal; only the allocation counter can.
+const WAT_OVERSIZED_HOST_BYTES_READ: &str = r#"
+    (module
+      (import "env" "host_cache_contains" (func $contains (param i32 i32) (result i32)))
+      (memory (export "memory") 1)
+      (func (export "run") (param i32 i32) (result i32)
+        i32.const 0
+        i32.const 67108864
+        call $contains
+        drop
+        i32.const 0
+      )
+    )
+"#;
+
+#[tokio::test]
+async fn oversized_host_bytes_read_is_rejected_before_allocating() {
+    use std::sync::atomic::Ordering;
+    let _serialize = ALLOC_OBSERVER_LOCK.lock().await;
+
+    let engine = WasmEngine::new().unwrap();
+    let hash = engine
+        .compile_and_cache(WAT_OVERSIZED_HOST_BYTES_READ.as_bytes())
+        .unwrap();
+
+    let before = LARGE_ALLOCS.load(Ordering::SeqCst);
+    let result = engine
+        .invoke(
+            &hash,
+            &make_context(),
+            make_host(),
+            &WasmResourceLimits::default(),
+            make_streams(),
+        )
+        .await;
+    let large_allocs = LARGE_ALLOCS.load(Ordering::SeqCst) - before;
+
+    assert!(
+        result.is_ok(),
+        "the guest itself must run cleanly: {result:?}"
+    );
+    assert_eq!(
+        large_allocs, 0,
+        "read_guest_bytes must refuse the 64 MiB length before allocating; \
+         {large_allocs} allocation(s) >= {LARGE_ALLOC_THRESHOLD} bytes were made"
+    );
+}
+
+#[tokio::test]
+async fn oversized_host_read_is_rejected_before_allocating() {
+    use std::sync::atomic::Ordering;
+    let _serialize = ALLOC_OBSERVER_LOCK.lock().await;
+
+    let engine = WasmEngine::new().unwrap();
+    let hash = engine
+        .compile_and_cache(WAT_OVERSIZED_HOST_READ.as_bytes())
+        .unwrap();
+
+    let before = LARGE_ALLOCS.load(Ordering::SeqCst);
+    let result = engine
+        .invoke(
+            &hash,
+            &make_context(),
+            make_host(),
+            &WasmResourceLimits::default(),
+            make_streams(),
+        )
+        .await;
+    let large_allocs = LARGE_ALLOCS.load(Ordering::SeqCst) - before;
+
+    // The guest asserts it got -1 back, so a successful invocation proves the
+    // read was refused rather than served.
+    assert!(
+        result.is_ok(),
+        "host must return the error sentinel for an out-of-bounds read: {result:?}"
+    );
+    // And it was refused *before* allocating the guest-chosen 64 MiB.
+    assert_eq!(
+        large_allocs, 0,
+        "a guest-supplied length must not drive a large host allocation; \
+         {large_allocs} allocation(s) >= {LARGE_ALLOC_THRESHOLD} bytes were made"
+    );
+}
+
+#[test]
+fn guest_memory_reads_stay_inside_the_bounds_checked_helpers() {
+    // ARN-226 (class guard). The individual guards are locked by the mutation
+    // tests above, but nothing stopped a future edit from reintroducing a raw
+    // `memory.read` + `vec![0u8; len]` at a new call site — which is exactly how
+    // the original vulnerability was spread across ten places. This asserts the
+    // structural invariant instead: in this file, guest memory is only ever read
+    // inside `read_guest_string` / `read_guest_bytes`, which bounds-check first.
+    //
+    // If you are adding a host function, call one of those helpers rather than
+    // relaxing this test.
+    const ALLOWED_READ_SITES: usize = 2;
+    let source = include_str!("host_functions.rs");
+    let reads = source
+        .lines()
+        .filter(|line| {
+            let trimmed = line.trim_start();
+            // A guest-memory read passes arguments (store/caller, offset, buffer).
+            // `RwLock::read()` takes none, so the empty-paren form is excluded.
+            !trimmed.starts_with("//") && trimmed.contains(".read(") && !trimmed.contains(".read()")
+        })
+        .count();
+    assert_eq!(
+        reads, ALLOWED_READ_SITES,
+        "guest memory must only be read inside the bounds-checked helpers; \
+         found {reads} `.read(` call sites in host_functions.rs (expected \
+         {ALLOWED_READ_SITES}: one in read_guest_string, one in read_guest_bytes)"
+    );
+}

--- a/crates/temper-wasm/src/engine/host_functions.rs
+++ b/crates/temper-wasm/src/engine/host_functions.rs
@@ -97,6 +97,14 @@ pub(crate) enum FieldResolution {
     HostError,
 }
 
+/// True if a `[ptr, ptr + len)` read lies fully within a guest linear memory of
+/// `mem_size` bytes. Checked BEFORE allocating a read buffer so a guest-supplied
+/// `len` can't force a large host allocation ahead of wasmtime's own bounds check
+/// (ARN-226). `checked_add` also rejects a `ptr + len` that overflows `usize`.
+pub(super) fn guest_read_bounds_ok(mem_size: usize, ptr: usize, len: usize) -> bool {
+    ptr.checked_add(len).is_some_and(|end| end <= mem_size)
+}
+
 fn read_guest_string(caller: &mut Caller<'_, HostState>, ptr: i32, len: i32) -> Result<String, ()> {
     if ptr < 0 || len < 0 {
         return Err(());
@@ -105,9 +113,18 @@ fn read_guest_string(caller: &mut Caller<'_, HostState>, ptr: i32, len: i32) -> 
     let Some(memory) = memory else {
         return Err(());
     };
+    if !guest_read_bounds_ok(memory.data_size(&mut *caller), ptr as usize, len as usize) {
+        tracing::warn!(
+            host_fn = "read_guest_string",
+            ptr,
+            len,
+            "guest string read range exceeds linear memory; returning error before allocating"
+        );
+        return Err(());
+    }
     let mut buf = vec![0u8; len as usize];
     memory
-        .read(caller, ptr as usize, &mut buf)
+        .read(&mut *caller, ptr as usize, &mut buf)
         .map_err(|_| ())?;
     String::from_utf8(buf).map_err(|_| ())
 }
@@ -136,6 +153,16 @@ fn read_guest_bytes(
         );
         return Err(());
     }
+    if !guest_read_bounds_ok(memory.data_size(caller), ptr as usize, len as usize) {
+        tracing::warn!(
+            host_fn,
+            operand = what,
+            ptr,
+            len,
+            "guest read range exceeds linear memory; returning error before allocating"
+        );
+        return Err(());
+    }
     let mut buf = vec![0u8; len as usize];
     if let Err(error) = memory.read(caller, ptr as usize, &mut buf) {
         tracing::warn!(
@@ -160,7 +187,12 @@ fn read_guest_lossy(
     what: &'static str,
 ) -> Result<String, ()> {
     let buf = read_guest_bytes(caller, memory, ptr, len, host_fn, what)?;
-    Ok(String::from_utf8_lossy(&buf).to_string())
+    // Take the buffer by value when it is already valid UTF-8 (the common case);
+    // only the invalid path pays for a second, lossy copy.
+    Ok(match String::from_utf8(buf) {
+        Ok(text) => text,
+        Err(error) => String::from_utf8_lossy(error.as_bytes()).into_owned(),
+    })
 }
 
 /// Write `bytes` into guest memory at `ptr`.
@@ -424,15 +456,9 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
             "env",
             "host_emit_progress",
             |mut caller: Caller<'_, HostState>, ptr: i32, len: i32| -> i32 {
-                let memory = caller.get_export("memory").and_then(|e| e.into_memory());
-                let Some(memory) = memory else {
-                    return -1;
-                };
-                let mut buf = vec![0u8; len as usize];
-                if memory.read(&caller, ptr as usize, &mut buf).is_err() {
-                    return -1;
-                }
-                let Ok(payload) = String::from_utf8(buf) else {
+                // ARN-226: read via the bounds-checked helper so a guest-supplied
+                // `len` can't drive a host allocation ahead of the bounds check.
+                let Ok(payload) = read_guest_string(&mut caller, ptr, len) else {
                     return -1;
                 };
                 let _guest_span = caller.data().guest_spans.enter_active();
@@ -450,15 +476,9 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
             "env",
             "host_emit_wide_event",
             |mut caller: Caller<'_, HostState>, ptr: i32, len: i32| -> i32 {
-                let memory = caller.get_export("memory").and_then(|e| e.into_memory());
-                let Some(memory) = memory else {
-                    return -1;
-                };
-                let mut buf = vec![0u8; len as usize];
-                if memory.read(&caller, ptr as usize, &mut buf).is_err() {
-                    return -1;
-                }
-                let Ok(payload) = String::from_utf8(buf) else {
+                // ARN-226: read via the bounds-checked helper so a guest-supplied
+                // `len` can't drive a host allocation ahead of the bounds check.
+                let Ok(payload) = read_guest_string(&mut caller, ptr, len) else {
                     return -1;
                 };
                 let _guest_span = caller.data().guest_spans.enter_active();
@@ -476,15 +496,9 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
             "env",
             "host_log_structured",
             |mut caller: Caller<'_, HostState>, ptr: i32, len: i32| -> i32 {
-                let memory = caller.get_export("memory").and_then(|e| e.into_memory());
-                let Some(memory) = memory else {
-                    return -1;
-                };
-                let mut buf = vec![0u8; len as usize];
-                if memory.read(&caller, ptr as usize, &mut buf).is_err() {
-                    return -1;
-                }
-                let Ok(payload) = String::from_utf8(buf) else {
+                // ARN-226: read via the bounds-checked helper so a guest-supplied
+                // `len` can't drive a host allocation ahead of the bounds check.
+                let Ok(payload) = read_guest_string(&mut caller, ptr, len) else {
                     return -1;
                 };
                 let _guest_span = caller.data().guest_spans.enter_active();
@@ -502,15 +516,9 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
             "env",
             "host_emit_metric",
             |mut caller: Caller<'_, HostState>, ptr: i32, len: i32| -> i32 {
-                let memory = caller.get_export("memory").and_then(|e| e.into_memory());
-                let Some(memory) = memory else {
-                    return -1;
-                };
-                let mut buf = vec![0u8; len as usize];
-                if memory.read(&caller, ptr as usize, &mut buf).is_err() {
-                    return -1;
-                }
-                let Ok(payload) = String::from_utf8(buf) else {
+                // ARN-226: read via the bounds-checked helper so a guest-supplied
+                // `len` can't drive a host allocation ahead of the bounds check.
+                let Ok(payload) = read_guest_string(&mut caller, ptr, len) else {
                     return -1;
                 };
                 let _guest_span = caller.data().guest_spans.enter_active();
@@ -1323,14 +1331,17 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                     return -3;
                 };
 
-                let mut name_buf = vec![0u8; field_name_len as usize];
-                if memory
-                    .read(&caller, field_name_ptr as usize, &mut name_buf)
-                    .is_err()
-                {
+                // ARN-226: bounds-checked read before allocating.
+                let Ok(field_name) = read_guest_lossy(
+                    &caller,
+                    &memory,
+                    field_name_ptr,
+                    field_name_len,
+                    "host_read_field",
+                    "field_name",
+                ) else {
                     return -3;
-                }
-                let field_name = String::from_utf8_lossy(&name_buf).to_string();
+                };
                 let started = Instant::now();
                 let _guest_span = caller.data().guest_spans.enter_active();
                 let span = tracing::info_span!(
@@ -1708,46 +1719,51 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                     return -1;
                 };
 
-                // Read IOA source
-                let mut ioa_buf = vec![0u8; ioa_len as usize];
-                if memory
-                    .read(&caller, ioa_ptr as usize, &mut ioa_buf)
-                    .is_err()
-                {
+                // ARN-226: bounds-checked reads before allocating.
+                let Ok(ioa_source) = read_guest_lossy(
+                    &caller,
+                    &memory,
+                    ioa_ptr,
+                    ioa_len,
+                    "host_evaluate_spec",
+                    "ioa_source",
+                ) else {
                     return -1;
-                }
-                let ioa_source = String::from_utf8_lossy(&ioa_buf).to_string();
-
-                // Read current state
-                let mut state_buf = vec![0u8; state_len as usize];
-                if memory
-                    .read(&caller, state_ptr as usize, &mut state_buf)
-                    .is_err()
-                {
+                };
+                let Ok(current_state) = read_guest_lossy(
+                    &caller,
+                    &memory,
+                    state_ptr,
+                    state_len,
+                    "host_evaluate_spec",
+                    "current_state",
+                ) else {
                     return -1;
-                }
-                let current_state = String::from_utf8_lossy(&state_buf).to_string();
-
-                // Read action
-                let mut action_buf = vec![0u8; action_len as usize];
-                if memory
-                    .read(&caller, action_ptr as usize, &mut action_buf)
-                    .is_err()
-                {
+                };
+                let Ok(action) = read_guest_lossy(
+                    &caller,
+                    &memory,
+                    action_ptr,
+                    action_len,
+                    "host_evaluate_spec",
+                    "action",
+                ) else {
                     return -1;
-                }
-                let action = String::from_utf8_lossy(&action_buf).to_string();
+                };
 
-                // Read params JSON
+                // Read params JSON (ARN-226: bounds-checked read before allocating).
                 let params_json = if params_len > 0 {
-                    let mut params_buf = vec![0u8; params_len as usize];
-                    if memory
-                        .read(&caller, params_ptr as usize, &mut params_buf)
-                        .is_err()
-                    {
-                        return -1;
+                    match read_guest_lossy(
+                        &caller,
+                        &memory,
+                        params_ptr,
+                        params_len,
+                        "host_evaluate_spec",
+                        "params_json",
+                    ) {
+                        Ok(s) => s,
+                        Err(()) => return -1,
                     }
-                    String::from_utf8_lossy(&params_buf).to_string()
                 } else {
                     "{}".to_string()
                 };
@@ -2148,10 +2164,17 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
                 let memory = caller.get_export("memory").and_then(|e| e.into_memory());
                 let Some(memory) = memory else { return -4 };
 
-                let mut buf = vec![0u8; head_len as usize];
-                if memory.read(&caller, head_ptr as usize, &mut buf).is_err() {
+                // ARN-226: bounds-checked read before allocating.
+                let Ok(buf) = read_guest_bytes(
+                    &caller,
+                    &memory,
+                    head_ptr,
+                    head_len,
+                    "host_http_stream_send_response_head",
+                    "head",
+                ) else {
                     return -4;
-                }
+                };
                 #[derive(serde::Deserialize)]
                 struct RawHead {
                     status: u16,
@@ -2217,6 +2240,41 @@ pub(super) fn link_host_functions(linker: &mut Linker<HostState>) -> Result<(), 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn guest_read_bounds_ok_rejects_out_of_bounds_and_overflow() {
+        // ARN-226: a guest-supplied `len` must be validated against the guest memory
+        // size BEFORE a read buffer is allocated. Out-of-bounds or overflowing
+        // `(ptr, len)` ranges must be rejected so a huge `len` can't drive a large
+        // host allocation.
+        let mem = 64 * 1024; // 64 KiB guest linear memory
+        assert!(
+            !guest_read_bounds_ok(mem, 0, i32::MAX as usize),
+            "an i32::MAX len must be rejected before allocating ~2 GiB"
+        );
+        assert!(
+            !guest_read_bounds_ok(mem, 0, mem + 1),
+            "a len past the end of memory must be rejected"
+        );
+        assert!(
+            !guest_read_bounds_ok(mem, mem, 1),
+            "a read starting at the end of memory must be rejected"
+        );
+        assert!(
+            !guest_read_bounds_ok(mem, usize::MAX, 1),
+            "a ptr + len that overflows usize must be rejected"
+        );
+        // Legitimate in-bounds reads are still allowed.
+        assert!(
+            guest_read_bounds_ok(mem, 0, mem),
+            "a full in-bounds read is allowed"
+        );
+        assert!(guest_read_bounds_ok(mem, 0, 0), "an empty read is allowed");
+        assert!(
+            guest_read_bounds_ok(mem, 100, 200),
+            "an interior read is allowed"
+        );
+    }
 
     fn ctx_json_with_fields(fields: serde_json::Value) -> String {
         serde_json::json!({

--- a/crates/temper-wasm/src/engine/mod.rs
+++ b/crates/temper-wasm/src/engine/mod.rs
@@ -3,6 +3,9 @@
 //! Modules are compiled once and cached by SHA-256 hash. Each invocation
 //! gets a fresh `Store` with fuel + memory limits (TigerStyle budgets).
 
+#[cfg(test)]
+#[path = "guest_read_bounds_test.rs"]
+mod guest_read_bounds_test;
 mod guest_spans;
 mod host_functions;
 mod telemetry;
@@ -710,6 +713,19 @@ impl WasmEngine {
                 let result_len = u32::from_le_bytes(len_bytes) as usize;
                 phase.record("result_bytes", result_len as u64);
 
+                // ARN-226: bound the result allocation by the guest's memory size
+                // before allocating, so a forged length prefix can't drive a large
+                // host allocation ahead of the bounds check.
+                if !host_functions::guest_read_bounds_ok(
+                    memory.data_size(&store),
+                    result_ptr as usize,
+                    result_len,
+                ) {
+                    store.data_mut().guest_spans.cleanup_unclosed();
+                    return Err(WasmError::Invocation(
+                        "result length exceeds guest linear memory".to_string(),
+                    ));
+                }
                 let mut result_bytes = vec![0u8; result_len];
                 if let Err(e) = memory.read(&store, result_ptr as usize, &mut result_bytes) {
                     store.data_mut().guest_spans.cleanup_unclosed();

--- a/crates/temper-wasm/src/engine/tests.rs
+++ b/crates/temper-wasm/src/engine/tests.rs
@@ -183,7 +183,7 @@ impl WasmHost for SlowHttpHost {
     fn log(&self, _level: &str, _message: &str) {}
 }
 
-fn make_context() -> WasmInvocationContext {
+pub(super) fn make_context() -> WasmInvocationContext {
     WasmInvocationContext {
         tenant: "test".into(),
         entity_type: "Order".into(),
@@ -203,11 +203,11 @@ fn make_context() -> WasmInvocationContext {
     }
 }
 
-fn make_host() -> Arc<dyn WasmHost> {
+pub(super) fn make_host() -> Arc<dyn WasmHost> {
     Arc::new(SimWasmHost::new())
 }
 
-fn make_streams() -> Arc<RwLock<StreamRegistry>> {
+pub(super) fn make_streams() -> Arc<RwLock<StreamRegistry>> {
     Arc::new(RwLock::new(StreamRegistry::default()))
 }
 

--- a/docs/adrs/0164-wasm-guest-read-bounds-before-alloc.md
+++ b/docs/adrs/0164-wasm-guest-read-bounds-before-alloc.md
@@ -1,0 +1,126 @@
+# ADR-0164: Bounds-check guest reads before allocating
+
+- Status: Accepted
+- Date: 2026-07-12
+- Deciders: Temper core maintainers
+- Related:
+  - `crates/temper-wasm/src/engine/host_functions.rs` (guest memory reads)
+  - `crates/temper-wasm/src/engine/mod.rs` (post-invocation result read)
+  - ARN-226 (security finding)
+
+## Context
+
+WASM host functions read caller-supplied `(ptr, len)` operands out of the guest's
+linear memory. The read helpers allocate the destination buffer **before** the
+bounds check runs (`host_functions.rs`):
+
+```rust
+fn read_guest_bytes(caller, memory, ptr, len, …) -> Result<Vec<u8>, ()> {
+    if ptr < 0 || len < 0 { … return Err(()); }
+    let mut buf = vec![0u8; len as usize];        // allocation happens first
+    memory.read(caller, ptr as usize, &mut buf)?; // bounds check happens here
+    …
+}
+```
+
+`len` is an `i32` chosen by the guest, so a single call with `len = i32::MAX`
+forces the host to allocate ~2 GiB **before** `memory.read` rejects the
+out-of-bounds range. A guest can repeat this cheaply, so it is an unauthenticated
+host-side memory-exhaustion / DoS: the allocation is driven entirely by an
+attacker-controlled length that is never validated against the guest's actual
+memory size. `read_guest_string` has the same shape.
+
+## Decision
+
+Validate that the `[ptr, ptr + len)` range lies within the guest's current linear
+memory **before** allocating. `guest_read_bounds_ok(mem_size, ptr, len)` returns
+true only when `ptr + len` does not overflow `usize` and is `<= mem_size`
+(`memory.data_size(store)`). The read helpers call it first and return the ABI
+error sentinel on failure, so no buffer is allocated for an out-of-bounds length.
+
+Each allocation is therefore bounded by the guest's linear memory size, which is
+itself capped by `WasmResourceLimits::max_memory`: an oversized `len` is rejected
+before any allocation, so no single read can allocate more than the guest could
+legitimately hold.
+
+This is a **per-allocation** bound, not a per-invocation one. A host function that
+performs several reads (`host_evaluate_spec` holds four) still peaks at a multiple
+of the guest's memory, and the outbound stream channel is bounded in chunks rather
+than bytes. An aggregate copy budget is the right next tightening and is tracked
+separately (see Follow-ups); it is out of scope here because it is a functionality
+cap, not a fix for the disclosed vector.
+
+The guard is applied at every guest-length-driven allocation, not only the two
+helpers:
+
+- `read_guest_string` / `read_guest_bytes` check internally, and the ten previously
+  inline `vec![0u8; len]` sites (the `host_emit_*` family, `host_read_field`,
+  `host_evaluate_spec`, `host_http_stream_send_response_head`) are refactored onto
+  them. Four of those had no negative-length check at all, so `len = -1` requested a
+  `usize::MAX`-sized allocation.
+- The **post-invocation result read** (`engine/mod.rs`) is a separate vector: the
+  guest returns a pointer whose preceding four bytes are a `u32` length prefix, so a
+  forged prefix could drive a ~4 GiB allocation. It calls `guest_read_bounds_ok`
+  directly before allocating and fails with a distinct
+  `"result length exceeds guest linear memory"`.
+
+Tests cover the predicate *and* the wiring, because a returned error sentinel alone
+cannot distinguish "rejected before allocating" from "allocated, then failed":
+
+- a unit test pins the predicate's boundaries (`end == mem_size` allowed; overflow
+  and out-of-range rejected);
+- two end-to-end tests drive a guest calling a helper-backed host function with a
+  64 MiB length against a 64 KiB page — one per helper (`host_emit_progress` for
+  `read_guest_string`, `host_cache_contains` for `read_guest_bytes`) — and a counting
+  allocator in the test binary asserts **no allocation at or above 32 MiB happened**.
+  This is the only way to catch a deleted helper guard: the guest sees the same
+  result either way (`-1`, and for the cache ABI a plain `0`), so only the
+  allocation itself distinguishes "refused" from "allocated, then failed";
+- a second end-to-end test returns a forged 64 MiB result-length prefix and asserts
+  both the distinct error and the absence of a large allocation, so moving the
+  allocation above the guard is caught as well;
+- a third returns a length that is small on its own but whose `ptr + len` runs past
+  the end of memory, pinning the check to the whole range rather than the length.
+
+Each of those five mutations — deleting either helper guard, deleting the result
+guard, moving the result allocation above its guard, and weakening the check to
+`len` alone — was applied and confirmed to turn the suite red.
+
+A sixth test guards the *class* rather than the instances: it asserts that guest
+memory is read in exactly two places in `host_functions.rs` (inside the two
+bounds-checked helpers). The original vulnerability existed because the raw
+allocate-then-read shape had been copied to ten call sites; this fails if an
+eleventh appears, instead of waiting for someone to notice.
+
+## Consequences
+
+### Positive
+- A guest-supplied `len` can no longer force a host allocation larger than the
+  guest's own (already bounded) memory. Host-function reads fail fast with the same
+  ABI error sentinel the out-of-bounds `memory.read` would have produced, minus the
+  allocation; the post-invocation result path deliberately reports a distinct
+  `"result length exceeds guest linear memory"` so its guard is observable in tests.
+
+### Behavior
+- Legitimate in-bounds reads are unchanged (the extra check is a single
+  comparison). Out-of-bounds reads already failed; they now fail before rather
+  than after allocating.
+
+### DST Compliance
+- Pure integer arithmetic (`checked_add`, comparison); no wall clock, no threads,
+  no `HashMap`, no ambient I/O. Deterministic.
+
+## Non-Goals / Follow-ups
+- **Aggregate host-copy budget — tracked as ARN-348.** This ADR bounds each
+  allocation by the guest's own memory; it does not bound their *sum*. In-bounds
+  paths still amplify: `host_evaluate_spec` holds four reads at once, the outbound
+  stream channel is bounded in chunks rather than bytes (so large in-bounds writes
+  can pin far more than the intended ~1 MiB), and `max_response_bytes` is still not
+  enforced on the HTTP body path. Fuel and `max_duration` bound execution, not
+  resident host bytes, so they are not substitutes. That work is a functionality
+  cap as much as a security one and needs its own sign-off.
+
+## Alternatives Considered
+1. **Clamp `len` to a fixed constant.** Rejected: a fixed cap either breaks
+   legitimate large reads or is still larger than needed; bounding by the guest's
+   own memory size is exact and self-adjusting.


### PR DESCRIPTION
Closes the disclosed vector in **ARN-226**. Supersedes #374 (rebased onto current `main`, hardened after three adversarial rounds).

## Vulnerability
Host functions read guest memory with a guest-supplied `(ptr, len)`, but allocated the destination buffer **before** the bounds check. `len = i32::MAX` → ~2 GiB host allocation before `memory.read` rejects it; repeatable and unauthenticated. Four inline sites had no negative check at all, so `len = -1` requested a `usize::MAX` allocation. The ResourceLimiter bounds *guest* memory — not host allocations inside host functions.

## Fix
`guest_read_bounds_ok` validates `[ptr, ptr+len)` (overflow-checked) against the guest's current memory **before** allocating. Both helpers check internally, the ten inline `vec![0u8; len]` sites are refactored onto them, and the post-invocation result read — where a forged `u32` length prefix could drive ~4 GiB — checks directly.

## Why this took three Grok rounds — the testing, not the fix
A guest sees the **same result** whether the check runs before or after the allocation, so no ordinary assertion distinguishes them:
- **Round 1**: only the predicate was tested — deleting a real guard failed **zero** tests.
- **Round 2**: I'd locked only `read_guest_string`; `read_guest_bytes` still failed zero tests, and the result test locked *presence* but not *ordering*.
- **Now**: a counting allocator asserts **no allocation ≥32 MiB happened**, driving each helper through a host function whose ABI cannot report the refusal (`host_cache_contains` returns a plain `0`).

**Six mutations applied and confirmed red** — and the final reviewer independently reproduced all of them by cloning the worktree:
1. delete `read_guest_string` guard 2. delete `read_guest_bytes` guard 3. delete result guard 4. **move the allocation above its guard** 5. weaken to a `len`-only check 6. **reintroduce a raw allocate-then-read at a new site** (a class guard — the original bug existed because that shape was copied to ten places)

## Scope — deliberately per-allocation, not per-invocation
This bounds each allocation by the guest's own memory. It does **not** bound their sum: `host_evaluate_spec` holds four reads at once, the outbound stream channel is bounded in **chunks not bytes** (so large in-bounds writes can pin far more than the intended ~1 MiB), and `max_response_bytes` is still unenforced on the HTTP body path. Filed as **ARN-348** and stated in the ADR rather than left implied. Fuel and `max_duration` bound execution, not resident host bytes, so they aren't substitutes.

**ARN-226 should stay open until ARN-348 lands** — this closes the disclosed vector, not the whole issue.

@greptile-apps review

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR prevents guest-controlled lengths from causing host allocations before guest-memory bounds validation.
- Adds overflow-safe range validation to both guest-read helpers and the post-invocation result path.
- Refactors inline guest-memory reads through the guarded helpers.
- Adds allocation-observing integration tests, predicate coverage, a structural regression test, and an ADR documenting scope and residual aggregate-memory risks.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/temper-wasm/src/engine/host_functions.rs | Adds overflow-safe pre-allocation bounds checks and routes previously inline guest reads through the guarded helpers. |
| crates/temper-wasm/src/engine/mod.rs | Validates the guest-returned result range before allocating the result buffer. |
| crates/temper-wasm/src/engine/guest_read_bounds_test.rs | Adds predicate, end-to-end allocation-ordering, range-overrun, and structural regression coverage. |
| docs/adrs/0164-wasm-guest-read-bounds-before-alloc.md | Documents the vulnerability, pre-allocation validation design, test strategy, and explicitly deferred aggregate-memory controls. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Guest
  participant HostFn as Host function
  participant Guard as guest_read_bounds_ok
  participant Memory as Guest linear memory
  Guest->>HostFn: ptr, len
  HostFn->>Memory: data_size()
  HostFn->>Guard: mem_size, ptr, len
  alt Range is out of bounds or overflows
    Guard-->>HostFn: false
    HostFn-->>Guest: ABI error sentinel
  else Range is valid
    Guard-->>HostFn: true
    HostFn->>HostFn: allocate len-byte buffer
    HostFn->>Memory: read(ptr, buffer)
    HostFn-->>Guest: host-function result
  end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(wasm): bounds-check guest reads befo..."](https://github.com/nerdsane/temper/commit/7383e045c55d4ba3ec6ef705648a088d744743e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53995814)</sub>

**Context used:**

- Knowledge Base — [Temper WASM Runtime](https://app.greptile.com/arni-labs/-/custom-context/knowledge-base/nerdsane/temper/-/docs/temper-wasm.md)

<!-- /greptile_comment -->