### PR TITLE
fix(platform): seed operator manage_policies and block self-approval (ARN-389)

### DIFF
--- a/crates/temper-platform/Cargo.toml
+++ b/crates/temper-platform/Cargo.toml
@@ -10,7 +10,7 @@ description = "Dogfooded hosting platform for Temper — verify-and-deploy pipel
 temper-spec = { workspace = true }
 temper-verify = { workspace = true }
 temper-jit = { workspace = true }
-temper-server = { workspace = true }
+temper-server = { workspace = true, features = ["observe"] }
 temper-store-turso = { workspace = true }
 temper-observe = { workspace = true }
 temper-runtime = { workspace = true }

--- a/crates/temper-platform/src/bootstrap.rs
+++ b/crates/temper-platform/src/bootstrap.rs
@@ -394,12 +394,16 @@ pub async fn persist_agent_verification(
 ///
 /// When the platform boots with a `TEMPER_API_KEY` configured, this function
 /// ensures a corresponding `AgentType` ("operator") and `AgentCredential`
-/// exist in the default tenant so the bearer auth middleware can resolve
-/// the key resolves as a verified identity in that tenant. Registration in one
-/// tenant deliberately grants no authority in any other tenant.
+/// exist in the given tenant so the bearer auth middleware can resolve the
+/// key as a verified identity in that tenant. Registration in one tenant
+/// deliberately grants no authority in any other tenant.
 ///
-/// This is idempotent: if the entities already exist (e.g., from a previous
-/// boot), the actions are no-ops (entity already in target state).
+/// Also seeds a narrow Cedar permit so a verified operator can
+/// `manage_policies` on that tenant's `PolicySet` (ADR-0172). The permit is
+/// merged into live Cedar, persisted as a granular row, and is idempotent.
+///
+/// This is idempotent: if the entities and permit already exist (e.g., from a
+/// previous boot), the actions are no-ops.
 pub async fn bootstrap_operator_credential(state: &PlatformState, api_key: &str, tenant: &str) {
     use temper_server::identity::hash_token;
 
@@ -453,6 +457,8 @@ pub async fn bootstrap_operator_credential(state: &PlatformState, api_key: &str,
             &agent_ctx,
         )
         .await;
+
+    crate::operator_manage_policies::seed_operator_manage_policies(state, tenant).await;
 
     tracing::info!(
         "Operator credential bootstrapped for tenant '{tenant}' (key_hash={}...)",

--- a/crates/temper-platform/src/lib.rs
+++ b/crates/temper-platform/src/lib.rs
@@ -12,6 +12,7 @@ pub mod deploy;
 pub mod genesis_install;
 pub mod hooks;
 pub mod integration;
+mod operator_manage_policies;
 pub mod optimization;
 pub mod os_apps;
 pub mod protocol;

--- a/crates/temper-platform/src/operator_manage_policies.rs
+++ b/crates/temper-platform/src/operator_manage_policies.rs
@@ -1,0 +1,139 @@
+//! Narrow operator `manage_policies` permit seeded at credential bootstrap.
+//!
+//! See ADR-0172. This is ordinary Cedar — merged into live tenant policy,
+//! persisted as a granular row, not a code bypass and not permit-all.
+
+use temper_server::authz::persist_and_activate_policy;
+
+use crate::state::PlatformState;
+
+/// Stable granular policy id for the operator bootstrap permit.
+pub const OPERATOR_MANAGE_POLICIES_POLICY_ID: &str = "operator-bootstrap-manage-policies";
+
+/// Cedar statement granting a verified operator `manage_policies` on this tenant.
+pub fn operator_manage_policies_cedar(tenant: &str) -> String {
+    debug_assert!(
+        !tenant.is_empty() && !tenant.contains('"'),
+        "tenant id must be a Cedar-safe identifier"
+    );
+    format!(
+        r#"permit(
+  principal is Agent,
+  action == Action::"manage_policies",
+  resource == PolicySet::"{tenant}"
+) when {{
+  principal.agent_type == "operator" &&
+  principal.agentTypeVerified == true
+}};"#
+    )
+}
+
+/// Append `statement` to `existing` when it is not already present.
+pub fn merge_cedar_statement(existing: &str, statement: &str) -> String {
+    let statement = statement.trim();
+    let existing = existing.trim_end();
+    if statement.is_empty() || existing.contains(statement) {
+        return existing.to_string();
+    }
+    if existing.is_empty() {
+        statement.to_string()
+    } else {
+        format!("{existing}\n{statement}")
+    }
+}
+
+fn live_tenant_policy_text(state: &PlatformState, tenant: &str) -> String {
+    if let Some(active_text) = state
+        .server
+        .authz
+        .get_tenant_policy_text(tenant)
+        .filter(|policy_text| !policy_text.trim().is_empty())
+    {
+        return active_text;
+    }
+
+    state
+        .server
+        .tenant_policies
+        .read()
+        .ok()
+        .and_then(|policies| policies.get(tenant).cloned())
+        .unwrap_or_default()
+}
+
+/// Merge, activate, and persist the operator `manage_policies` permit for `tenant`.
+///
+/// Idempotent: re-bootstrap does not duplicate the live statement or the
+/// granular row. Does not replace existing app Cedar.
+pub async fn seed_operator_manage_policies(state: &PlatformState, tenant: &str) {
+    assert!(
+        !tenant.is_empty() && !tenant.contains('"'),
+        "tenant id must be a Cedar-safe identifier"
+    );
+
+    let statement = operator_manage_policies_cedar(tenant);
+    let existing = live_tenant_policy_text(state, tenant);
+    let merged = merge_cedar_statement(&existing, &statement);
+
+    if let Err(error) = state.server.authz.reload_tenant_policies(tenant, &merged) {
+        tracing::warn!(
+            tenant,
+            error = %error,
+            "failed to activate operator manage_policies Cedar permit"
+        );
+        return;
+    }
+
+    {
+        let mut policies = state
+            .server
+            .tenant_policies
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        policies.insert(tenant.to_string(), merged);
+    }
+
+    persist_and_activate_policy(
+        &state.server,
+        tenant,
+        OPERATOR_MANAGE_POLICIES_POLICY_ID,
+        &statement,
+        "bootstrap",
+    )
+    .await;
+
+    tracing::info!(
+        tenant,
+        policy_id = OPERATOR_MANAGE_POLICIES_POLICY_ID,
+        "operator manage_policies Cedar permit seeded"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merge_cedar_statement_is_idempotent_and_preserves_existing() {
+        let statement = operator_manage_policies_cedar("acme");
+        let app = r#"permit(principal, action == Action::"read", resource is Issue);"#;
+
+        let once = merge_cedar_statement(app, &statement);
+        assert!(once.contains("resource is Issue"));
+        assert!(once.contains(r#"Action::"manage_policies""#));
+        assert_eq!(merge_cedar_statement(&once, &statement), once);
+
+        assert_eq!(merge_cedar_statement("", &statement), statement.trim());
+    }
+
+    #[test]
+    fn operator_manage_policies_cedar_is_tenant_scoped() {
+        let acme = operator_manage_policies_cedar("acme");
+        let other = operator_manage_policies_cedar("other");
+        assert!(acme.contains(r#"PolicySet::"acme""#));
+        assert!(!acme.contains(r#"PolicySet::"other""#));
+        assert!(other.contains(r#"PolicySet::"other""#));
+        assert!(acme.contains(r#"principal.agent_type == "operator""#));
+        assert!(acme.contains("principal.agentTypeVerified == true"));
+    }
+}

--- a/crates/temper-platform/tests/operator_bootstrap_cedar.rs
+++ b/crates/temper-platform/tests/operator_bootstrap_cedar.rs
@@ -1,0 +1,479 @@
+//! ARN-389 / ADR-0172: operator bootstrap seeds `manage_policies`.
+//!
+//! Proves a virgin store's verified operator can manage Cedar, that
+//! unverified / non-operator principals stay denied, that re-bootstrap is
+//! idempotent, and that OS-app Cedar still loads.
+
+use std::collections::{BTreeMap, HashMap};
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::json;
+use temper_authz::{AuthzDecision, SecurityContext};
+use temper_platform::bootstrap::{bootstrap_agent_specs, bootstrap_operator_credential};
+use temper_platform::install_os_app;
+use temper_platform::recovery::recover_cedar_policies;
+use temper_platform::router::build_platform_router;
+use temper_platform::state::PlatformState;
+use temper_runtime::tenant::TenantId;
+use temper_server::StorageStack;
+use temper_server::identity::hash_token;
+use temper_server::request_context::AgentContext;
+use temper_server::state::PendingDecision;
+use temper_store_turso::TursoEventStore;
+use tower::ServiceExt;
+
+mod common;
+use common::http::body_json;
+
+const OPERATOR_KEY: &str = "tmpr_operator-bootstrap-cedar";
+const DEVELOPER_KEY: &str = "tmpr_developer-bootstrap-cedar";
+const POLICY_ID: &str = "operator-bootstrap-manage-policies";
+
+fn virgin_state(tenant: &str) -> PlatformState {
+    let state = PlatformState::new(None);
+    bootstrap_agent_specs(&state, tenant, false, &BTreeMap::new());
+    state
+}
+
+async fn virgin_state_with_store(tenant: &str) -> (PlatformState, tempfile::TempDir) {
+    let temp = tempfile::tempdir().expect("temp policy db");
+    let db_url = format!("file:{}", temp.path().join("policy.db").display());
+    let store = TursoEventStore::new(&db_url, None)
+        .await
+        .expect("create turso store");
+    let mut state = virgin_state(tenant);
+    state
+        .server
+        .set_storage_stack(StorageStack::from_turso(store));
+    (state, temp)
+}
+
+fn manage_policies_attrs(tenant: &str) -> HashMap<String, serde_json::Value> {
+    let mut attrs = HashMap::new();
+    attrs.insert("id".to_string(), json!(tenant));
+    attrs.insert("tenant".to_string(), json!(tenant));
+    attrs
+}
+
+fn authorize_manage_policies(
+    state: &PlatformState,
+    tenant: &str,
+    ctx: &SecurityContext,
+) -> AuthzDecision {
+    state.server.authz.authorize_for_tenant(
+        tenant,
+        ctx,
+        "manage_policies",
+        "PolicySet",
+        &manage_policies_attrs(tenant),
+    )
+}
+
+fn unverified_operator_context() -> SecurityContext {
+    let mut ctx = SecurityContext::from_resolved_identity("operator", "operator", None);
+    ctx.principal
+        .attributes
+        .insert("agentTypeVerified".to_string(), json!(false));
+    ctx.context_attrs
+        .insert("agentTypeVerified".to_string(), json!(false));
+    ctx
+}
+
+async fn issue_developer_credential(state: &PlatformState, tenant: &str, plaintext: &str) {
+    let tenant_id = TenantId::new(tenant);
+    let ctx = AgentContext::system();
+    let key_hash = hash_token(plaintext);
+    let _ = state
+        .server
+        .dispatch_tenant_action(
+            &tenant_id,
+            "AgentType",
+            "developer-type",
+            "Define",
+            json!({
+                "name": "developer",
+                "system_prompt": "test",
+                "tool_set": "local",
+                "model": "none",
+                "max_turns": "0",
+                "adapter_config": "{}",
+                "default_budget_cents": "0"
+            }),
+            &ctx,
+        )
+        .await;
+    let _ = state
+        .server
+        .dispatch_tenant_action(
+            &tenant_id,
+            "AgentCredential",
+            &key_hash,
+            "Issue",
+            json!({
+                "agent_type_id": "developer-type",
+                "agent_instance_id": "developer",
+                "key_hash": key_hash,
+                "key_prefix": plaintext.chars().take(8).collect::<String>(),
+                "description": "non-operator test credential",
+                "created_by": "test",
+                "expires_at": ""
+            }),
+            &ctx,
+        )
+        .await;
+}
+
+fn statement_occurrences(haystack: &str, tenant: &str) -> usize {
+    let needle = format!(r#"resource == PolicySet::"{tenant}""#);
+    haystack.matches(&needle).count()
+}
+
+#[tokio::test]
+async fn virgin_store_verified_operator_can_manage_policies() {
+    let tenant = "acme";
+    let state = virgin_state(tenant);
+    bootstrap_operator_credential(&state, OPERATOR_KEY, tenant).await;
+
+    let operator = SecurityContext::from_resolved_identity("operator", "operator", None);
+    let decision = authorize_manage_policies(&state, tenant, &operator);
+    assert!(
+        decision.is_allowed(),
+        "verified operator must be allowed manage_policies on a virgin store, got {decision:?}"
+    );
+
+    let text = state
+        .server
+        .authz
+        .get_tenant_policy_text(tenant)
+        .expect("seeded policy text");
+    assert!(text.contains(r#"Action::"manage_policies""#));
+    assert!(text.contains(r#"PolicySet::"acme""#));
+}
+
+#[tokio::test]
+async fn unverified_or_non_operator_cannot_manage_policies() {
+    let tenant = "acme";
+    let state = virgin_state(tenant);
+    bootstrap_operator_credential(&state, OPERATOR_KEY, tenant).await;
+
+    let unverified = authorize_manage_policies(&state, tenant, &unverified_operator_context());
+    assert!(
+        !unverified.is_allowed(),
+        "unverified operator must stay denied, got {unverified:?}"
+    );
+
+    let developer = SecurityContext::from_resolved_identity("developer", "developer", None);
+    let denied = authorize_manage_policies(&state, tenant, &developer);
+    assert!(
+        !denied.is_allowed(),
+        "non-operator must stay denied, got {denied:?}"
+    );
+}
+
+#[tokio::test]
+async fn rebootstrap_is_idempotent_and_persists_one_granular_row() {
+    let tenant = "acme";
+    let (state, _temp) = virgin_state_with_store(tenant).await;
+
+    bootstrap_operator_credential(&state, OPERATOR_KEY, tenant).await;
+    bootstrap_operator_credential(&state, OPERATOR_KEY, tenant).await;
+
+    let text = state
+        .server
+        .authz
+        .get_tenant_policy_text(tenant)
+        .expect("seeded policy text");
+    assert_eq!(
+        statement_occurrences(&text, tenant),
+        1,
+        "re-bootstrap must not duplicate the live permit: {text}"
+    );
+
+    let rows = state
+        .server
+        .policy_store()
+        .expect("policy store")
+        .load_policies_for_tenant(tenant)
+        .await
+        .expect("load policies");
+    let matches: Vec<_> = rows
+        .iter()
+        .filter(|row| row.policy_id == POLICY_ID)
+        .collect();
+    assert_eq!(
+        matches.len(),
+        1,
+        "re-bootstrap must not create duplicate granular rows: {rows:?}"
+    );
+    assert!(matches[0].enabled);
+    assert!(
+        matches[0]
+            .cedar_text
+            .contains(r#"Action::"manage_policies""#)
+    );
+}
+
+#[tokio::test]
+async fn existing_app_cedar_still_loads_after_operator_bootstrap() {
+    let tenant = "app-tenant";
+    let (state, _temp) = virgin_state_with_store(tenant).await;
+
+    bootstrap_operator_credential(&state, OPERATOR_KEY, tenant).await;
+    install_os_app(&state, tenant, "project-management")
+        .await
+        .expect("install project-management");
+
+    let operator = SecurityContext::from_resolved_identity("operator", "operator", None);
+    assert!(
+        authorize_manage_policies(&state, tenant, &operator).is_allowed(),
+        "operator manage_policies must survive app install"
+    );
+
+    let any = SecurityContext::from_resolved_identity("operator", "operator", None);
+    let mut issue_attrs = HashMap::new();
+    issue_attrs.insert("id".to_string(), json!("issue-1"));
+    let create =
+        state
+            .server
+            .authz
+            .authorize_for_tenant(tenant, &any, "create", "Issue", &issue_attrs);
+    assert!(
+        create.is_allowed(),
+        "project-management Issue.create must remain allowed after operator seed: {create:?}"
+    );
+
+    let rows = state
+        .server
+        .policy_store()
+        .expect("policy store")
+        .load_policies_for_tenant(tenant)
+        .await
+        .expect("load policies");
+    assert!(
+        rows.iter().any(|row| row.policy_id == POLICY_ID),
+        "operator bootstrap row must remain: {rows:?}"
+    );
+    assert!(
+        rows.iter().any(|row| {
+            row.policy_id == "project-management-issue"
+                && row.cedar_text.contains("resource is Issue")
+        }),
+        "app Issue cedar row must persist: {rows:?}"
+    );
+}
+
+#[tokio::test]
+async fn recovered_granular_row_still_allows_verified_operator() {
+    let tenant = "acme";
+    let temp = tempfile::tempdir().expect("temp recovery db");
+    let db_url = format!("file:{}", temp.path().join("policy.db").display());
+    let store = TursoEventStore::new(&db_url, None)
+        .await
+        .expect("create turso store");
+
+    let mut seeded = virgin_state(tenant);
+    seeded
+        .server
+        .set_storage_stack(StorageStack::from_turso(store.clone()));
+    bootstrap_operator_credential(&seeded, OPERATOR_KEY, tenant).await;
+
+    let recovered = PlatformState::new(None);
+    recover_cedar_policies(&recovered, &store).await;
+
+    let operator = SecurityContext::from_resolved_identity("operator", "operator", None);
+    let decision = authorize_manage_policies(&recovered, tenant, &operator);
+    assert!(
+        decision.is_allowed(),
+        "recovered operator permit must allow manage_policies, got {decision:?}"
+    );
+}
+
+#[tokio::test]
+async fn http_policy_api_allows_operator_and_denies_developer() {
+    let tenant = "acme";
+    let (state, _temp) = virgin_state_with_store(tenant).await;
+    bootstrap_operator_credential(&state, OPERATOR_KEY, tenant).await;
+    issue_developer_credential(&state, tenant, DEVELOPER_KEY).await;
+
+    let app = build_platform_router(state);
+
+    let allowed = app
+        .clone()
+        .oneshot(
+            Request::get(format!("/api/tenants/{tenant}/policies"))
+                .header("Authorization", format!("Bearer {OPERATOR_KEY}"))
+                .header("X-Tenant-Id", tenant)
+                .body(Body::empty())
+                .expect("operator GET policies"),
+        )
+        .await
+        .expect("operator GET policies should run");
+    assert_eq!(
+        allowed.status(),
+        StatusCode::OK,
+        "verified operator GET /policies must succeed"
+    );
+    let body = body_json(allowed).await;
+    let text = body["policy_text"].as_str().unwrap_or_default();
+    assert!(text.contains(r#"Action::"manage_policies""#), "{body}");
+
+    let listed = app
+        .clone()
+        .oneshot(
+            Request::get(format!("/api/tenants/{tenant}/policies/list"))
+                .header("Authorization", format!("Bearer {OPERATOR_KEY}"))
+                .header("X-Tenant-Id", tenant)
+                .body(Body::empty())
+                .expect("operator list policies"),
+        )
+        .await
+        .expect("operator list should run");
+    assert_eq!(listed.status(), StatusCode::OK);
+    let listed_body = body_json(listed).await;
+    let empty_policies = Vec::new();
+    let ids: Vec<&str> = listed_body["policies"]
+        .as_array()
+        .unwrap_or(&empty_policies)
+        .iter()
+        .filter_map(|row| row["policy_id"].as_str())
+        .collect();
+    assert!(
+        ids.contains(&POLICY_ID),
+        "list must include the bootstrap row: {listed_body}"
+    );
+
+    let denied = app
+        .oneshot(
+            Request::get(format!("/api/tenants/{tenant}/policies"))
+                .header("Authorization", format!("Bearer {DEVELOPER_KEY}"))
+                .header("X-Tenant-Id", tenant)
+                .body(Body::empty())
+                .expect("developer GET policies"),
+        )
+        .await
+        .expect("developer GET policies should run");
+    assert_eq!(
+        denied.status(),
+        StatusCode::FORBIDDEN,
+        "non-operator GET /policies must be 403"
+    );
+}
+
+#[tokio::test]
+async fn denied_developer_cannot_self_approve_operator_can() {
+    let tenant = "acme";
+    let (state, _temp) = virgin_state_with_store(tenant).await;
+    bootstrap_operator_credential(&state, OPERATOR_KEY, tenant).await;
+    issue_developer_credential(&state, tenant, DEVELOPER_KEY).await;
+
+    let developer_permit = format!(
+        r#"permit(
+  principal is Agent,
+  action == Action::"manage_policies",
+  resource == PolicySet::"{tenant}"
+) when {{
+  principal.agent_type == "developer" &&
+  principal.agentTypeVerified == true
+}};"#
+    );
+    let pending = PendingDecision::from_denial(
+        tenant,
+        "developer",
+        "Assign",
+        "Issue",
+        "issue-1",
+        json!({"id": "issue-1"}),
+        "test denial",
+        None,
+    );
+    let decision_id = pending.id.clone();
+    state
+        .server
+        .persist_pending_decision(&pending)
+        .await
+        .expect("persist pending decision");
+
+    let app = build_platform_router(state);
+    let created = app
+        .clone()
+        .oneshot(
+            Request::post(format!("/api/tenants/{tenant}/policies/create"))
+                .header("Authorization", format!("Bearer {OPERATOR_KEY}"))
+                .header("X-Tenant-Id", tenant)
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "policy_id": "developer-manage-policies",
+                        "cedar_text": developer_permit,
+                    })
+                    .to_string(),
+                ))
+                .expect("create developer policy"),
+        )
+        .await
+        .expect("create developer policy should run");
+    assert_eq!(
+        created.status(),
+        StatusCode::CREATED,
+        "operator must be able to add Cedar"
+    );
+
+    let approve_body = json!({
+        "scope": {
+            "principal": "this_agent",
+            "action": "this_action",
+            "resource": "this_resource",
+            "duration": "always"
+        }
+    })
+    .to_string();
+
+    let self_approve = app
+        .clone()
+        .oneshot(
+            Request::post(format!(
+                "/api/tenants/{tenant}/decisions/{decision_id}/approve"
+            ))
+            .header("Authorization", format!("Bearer {DEVELOPER_KEY}"))
+            .header("X-Tenant-Id", tenant)
+            .header("content-type", "application/json")
+            .body(Body::from(approve_body.clone()))
+            .expect("developer self-approve"),
+        )
+        .await
+        .expect("developer self-approve should run");
+    assert_eq!(
+        self_approve.status(),
+        StatusCode::FORBIDDEN,
+        "developer with manage_policies must still get 403 on their own decision"
+    );
+
+    let operator_approve = app
+        .oneshot(
+            Request::post(format!(
+                "/api/tenants/{tenant}/decisions/{decision_id}/approve"
+            ))
+            .header("Authorization", format!("Bearer {OPERATOR_KEY}"))
+            .header("X-Tenant-Id", tenant)
+            .header("content-type", "application/json")
+            .body(Body::from(approve_body))
+            .expect("operator approve"),
+        )
+        .await
+        .expect("operator approve should run");
+    assert_eq!(
+        operator_approve.status(),
+        StatusCode::OK,
+        "verified operator must approve another agent's decision"
+    );
+    let approved = body_json(operator_approve).await;
+    assert_eq!(approved["status"], "approved");
+    assert!(
+        approved["generated_policy"]
+            .as_str()
+            .unwrap_or_default()
+            .contains(r#"Action::"Assign""#),
+        "{approved}"
+    );
+}

--- a/crates/temper-server/src/api/decisions.rs
+++ b/crates/temper-server/src/api/decisions.rs
@@ -139,6 +139,10 @@ pub(crate) async fn handle_approve_decision(
             .into_response();
     }
 
+    if let Some(resp) = decisions_access::reject_self_resolution(&decided_by, &decision) {
+        return resp;
+    }
+
     let generated_policy = decision.generate_policy_from_matrix(&scope);
     let evolution_record_id = decision.evolution_record_id.clone();
     let pending_decision_json = match serde_json::to_string(&decision) {
@@ -347,7 +351,7 @@ pub(crate) async fn handle_deny_decision(
     _body: Option<axum::Json<serde_json::Value>>,
 ) -> impl IntoResponse {
     let tenant = auth.tenant().as_str().to_string();
-    let decided_by = Some(auth.security_context().principal.id.clone());
+    let principal_id = auth.security_context().principal.id.clone();
 
     // Read decision from the durable metadata backend.
     let mut decision: PendingDecision = {
@@ -391,8 +395,12 @@ pub(crate) async fn handle_deny_decision(
             .into_response();
     }
 
+    if let Some(resp) = decisions_access::reject_self_resolution(&principal_id, &decision) {
+        return resp;
+    }
+
     decision.status = DecisionStatus::Denied;
-    decision.decided_by = decided_by;
+    decision.decided_by = Some(principal_id);
     decision.decided_at = Some(sim_now().to_rfc3339());
     let denied_decision = decision.clone();
 

--- a/crates/temper-server/src/api/decisions_access.rs
+++ b/crates/temper-server/src/api/decisions_access.rs
@@ -1,10 +1,46 @@
 //! Decision read access helpers.
 
-use axum::response::Response;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
 use temper_authz::{AuthenticatedRequestContext, PrincipalKind};
 
 use super::require_policy_auth;
 use crate::state::{PendingDecision, ServerState};
+
+/// True when the caller is the principal who was denied.
+pub(crate) fn is_self_resolution(principal_id: &str, denied_agent_id: &str) -> bool {
+    principal_id == denied_agent_id
+}
+
+/// Forbid the denied principal from approving or denying their own decision.
+///
+/// Independent of Cedar (ADR-0172). A caller with `manage_policies` still
+/// cannot resolve a decision whose `agent_id` is their own principal id.
+pub(crate) fn reject_self_resolution(
+    principal_id: &str,
+    decision: &PendingDecision,
+) -> Option<Response> {
+    if !is_self_resolution(principal_id, &decision.agent_id) {
+        return None;
+    }
+    tracing::warn!(
+        decision_id = %decision.id,
+        agent_id = %decision.agent_id,
+        "denied principal cannot approve or deny their own decision"
+    );
+    Some(
+        (
+            StatusCode::FORBIDDEN,
+            axum::Json(serde_json::json!({
+                "error": {
+                    "code": "AuthorizationDenied",
+                    "message": "The denied principal cannot approve or deny this decision",
+                }
+            })),
+        )
+            .into_response(),
+    )
+}
 
 pub(crate) enum DecisionListAccess {
     Full,
@@ -41,5 +77,33 @@ pub(crate) async fn decision_list_access(
     match require_policy_auth(state, authenticated).await {
         Some(response) => Err(response),
         None => Ok(DecisionListAccess::Full),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn self_resolution_matches_denied_principal_only() {
+        assert!(is_self_resolution("developer", "developer"));
+        assert!(!is_self_resolution("operator", "developer"));
+        assert!(!is_self_resolution("developer", "operator"));
+    }
+
+    #[test]
+    fn reject_self_resolution_blocks_denied_principal() {
+        let decision = PendingDecision::from_denial(
+            "acme",
+            "developer",
+            "Assign",
+            "Issue",
+            "issue-1",
+            serde_json::json!({"id": "issue-1"}),
+            "denied",
+            None,
+        );
+        assert!(reject_self_resolution("developer", &decision).is_some());
+        assert!(reject_self_resolution("operator", &decision).is_none());
     }
 }

--- a/crates/temper-server/src/observe/mod_test.rs
+++ b/crates/temper-server/src/observe/mod_test.rs
@@ -1232,6 +1232,99 @@ async fn test_tenant_decision_mutations_require_manage_policies() {
 }
 
 #[tokio::test]
+async fn denied_principal_cannot_approve_or_deny_even_with_manage_policies() {
+    let state = test_state_with_turso().await;
+    state
+        .authz
+        .reload_tenant_policies(
+            "default",
+            r#"
+permit(
+  principal is Agent,
+  action == Action::"manage_policies",
+  resource is PolicySet
+);
+permit(
+  principal is Admin,
+  action == Action::"manage_policies",
+  resource is PolicySet
+);
+"#,
+        )
+        .expect("manage_policies policy should parse");
+
+    let pending = crate::state::PendingDecision::from_denial(
+        "default",
+        "agent-1",
+        "Assign",
+        "Issue",
+        "issue-1",
+        serde_json::json!({"id":"issue-1"}),
+        "test denial",
+        None,
+    );
+    let decision_id = pending.id.clone();
+    state
+        .persist_pending_decision(&pending)
+        .await
+        .expect("persist pending decision");
+
+    let app = build_app_with_state(state.clone());
+    let approve_body = r#"{"scope":{"principal":"this_agent","action":"this_action","resource":"this_resource","duration":"always"}}"#;
+
+    let self_approve = app
+        .clone()
+        .oneshot(agent_request(
+            Request::post(format!(
+                "/api/tenants/default/decisions/{decision_id}/approve"
+            ))
+            .header("content-type", "application/json")
+            .body(Body::from(approve_body))
+            .unwrap(),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        self_approve.status(),
+        StatusCode::FORBIDDEN,
+        "denied agent must not approve their own decision"
+    );
+
+    let self_deny = app
+        .clone()
+        .oneshot(agent_request(
+            Request::post(format!("/api/tenants/default/decisions/{decision_id}/deny"))
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        self_deny.status(),
+        StatusCode::FORBIDDEN,
+        "denied agent must not deny their own decision"
+    );
+
+    let operator_approve = app
+        .oneshot(admin_request(
+            Request::post(format!(
+                "/api/tenants/default/decisions/{decision_id}/approve"
+            ))
+            .header("content-type", "application/json")
+            .body(Body::from(approve_body))
+            .unwrap(),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        operator_approve.status(),
+        StatusCode::OK,
+        "a different principal with manage_policies must still approve"
+    );
+}
+
+#[tokio::test]
 async fn test_approve_decision_reload_failure_keeps_pending_and_policies_unchanged() {
     let state = test_state_with_turso().await;
     install_admin_policy(&state);

--- a/docs/adrs/0172-operator-bootstrap-manage-policies.md
+++ b/docs/adrs/0172-operator-bootstrap-manage-policies.md
@@ -1,0 +1,202 @@
+# ADR-0172: Seed a Narrow Operator `manage_policies` Permit at Credential Bootstrap
+
+- Status: Accepted
+- Date: 2026-08-20
+- Deciders: Temper core maintainers
+- Related:
+  - ADR-0014: Governance gap closure (`manage_policies` on `PolicySet`)
+  - ADR-0032: Granular Cedar policy storage
+  - ADR-0033: Platform-assigned agent identity
+  - ADR-0144: Idempotent Cedar merges
+  - ADR-0157: Credential-bound Class A authentication edge
+  - `crates/temper-platform/src/bootstrap.rs` (`bootstrap_operator_credential`)
+  - `crates/temper-server/src/api/decisions.rs` (approve / deny)
+  - `crates/temper-server/src/api/decisions_access.rs`
+  - `crates/temper-server/src/authz/policy_persistence.rs`
+  - `crates/temper-server/tests/policy_authorization.rs`
+
+## Context
+
+A new tenant can boot and run installed apps. `temper serve --app` and
+`install_os_app` are process load, not Cedar. After boot, Cedar is
+default-deny.
+
+Approving a denied action (`POST /api/tenants/{tenant}/decisions/{id}/approve`,
+`temper decide`) and adding Cedar (the policy API) both require action
+`manage_policies` on resource `PolicySet`. OS-app Cedar does not grant that.
+
+`bootstrap_operator_credential` creates the operator `AgentType` and
+`AgentCredential` so `TEMPER_API_KEY` resolves as a verified identity. It does
+not persist or activate a `manage_policies` permit. On a virgin store the
+operator therefore cannot approve a denial or add Cedar. That is the
+governance loop, not "apps cannot install" and not "named actions the app
+already permits."
+
+This is ARN-389.
+
+Closing that door is not enough. An agent who was denied must not be able
+to approve or deny that same decision, even if they somehow have
+`manage_policies`. "They lack the permit" is not the control.
+
+## Decision
+
+Two halves, both required:
+
+1. When the operator credential is bootstrapped for a tenant, persist and
+   activate a **narrow** Cedar permit through the same door as every other
+   policy: validate, merge into the tenant's live Cedar, write a granular
+   `policies` row, survive restart. Not a code bypass. Not permit-all.
+2. On the approve and deny HTTP paths, reject the request when the
+   caller's principal id equals `PendingDecision.agent_id`. 403. This is
+   independent of Cedar.
+
+### Sub-Decision 1: Seed inside `bootstrap_operator_credential`
+
+The permit is created in `bootstrap_operator_credential` for **that**
+tenant. Every caller that bootstraps an operator credential gets the door,
+not only `"default"`. CLI Phase 8 today still registers the deployment key
+in `default` only (ADR-0157); this ADR does not change that scope.
+
+**Why this approach**: the missing permit is a property of the operator
+identity, not of a particular tenant name. Wiring at the credential
+function keeps the seed and the identity on the same path.
+
+### Sub-Decision 2: Exact permit shape
+
+Use the statement already proven in `policy_authorization.rs`:
+
+```
+permit(
+  principal is Agent,
+  action == Action::"manage_policies",
+  resource == PolicySet::"{tenant}"
+) when {
+  principal.agent_type == "operator" &&
+  principal.agentTypeVerified == true
+};
+```
+
+`{tenant}` is the tenant being bootstrapped. Unverified principals and
+non-operator agent types remain default-deny for `manage_policies`.
+
+**Why this approach**: it is the smallest Cedar that closes the approval
+loop, matches the existing HTTP authorization test, and does not grant
+entity actions or `create_tenant`.
+
+### Sub-Decision 3: Merge live Cedar; persist a stable granular row
+
+1. Read the tenant's current live policy text.
+2. Append the permit only if that statement is not already present
+   (ADR-0144-style idempotent merge). Do not replace app Cedar.
+3. Reload the tenant Cedar engine with the merged text.
+4. Persist the **isolated** statement as granular policy id
+   `operator-bootstrap-manage-policies` via `persist_and_activate_policy`
+   (`created_by = "bootstrap"`). Hash-gated writes make re-bootstrap a
+   no-op once the row exists.
+
+Restart recovery (`recover_cedar_policies`) already concatenates granular
+rows, so the permit survives reboot without a special case.
+
+**Why this approach**: OS-app install already merges into live Cedar and
+persists per-file rows. Reusing that pattern keeps operator bootstrap on
+the same storage and activation path. Persisting only the statement (not
+the whole live blob as `primary`) avoids wiping or duplicating app policy
+rows.
+
+### Sub-Decision 4: `create_tenant` stays a separate door
+
+`create_tenant` is not required to list policies, add a Cedar rule, or
+approve a denial in the bootstrapped tenant. This ADR does not grant it.
+If a later loop is blocked on tenant provisioning, that is a different
+permit and a different decision.
+
+### Sub-Decision 5: Denied principal cannot resolve their own decision
+
+After `manage_policies` succeeds, `POST .../decisions/{id}/approve` and
+`POST .../decisions/{id}/deny` compare `security_context.principal.id` to
+`PendingDecision.agent_id`. On match, return 403 and do not change the
+decision or Cedar.
+
+This is not Cedar. An agent who was granted `manage_policies` still cannot
+approve themselves into power. A verified operator who is **not** the
+denied principal can approve.
+
+**Why this approach**: the missing operator door and the self-approval
+ban are different failures. Cedar grants the governance door; the
+approve/deny handlers refuse to let the subject of the denial walk
+through it for that decision.
+
+## Rollout Plan
+
+1. **Phase 0 (this PR)** — ADR, seed in `bootstrap_operator_credential`,
+   self-resolution reject on approve/deny, red-green tests, live local
+   `temper serve` on an isolated virgin store.
+2. **Phase 1** — None required. Existing tenants pick up the row on the
+   next process that runs `bootstrap_operator_credential`.
+
+## Consequences
+
+### Positive
+
+- A verified operator can approve denials and manage Cedar on a virgin
+  store without a hand-seeded policy file.
+- The permit is ordinary Cedar: visible, persistable, and disableable
+  like any other granular row.
+- App Cedar remains intact across bootstrap, install, and restart.
+- The denied agent cannot close their own governance loop, even with
+  `manage_policies`.
+
+### Negative
+
+- A stolen `TEMPER_API_KEY` that resolves as the verified operator can
+  manage policies for that tenant. That is the same trust already placed
+  in the bootstrap key for identity; this ADR only makes the intended
+  governance door reachable.
+
+### Risks
+
+- Re-bootstrap must not append forever. Mitigated by exact-statement
+  merge plus hash-gated `save_policy` on a stable policy id.
+- Loading only persisted rows after seed (and before app rows exist)
+  would drop in-memory app Cedar. Mitigated by merging into live text
+  and never calling `load_and_activate_tenant_policies` as the seed
+  path.
+
+### DST Compliance
+
+- `persist_and_activate_policy` already uses `sim_now()` for trajectory
+  timestamps.
+- No new `HashMap`/`HashSet`, threads, or wall-clock in simulation-visible
+  crates beyond existing persistence helpers.
+
+## Non-Goals
+
+- Skipping Cedar on approve or policy writes.
+- Seeding `permit(principal, action, resource);`.
+- Treating boot-time Cedar skip / `--app` process load as the fix.
+- Granting `create_tenant`.
+- Auto-registering the deployment key in every tenant (ADR-0157).
+- Changing OS-app Cedar or named-action permits.
+
+## Alternatives Considered
+
+1. **Code bypass for `manage_policies` when principal is operator** —
+   Rejected. Authority would not be Cedar, would not persist as a policy
+   row, and would be invisible to the policy API.
+2. **Permit-all for the operator** — Rejected. The bug is the governance
+   door, not missing entity actions. OS-app Cedar already covers named
+   actions it intends to allow.
+3. **Document that operators must load a policy file** — Rejected. A
+   virgin store cannot approve the first denial; the operator cannot
+   write the file through the API that the file is meant to unlock.
+4. **Grant `create_tenant` in the same seed** — Rejected. Separate door;
+   not required for approve / add Cedar in the bootstrapped tenant.
+5. **Rely on default-deny so the denied agent cannot approve** —
+   Rejected. That fails as soon as they obtain `manage_policies`. The
+   ban is on the approve/deny path.
+
+## Rollback Policy
+
+Delete or disable the `operator-bootstrap-manage-policies` row and restart,
+or stop calling `bootstrap_operator_credential`. The credential entities
+remain; only the Cedar door is removed.


### PR DESCRIPTION
## Summary

- Seed a narrow Cedar permit at `bootstrap_operator_credential`: a verified operator (`agent_type == "operator"` AND `agentTypeVerified == true`) may `manage_policies` on that tenant's `PolicySet`. Persisted as granular row `operator-bootstrap-manage-policies`. Idempotent. Not permit-all. Not a Cedar skip. ADR-0172.
- On approve/deny, the denied principal (`PendingDecision.agent_id`) cannot resolve that decision. 403 even if they have `manage_policies`. ADR-0172 sub-decision 5.

## How each half is enforced

**Half 1 — seed permit**
- Permit text: `crates/temper-platform/src/operator_manage_policies.rs:14-28`
- Merge + persist + reload: `crates/temper-platform/src/operator_manage_policies.rs:68-106`
- Called from credential bootstrap: `crates/temper-platform/src/bootstrap.rs:461`

**Half 2 — no self-approval**
- Compare caller to `PendingDecision.agent_id`: `crates/temper-server/src/api/decisions_access.rs:11-42`
- Approve path (authenticated principal, not a body field): `crates/temper-server/src/api/decisions.rs:89` and `:142-144`
- Deny path: `crates/temper-server/src/api/decisions.rs:354` and `:398-400`

## Live QA (isolated virgin store)

`TURSO_URL=file:$TMP/agents.db`, unused port `18765`, `--no-observe --app project-management`, `TEMPER_API_KEY=tmpr_arn389_operator_live`. No `load-dir`. Home isolated so this did not touch `~/.local/share/temper/agents.db`.

| Step | Result |
|---|---|
| Operator `GET /api/tenants/default/policies` | **200** — seeded `manage_policies` permit + PM Cedar |
| Operator `GET /api/tenants/default/policies/list` | **200** — row `operator-bootstrap-manage-policies`, `created_by=bootstrap` |
| Unknown key `GET /policies` | **401** |
| Operator `POST /policies/create` (identity Cedar) | **201** |
| Operator creates developer `AgentType` + `AgentCredential` via TData | **201 / 200** |
| Developer `GET /policies` (no permit yet) | **403** — `Decision PD-01a0214c-0efe-7672-9932-81dd59d342a1` |
| Operator grants developer `manage_policies` | **201** |
| Developer `GET /policies` after grant | **200** (they now have the permit) |
| Developer `POST .../decisions/PD-01a0214c-…/approve` | **403** — `The denied principal cannot approve or deny this decision` |
| Operator `POST` same approve | **200** — `status=approved` |

`create_tenant` was not granted (separate door).

## Test plan

- [x] `cargo test -p temper-platform --test operator_bootstrap_cedar` (7 passed)
- [x] `cargo test -p temper-server --features observe --lib decisions_access`
- [x] `cargo test -p temper-server --features observe denied_principal_cannot_approve`
- [x] Isolated live `temper serve` curls above
- [x] Pre-push workspace suite (fmt, clippy, readability, full tests)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR gives each bootstrapped, verified operator a narrow tenant-scoped `manage_policies` Cedar permit and prevents a denied principal from approving or denying its own decision.

- Adds live activation and granular persistence of the bootstrap operator policy.
- Adds authenticated-principal checks to both decision-resolution paths.
- Adds integration coverage and ADR-0172 documenting the governance model.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The policy persistence failure must be handled before merging because bootstrap can claim success while creating an operator grant that disappears after restart.

The new bootstrap path establishes authority in memory before a fallible durable write, discards the failure signal, and therefore violates the documented restart-survival contract.

**Files Needing Attention:** crates/temper-platform/src/operator_manage_policies.rs
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/temper-platform/src/operator_manage_policies.rs | Adds tenant-scoped policy merge, activation, and persistence, but ignores a failed durable write and can falsely report successful seeding. |
| crates/temper-platform/src/bootstrap.rs | Extends operator credential bootstrap to invoke the new policy seed for the same tenant. |
| crates/temper-server/src/api/decisions.rs | Applies the self-resolution rejection after loading a pending decision on both approve and deny paths. |
| crates/temper-server/src/api/decisions_access.rs | Adds a shared authenticated-principal equality guard returning a structured 403 response. |
| crates/temper-platform/tests/operator_bootstrap_cedar.rs | Covers authorization scope, idempotency, persistence, recovery, policy coexistence, and self-approval behavior, but not persistence failure. |
| docs/adrs/0172-operator-bootstrap-manage-policies.md | Documents the narrow bootstrap grant, persistence requirement, and independent self-resolution prohibition. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Boot as Operator bootstrap
    participant Authz as Cedar engine
    participant Store as Policy store
    participant API as Decision API
    Boot->>Authz: Activate tenant-scoped manage_policies permit
    Boot->>Store: Persist granular bootstrap policy
    Note over Boot,Store: Persistence failure is currently not propagated
    API->>Authz: Authorize manage_policies
    Authz-->>API: Allow
    API->>API: Compare caller ID with denied agent ID
    alt Same principal
        API-->>API: Return 403
    else Different principal
        API-->>API: Approve or deny decision
    end
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20nerdsane%2Ftemper%20PR%20%23432%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=nerdsane%2Ftemper&pr=432&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Acrates%2Ftemper-platform%2Fsrc%2Foperator_manage_policies.rs%3A96-103%0A**Durable%20policy%20failure%20is%20ignored**%0A%0AWhen%20the%20policy%20store%20is%20unavailable%20or%20rejects%20the%20write%2C%20this%20path%20discards%20the%20%60false%60%20result%20from%20%60persist_and_activate_policy%60%20after%20activating%20the%20permit%20in%20memory%20and%20then%20logs%20that%20seeding%20succeeded.%20Restart%20recovery%20rebuilds%20Cedar%20from%20durable%20rows%2C%20so%20the%20operator%20subsequently%20loses%20%60manage_policies%60%20access.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=nerdsane%2Ftemper&pr=432&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22grok%2Foperator-governance%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22grok%2Foperator-governance%22.%0A%0A%23%23%23%20Issue%201%0Acrates%2Ftemper-platform%2Fsrc%2Foperator_manage_policies.rs%3A96-103%0A**Durable%20policy%20failure%20is%20ignored**%0A%0AWhen%20the%20policy%20store%20is%20unavailable%20or%20rejects%20the%20write%2C%20this%20path%20discards%20the%20%60false%60%20result%20from%20%60persist_and_activate_policy%60%20after%20activating%20the%20permit%20in%20memory%20and%20then%20logs%20that%20seeding%20succeeded.%20Restart%20recovery%20rebuilds%20Cedar%20from%20durable%20rows%2C%20so%20the%20operator%20subsequently%20loses%20%60manage_policies%60%20access.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=nerdsane%2Ftemper&pr=432&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Acrates%2Ftemper-platform%2Fsrc%2Foperator_manage_policies.rs%3A96-103%0A**Durable%20policy%20failure%20is%20ignored**%0A%0AWhen%20the%20policy%20store%20is%20unavailable%20or%20rejects%20the%20write%2C%20this%20path%20discards%20the%20%60false%60%20result%20from%20%60persist_and_activate_policy%60%20after%20activating%20the%20permit%20in%20memory%20and%20then%20logs%20that%20seeding%20succeeded.%20Restart%20recovery%20rebuilds%20Cedar%20from%20durable%20rows%2C%20so%20the%20operator%20subsequently%20loses%20%60manage_policies%60%20access.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=432&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
crates/temper-platform/src/operator_manage_policies.rs:96-103
**Durable policy failure is ignored**

When the policy store is unavailable or rejects the write, this path discards the `false` result from `persist_and_activate_policy` after activating the permit in memory and then logs that seeding succeeded. Restart recovery rebuilds Cedar from durable rows, so the operator subsequently loses `manage_policies` access.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(platform): seed operator manage\_poli..."](https://github.com/nerdsane/temper/commit/234469fc0d879995244cbed289e0f50ae1e934cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55380631)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [temper-authz: Cedar-Based Authorization for Agents](https://app.greptile.com/arni-labs/-/custom-context/knowledge-base/nerdsane/temper/-/docs/temper-authz.md)
- Knowledge Base — [temper-platform authentication and tenant boundary](https://app.greptile.com/arni-labs/-/custom-context/knowledge-base/nerdsane/temper/-/docs/temper-platform.md)

<!-- /greptile_comment -->