### PR TITLE
fix(sdk): TemperClient.list() paginates to completion — the real pagination fix (ARN-363)

### DIFF
--- a/packages/temper-sdk-ts/src/client.ts
+++ b/packages/temper-sdk-ts/src/client.ts
@@ -61,12 +61,61 @@ export class TemperClient {
 
   // ── Entity CRUD ──────────────────────────────────────────────────
 
-  /** List all entities of the given type. */
-  async list(entityType: string): Promise<unknown[]> {
-    const url = `${this.baseUrl}/tdata/${entityType}`;
-    const resp = await fetch(url, {
-      headers: this.defaultHeaders(),
-    });
+  /**
+   * List entities of the given type, following server-driven paging to
+   * completion.
+   *
+   * A Temper list read is capped at a default page size and returns an
+   * `@odata.nextLink` (`$skiptoken`) for the remainder. A single bare GET
+   * therefore returns only the first page — a silent-truncation footgun
+   * (ARN-363). This method follows the nextLink until the collection is
+   * exhausted, so it honours its name and returns *all* matching entities.
+   *
+   * @param entityType - The entity set (e.g., "Tasks").
+   * @param options.filter - Optional OData `$filter` expression.
+   * @param options.pageSize - Rows per underlying request (default 500).
+   */
+  async list(
+    entityType: string,
+    options?: { filter?: string; pageSize?: number }
+  ): Promise<unknown[]> {
+    const filterQ = options?.filter
+      ? `$filter=${encodeURIComponent(options.filter)}&`
+      : "";
+    const top = options?.pageSize ?? 500;
+    let url: string | null = `${this.baseUrl}/tdata/${entityType}?${filterQ}$top=${top}`;
+    const out: unknown[] = [];
+    // Bounded loop: a defensive ceiling so a misbehaving server can never
+    // spin this forever.
+    for (let page = 0; url && page < 10_000; page++) {
+      const current: string = url;
+      const resp = await fetch(current, { headers: this.defaultHeaders() });
+      this.checkStatus(resp, "list", entityType);
+      const body = (await resp.json()) as {
+        value?: unknown[];
+        "@odata.nextLink"?: string;
+      };
+      if (Array.isArray(body.value)) out.push(...body.value);
+      const next = body["@odata.nextLink"];
+      // nextLink may be absolute or relative to the request URI; resolve it
+      // the spec-correct way against the URL we just fetched.
+      url = next ? new URL(next, current).toString() : null;
+    }
+    return out;
+  }
+
+  /** Fetch only the first page of a list read (no pagination). Use when you
+   *  deliberately want a bounded sample; prefer {@link list} for completeness. */
+  async listPage(
+    entityType: string,
+    options?: { filter?: string; pageSize?: number }
+  ): Promise<unknown[]> {
+    const filterQ = options?.filter
+      ? `$filter=${encodeURIComponent(options.filter)}&`
+      : "";
+    const top = options?.pageSize ?? 100;
+    const url = `${this.baseUrl}/tdata/${entityType}?${filterQ}$top=${top}`;
+    const resp = await fetch(url, { headers: this.defaultHeaders() });
     this.checkStatus(resp, "list", entityType);
     const body = await resp.json();
     return body?.value ?? [];


### PR DESCRIPTION
Durable, generic fix for the recurring 100-row silent-truncation footgun (ARN-363), replacing the reverted default-page-size band-aid (#430, closed).

`TemperClient.list()` promised "all entities" but did a single bare GET and returned only the first page. Now it follows `@odata.nextLink` (`$skiptoken`) to completion with spec-correct relative resolution (`new URL(next, current)`); adds `listPage()` for deliberately-bounded reads + optional `{ filter, pageSize }`.

Verified: 7/7 tests pass; against prod, listing 272 published languages returns all 272 across 7 pages (pageSize 40). The buggy `${base}/${next}` resolution returned 0 on page 2 — what bit hand-rolled consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9E6ZCTB9exceniQEgmfmR

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR extends the TypeScript SDK’s entity-listing API with server-driven pagination, filtering, configurable page sizes, and a deliberately single-page `listPage()` method.

- Resolves relative or absolute `@odata.nextLink` values against the current request URL.
- Accumulates pages in `list()` and exposes bounded reads through `listPage()`.
- Adds two silent truncation paths through the fixed iteration ceiling and acceptance of a zero page size.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until `list()` rejects or reports incomplete pagination instead of silently returning partial results at the zero-page and iteration-limit boundaries.

The new API promises complete enumeration, but `pageSize: 0` can return no entities and a collection spanning more than 10,000 requested pages is returned partially while still resolving successfully.

**Files Needing Attention:** packages/temper-sdk-ts/src/client.ts
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/temper-sdk-ts/src/client.ts | Adds complete-list pagination and first-page reads, but valid zero-sized pages and the hard page-count ceiling can return incomplete data without an error. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Caller invokes list] --> B[Build request with filter and top]
  B --> C[Fetch current page]
  C --> D[Append response value]
  D --> E{nextLink present?}
  E -->|No| F[Return accumulated entities]
  E -->|Yes| G[Resolve nextLink against current URL]
  G --> H{Fewer than 10,000 pages?}
  H -->|Yes| C
  H -->|No| I[Return silently truncated entities]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20nerdsane%2Ftemper%20PR%20%23438%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=nerdsane%2Ftemper&pr=438&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Ftemper-sdk-ts%2Fsrc%2Fclient.ts%3A88%0A**Page%20ceiling%20silently%20truncates%20results**%0A%0AWhen%20a%20valid%20collection%20requires%20more%20than%2010%2C000%20pages%2C%20the%20loop%20exits%20while%20a%20continuation%20link%20remains%20and%20returns%20the%20accumulated%20rows%20as%20a%20successful%20result%2C%20violating%20%60list%28%29%60's%20promise%20to%20return%20all%20matching%20entities.%0A%0A%23%23%23%20Issue%202%0Apackages%2Ftemper-sdk-ts%2Fsrc%2Fclient.ts%3A82%0A**Zero%20page%20size%20empties%20lists**%0A%0AWhen%20a%20caller%20passes%20%60pageSize%3A%200%60%2C%20nullish%20coalescing%20preserves%20zero%20and%20the%20server%20returns%20an%20empty%20page%20without%20a%20continuation%20link%2C%20causing%20%60list%28%29%60%20to%20return%20%60%5B%5D%60%20even%20when%20matching%20entities%20exist%3B%20%60listPage%28%29%60%20has%20the%20same%20invalid%20empty-result%20behavior.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=nerdsane%2Ftemper&pr=438&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22claude%2Fsdk-paginating-list%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fsdk-paginating-list%22.%0A%0A%23%23%23%20Issue%201%0Apackages%2Ftemper-sdk-ts%2Fsrc%2Fclient.ts%3A88%0A**Page%20ceiling%20silently%20truncates%20results**%0A%0AWhen%20a%20valid%20collection%20requires%20more%20than%2010%2C000%20pages%2C%20the%20loop%20exits%20while%20a%20continuation%20link%20remains%20and%20returns%20the%20accumulated%20rows%20as%20a%20successful%20result%2C%20violating%20%60list%28%29%60's%20promise%20to%20return%20all%20matching%20entities.%0A%0A%23%23%23%20Issue%202%0Apackages%2Ftemper-sdk-ts%2Fsrc%2Fclient.ts%3A82%0A**Zero%20page%20size%20empties%20lists**%0A%0AWhen%20a%20caller%20passes%20%60pageSize%3A%200%60%2C%20nullish%20coalescing%20preserves%20zero%20and%20the%20server%20returns%20an%20empty%20page%20without%20a%20continuation%20link%2C%20causing%20%60list%28%29%60%20to%20return%20%60%5B%5D%60%20even%20when%20matching%20entities%20exist%3B%20%60listPage%28%29%60%20has%20the%20same%20invalid%20empty-result%20behavior.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=nerdsane%2Ftemper&pr=438&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Apackages%2Ftemper-sdk-ts%2Fsrc%2Fclient.ts%3A88%0A**Page%20ceiling%20silently%20truncates%20results**%0A%0AWhen%20a%20valid%20collection%20requires%20more%20than%2010%2C000%20pages%2C%20the%20loop%20exits%20while%20a%20continuation%20link%20remains%20and%20returns%20the%20accumulated%20rows%20as%20a%20successful%20result%2C%20violating%20%60list%28%29%60's%20promise%20to%20return%20all%20matching%20entities.%0A%0A%23%23%23%20Issue%202%0Apackages%2Ftemper-sdk-ts%2Fsrc%2Fclient.ts%3A82%0A**Zero%20page%20size%20empties%20lists**%0A%0AWhen%20a%20caller%20passes%20%60pageSize%3A%200%60%2C%20nullish%20coalescing%20preserves%20zero%20and%20the%20server%20returns%20an%20empty%20page%20without%20a%20continuation%20link%2C%20causing%20%60list%28%29%60%20to%20return%20%60%5B%5D%60%20even%20when%20matching%20entities%20exist%3B%20%60listPage%28%29%60%20has%20the%20same%20invalid%20empty-result%20behavior.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=438&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/temper-sdk-ts/src/client.ts:88
**Page ceiling silently truncates results**

When a valid collection requires more than 10,000 pages, the loop exits while a continuation link remains and returns the accumulated rows as a successful result, violating `list()`'s promise to return all matching entities.

### Issue 2
packages/temper-sdk-ts/src/client.ts:82
**Zero page size empties lists**

When a caller passes `pageSize: 0`, nullish coalescing preserves zero and the server returns an empty page without a continuation link, causing `list()` to return `[]` even when matching entities exist; `listPage()` has the same invalid empty-result behavior.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sdk): TemperClient.list() paginates ..."](https://github.com/nerdsane/temper/commit/67e4798ed635b2b11bec039f3dc71573cc0e5bb0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56796631)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Interfaces and integrations](https://app.greptile.com/arni-labs/-/custom-context/knowledge-base/nerdsane/temper/-/docs/interfaces-and-integrations.md)
- Knowledge Base — [CLI and SDK access](https://app.greptile.com/arni-labs/-/custom-context/knowledge-base/nerdsane/temper/-/docs/cli-and-sdk.md)

<!-- /greptile_comment -->