### PR TITLE
feat(server): unauthenticated /version route reporting the build commit (ARN-438)

### DIFF
--- a/.agents/skills/verify-temper/features/README.md
+++ b/.agents/skills/verify-temper/features/README.md
@@ -2,7 +2,7 @@
 
 Surface enumeration.
 
-Served route trees (`crates/temper-server/src`): `/tdata` (OData reads, bound actions, `$metadata`, `$hints`, `$events`), `/observe` (UI, entity history, replay-parity, specs, health), `/api` (authorize, decisions, policies, audit, specs load/validate), `/webhooks/{tenant}/{*path}` (inbound signed webhooks), `/_admin` (profiling). The unauthenticated `/healthz` liveness route is registered one layer up in `crates/temper-platform/src/router.rs` (`build_platform_router`); there is no `/version` route.
+Served route trees (`crates/temper-server/src`): `/tdata` (OData reads, bound actions, `$metadata`, `$hints`, `$events`), `/observe` (UI, entity history, replay-parity, specs, health), `/api` (authorize, decisions, policies, audit, specs load/validate), `/webhooks/{tenant}/{*path}` (inbound signed webhooks), `/_admin` (profiling). The unauthenticated `/healthz` (liveness) and `/version` (deploy-identity, returns `{commit}`) routes are registered one layer up in `crates/temper-platform/src/router.rs` (`build_platform_router`), not in temper-server; both are reserved built-ins that take precedence over any tenant HttpEndpoint at those paths.
 CLI verbs (`temper-cli`): `serve`, `mcp`, `verify`, `verify-ioa`, `verify-remote`, `init`, `codegen`, `install`, `decide`, `migrate-turso-to-postgres`.
 Plus the DST suites (`crates/temper-server/tests/dst_*`, `crates/temper-platform/tests`).
 

--- a/crates/temper-platform/src/bearer_auth.rs
+++ b/crates/temper-platform/src/bearer_auth.rs
@@ -198,7 +198,9 @@ fn is_public_request(req: &Request) -> bool {
     temper_server::authz::is_public_kernel_request(req.method(), req.uri().path())
         || matches!(
             (req.method(), req.uri().path()),
-            (&Method::GET, "/healthz") | (&Method::POST, "/api/identity/resolve")
+            (&Method::GET, "/healthz")
+                | (&Method::GET, "/version")
+                | (&Method::POST, "/api/identity/resolve")
         )
 }
 

