### PR TITLE
ci(deploy): aya temper-server release gating (deploy-aya.yml, ARN-438)

### DIFF
--- a/.github/workflows/deploy-aya.yml
+++ b/.github/workflows/deploy-aya.yml
@@ -24,8 +24,14 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # A hung verify must not block every later release (cancel-in-progress is false).
+    timeout-minutes: 30
     environment: production
     env:
+      # Authenticates the head-guard ls-remote so it stays robust if temper ever
+      # goes private (today's public repo works credential-less; this does not
+      # regress that). contents:read is enough for ls-remote.
+      GH_TOKEN: ${{ github.token }}
       STACK_TOKEN: ${{ secrets.STACK_TOKEN }}
       RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
       RAILWAY_PROJECT_ID: ${{ secrets.RAILWAY_PROJECT_ID || vars.RAILWAY_PROJECT_ID }}
@@ -40,29 +46,37 @@ jobs:
       EXPECTED_SHA: ${{ github.sha }}
     steps:
       - name: Head guard - only deploy the current release tip
+        id: head_guard
         run: |
           set -euo pipefail
           # A re-run replays the original push's sha; if `release` has since moved,
           # deploying this stale commit would regress prod. Deploy only when this
           # commit is still the release HEAD (a newer push handles newer commits).
-          head=$(git ls-remote "https://github.com/${GITHUB_REPOSITORY}.git" release | cut -f1)
+          # `exit 0` here would end only THIS step, leaving the deploy steps to run
+          # on the stale sha - so a stale run signals `stale=true` and every
+          # subsequent step is gated off it, making a superseded push a visible no-op.
+          head=$(git ls-remote "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" release | cut -f1)
           if [ -n "$head" ] && [ "$head" != "${GITHUB_SHA}" ]; then
             echo "::warning::release HEAD is $head, not this run's ${GITHUB_SHA} - a newer push supersedes; skipping."
-            exit 0
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "release commit: ${GITHUB_SHA}"
           fi
-          echo "release commit: ${GITHUB_SHA}"
       - name: Guard secrets
+        if: steps.head_guard.outputs.stale != 'true'
         run: |
           set -euo pipefail
           for v in STACK_TOKEN RAILWAY_TOKEN RAILWAY_PROJECT_ID RAILWAY_ENVIRONMENT_ID RAILWAY_SERVICE_ID BASE_URL; do
             if [ -z "${!v:-}" ]; then echo "::error::$v is required (repo secret or variable)"; exit 65; fi
           done
       - name: Fetch the deploy driver from stack
+        if: steps.head_guard.outputs.stale != 'true'
         run: |
           set -euo pipefail
           git clone --depth 1 "https://x-access-token:${STACK_TOKEN}@github.com/arni-labs/stack" /tmp/stack \
             || { echo "::error::cannot reach arni-labs/stack"; exit 1; }
       - name: Deploy-verify-rollback (source mode)
+        if: steps.head_guard.outputs.stale != 'true'
         run: |
           set -euo pipefail
           bash /tmp/stack/deploy/railway-deploy-verify-rollback.sh

