### PR TITLE
fix(odata): default page size 100 → 1000 — stop the silent-truncation footgun (ARN-363)

### DIFF
--- a/crates/temper-server/src/odata/read_support/config.rs
+++ b/crates/temper-server/src/odata/read_support/config.rs
@@ -20,9 +20,16 @@ fn env_bool(name: &str, default: bool) -> bool {
 }
 
 /// Default OData collection page size when `$top` is absent.
+///
+/// Defaults to the same value as `odata_max_entities` (the no-`$top` safety
+/// ceiling): a bare list read returns the whole realistic collection in one
+/// page, with an `@odata.nextLink` (`$skiptoken`) only beyond the ceiling.
+/// The previous default of 100 was an arbitrary small cap that silently
+/// returned only the first 100 rows to any consumer that didn't follow the
+/// nextLink — a recurring data-loss footgun (ARN-363). Overridable via env.
 pub(in crate::odata) fn odata_default_page_size() -> usize {
     static DEFAULT_PAGE_SIZE: OnceLock<usize> = OnceLock::new();
-    *DEFAULT_PAGE_SIZE.get_or_init(|| env_usize("TEMPER_ODATA_DEFAULT_PAGE_SIZE", 100))
+    *DEFAULT_PAGE_SIZE.get_or_init(|| env_usize("TEMPER_ODATA_DEFAULT_PAGE_SIZE", 1000))
 }
 
 /// Maximum OData collection page size.


### PR DESCRIPTION
A bare list read (no `$top`) was capped at **100** while the no-`$top` safety ceiling (`odata_max_entities`) is already **1000** and truncation already emits an `@odata.nextLink` (`$skiptoken`). The arbitrary 100 default silently returned only the first 100 rows to any consumer that didn't follow the nextLink — a recurring data-loss footgun (Katagami saw 100 of 272/270/154; our own contribution MCP search was truncated in prod).

**Fix:** raise the default to the ceiling (`read_support/config.rs`) so a bare read returns the whole realistic collection in one page; nextLink still paginates beyond 1000. Not a band-aid — the nextLink safety already exists, so this just removes the pointless small cap. Overridable via `TEMPER_ODATA_DEFAULT_PAGE_SIZE`.

Considered and rejected: *always emit `@odata.count`* — in this kernel `$count` disables filter-pushdown and forces full materialization, so it'd be a platform-wide perf regression.

`cargo check -p temper-server` clean. Tests inject their own `default_page_size`, so unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9E6ZCTB9exceniQEgmfmR

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR raises the default OData collection page size from 100 to 1000 to reduce accidental truncation for clients that do not follow next links. However, the unchanged candidate-scan budget makes some sparsely authorized bare reads fail with HTTP 413 instead of returning a page.
- Changes `TEMPER_ODATA_DEFAULT_PAGE_SIZE`'s fallback to 1000.
- Adds documentation explaining the intended relationship with the no-`$top` ceiling.
- Leaves maximum-entity and authorization-scan limits unchanged.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The sparse-authorization pagination regression should be fixed before merging because affected bare collection reads can now return HTTP 413 instead of a usable page and nextLink.

Increasing the target page from 100 to 1000 without increasing or decoupling the candidate scan budget requires substantially more authorized rows per request, causing budget exhaustion on reachable low-visibility collection reads.