--- a/crates/temper-platform/src/router.rs
+++ b/crates/temper-platform/src/router.rs
@@ -68,6 +68,11 @@ pub fn build_platform_router(state: PlatformState) -> Router {
 /// from. Read at runtime from `RAILWAY_GIT_COMMIT_SHA` (Railway injects it into
 /// GitHub-connected builds), else the build-time `GIT_COMMIT_SHA`, else "unknown".
 /// Commit only - the release verifier compares it against the release-branch HEAD.
+///
+/// `/version` is a reserved built-in (like `/healthz`): it is matched here before
+/// the kernel's HttpEndpoint fallback, so it takes precedence over any tenant
+/// HttpEndpoint at `/version` - the path is listed in the HttpEndpoint reserved
+/// namespaces (`temper-server/src/http_endpoint.rs`) so a tenant cannot register it.
 async fn version_info() -> axum::Json<serde_json::Value> {
     let commit = std::env::var("RAILWAY_GIT_COMMIT_SHA")
         .ok()
@@ -178,6 +183,30 @@ permit(
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_version_route_reports_the_env_commit_not_a_constant() {
+        // Pin the source: with RAILWAY_GIT_COMMIT_SHA set, /version must echo that
+        // exact value - an always-"unknown" (or hardcoded) implementation fails here.
+        let want = "deadbeefcafef00d1234567890abcdef12345678";
+        unsafe { std::env::set_var("RAILWAY_GIT_COMMIT_SHA", want) };
+        let app = build_platform_router(test_state());
+        let response = app
+            .oneshot(Request::get("/version").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            json.get("commit").and_then(|c| c.as_str()),
+            Some(want),
+            "version must echo RAILWAY_GIT_COMMIT_SHA, not a constant"
+        );
+        unsafe { std::env::remove_var("RAILWAY_GIT_COMMIT_SHA") };
     }
 
     #[tokio::test]

--- a/crates/temper-platform/src/router.rs
+++ b/crates/temper-platform/src/router.rs
@@ -74,12 +74,18 @@ pub fn build_platform_router(state: PlatformState) -> Router {
 /// HttpEndpoint at `/version` - the path is listed in the HttpEndpoint reserved
 /// namespaces (`temper-server/src/http_endpoint.rs`) so a tenant cannot register it.
 async fn version_info() -> axum::Json<serde_json::Value> {
-    let commit = std::env::var("RAILWAY_GIT_COMMIT_SHA")
-        .ok()
+    axum::Json(serde_json::json!({ "commit": version_commit(|k| std::env::var(k).ok()) }))
+}
+
+/// Resolve the build commit from an injected env lookup: runtime
+/// `RAILWAY_GIT_COMMIT_SHA` (non-empty), else the build-time `GIT_COMMIT_SHA`, else
+/// "unknown". The lookup is a parameter so tests supply a fake environment instead of
+/// mutating process-global env, which races the other parallel test threads.
+fn version_commit(get: impl Fn(&str) -> Option<String>) -> String {
+    get("RAILWAY_GIT_COMMIT_SHA")
         .filter(|s| !s.is_empty())
         .or_else(|| option_env!("GIT_COMMIT_SHA").map(str::to_string))
-        .unwrap_or_else(|| "unknown".to_string());
-    axum::Json(serde_json::json!({ "commit": commit }))
+        .unwrap_or_else(|| "unknown".to_string())
 }
 
 #[cfg(test)]
@@ -185,28 +191,27 @@ permit(
         assert_eq!(response.status(), StatusCode::OK);
     }
 
-    #[tokio::test]
-    async fn test_version_route_reports_the_env_commit_not_a_constant() {
-        // Pin the source: with RAILWAY_GIT_COMMIT_SHA set, /version must echo that
-        // exact value - an always-"unknown" (or hardcoded) implementation fails here.
+    #[test]
+    fn test_version_commit_echoes_env_not_a_constant() {
+        // Pin the source without touching process-global env: with
+        // RAILWAY_GIT_COMMIT_SHA present, the resolver must echo that exact value -
+        // an always-"unknown" (or hardcoded) implementation fails the first assert.
         let want = "deadbeefcafef00d1234567890abcdef12345678";
-        unsafe { std::env::set_var("RAILWAY_GIT_COMMIT_SHA", want) };
-        let app = build_platform_router(test_state());
-        let response = app
-            .oneshot(Request::get("/version").body(Body::empty()).unwrap())
-            .await
-            .unwrap();
-        assert_eq!(response.status(), StatusCode::OK);
-        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let echoed = version_commit(|k| (k == "RAILWAY_GIT_COMMIT_SHA").then(|| want.to_string()));
         assert_eq!(
-            json.get("commit").and_then(|c| c.as_str()),
-            Some(want),
+            echoed, want,
             "version must echo RAILWAY_GIT_COMMIT_SHA, not a constant"
         );
-        unsafe { std::env::remove_var("RAILWAY_GIT_COMMIT_SHA") };
+
+        // Empty runtime value falls through (Railway can inject ""), and an absent
+        // env must not fabricate the runtime commit.
+        let empty = version_commit(|k| (k == "RAILWAY_GIT_COMMIT_SHA").then(String::new));
+        assert_ne!(empty, want, "empty RAILWAY_GIT_COMMIT_SHA must not echo");
+        let absent = version_commit(|_| None);
+        assert_ne!(
+            absent, want,
+            "absent env must not fabricate the runtime commit"
+        );
     }
 
     #[tokio::test]

--- a/crates/temper-platform/src/router.rs
+++ b/crates/temper-platform/src/router.rs
@@ -25,7 +25,9 @@ use crate::tenant_access::tenant_access_check;
 /// first registered tenant in the SpecRegistry.
 pub fn build_platform_router(state: PlatformState) -> Router {
     let tenant_api = crate::tenant_api::tenant_api_router();
-    let health = Router::new().route("/healthz", routing::get(|| async { StatusCode::OK }));
+    let health = Router::new()
+        .route("/healthz", routing::get(|| async { StatusCode::OK }))
+        .route("/version", routing::get(version_info));
 
     // Platform observe routes — merged at /observe/* to avoid the /api double-nest
     // collision between temper-server's /api routes and the platform's /api routes.
@@ -60,6 +62,19 @@ pub fn build_platform_router(state: PlatformState) -> Router {
         .layer(middleware::from_fn(
             temper_server::authz::strip_inbound_identity_headers,
         ))
+}
+
+/// Unauthenticated deploy-identity probe: the commit the running binary was built
+/// from. Read at runtime from `RAILWAY_GIT_COMMIT_SHA` (Railway injects it into
+/// GitHub-connected builds), else the build-time `GIT_COMMIT_SHA`, else "unknown".
+/// Commit only - the release verifier compares it against the release-branch HEAD.
+async fn version_info() -> axum::Json<serde_json::Value> {
+    let commit = std::env::var("RAILWAY_GIT_COMMIT_SHA")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .or_else(|| option_env!("GIT_COMMIT_SHA").map(str::to_string))
+        .unwrap_or_else(|| "unknown".to_string());
+    axum::Json(serde_json::json!({ "commit": commit }))
 }
 
 #[cfg(test)]
@@ -163,6 +178,25 @@ permit(
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_version_route_is_public_and_reports_a_commit() {
+        // Unauthenticated (no credential) - proves it is in the public allowlist.
+        let app = build_platform_router(test_state());
+        let response = app
+            .oneshot(Request::get("/version").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert!(
+            json.get("commit").and_then(|c| c.as_str()).is_some(),
+            "version route must report a string `commit` field, got {json}"
+        );
     }
 
     #[tokio::test]

--- a/crates/temper-platform/src/specs/HttpEndpoint.ioa.toml
+++ b/crates/temper-platform/src/specs/HttpEndpoint.ioa.toml
@@ -9,8 +9,10 @@
 # Phase 2: wire end-to-end on top of ADR-0057 http_call_streaming.
 #
 # Field-level shape invariants (path_prefix starts with '/', methods
-# non-empty, timeout_secs in [1, 600], reserved-namespace check) are
-# enforced in the action handler at runtime. IOA field_invariant
+# non-empty, timeout_secs in [1, 600], reserved-namespace check - the
+# reserved set includes the platform-router built-ins /healthz and
+# /version alongside /tdata, /webhooks, /_admin, /observe, /api,
+# /_internal) are enforced in the action handler at runtime. IOA field_invariant
 # grammar today supports only absent/equals/empty combinators — a
 # follow-up ADR will extend it with `matches` + `gte`/`lte` so these
 # invariants can move into the spec and become DST-verifiable.

--- a/crates/temper-server/src/http_endpoint.rs
+++ b/crates/temper-server/src/http_endpoint.rs
@@ -14,8 +14,14 @@
 //!   * Longest-prefix match wins; ties on length are rejected at
 //!     `Create` time by a cross-field invariant.
 //!   * Built-in namespaces (`/tdata`, `/webhooks`, `/_admin`,
-//!     `/observe`, `/api`, `/_internal`) are reserved; the spec's
-//!     invariants block them at write time.
+//!     `/observe`, `/api`, `/_internal`, and the platform-router
+//!     built-ins `/healthz` and `/version`) are reserved; the spec's
+//!     invariants block them at write time. The `/healthz` and
+//!     `/version` routes live one layer up in the platform router
+//!     (`temper-platform/src/router.rs`) and win by axum precedence over
+//!     this fallback, so a tenant HttpEndpoint there would be shadowed -
+//!     hence reserved. (Enforcement is the Phase-2 runtime check; the
+//!     spec notes dispatch is stubbed 501 until then.)
 //!   * Methods are matched case-insensitively against the row's
 //!     comma-separated Methods column.
 //!   * `Paused` / `Deleted` endpoints never match.

--- a/docs/efforts/ARN-438/decisions.md
+++ b/docs/efforts/ARN-438/decisions.md
@@ -182,3 +182,21 @@ matches the live 404 probe (/version does not exist until the parked /version PR
 adds it). Force-pushing would silently discard a valid concurrent fix. Only
 decisions.md needed a both-entries merge.
 **Where:** `features/serve-and-odata.md` (from 9453ba0f); this entry.
+
+---
+
+**Decision:** Add a minimal unauthenticated `GET /version` route to temper-server
+returning `{commit}` only, sourced from `RAILWAY_GIT_COMMIT_SHA` (runtime) then a
+build-time `GIT_COMMIT_SHA` (`option_env!`) then "unknown" (ARN-438 item 5, step 2).
+**Came up because:** the aya temper-server release-gating driver must verify the live
+deploy reports the expected commit, but the kernel had NO sha-reporting route (probed
+prod: /version, /readyz, /observe/version, /paw/version all 404; /observe/health carries no sha).
+**Options:** (a) a full GHCR image pipeline so the existing driver's image-identity
+check works; (b) the smallest kernel addition - a /version route reading the commit
+from env; (c) no route, verify liveness only.
+**Chose (b) over (a)/(c) because:** (a) is machinery for a secondary standalone kernel
+whose primary deploy leg is already the temperpaw pin (owner rejected it); (c) cannot
+confirm the deployed code identity. (b) is a few lines, unauth like /healthz, commit-only.
+Degrades to "unknown" where the env is absent, verified empirically on first deploy.
+**Where:** `crates/temper-platform/src/router.rs` (`version_info` + route),
+`crates/temper-platform/src/bearer_auth.rs` (public allowlist).

--- a/docs/efforts/ARN-438/spec.md
+++ b/docs/efforts/ARN-438/spec.md
@@ -45,3 +45,13 @@ turso`), confirm `/healthz` + `/tdata/$metadata`, run the cascade
 (`temper verify`) and at least one `dst_*` suite, and capture the output as
 evidence that the skill's commands are real. The remaining CI checks (fmt/clippy,
 the SDLC gates) run on the PR.
+
+## Item 5 (identity leg): the /version route
+
+This effort's temper slice also carries item 5's kernel piece: an unauthenticated
+`GET /version` route on the platform router returning `{commit}` (from
+`RAILWAY_GIT_COMMIT_SHA`, else a build-time value, else "unknown"), the deploy
+identity the aya release-gating driver verifies. Shipped as its own small PR
+(temper #452) after this one merged; the driver source mode and the deploy-aya
+workflow are the other item-5 pieces (stack + temperpaw). See the decision log
+entry "Add a minimal unauthenticated GET /version route".


### PR DESCRIPTION
The minimal `/version` route for the aya temper-server release gating (ARN-438 item 5, step 2). Splits out from the verify-temper PR (#448, merged) as its own small change.

Adds an unauthenticated `GET /version` to the platform router (public alongside `/healthz`), returning `{commit}` only — sourced from `RAILWAY_GIT_COMMIT_SHA` (runtime, injected by Railway's GitHub build), else a build-time `GIT_COMMIT_SHA` (`option_env!`), else `"unknown"`. This is the identity endpoint the release-gating driver verifies: the kernel had no sha-reporting route (prod probe: /version, /readyz, /observe/version, /paw/version all 404). Commit-only payload, unauth so the driver needs no key for identity.

Verified: the new `test_version_route_is_public_and_reports_a_commit` passes (route returns 200 unauthenticated with a `commit` field); clippy + fmt clean on temper-platform. Pairs with the stack driver source-mode PR (stack#3) and the deploy-aya workflow (temper #449).

## Decisions & Tradeoffs

**Decision:** Add a minimal unauthenticated `GET /version` returning `{commit}` (RAILWAY_GIT_COMMIT_SHA → build-time → "unknown") rather than a GHCR image pipeline or liveness-only verification.
**Came up because:** the release driver must verify the deployed commit; no sha-reporting route existed.
**Options:** (a) GHCR image pipeline so the driver's image-identity check works; (b) the smallest kernel addition — a /version route from env; (c) no route, verify liveness only.
**Chose (b) over (a)/(c) because:** (a) is machinery for a secondary kernel whose primary deploy leg is the temperpaw pin (owner rejected it); (c) can't confirm the deployed code identity. (b) is a few lines, unauth like /healthz, commit-only; degrades to "unknown" where the env is absent (verified empirically on first deploy).
**Where:** `crates/temper-platform/src/router.rs` (`version_info` + route), `crates/temper-platform/src/bearer_auth.rs` (public allowlist).


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds an unauthenticated platform-level `GET /version` endpoint that reports the Railway runtime commit, a build-time fallback, or `"unknown"`.

- Adds `/version` routing and public-authentication handling.
- Adds commit-source resolution and route tests.
- Documents `/version` as a reserved HttpEndpoint namespace and updates ARN-438 release-gating documentation.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until tenant HttpEndpoint creation rejects `/version`, preventing successfully registered endpoints from being silently shadowed.

The new exact platform route makes an accepted tenant `/version` endpoint unreachable because the documented reservation is not enforced in the write or projection path; the missing ADR is also actionable but non-blocking.

**Files Needing Attention:** crates/temper-platform/src/router.rs, crates/temper-platform/src/specs/HttpEndpoint.ioa.toml, crates/temper-server/src/http_endpoint.rs
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/temper-platform/src/router.rs | Adds the version route, resolver, and tests, but the exact built-in route can shadow an accepted tenant endpoint at the same path. |
| crates/temper-platform/src/bearer_auth.rs | Adds GET `/version` to the platform public-request allowlist. |
| crates/temper-platform/src/specs/HttpEndpoint.ioa.toml | Documents `/version` as reserved without adding a corresponding executable invariant. |
| crates/temper-server/src/http_endpoint.rs | Documents the new reserved namespace, while existing projection logic still accepts it. |
| docs/efforts/ARN-438/decisions.md | Records the release-identity decision in the effort log, but not in the repository-required ADR location. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Probe[Release-gating probe] -->|GET /version| Auth[Public-route allowlist]
  Auth --> Route[Platform /version route]
  Runtime[RAILWAY_GIT_COMMIT_SHA] --> Resolve[Commit resolver]
  Build[GIT_COMMIT_SHA at build time] --> Resolve
  Unknown[unknown fallback] --> Resolve
  Resolve --> Route
  Route --> Response[JSON commit response]
  Tenant[Tenant HttpEndpoint /version] -. shadowed .-> Route
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20nerdsane%2Ftemper%20PR%20%23452%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=nerdsane%2Ftemper&pr=452&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Acrates%2Ftemper-platform%2Fsrc%2Frouter.rs%3A30%0A**Tenant%20%60%2Fversion%60%20endpoints%20are%20shadowed**%0A%0AWhen%20a%20tenant%20creates%20an%20active%20HttpEndpoint%20at%20%60%2Fversion%60%2C%20the%20write%20and%20projection%20paths%20accept%20it%2C%20but%20this%20exact%20platform%20route%20takes%20precedence%20over%20the%20tenant%20fallback%2C%20causing%20the%20registered%20endpoint%20to%20remain%20permanently%20unreachable.%0A%0A%23%23%23%20Issue%202%0Acrates%2Ftemper-platform%2Fsrc%2Frouter.rs%3A29-30%0A**Cross-crate%20route%20lacks%20required%20ADR**%0A%0AThis%20new%20public%20route%20establishes%20routing%2C%20authentication%2C%20identity-source%2C%20and%20reserved-namespace%20behavior%20across%20multiple%20crates%2C%20but%20records%20the%20decision%20only%20in%20the%20effort%20log%20rather%20than%20the%20required%20%60docs%2Fadrs%2F%60%20architecture%20record%2C%20making%20the%20contract%20harder%20to%20maintain%20consistently.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=nerdsane%2Ftemper&pr=452&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22nerdsane%2Ftemper%22%20on%20the%20existing%20branch%20%22claude%2Farn-438-version%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Farn-438-version%22.%0A%0A%23%23%23%20Issue%201%0Acrates%2Ftemper-platform%2Fsrc%2Frouter.rs%3A30%0A**Tenant%20%60%2Fversion%60%20endpoints%20are%20shadowed**%0A%0AWhen%20a%20tenant%20creates%20an%20active%20HttpEndpoint%20at%20%60%2Fversion%60%2C%20the%20write%20and%20projection%20paths%20accept%20it%2C%20but%20this%20exact%20platform%20route%20takes%20precedence%20over%20the%20tenant%20fallback%2C%20causing%20the%20registered%20endpoint%20to%20remain%20permanently%20unreachable.%0A%0A%23%23%23%20Issue%202%0Acrates%2Ftemper-platform%2Fsrc%2Frouter.rs%3A29-30%0A**Cross-crate%20route%20lacks%20required%20ADR**%0A%0AThis%20new%20public%20route%20establishes%20routing%2C%20authentication%2C%20identity-source%2C%20and%20reserved-namespace%20behavior%20across%20multiple%20crates%2C%20but%20records%20the%20decision%20only%20in%20the%20effort%20log%20rather%20than%20the%20required%20%60docs%2Fadrs%2F%60%20architecture%20record%2C%20making%20the%20contract%20harder%20to%20maintain%20consistently.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=nerdsane%2Ftemper&pr=452&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Acrates%2Ftemper-platform%2Fsrc%2Frouter.rs%3A30%0A**Tenant%20%60%2Fversion%60%20endpoints%20are%20shadowed**%0A%0AWhen%20a%20tenant%20creates%20an%20active%20HttpEndpoint%20at%20%60%2Fversion%60%2C%20the%20write%20and%20projection%20paths%20accept%20it%2C%20but%20this%20exact%20platform%20route%20takes%20precedence%20over%20the%20tenant%20fallback%2C%20causing%20the%20registered%20endpoint%20to%20remain%20permanently%20unreachable.%0A%0A%23%23%23%20Issue%202%0Acrates%2Ftemper-platform%2Fsrc%2Frouter.rs%3A29-30%0A**Cross-crate%20route%20lacks%20required%20ADR**%0A%0AThis%20new%20public%20route%20establishes%20routing%2C%20authentication%2C%20identity-source%2C%20and%20reserved-namespace%20behavior%20across%20multiple%20crates%2C%20but%20records%20the%20decision%20only%20in%20the%20effort%20log%20rather%20than%20the%20required%20%60docs%2Fadrs%2F%60%20architecture%20record%2C%20making%20the%20contract%20harder%20to%20maintain%20consistently.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=452&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
crates/temper-platform/src/router.rs:30
**Tenant `/version` endpoints are shadowed**

When a tenant creates an active HttpEndpoint at `/version`, the write and projection paths accept it, but this exact platform route takes precedence over the tenant fallback, causing the registered endpoint to remain permanently unreachable.

### Issue 2
crates/temper-platform/src/router.rs:29-30
**Cross-crate route lacks required ADR**

This new public route establishes routing, authentication, identity-source, and reserved-namespace behavior across multiple crates, but records the decision only in the effort log rather than the required `docs/adrs/` architecture record, making the contract harder to maintain consistently.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(server): version commit via injected..."](https://github.com/nerdsane/temper/commit/60a2e7bf7247f91ddbc9aa96db2789aee5f6c5d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58660504)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/nerdsane/temper/blob/main/CLAUDE.md))

<!-- /greptile_comment -->