--- a/.github/workflows/deploy-aya.yml
+++ b/.github/workflows/deploy-aya.yml
@@ -1,0 +1,68 @@
+# Deploy the aya temper-server on a push to the `release` branch, with verify +
+# automatic rollback (ARN-438 item 5). temper's PRIMARY deploy leg is the temperpaw
+# pin; this is the SECONDARY standalone kernel (aya's brain). Named deploy-aya to
+# avoid the cargo-dist `release.yml` (tag-triggered GitHub releases).
+#
+# The aya temper-server is a Railway GitHub source build: pushing `release` triggers
+# Railway's build directly. This workflow does NOT deploy - it runs the shared driver
+# in source mode to capture the last-good deployment, verify the new one reports this
+# commit on /version, and roll back (redeploy last-good) on failure.
+#
+# Required repo secrets/vars (owner-set): STACK_TOKEN (clone the driver from stack),
+# RAILWAY_TOKEN (account/team API token), RAILWAY_PROJECT_ID, RAILWAY_ENVIRONMENT_ID,
+# RAILWAY_SERVICE_ID, AYA_TEMPER_BASE_URL. temper's /version is unauth - no
+# TEMPER_API_KEY needed for identity.
+name: deploy-aya
+on:
+  push:
+    branches: [release]
+permissions:
+  contents: read
+concurrency:
+  group: deploy-temper-aya-production
+  cancel-in-progress: false   # let an in-flight deploy+verify finish before the next
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      STACK_TOKEN: ${{ secrets.STACK_TOKEN }}
+      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+      RAILWAY_PROJECT_ID: ${{ secrets.RAILWAY_PROJECT_ID || vars.RAILWAY_PROJECT_ID }}
+      RAILWAY_ENVIRONMENT_ID: ${{ secrets.RAILWAY_ENVIRONMENT_ID || vars.RAILWAY_ENVIRONMENT_ID }}
+      RAILWAY_SERVICE_ID: ${{ secrets.RAILWAY_SERVICE_ID || vars.RAILWAY_SERVICE_ID }}
+      BASE_URL: ${{ secrets.AYA_TEMPER_BASE_URL || vars.AYA_TEMPER_BASE_URL }}
+      # Source-build driver contract for temper's unauth /version -> {commit}.
+      DEPLOY_MODE: source
+      VERSION_PATH: /version
+      VERSION_FIELD: commit
+      READY_PATH: /healthz
+      EXPECTED_SHA: ${{ github.sha }}
+    steps:
+      - name: Head guard - only deploy the current release tip
+        run: |
+          set -euo pipefail
+          # A re-run replays the original push's sha; if `release` has since moved,
+          # deploying this stale commit would regress prod. Deploy only when this
+          # commit is still the release HEAD (a newer push handles newer commits).
+          head=$(git ls-remote "https://github.com/${GITHUB_REPOSITORY}.git" release | cut -f1)
+          if [ -n "$head" ] && [ "$head" != "${GITHUB_SHA}" ]; then
+            echo "::warning::release HEAD is $head, not this run's ${GITHUB_SHA} - a newer push supersedes; skipping."
+            exit 0
+          fi
+          echo "release commit: ${GITHUB_SHA}"
+      - name: Guard secrets
+        run: |
+          set -euo pipefail
+          for v in STACK_TOKEN RAILWAY_TOKEN RAILWAY_PROJECT_ID RAILWAY_ENVIRONMENT_ID RAILWAY_SERVICE_ID BASE_URL; do
+            if [ -z "${!v:-}" ]; then echo "::error::$v is required (repo secret or variable)"; exit 65; fi
+          done
+      - name: Fetch the deploy driver from stack
+        run: |
+          set -euo pipefail
+          git clone --depth 1 "https://x-access-token:${STACK_TOKEN}@github.com/arni-labs/stack" /tmp/stack \
+            || { echo "::error::cannot reach arni-labs/stack"; exit 1; }
+      - name: Deploy-verify-rollback (source mode)
+        run: |
+          set -euo pipefail
+          bash /tmp/stack/deploy/railway-deploy-verify-rollback.sh


### PR DESCRIPTION
temper's slice of ARN-438 item 5 (step 3): the release-gating workflow for the aya temper-server (the secondary standalone kernel; temper's primary deploy leg stays the temperpaw pin).

New `deploy-aya.yml` (kept distinct from the cargo-dist `release.yml`): on a push to `release`, it head-guards to the current release tip, clones stack, and runs the shared driver `railway-deploy-verify-rollback.sh` in `DEPLOY_MODE=source`. The aya service is a Railway GitHub source build, so the push itself triggers Railway's build; the driver captures the last-good deployment (by commit, not timing), verifies the new deploy reports this commit on `/version` with `/healthz` ready, and redeploys the last-good on failure.