**Files Needing Attention:** crates/temper-server/src/odata/read_support/config.rs
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/temper-server/src/odata/read_support/config.rs | The larger default improves common bare reads but can turn sparsely authorized collection reads into HTTP 413 responses, and its comment overstates the relationship between independently configurable limits. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20nerdsane%2Ftemper%20PR%20%23430%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=nerdsane%2Ftemper&pr=430&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Acrates%2Ftemper-server%2Fsrc%2Fodata%2Fread_support%2Fconfig.rs%3A32%0A**Sparse%20authorization%20exhausts%20scan%20budget**%0A%0AIf%20a%20bare%20collection%20read%20has%20more%20than%2010%2C000%20candidates%20and%20authorization%20exposes%20enough%20rows%20for%20the%20former%20100-row%20page%20but%20fewer%20than%201%2C001%20within%20the%20unchanged%20scan%20budget%2C%20the%20new%20default%20exhausts%20that%20budget%20while%20filling%20the%20page%2C%20causing%20the%20request%20to%20return%20HTTP%20413%20instead%20of%20100%20rows%20with%20an%20%60%40odata.nextLink%60.%0A%0A%23%23%23%20Issue%202%0Acrates%2Ftemper-server%2Fsrc%2Fodata%2Fread_support%2Fconfig.rs%3A24-25%0A**Independent%20limits%20documented%20as%20equal**%0A%0AWhen%20%60TEMPER_ODATA_MAX_ENTITIES%60%20is%20overridden%20independently%2C%20the%20default%20page%20size%20no%20longer%20has%20the%20same%20value%20as%20%60odata_max_entities%60%3B%20this%20wording%20obscures%20the%20effective%20bare-read%20size%20for%20operators.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20Defaults%20to%201000%20and%20is%20capped%20by%20%60odata_max_entities%60%20%28the%20no-%60%24top%60%0A%2F%2F%2F%20safety%20ceiling%29%3A%20a%20bare%20list%20read%20returns%20the%20whole%20realistic%20collection%20in%20one%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=nerdsane%2Ftemper&pr=430&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22claude%2Fodata-count-nonsilent%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fodata-count-nonsilent%22.%0A%0A%23%23%23%20Issue%201%0Acrates%2Ftemper-server%2Fsrc%2Fodata%2Fread_support%2Fconfig.rs%3A32%0A**Sparse%20authorization%20exhausts%20scan%20budget**%0A%0AIf%20a%20bare%20collection%20read%20has%20more%20than%2010%2C000%20candidates%20and%20authorization%20exposes%20enough%20rows%20for%20the%20former%20100-row%20page%20but%20fewer%20than%201%2C001%20within%20the%20unchanged%20scan%20budget%2C%20the%20new%20default%20exhausts%20that%20budget%20while%20filling%20the%20page%2C%20causing%20the%20request%20to%20return%20HTTP%20413%20instead%20of%20100%20rows%20with%20an%20%60%40odata.nextLink%60.%0A%0A%23%23%23%20Issue%202%0Acrates%2Ftemper-server%2Fsrc%2Fodata%2Fread_support%2Fconfig.rs%3A24-25%0A**Independent%20limits%20documented%20as%20equal**%0A%0AWhen%20%60TEMPER_ODATA_MAX_ENTITIES%60%20is%20overridden%20independently%2C%20the%20default%20page%20size%20no%20longer%20has%20the%20same%20value%20as%20%60odata_max_entities%60%3B%20this%20wording%20obscures%20the%20effective%20bare-read%20size%20for%20operators.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20Defaults%20to%201000%20and%20is%20capped%20by%20%60odata_max_entities%60%20%28the%20no-%60%24top%60%0A%2F%2F%2F%20safety%20ceiling%29%3A%20a%20bare%20list%20read%20returns%20the%20whole%20realistic%20collection%20in%20one%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=nerdsane%2Ftemper&pr=430&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Acrates%2Ftemper-server%2Fsrc%2Fodata%2Fread_support%2Fconfig.rs%3A32%0A**Sparse%20authorization%20exhausts%20scan%20budget**%0A%0AIf%20a%20bare%20collection%20read%20has%20more%20than%2010%2C000%20candidates%20and%20authorization%20exposes%20enough%20rows%20for%20the%20former%20100-row%20page%20but%20fewer%20than%201%2C001%20within%20the%20unchanged%20scan%20budget%2C%20the%20new%20default%20exhausts%20that%20budget%20while%20filling%20the%20page%2C%20causing%20the%20request%20to%20return%20HTTP%20413%20instead%20of%20100%20rows%20with%20an%20%60%40odata.nextLink%60.%0A%0A%23%23%23%20Issue%202%0Acrates%2Ftemper-server%2Fsrc%2Fodata%2Fread_support%2Fconfig.rs%3A24-25%0A**Independent%20limits%20documented%20as%20equal**%0A%0AWhen%20%60TEMPER_ODATA_MAX_ENTITIES%60%20is%20overridden%20independently%2C%20the%20default%20page%20size%20no%20longer%20has%20the%20same%20value%20as%20%60odata_max_entities%60%3B%20this%20wording%20obscures%20the%20effective%20bare-read%20size%20for%20operators.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20Defaults%20to%201000%20and%20is%20capped%20by%20%60odata_max_entities%60%20%28the%20no-%60%24top%60%0A%2F%2F%2F%20safety%20ceiling%29%3A%20a%20bare%20list%20read%20returns%20the%20whole%20realistic%20collection%20in%20one%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=430&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
crates/temper-server/src/odata/read_support/config.rs:32
**Sparse authorization exhausts scan budget**

If a bare collection read has more than 10,000 candidates and authorization exposes enough rows for the former 100-row page but fewer than 1,001 within the unchanged scan budget, the new default exhausts that budget while filling the page, causing the request to return HTTP 413 instead of 100 rows with an `@odata.nextLink`.

### Issue 2
crates/temper-server/src/odata/read_support/config.rs:24-25
**Independent limits documented as equal**

When `TEMPER_ODATA_MAX_ENTITIES` is overridden independently, the default page size no longer has the same value as `odata_max_entities`; this wording obscures the effective bare-read size for operators.

```suggestion
/// Defaults to 1000 and is capped by `odata_max_entities` (the no-`$top`
/// safety ceiling): a bare list read returns the whole realistic collection in one
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(odata): default page size 100 -&gt; 100..."](https://github.com/nerdsane/temper/commit/0bc3ea9d81bf962edcbd35855500616766cd0d3c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54606520)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [temper-server](https://app.greptile.com/arni-labs/-/custom-context/knowledge-base/nerdsane/temper/-/docs/temper-server.md)

<!-- /greptile_comment -->