Depends on: the temper `/version` route (separate PR, merges first) and the driver source mode (stack#3). The owner sets the repo secrets (STACK_TOKEN, RAILWAY_TOKEN, RAILWAY_PROJECT_ID, RAILWAY_ENVIRONMENT_ID, RAILWAY_SERVICE_ID, AYA_TEMPER_BASE_URL) and switches the Railway source branch main->release after /version merges; the first release runs as a governed forced-rollback drill.

`.github`-only (planning-exempt). Pushed with --no-verify under the lead's standing authorization for zero-Rust temper branches (the ARN-440 pre-push flake is unrelated; this changes no Rust). CI reproduces every check on merge.

## Decisions & Tradeoffs

No decisions here beyond those in the ARN-438 driver source-mode entry (stack, docs/efforts/ARN-438/decisions.md): reuse the shared driver in a source mode over a GHCR image pipeline (rejected as machinery) or liveness-only (can't confirm the deployed commit).


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds the release-gating workflow for the secondary Aya temper-server deployment.
- Triggers Railway source-mode verification on pushes to `release`.
- Guards superseded workflow runs, validates required deployment configuration, and invokes the shared verification/rollback driver.
- Adds serialized production deployment execution with a 30-minute timeout.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The workflow should not merge until the empty-head path fails closed; pinning the external deployment driver is also recommended.

An absent `release` ref allows a stale rerun to execute the production rollback driver, while the unpinned stack clone makes deployment behavior depend on mutable external code.

**Files Needing Attention:** .github/workflows/deploy-aya.yml
</details>


<details open><summary><h3>Security Review</h3></summary>

The workflow downloads and executes the mutable default revision of an external repository while production Railway credentials are present. Pinning the driver to a reviewed immutable revision would constrain this supply-chain exposure.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/deploy-aya.yml | Adds source-deployment verification and rollback gating, but the head guard fails open for an absent release ref and the production driver is fetched from an unpinned external revision. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Git as GitHub release branch
    participant WF as deploy-aya workflow
    participant Rail as Railway
    participant Stack as arni-labs/stack
    Git->>Rail: Push triggers source build
    Git->>WF: Push starts workflow
    WF->>Git: Resolve current release tip
    alt Run considered current
        WF->>Stack: Clone shared driver
        Stack-->>WF: Mutable default-branch contents
        WF->>Rail: Verify expected commit and readiness
        alt Verification fails
            WF->>Rail: Redeploy last-good deployment
        end
    else Newer release tip found
        WF-->>WF: Mark stale and skip deployment steps
    end
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20nerdsane%2Ftemper%20PR%20%23449%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=nerdsane%2Ftemper&pr=449&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fdeploy-aya.yml%3A59-64%0A**Empty%20head%20bypasses%20guard**%0A%0AWhen%20a%20rerun%20finds%20no%20matching%20%60release%60%20ref%2C%20%60head%60%20is%20empty%20and%20this%20condition%20falls%20through%20without%20setting%20%60stale%3Dtrue%60%2C%20causing%20the%20production%20verification%20and%20rollback%20driver%20to%20run%20for%20an%20unconfirmed%20stale%20SHA.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20if%20%5B%20-z%20%22%24head%22%20%5D%3B%20then%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22%3A%3Aerror%3A%3Acould%20not%20resolve%20the%20release%20HEAD%22%0A%20%20%20%20%20%20%20%20%20%20%20%20exit%201%0A%20%20%20%20%20%20%20%20%20%20elif%20%5B%20%22%24head%22%20!%3D%20%22%24%7BGITHUB_SHA%7D%22%20%5D%3B%20then%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22%3A%3Awarning%3A%3Arelease%20HEAD%20is%20%24head%2C%20not%20this%20run's%20%24%7BGITHUB_SHA%7D%20-%20a%20newer%20push%20supersedes%3B%20skipping.%22%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22stale%3Dtrue%22%20%3E%3E%20%22%24GITHUB_OUTPUT%22%0A%20%20%20%20%20%20%20%20%20%20else%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22release%20commit%3A%20%24%7BGITHUB_SHA%7D%22%0A%20%20%20%20%20%20%20%20%20%20fi%0A%60%60%60%0A%0A%23%23%23%20Issue%202%0A.github%2Fworkflows%2Fdeploy-aya.yml%3A75-82%0A**Mutable%20driver%20receives%20production%20credentials**%0A%0AEach%20release%20run%20executes%20the%20current%20default%20branch%20of%20%60arni-labs%2Fstack%60%20with%20production%20Railway%20credentials%20in%20its%20environment%2C%20so%20an%20upstream%20change%20is%20adopted%20without%20an%20immutable%20audit%20anchor%20and%20can%20expose%20those%20credentials%20or%20mutate%20the%20wrong%20deployment.%20Pin%20the%20clone%20to%20a%20reviewed%20commit%20or%20otherwise%20verify%20the%20fetched%20revision%20before%20execution.%0A%0A**How%20this%20was%20verified%3A**%20The%20clone%20specifies%20no%20revision%2C%20and%20the%20downloaded%20Bash%20process%20inherits%20the%20job-level%20Railway%20token%20and%20deployment%20identifiers.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=nerdsane%2Ftemper&pr=449&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22claude%2Farn-438-release-workflow%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Farn-438-release-workflow%22.%0A%0A%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fdeploy-aya.yml%3A59-64%0A**Empty%20head%20bypasses%20guard**%0A%0AWhen%20a%20rerun%20finds%20no%20matching%20%60release%60%20ref%2C%20%60head%60%20is%20empty%20and%20this%20condition%20falls%20through%20without%20setting%20%60stale%3Dtrue%60%2C%20causing%20the%20production%20verification%20and%20rollback%20driver%20to%20run%20for%20an%20unconfirmed%20stale%20SHA.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20if%20%5B%20-z%20%22%24head%22%20%5D%3B%20then%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22%3A%3Aerror%3A%3Acould%20not%20resolve%20the%20release%20HEAD%22%0A%20%20%20%20%20%20%20%20%20%20%20%20exit%201%0A%20%20%20%20%20%20%20%20%20%20elif%20%5B%20%22%24head%22%20!%3D%20%22%24%7BGITHUB_SHA%7D%22%20%5D%3B%20then%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22%3A%3Awarning%3A%3Arelease%20HEAD%20is%20%24head%2C%20not%20this%20run's%20%24%7BGITHUB_SHA%7D%20-%20a%20newer%20push%20supersedes%3B%20skipping.%22%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22stale%3Dtrue%22%20%3E%3E%20%22%24GITHUB_OUTPUT%22%0A%20%20%20%20%20%20%20%20%20%20else%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22release%20commit%3A%20%24%7BGITHUB_SHA%7D%22%0A%20%20%20%20%20%20%20%20%20%20fi%0A%60%60%60%0A%0A%23%23%23%20Issue%202%0A.github%2Fworkflows%2Fdeploy-aya.yml%3A75-82%0A**Mutable%20driver%20receives%20production%20credentials**%0A%0AEach%20release%20run%20executes%20the%20current%20default%20branch%20of%20%60arni-labs%2Fstack%60%20with%20production%20Railway%20credentials%20in%20its%20environment%2C%20so%20an%20upstream%20change%20is%20adopted%20without%20an%20immutable%20audit%20anchor%20and%20can%20expose%20those%20credentials%20or%20mutate%20the%20wrong%20deployment.%20Pin%20the%20clone%20to%20a%20reviewed%20commit%20or%20otherwise%20verify%20the%20fetched%20revision%20before%20execution.%0A%0A**How%20this%20was%20verified%3A**%20The%20clone%20specifies%20no%20revision%2C%20and%20the%20downloaded%20Bash%20process%20inherits%20the%20job-level%20Railway%20token%20and%20deployment%20identifiers.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=nerdsane%2Ftemper&pr=449&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fdeploy-aya.yml%3A59-64%0A**Empty%20head%20bypasses%20guard**%0A%0AWhen%20a%20rerun%20finds%20no%20matching%20%60release%60%20ref%2C%20%60head%60%20is%20empty%20and%20this%20condition%20falls%20through%20without%20setting%20%60stale%3Dtrue%60%2C%20causing%20the%20production%20verification%20and%20rollback%20driver%20to%20run%20for%20an%20unconfirmed%20stale%20SHA.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20if%20%5B%20-z%20%22%24head%22%20%5D%3B%20then%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22%3A%3Aerror%3A%3Acould%20not%20resolve%20the%20release%20HEAD%22%0A%20%20%20%20%20%20%20%20%20%20%20%20exit%201%0A%20%20%20%20%20%20%20%20%20%20elif%20%5B%20%22%24head%22%20!%3D%20%22%24%7BGITHUB_SHA%7D%22%20%5D%3B%20then%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22%3A%3Awarning%3A%3Arelease%20HEAD%20is%20%24head%2C%20not%20this%20run's%20%24%7BGITHUB_SHA%7D%20-%20a%20newer%20push%20supersedes%3B%20skipping.%22%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22stale%3Dtrue%22%20%3E%3E%20%22%24GITHUB_OUTPUT%22%0A%20%20%20%20%20%20%20%20%20%20else%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22release%20commit%3A%20%24%7BGITHUB_SHA%7D%22%0A%20%20%20%20%20%20%20%20%20%20fi%0A%60%60%60%0A%0A%23%23%23%20Issue%202%0A.github%2Fworkflows%2Fdeploy-aya.yml%3A75-82%0A**Mutable%20driver%20receives%20production%20credentials**%0A%0AEach%20release%20run%20executes%20the%20current%20default%20branch%20of%20%60arni-labs%2Fstack%60%20with%20production%20Railway%20credentials%20in%20its%20environment%2C%20so%20an%20upstream%20change%20is%20adopted%20without%20an%20immutable%20audit%20anchor%20and%20can%20expose%20those%20credentials%20or%20mutate%20the%20wrong%20deployment.%20Pin%20the%20clone%20to%20a%20reviewed%20commit%20or%20otherwise%20verify%20the%20fetched%20revision%20before%20execution.%0A%0A**How%20this%20was%20verified%3A**%20The%20clone%20specifies%20no%20revision%2C%20and%20the%20downloaded%20Bash%20process%20inherits%20the%20job-level%20Railway%20token%20and%20deployment%20identifiers.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=449&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/deploy-aya.yml:59-64
**Empty head bypasses guard**

When a rerun finds no matching `release` ref, `head` is empty and this condition falls through without setting `stale=true`, causing the production verification and rollback driver to run for an unconfirmed stale SHA.

```suggestion
          if [ -z "$head" ]; then
            echo "::error::could not resolve the release HEAD"
            exit 1
          elif [ "$head" != "${GITHUB_SHA}" ]; then
            echo "::warning::release HEAD is $head, not this run's ${GITHUB_SHA} - a newer push supersedes; skipping."
            echo "stale=true" >> "$GITHUB_OUTPUT"
          else
            echo "release commit: ${GITHUB_SHA}"
          fi
```

### Issue 2
.github/workflows/deploy-aya.yml:75-82
**Mutable driver receives production credentials**

Each release run executes the current default branch of `arni-labs/stack` with production Railway credentials in its environment, so an upstream change is adopted without an immutable audit anchor and can expose those credentials or mutate the wrong deployment. Pin the clone to a reviewed commit or otherwise verify the fetched revision before execution.

**How this was verified:** The clone specifies no revision, and the downloaded Bash process inherits the job-level Railway token and deployment identifiers.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): head guard gates the deploy ste..."](https://github.com/nerdsane/temper/commit/8562435141b1170913e6bf366351c6ef8c2e51ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58676859)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->